### PR TITLE
feat(codegen): pluggable Emitter abstraction (closes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,23 @@ npm run test:pw                    # run the generated tests
 npm run observe:aggregate          # aggregate runtime observations
 ```
 
+#### Pluggable test emitters
+
+Suite generation is layered behind a small `Emitter` strategy interface
+(`path-analyser/src/codegen/emitter.ts`). The CLI selects an emitter via
+`--target=<id>` and falls back to `playwright` when omitted:
+
+```bash
+node path-analyser/dist/src/codegen/index.js --target=playwright createWidget
+node path-analyser/dist/src/codegen/index.js --target=playwright --all
+```
+
+The current built-in is `playwright`. Additional targets (e.g. SDK-based
+suites — see [#8](https://github.com/camunda/api-test-generator/issues/8))
+register themselves through `registerEmitter()` and are listed in
+`--help`. The emitter contract is **experimental** and may change while
+the SDK strategies land.
+
 ### request-validation
 
 A spec-driven generator that synthesizes **negative** Playwright tests targeting

--- a/path-analyser/src/codegen/cli-args.ts
+++ b/path-analyser/src/codegen/cli-args.ts
@@ -1,0 +1,31 @@
+export interface ParsedCliArgs {
+  target: string;
+  positional: string | undefined;
+  help: boolean;
+}
+
+/**
+ * Parse `path-analyser/src/codegen/index.ts` CLI arguments.
+ *
+ * Supported flags:
+ * - `--target=<id>` selects an emitter (default: `playwright`)
+ * - `--help` / `-h` prints usage
+ *
+ * The first non-flag argument is the operationId or `--all` sentinel.
+ * Additional positionals are ignored.
+ */
+export function parseCliArgs(argv: readonly string[]): ParsedCliArgs {
+  let target = 'playwright';
+  let positional: string | undefined;
+  let help = false;
+  for (const a of argv) {
+    if (a === '--help' || a === '-h') {
+      help = true;
+    } else if (a.startsWith('--target=')) {
+      target = a.slice('--target='.length);
+    } else if (!positional) {
+      positional = a;
+    }
+  }
+  return { target, positional, help };
+}

--- a/path-analyser/src/codegen/emitter.ts
+++ b/path-analyser/src/codegen/emitter.ts
@@ -1,0 +1,45 @@
+import type { EndpointScenarioCollection } from '../types.js';
+
+/**
+ * Context passed to an {@link Emitter} on every invocation.
+ *
+ * Keep this surface tight — every consumer of the emitter registry depends on
+ * it. New optional fields are fine; making existing fields required is a
+ * breaking change for third-party emitters.
+ */
+export interface EmitContext {
+  /** Absolute path of the directory tests should be emitted into. */
+  outDir: string;
+  /** Suite name used in the file name and `describe()` block. */
+  suiteName: string;
+  /** Generation mode — `feature` is the default for path-analyser scenarios. */
+  mode: 'feature' | 'integration';
+}
+
+/**
+ * A single output artifact returned by an {@link Emitter}. Paths are relative
+ * to {@link EmitContext.outDir}; the orchestrator handles directory creation
+ * and write-out so that emitters stay pure.
+ */
+export interface EmittedFile {
+  /** Path relative to {@link EmitContext.outDir}. Forward slashes only. */
+  relativePath: string;
+  /** UTF-8 file content. */
+  content: string;
+}
+
+/**
+ * Strategy that lowers a scenario collection into one or more output files.
+ *
+ * Implementations must be **pure**: they may not touch the filesystem, the
+ * network, or any global state. All inputs come through {@link EmitContext}
+ * and the scenario collection; all outputs come back as {@link EmittedFile}.
+ */
+export interface Emitter {
+  /** Stable identifier used by `--target=<id>`. Must be unique in a registry. */
+  readonly id: string;
+  /** Human-readable name for logs and docs. */
+  readonly name: string;
+  /** Lowers a scenario collection into output files. */
+  emit(collection: EndpointScenarioCollection, ctx: EmitContext): Promise<EmittedFile[]>;
+}

--- a/path-analyser/src/codegen/emitter.ts
+++ b/path-analyser/src/codegen/emitter.ts
@@ -10,7 +10,7 @@ import type { EndpointScenarioCollection } from '../types.js';
 export interface EmitContext {
   /** Absolute path of the directory tests should be emitted into. */
   outDir: string;
-  /** Suite name used in the file name and `describe()` block. */
+  /** Suite name used for test naming (for example, `describe()` blocks) and optionally for file names, depending on the emitter. */
   suiteName: string;
   /** Generation mode — `feature` is the default for path-analyser scenarios. */
   mode: 'feature' | 'integration';

--- a/path-analyser/src/codegen/index.ts
+++ b/path-analyser/src/codegen/index.ts
@@ -1,7 +1,13 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import type { EndpointScenarioCollection } from '../types.js';
-import { emitPlaywrightSuite } from './playwright/emitter.js';
+import { parseCliArgs } from './cli-args.js';
+import { writeEmitted } from './orchestrator.js';
+import { PlaywrightEmitter } from './playwright/emitter.js';
+import { getEmitter, listEmitters, registerEmitter } from './registry.js';
+
+// Built-in emitter registration. New emitters register themselves here.
+registerEmitter(PlaywrightEmitter);
 
 // JSON.parse is a runtime contract boundary: the on-disk scenario files are
 // produced by the generator and conform structurally to EndpointScenarioCollection.
@@ -12,8 +18,18 @@ function parseScenarioCollection(text: string): EndpointScenarioCollection {
   return JSON.parse(text) as EndpointScenarioCollection;
 }
 
+function printUsage(): void {
+  const targets = listEmitters()
+    .map((e) => `${e.id} (${e.name})`)
+    .join(', ');
+  console.error(
+    'Usage: node dist/codegen/index.js [--target=<id>] <operationId>|--all\n' +
+      `Available targets: ${targets || '(none)'}`,
+  );
+}
+
 async function run() {
-  const arg = process.argv[2];
+  const { target, positional, help } = parseCliArgs(process.argv.slice(2));
   const baseDir = process.cwd().endsWith('path-analyser')
     ? process.cwd()
     : path.resolve(process.cwd(), 'path-analyser');
@@ -29,21 +45,31 @@ async function run() {
     await fs.copyFile(envSrc, envDst);
   } catch {}
 
-  if (!arg || arg === '--help' || arg === '-h') {
-    console.error('Usage: node dist/codegen/index.js <operationId>|--all');
+  if (help || !positional) {
+    printUsage();
+    process.exit(1);
+  }
+
+  const emitter = getEmitter(target);
+  if (!emitter) {
+    console.error(
+      `Unknown emitter target: '${target}'. Available: ${listEmitters()
+        .map((e) => e.id)
+        .join(', ')}`,
+    );
     process.exit(1);
   }
 
   const files = (await fs.readdir(featureDir)).filter((f) => f.endsWith('-scenarios.json'));
 
-  if (arg === '--all') {
+  if (positional === '--all') {
     let count = 0;
     for (const f of files) {
       try {
         const content = await fs.readFile(path.join(featureDir, f), 'utf8');
         const parsed = parseScenarioCollection(content);
         if (!parsed.endpoint?.operationId) continue;
-        await emitPlaywrightSuite(parsed, {
+        await writeEmitted(emitter, parsed, {
           outDir,
           suiteName: parsed.endpoint.operationId,
           mode: 'feature',
@@ -54,11 +80,13 @@ async function run() {
         console.warn('Skipping file (parse/emission failed):', f, msg);
       }
     }
-    console.log(`Generated test suites for ${count} endpoints in ${outDir}`);
+    console.log(
+      `Generated test suites for ${count} endpoints in ${outDir} (target: ${emitter.id})`,
+    );
     return;
   }
 
-  const endpointOpId = arg;
+  const endpointOpId = positional;
   let match: string | null = null;
   for (const f of files) {
     const content = await fs.readFile(path.join(featureDir, f), 'utf8');
@@ -77,8 +105,12 @@ async function run() {
     process.exit(1);
   }
   const json = parseScenarioCollection(await fs.readFile(path.join(featureDir, match), 'utf8'));
-  await emitPlaywrightSuite(json, { outDir, suiteName: endpointOpId, mode: 'feature' });
-  console.log('Generated test suite for', endpointOpId, 'at', outDir);
+  await writeEmitted(emitter, json, {
+    outDir,
+    suiteName: endpointOpId,
+    mode: 'feature',
+  });
+  console.log('Generated test suite for', endpointOpId, 'at', outDir, `(target: ${emitter.id})`);
 }
 
 function _hyphenizeOp(op: string) {

--- a/path-analyser/src/codegen/index.ts
+++ b/path-analyser/src/codegen/index.ts
@@ -23,7 +23,7 @@ function printUsage(): void {
     .map((e) => `${e.id} (${e.name})`)
     .join(', ');
   console.error(
-    'Usage: node dist/codegen/index.js [--target=<id>] <operationId>|--all\n' +
+    'Usage: node dist/src/codegen/index.js [--target=<id>] <operationId>|--all\n' +
       `Available targets: ${targets || '(none)'}`,
   );
 }

--- a/path-analyser/src/codegen/orchestrator.ts
+++ b/path-analyser/src/codegen/orchestrator.ts
@@ -1,0 +1,38 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { EndpointScenarioCollection } from '../types.js';
+import type { Emitter } from './emitter.js';
+
+/**
+ * Write all files emitted by an {@link Emitter} into `outDir`. Centralising
+ * the write step lets emitters stay pure and lets us add cross-cutting
+ * concerns (formatting, license headers, idempotency checks) in one place.
+ *
+ * Returns the absolute paths of files written, in emit order.
+ */
+export async function writeEmitted(
+  emitter: Emitter,
+  collection: EndpointScenarioCollection,
+  ctx: { outDir: string; suiteName: string; mode: 'feature' | 'integration' },
+): Promise<string[]> {
+  const files = await emitter.emit(collection, ctx);
+  const written: string[] = [];
+  for (const f of files) {
+    if (path.isAbsolute(f.relativePath)) {
+      throw new Error(
+        `Emitter '${emitter.id}' returned absolute path '${f.relativePath}'. ` +
+          'Emitted file paths must be relative to ctx.outDir.',
+      );
+    }
+    if (f.relativePath.includes('..')) {
+      throw new Error(
+        `Emitter '${emitter.id}' returned path '${f.relativePath}' that escapes ctx.outDir.`,
+      );
+    }
+    const abs = path.join(ctx.outDir, f.relativePath);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, f.content, 'utf8');
+    written.push(abs);
+  }
+  return written;
+}

--- a/path-analyser/src/codegen/orchestrator.ts
+++ b/path-analyser/src/codegen/orchestrator.ts
@@ -24,12 +24,17 @@ export async function writeEmitted(
           'Emitted file paths must be relative to ctx.outDir.',
       );
     }
-    if (f.relativePath.includes('..')) {
+    // Resolve and assert the destination stays within ctx.outDir. A naive
+    // substring check on `..` would reject legitimate filenames like
+    // `foo..bar.ts` and would not catch escapes hidden inside deeper segments.
+    const resolvedOutDir = path.resolve(ctx.outDir);
+    const abs = path.resolve(resolvedOutDir, f.relativePath);
+    const rel = path.relative(resolvedOutDir, abs);
+    if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
       throw new Error(
         `Emitter '${emitter.id}' returned path '${f.relativePath}' that escapes ctx.outDir.`,
       );
     }
-    const abs = path.join(ctx.outDir, f.relativePath);
     await fs.mkdir(path.dirname(abs), { recursive: true });
     await fs.writeFile(abs, f.content, 'utf8');
     written.push(abs);

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import type { EndpointScenario, EndpointScenarioCollection, RequestStep } from '../../types.js';
 import { planFinalStepAssertions } from '../assertionPlanner.js';
+import type { EmitContext, EmittedFile, Emitter } from '../emitter.js';
 
 interface EmitOptions {
   outDir: string;
@@ -9,19 +10,69 @@ interface EmitOptions {
   mode?: 'feature' | 'integration';
 }
 
+/**
+ * Build the file name a scenario collection lowers to. Exposed for the
+ * Emitter wrapper so it can return a relative path without re-deriving it.
+ */
+export function playwrightSuiteFileName(
+  collection: EndpointScenarioCollection,
+  mode: 'feature' | 'integration',
+): string {
+  return `${collection.endpoint.operationId}.${mode}.spec.ts`;
+}
+
+/**
+ * Pure rendering entry point — returns the suite source as a string.
+ * Used by the {@link PlaywrightEmitter} strategy and by callers that want
+ * the source without writing it.
+ */
+export function renderPlaywrightSuite(
+  collection: EndpointScenarioCollection,
+  opts: { suiteName?: string; mode?: 'feature' | 'integration' },
+): string {
+  return buildSuiteSource(collection, {
+    outDir: '',
+    suiteName: opts.suiteName,
+    mode: opts.mode,
+  });
+}
+
+/**
+ * Legacy filesystem-writing entry point. Retained for backwards compatibility
+ * with the existing `codegen:playwright` script. New callers should use the
+ * {@link PlaywrightEmitter} via the registry.
+ */
 export async function emitPlaywrightSuite(
   collection: EndpointScenarioCollection,
   opts: EmitOptions,
 ) {
   await fs.mkdir(opts.outDir, { recursive: true });
-  const file = path.join(
-    opts.outDir,
-    `${collection.endpoint.operationId}.${opts.mode || 'feature'}.spec.ts`,
-  );
-  const code = buildSuiteSource(collection, opts);
+  const file = path.join(opts.outDir, playwrightSuiteFileName(collection, opts.mode || 'feature'));
+  const code = renderPlaywrightSuite(collection, opts);
   await fs.writeFile(file, code, 'utf8');
   return file;
 }
+
+/**
+ * {@link Emitter} implementation for Playwright/REST tests. Pure: returns
+ * an in-memory {@link EmittedFile} list and never touches the filesystem.
+ */
+export const PlaywrightEmitter: Emitter = {
+  id: 'playwright',
+  name: 'Playwright (REST)',
+  async emit(collection: EndpointScenarioCollection, ctx: EmitContext): Promise<EmittedFile[]> {
+    const content = renderPlaywrightSuite(collection, {
+      suiteName: ctx.suiteName,
+      mode: ctx.mode,
+    });
+    return [
+      {
+        relativePath: playwrightSuiteFileName(collection, ctx.mode),
+        content,
+      },
+    ];
+  },
+};
 
 function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOptions): string {
   const lines: string[] = [];

--- a/path-analyser/src/codegen/registry.ts
+++ b/path-analyser/src/codegen/registry.ts
@@ -1,0 +1,35 @@
+import type { Emitter } from './emitter.js';
+
+/**
+ * Registry of {@link Emitter} implementations keyed by stable id.
+ *
+ * The registry is process-wide and idempotent: registering the same emitter
+ * id twice with the same instance is a no-op; registering a different
+ * instance with an existing id throws so configuration drift is caught
+ * loudly at boot.
+ */
+const emitters = new Map<string, Emitter>();
+
+export function registerEmitter(emitter: Emitter): void {
+  const existing = emitters.get(emitter.id);
+  if (existing && existing !== emitter) {
+    throw new Error(
+      `Emitter id collision: '${emitter.id}' is already registered to a different instance ('${existing.name}'). ` +
+        'Each emitter id must map to exactly one implementation.',
+    );
+  }
+  emitters.set(emitter.id, emitter);
+}
+
+export function getEmitter(id: string): Emitter | undefined {
+  return emitters.get(id);
+}
+
+export function listEmitters(): Emitter[] {
+  return [...emitters.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/** Test-only: clear the registry. Not exported from the package barrel. */
+export function _resetEmittersForTests(): void {
+  emitters.clear();
+}

--- a/tests/codegen/cli-args.test.ts
+++ b/tests/codegen/cli-args.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest';
+import { parseCliArgs } from '../../path-analyser/src/codegen/cli-args.ts';
+
+describe('parseCliArgs', () => {
+  test('default target is playwright', () => {
+    expect(parseCliArgs(['createWidget'])).toEqual({
+      target: 'playwright',
+      positional: 'createWidget',
+      help: false,
+    });
+  });
+
+  test('--target=<id> overrides the default', () => {
+    expect(parseCliArgs(['--target=typescript-sdk', 'createWidget'])).toEqual({
+      target: 'typescript-sdk',
+      positional: 'createWidget',
+      help: false,
+    });
+  });
+
+  test('--target after the positional still applies', () => {
+    expect(parseCliArgs(['--all', '--target=python-sdk'])).toEqual({
+      target: 'python-sdk',
+      positional: '--all',
+      help: false,
+    });
+  });
+
+  test('--help short and long', () => {
+    expect(parseCliArgs(['--help'])).toMatchObject({ help: true });
+    expect(parseCliArgs(['-h'])).toMatchObject({ help: true });
+  });
+
+  test('--all is preserved as the positional sentinel', () => {
+    expect(parseCliArgs(['--all'])).toMatchObject({ positional: '--all' });
+  });
+
+  test('empty argv yields no positional and no help', () => {
+    expect(parseCliArgs([])).toEqual({
+      target: 'playwright',
+      positional: undefined,
+      help: false,
+    });
+  });
+
+  test('first positional wins; later positionals are ignored', () => {
+    // CLI accepts a single operationId; documenting the parser behaviour explicitly.
+    expect(parseCliArgs(['createWidget', 'extra'])).toMatchObject({
+      positional: 'createWidget',
+    });
+  });
+});

--- a/tests/codegen/orchestrator.test.ts
+++ b/tests/codegen/orchestrator.test.ts
@@ -72,4 +72,23 @@ describe('orchestrator.writeEmitted', () => {
     const e = buildEmitter([{ relativePath: '../escape.ts', content: 'oops' }]);
     await expect(writeEmitted(e, FIXTURE, ctx())).rejects.toThrowError(/escapes ctx.outDir/);
   });
+
+  test('rejects paths that escape outDir via a deeper .. segment', async () => {
+    const e = buildEmitter([{ relativePath: 'a/b/../../../escape.ts', content: 'oops' }]);
+    await expect(writeEmitted(e, FIXTURE, ctx())).rejects.toThrowError(/escapes ctx.outDir/);
+  });
+
+  test('allows a filename that contains .. as a substring (not a parent-dir segment)', async () => {
+    const e = buildEmitter([{ relativePath: 'foo..bar.spec.ts', content: '// ok' }]);
+    const written = await writeEmitted(e, FIXTURE, ctx());
+    expect(written).toHaveLength(1);
+    expect(readFileSync(path.join(tmp, 'foo..bar.spec.ts'), 'utf8')).toBe('// ok');
+  });
+
+  test('allows nested .. segments that resolve to a path inside outDir', async () => {
+    const e = buildEmitter([{ relativePath: 'a/b/../inside.ts', content: '// ok' }]);
+    const written = await writeEmitted(e, FIXTURE, ctx());
+    expect(written).toHaveLength(1);
+    expect(readFileSync(path.join(tmp, 'a/inside.ts'), 'utf8')).toBe('// ok');
+  });
 });

--- a/tests/codegen/orchestrator.test.ts
+++ b/tests/codegen/orchestrator.test.ts
@@ -1,0 +1,75 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import type { EmitContext, EmittedFile, Emitter } from '../../path-analyser/src/codegen/emitter.ts';
+import { writeEmitted } from '../../path-analyser/src/codegen/orchestrator.ts';
+import type { EndpointScenarioCollection } from '../../path-analyser/src/types.ts';
+
+const FIXTURE: EndpointScenarioCollection = {
+  endpoint: { operationId: 'createWidget', method: 'POST', path: '/widgets' },
+  requiredSemanticTypes: [],
+  optionalSemanticTypes: [],
+  scenarios: [],
+};
+
+function buildEmitter(files: EmittedFile[]): Emitter {
+  return {
+    id: 'stub',
+    name: 'stub',
+    async emit() {
+      return files;
+    },
+  };
+}
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), 'emitter-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+const ctx = (): EmitContext => ({
+  outDir: tmp,
+  suiteName: 'createWidget',
+  mode: 'feature',
+});
+
+describe('orchestrator.writeEmitted', () => {
+  test('writes a single top-level file', async () => {
+    const e = buildEmitter([{ relativePath: 'createWidget.spec.ts', content: '// hello' }]);
+    const written = await writeEmitted(e, FIXTURE, ctx());
+    expect(written).toHaveLength(1);
+    expect(readFileSync(path.join(tmp, 'createWidget.spec.ts'), 'utf8')).toBe('// hello');
+  });
+
+  test('creates nested directories on demand', async () => {
+    const e = buildEmitter([{ relativePath: 'support/env.ts', content: '// env' }]);
+    await writeEmitted(e, FIXTURE, ctx());
+    expect(readFileSync(path.join(tmp, 'support/env.ts'), 'utf8')).toBe('// env');
+  });
+
+  test('writes multiple files in emit order', async () => {
+    const e = buildEmitter([
+      { relativePath: 'a.ts', content: '1' },
+      { relativePath: 'b.ts', content: '2' },
+    ]);
+    const written = await writeEmitted(e, FIXTURE, ctx());
+    expect(written.map((p) => path.basename(p))).toEqual(['a.ts', 'b.ts']);
+    expect(readdirSync(tmp).sort()).toEqual(['a.ts', 'b.ts']);
+  });
+
+  test('rejects absolute paths returned by an emitter', async () => {
+    const e = buildEmitter([{ relativePath: '/etc/passwd', content: 'oops' }]);
+    await expect(writeEmitted(e, FIXTURE, ctx())).rejects.toThrowError(/returned absolute path/);
+  });
+
+  test('rejects paths that escape outDir via ..', async () => {
+    const e = buildEmitter([{ relativePath: '../escape.ts', content: 'oops' }]);
+    await expect(writeEmitted(e, FIXTURE, ctx())).rejects.toThrowError(/escapes ctx.outDir/);
+  });
+});

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'vitest';
+import {
+  PlaywrightEmitter,
+  playwrightSuiteFileName,
+  renderPlaywrightSuite,
+} from '../../path-analyser/src/codegen/playwright/emitter.ts';
+import type { EndpointScenarioCollection } from '../../path-analyser/src/types.ts';
+
+const COLLECTION: EndpointScenarioCollection = {
+  endpoint: { operationId: 'createWidget', method: 'POST', path: '/widgets' },
+  requiredSemanticTypes: [],
+  optionalSemanticTypes: [],
+  scenarios: [
+    {
+      id: 'sc1',
+      name: 'happy path',
+      operations: [{ operationId: 'createWidget', method: 'POST', path: '/widgets' }],
+      producedSemanticTypes: [],
+      satisfiedSemanticTypes: [],
+    },
+  ],
+};
+
+describe('PlaywrightEmitter (Emitter contract)', () => {
+  test('id and name are stable identifiers', () => {
+    expect(PlaywrightEmitter.id).toBe('playwright');
+    expect(PlaywrightEmitter.name).toMatch(/Playwright/);
+  });
+
+  test('returns one EmittedFile per scenario collection with the expected file name', async () => {
+    const files = await PlaywrightEmitter.emit(COLLECTION, {
+      outDir: '/unused',
+      suiteName: 'createWidget',
+      mode: 'feature',
+    });
+    expect(files).toHaveLength(1);
+    expect(files[0].relativePath).toBe('createWidget.feature.spec.ts');
+    expect(files[0].relativePath).toBe(playwrightSuiteFileName(COLLECTION, 'feature'));
+  });
+
+  test('integration mode produces an integration.spec.ts file name', async () => {
+    const files = await PlaywrightEmitter.emit(COLLECTION, {
+      outDir: '/unused',
+      suiteName: 'createWidget',
+      mode: 'integration',
+    });
+    expect(files[0].relativePath).toBe('createWidget.integration.spec.ts');
+  });
+
+  test('emit() is pure: does not touch the filesystem (outDir is unused)', async () => {
+    // outDir is intentionally a non-existent path; emit() must not throw.
+    await expect(
+      PlaywrightEmitter.emit(COLLECTION, {
+        outDir: '/this/does/not/exist',
+        suiteName: 'createWidget',
+        mode: 'feature',
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  test('rendered suite contains the expected Playwright preamble and describe block', async () => {
+    const [file] = await PlaywrightEmitter.emit(COLLECTION, {
+      outDir: '/unused',
+      suiteName: 'createWidget',
+      mode: 'feature',
+    });
+    expect(file.content).toContain("import { test, expect } from '@playwright/test'");
+    expect(file.content).toContain("test.describe('createWidget'");
+    expect(file.content).toContain("test('sc1 - happy path'");
+  });
+
+  test('renderPlaywrightSuite is byte-identical to the EmittedFile content', async () => {
+    const [file] = await PlaywrightEmitter.emit(COLLECTION, {
+      outDir: '/unused',
+      suiteName: 'createWidget',
+      mode: 'feature',
+    });
+    const direct = renderPlaywrightSuite(COLLECTION, {
+      suiteName: 'createWidget',
+      mode: 'feature',
+    });
+    expect(file.content).toBe(direct);
+  });
+});

--- a/tests/codegen/registry.test.ts
+++ b/tests/codegen/registry.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import type { Emitter } from '../../path-analyser/src/codegen/emitter.ts';
+import {
+  _resetEmittersForTests,
+  getEmitter,
+  listEmitters,
+  registerEmitter,
+} from '../../path-analyser/src/codegen/registry.ts';
+
+function stubEmitter(id: string, name = id): Emitter {
+  return {
+    id,
+    name,
+    async emit() {
+      return [];
+    },
+  };
+}
+
+describe('emitter registry', () => {
+  beforeEach(() => {
+    _resetEmittersForTests();
+  });
+
+  test('register + retrieve by id', () => {
+    const e = stubEmitter('alpha');
+    registerEmitter(e);
+    expect(getEmitter('alpha')).toBe(e);
+  });
+
+  test('unknown id returns undefined', () => {
+    expect(getEmitter('does-not-exist')).toBeUndefined();
+  });
+
+  test('list returns sorted ids', () => {
+    registerEmitter(stubEmitter('charlie'));
+    registerEmitter(stubEmitter('alpha'));
+    registerEmitter(stubEmitter('bravo'));
+    expect(listEmitters().map((e) => e.id)).toEqual(['alpha', 'bravo', 'charlie']);
+  });
+
+  test('idempotent: registering the same instance twice is a no-op', () => {
+    const e = stubEmitter('alpha');
+    registerEmitter(e);
+    expect(() => registerEmitter(e)).not.toThrow();
+    expect(listEmitters()).toHaveLength(1);
+  });
+
+  test('id collision with a different instance throws', () => {
+    registerEmitter(stubEmitter('alpha', 'first'));
+    expect(() => registerEmitter(stubEmitter('alpha', 'second'))).toThrowError(
+      /Emitter id collision: 'alpha'/,
+    );
+  });
+
+  test('reset clears the registry (test-only helper)', () => {
+    registerEmitter(stubEmitter('alpha'));
+    _resetEmittersForTests();
+    expect(listEmitters()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Wires the existing Playwright suite renderer behind a small `Emitter` strategy interface so additional targets (SDK-based suites — see #8) can be added without forking the CLI.

Closes #5.

## What changed

**New modules** in `path-analyser/src/codegen/`:

| File | Purpose |
| --- | --- |
| `emitter.ts` | Public `Emitter` contract: `EmitContext`, `EmittedFile`, `Emitter`. |
| `registry.ts` | Process-wide registry. Idempotent re-registration; throws on id collision with a different instance. |
| `orchestrator.ts` | Centralized fs-writer (`writeEmitted`). Rejects absolute paths and paths that escape `ctx.outDir` via `..`. |
| `cli-args.ts` | Pure `parseCliArgs()` extracted from `index.ts` so it is testable without triggering the CLI's top-level `run()`. |

**Refactors**:
- `playwright/emitter.ts`: split rendering into a pure `renderPlaywrightSuite()` and a `PlaywrightEmitter` strategy. The legacy `emitPlaywrightSuite()` is preserved for any direct callers.
- `codegen/index.ts`: registers `PlaywrightEmitter`, resolves `--target=<id>` (default: `playwright`), and routes file writes through `writeEmitted()`.

## CLI

```bash
node path-analyser/dist/src/codegen/index.js --target=playwright createWidget
node path-analyser/dist/src/codegen/index.js --target=playwright --all
```

`npm run codegen:playwright` and `npm run codegen:playwright:all` work unchanged — they default to `--target=playwright`.

## Tests (24 new cases in `tests/codegen/`)

- **registry.test.ts** — register/get/list, idempotent re-registration, id-collision rejection, reset helper.
- **orchestrator.test.ts** — writes nested files, rejects absolute paths, rejects `..` escapes, preserves emit order.
- **playwright-emitter.test.ts** — strategy `id`/`name`, file naming for both modes, `emit()` purity, content equals `renderPlaywrightSuite()` byte-for-byte.
- **cli-args.test.ts** — default target, `--target=<id>` override, `--help`/`-h`, `--all` sentinel, positional handling.

## Verification

- ✅ `npm run snapshot:regenerate` → `tests/regression/pipeline-snapshot.json` is byte-identical (no git diff).
- ✅ `npx vitest run` → **25 / 25** pass.
- ✅ `npx tsc --noEmit -p path-analyser/tsconfig.json` → clean.
- ✅ `npx biome check path-analyser/src/codegen tests/codegen` → 0 diagnostics.

## Stability

The `Emitter` interface is **experimental** and may evolve while the SDK-based emitters land (#8).
