### PR TITLE
feat(path-analyser): emit runnable project scaffolding alongside Playwright specs

### DIFF
--- a/path-analyser/README.md
+++ b/path-analyser/README.md
@@ -67,13 +67,30 @@ Outputs go to `dist/generated-tests/`:
 
 ### Running the Generated Tests
 
-You can execute a generated spec with Playwright directly (ensure you have installed `@playwright/test`, which this package already depends on):
+The emitted suite at `dist/generated-tests/` is now a self-contained, runnable Playwright project. Each codegen run materializes:
+
+- `package.json` (declares the `test` script and `@playwright/test` devDep)
+- `playwright.config.ts`
+- `tsconfig.json`
+- `.env.example` (documents `API_BASE_URL`)
+- `README.md` (run instructions)
+- `support/` (vendored runtime helpers — `env.ts`, `recorder.ts`, `seeding.ts`, `seed-rules.json`)
+
+So you can install and run the suite in place against any reachable Camunda cluster:
+
+```bash
+cd dist/generated-tests
+npm install
+API_BASE_URL=http://localhost:8080/v2 npm test
+```
+
+Alternatively you can still execute a single spec via the parent project's already-installed Playwright:
 
 ```bash
 npx playwright test dist/generated-tests/searchProcessInstances.feature.spec.ts
 ```
 
-Or run all generated specs (when multiple exist):
+Or run all generated specs from the parent project:
 
 ```bash
 npx playwright test dist/generated-tests

--- a/path-analyser/src/codegen/playwright/materialize-support.ts
+++ b/path-analyser/src/codegen/playwright/materialize-support.ts
@@ -1,17 +1,24 @@
 // ---------------------------------------------------------------------------
-// Vendors the Playwright runtime support files into an emitted test suite.
+// Vendors the Playwright runtime support files AND project scaffolding into
+// an emitted test suite so the suite is runnable in place:
 //
-// The emitter produces standalone test suites: every generated `.spec.ts`
-// imports its helpers from `./support/...` (a sibling directory), so the
-// emitted suite has no compile-time or runtime dependency on this generator
-// project. The four template files (env.ts, recorder.ts, seeding.ts,
-// seed-rules.json) are copied verbatim from a build-time staging directory
-// (path-analyser/dist/src/codegen/playwright/support-templates/) into
-// `<outDir>/support/`.
+//   cd <outDir>
+//   npm install
+//   API_BASE_URL=http://localhost:8080/v2 npm test
 //
-// Keep this list in sync with path-analyser/scripts/copy-support-templates.js.
+// Two template sets are copied:
+//   * support/ — runtime helpers (env.ts, recorder.ts, seeding.ts,
+//                seed-rules.json). Sources: path-analyser/src/codegen/support/,
+//                staged into dist/src/codegen/playwright/support-templates/ at
+//                build time.
+//   * project root — package.json, playwright.config.ts, tsconfig.json,
+//                    .env.example, README.md.
+//                    Sources: path-analyser/templates/.
+//
+// Keep SUPPORT_TEMPLATE_FILES in sync with
+// path-analyser/scripts/copy-support-templates.js.
 // ---------------------------------------------------------------------------
-import { promises as fs } from 'node:fs';
+import { existsSync, promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -20,6 +27,15 @@ export const SUPPORT_TEMPLATE_FILES = [
   'recorder.ts',
   'seeding.ts',
   'seed-rules.json',
+] as const;
+
+/** Files copied directly into <outDir>/ (project root scaffolding). */
+export const PROJECT_TEMPLATE_FILES = [
+  'package.json',
+  'playwright.config.ts',
+  'tsconfig.json',
+  '.env.example',
+  'README.md',
 ] as const;
 
 /** Subdirectory created under the emitter's outDir to hold vendored helpers. */
@@ -41,25 +57,74 @@ function defaultTemplatesDir(): string {
 }
 
 /**
- * Copy the runtime support templates into `<outDir>/support/` so the
- * emitted Playwright suite is self-contained.
+ * Locate the project-root template directory (path-analyser/templates/).
  *
- * Idempotent: safe to call multiple times per emit run; later calls just
- * overwrite the previous copies.
- *
- * @param outDir       Directory to materialize the support files into.
- * @param templatesDir Optional override for the templates source directory.
- *                     Production callers should omit this; it exists so tests
- *                     can exercise the missing-template path without mutating
- *                     checked-in source files (which would race with other
- *                     tests under Vitest's `pool: 'forks'` configuration).
+ * Walks up from this module's location looking for a `templates/` directory
+ * containing `package.json`. Robust across both tsx (source) and dist runtime
+ * modes — the templates ship as plain checked-in files at <pkg>/templates/.
  */
-export async function materializeSupport(outDir: string, templatesDir?: string): Promise<string> {
+function defaultProjectTemplatesDir(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  let dir = here;
+  for (let i = 0; i < 6; i++) {
+    const candidate = path.join(dir, 'templates');
+    if (existsSync(path.join(candidate, 'package.json'))) {
+      return candidate;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  // Fall back to a sensible relative path; copyFile will fail loudly if absent.
+  return path.resolve(here, '..', '..', '..', '..', 'templates');
+}
+
+/**
+ * Copy the runtime support templates AND project-root scaffolding into
+ * `<outDir>/` so the emitted Playwright suite is self-contained and runnable
+ * in place (`cd <outDir> && npm install && npm test`).
+ *
+ * Idempotent: safe to call multiple times per emit run.
+ *
+ * @param outDir              Directory to materialize into (created if missing).
+ * @param templatesDir        Optional override for the support-templates source
+ *                            directory (env.ts, recorder.ts, seeding.ts,
+ *                            seed-rules.json). Production callers should omit
+ *                            this; it exists so tests can exercise the
+ *                            missing-template path without mutating
+ *                            checked-in source files.
+ * @param projectTemplatesDir Optional override for the project-root templates
+ *                            (package.json, playwright.config.ts, tsconfig.json,
+ *                            .env.example, README.md). Production callers
+ *                            should omit this.
+ * @param overwriteRoot       When false, root scaffolding files are only
+ *                            written if they don't already exist. Support
+ *                            files are always overwritten regardless.
+ *                            Default: true.
+ * @returns                   Path to the support directory under `outDir`.
+ */
+export async function materializeSupport(
+  outDir: string,
+  templatesDir?: string,
+  projectTemplatesDir?: string,
+  overwriteRoot: boolean = true,
+): Promise<string> {
   const srcDir = templatesDir ?? defaultTemplatesDir();
   const destDir = path.join(outDir, SUPPORT_DIR_NAME);
   await fs.mkdir(destDir, { recursive: true });
+
+  // Always overwrite support/ — these are part of the generator's contract.
   for (const name of SUPPORT_TEMPLATE_FILES) {
     await fs.copyFile(path.join(srcDir, name), path.join(destDir, name));
   }
+
+  // Project root scaffolding: overwritten by default; opt-out preserves user edits.
+  const projSrcDir = projectTemplatesDir ?? defaultProjectTemplatesDir();
+  for (const name of PROJECT_TEMPLATE_FILES) {
+    const dest = path.join(outDir, name);
+    if (!overwriteRoot && existsSync(dest)) continue;
+    await fs.copyFile(path.join(projSrcDir, name), dest);
+  }
+
   return destDir;
 }

--- a/path-analyser/templates/.env.example
+++ b/path-analyser/templates/.env.example
@@ -1,0 +1,8 @@
+# Base URL of the Camunda Orchestration Cluster REST API (including the /v2 prefix).
+# Defaults to http://localhost:8080/v2 when unset.
+API_BASE_URL=http://localhost:8080/v2
+
+# Optional: deterministic seeding for binding values (e.g. tenantIdVar).
+# Leave unset to use random suffixes; set to a stable string to make seeded
+# values reproducible across runs.
+# TEST_SEED=local-dev

--- a/path-analyser/templates/README.md
+++ b/path-analyser/templates/README.md
@@ -1,0 +1,23 @@
+# Camunda Path-Analyser Suite (Generated)
+
+This directory was produced by the [api-test-generator](https://github.com/camunda/api-test-generator) `path-analyser` Playwright emitter. Every file here is regenerated on each codegen run — **do not edit manually**.
+
+## Run
+
+```bash
+npm install
+API_BASE_URL=http://localhost:8080/v2 npm test
+```
+
+If your Camunda cluster is reachable at `http://localhost:8080/v2` you can simply run:
+
+```bash
+npm install
+npm test
+```
+
+See `.env.example` for the full list of supported environment variables.
+
+## What this suite covers
+
+End-to-end request scenarios derived from path-traversal of the OpenAPI spec — each test exercises a single endpoint plus its prerequisite setup steps. The runtime helpers under `support/` are vendored copies; do not import anything outside this directory.

--- a/path-analyser/templates/package.json
+++ b/path-analyser/templates/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "camunda-path-analyser-suite",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Generated Playwright integration suite produced by the api-test-generator path-analyser.",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.54.2",
+    "typescript": "^5.5.4"
+  }
+}

--- a/path-analyser/templates/playwright.config.ts
+++ b/path-analyser/templates/playwright.config.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: '**/*.spec.ts',
+  fullyParallel: true,
+  reporter: 'list',
+  use: {
+    trace: 'off',
+  },
+});

--- a/path-analyser/templates/tsconfig.json
+++ b/path-analyser/templates/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tests/codegen/materialize-support.test.ts
+++ b/tests/codegen/materialize-support.test.ts
@@ -1,9 +1,10 @@
-import { promises as fs } from 'node:fs';
+import { existsSync, promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import {
   materializeSupport,
+  PROJECT_TEMPLATE_FILES,
   SUPPORT_DIR_NAME,
   SUPPORT_TEMPLATE_FILES,
 } from '../../path-analyser/src/codegen/playwright/materialize-support.ts';
@@ -33,15 +34,53 @@ describe('materializeSupport', () => {
     }
   });
 
+  test('writes project-root scaffolding files into <outDir>/', async () => {
+    await materializeSupport(tmp);
+    for (const name of PROJECT_TEMPLATE_FILES) {
+      const stat = await fs.stat(path.join(tmp, name));
+      expect(stat.size).toBeGreaterThan(0);
+    }
+  });
+
+  test('emitted package.json declares a "test" script and @playwright/test devDep', async () => {
+    await materializeSupport(tmp);
+    const pkgRaw = await fs.readFile(path.join(tmp, 'package.json'), 'utf8');
+    // biome-ignore lint/plugin: test fixture parsing of known-good JSON
+    const pkg = JSON.parse(pkgRaw) as {
+      scripts?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    expect(pkg.scripts?.test).toMatch(/playwright/);
+    expect(pkg.devDependencies?.['@playwright/test']).toBeTruthy();
+  });
+
   test('is idempotent: a second call overwrites without error', async () => {
     await materializeSupport(tmp);
     await expect(materializeSupport(tmp)).resolves.toBe(path.join(tmp, SUPPORT_DIR_NAME));
-    const entries = await fs.readdir(path.join(tmp, SUPPORT_DIR_NAME));
-    expect(entries.sort()).toEqual([...SUPPORT_TEMPLATE_FILES].sort());
+    const supportEntries = await fs.readdir(path.join(tmp, SUPPORT_DIR_NAME));
+    expect(supportEntries.sort()).toEqual([...SUPPORT_TEMPLATE_FILES].sort());
+    for (const name of PROJECT_TEMPLATE_FILES) {
+      expect(existsSync(path.join(tmp, name))).toBe(true);
+    }
   });
 
-  test('respects the templatesDir override and copies from a custom source', async () => {
-    // Stage a complete set of template files in a tmp source directory.
+  test('overwriteRoot=false preserves user-edited root files but refreshes support/', async () => {
+    await materializeSupport(tmp);
+    // Simulate a user edit to a root file.
+    const userPkg = '{"name":"user-edited"}';
+    await fs.writeFile(path.join(tmp, 'package.json'), userPkg, 'utf8');
+
+    await materializeSupport(tmp, undefined, undefined, false);
+
+    expect(await fs.readFile(path.join(tmp, 'package.json'), 'utf8')).toBe(userPkg);
+    // Support files are still part of the contract — refreshed regardless.
+    for (const name of SUPPORT_TEMPLATE_FILES) {
+      const stat = await fs.stat(path.join(tmp, SUPPORT_DIR_NAME, name));
+      expect(stat.size).toBeGreaterThan(0);
+    }
+  });
+
+  test('respects the templatesDir override and copies from a custom support source', async () => {
     const fakeSrc = await fs.mkdtemp(path.join(os.tmpdir(), 'mat-support-src-'));
     try {
       for (const name of SUPPORT_TEMPLATE_FILES) {
@@ -57,11 +96,23 @@ describe('materializeSupport', () => {
     }
   });
 
-  test('fails with a clear filesystem error when a required template is missing', async () => {
-    // Use the templatesDir override to point at a tmp source directory that
-    // is missing one expected template. This exercises the missing-template
-    // path without mutating any checked-in source files (which would race
-    // with other tests under Vitest's `pool: 'forks'` configuration).
+  test('respects the projectTemplatesDir override', async () => {
+    const fakeProj = await fs.mkdtemp(path.join(os.tmpdir(), 'mat-proj-src-'));
+    try {
+      for (const name of PROJECT_TEMPLATE_FILES) {
+        await fs.writeFile(path.join(fakeProj, name), `fake-${name}`, 'utf8');
+      }
+      await materializeSupport(tmp, undefined, fakeProj);
+      for (const name of PROJECT_TEMPLATE_FILES) {
+        const content = await fs.readFile(path.join(tmp, name), 'utf8');
+        expect(content).toBe(`fake-${name}`);
+      }
+    } finally {
+      await fs.rm(fakeProj, { recursive: true, force: true });
+    }
+  });
+
+  test('fails with a clear filesystem error when a required support template is missing', async () => {
     const fakeSrc = await fs.mkdtemp(path.join(os.tmpdir(), 'mat-support-src-'));
     try {
       for (const name of SUPPORT_TEMPLATE_FILES.slice(1)) {

--- a/tests/regression/pipeline-snapshot.json
+++ b/tests/regression/pipeline-snapshot.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-26T05:48:17.630Z",
-  "fileCount": 406,
+  "generatedAt": "2026-04-26T05:54:24.782Z",
+  "fileCount": 411,
   "trees": [
     "semantic-graph-extractor/dist/output",
     "path-analyser/dist/output",
@@ -8,6 +8,7 @@
     "request-validation/generated"
   ],
   "files": {
+    "path-analyser/dist/generated-tests/.env.example": "77117daf3c11eee35b4ac6cd6eb9eb7f7094760758fb3fdc5501e898b269933a",
     "path-analyser/dist/generated-tests/activateAdHocSubProcessActivities.feature.spec.ts": "4b961f8bd547468b3b7f5457b5aa58d1356fe00c646e4496d8ae0aae848466ed",
     "path-analyser/dist/generated-tests/activateJobs.feature.spec.ts": "6688094748e620d7117b08984a179eb41bd02fb1613e235139504d6aff5ba155",
     "path-analyser/dist/generated-tests/assignClientToGroup.feature.spec.ts": "cc4c5a77ef4fd372f90cc6cb9c0104aaebbbf554f88696cc83e4308a8a677ec0",
@@ -117,8 +118,11 @@
     "path-analyser/dist/generated-tests/migrateProcessInstancesBatchOperation.feature.spec.ts": "fcb05535da15e7ed17c1da6fc14cb6fd02631fe864089d2a3a434bf42e4d47a1",
     "path-analyser/dist/generated-tests/modifyProcessInstance.feature.spec.ts": "052b1b5eadea85d7dab3b54b262cae2773c2d4bad52f8628a2005adb8a974476",
     "path-analyser/dist/generated-tests/modifyProcessInstancesBatchOperation.feature.spec.ts": "c0963fa82a66e809c281036f59919ccab26d9cc18803cbbf98a9418374ee2aa3",
+    "path-analyser/dist/generated-tests/package.json": "23e4444769ed20c8c0a5153a39c4b33dfb6c87d0b9b1ff4298c2f9ddd0c14f6d",
     "path-analyser/dist/generated-tests/pinClock.feature.spec.ts": "486e3f33c3f2fd5a79c256d5146ad5a90e5b2714acf0cd212a7aaf2ae81a5784",
+    "path-analyser/dist/generated-tests/playwright.config.ts": "e59aeec1bc49b340aed05266a493b9c41e76a4b84b960b399d1a827b83300351",
     "path-analyser/dist/generated-tests/publishMessage.feature.spec.ts": "fc5283309bddd36552501cd709aaa288fa83a14e7f79117f4df13e4ab92c5ae1",
+    "path-analyser/dist/generated-tests/README.md": "d3fd9aab51d4cdc397b13ff7adfe7d8a6410a50f4f7bca6039e7541b7c10b7d4",
     "path-analyser/dist/generated-tests/resetClock.feature.spec.ts": "bc377b94aa4060c646af4889bb60f6b706abc1856abfc1729ac27304c26a3b50",
     "path-analyser/dist/generated-tests/resolveIncident.feature.spec.ts": "e0c131b2495017f0291cd5f44217a515f6390e0617c974754515ce751375bb4b",
     "path-analyser/dist/generated-tests/resolveIncidentsBatchOperation.feature.spec.ts": "381969beb85ad95ffc3a2ffed27651b0aaca1927e99475ef571d07834ec9ca1a",
@@ -171,6 +175,7 @@
     "path-analyser/dist/generated-tests/support/seeding.ts": "931b97cedddf6711e11546fb15797b3aac1982bb0fe9cd86423feae6e94f6cdc",
     "path-analyser/dist/generated-tests/suspendBatchOperation.feature.spec.ts": "2fd7d06e8b77805983f4e0004c5f93f59876a691bfdecdff8944fe32de27d657",
     "path-analyser/dist/generated-tests/throwJobError.feature.spec.ts": "de9f7b25d756a98f2a6cfac62d1527dcec936ba61869dc388931051b5671a036",
+    "path-analyser/dist/generated-tests/tsconfig.json": "4cbe5253520faab8eaee005058db1cb5a36c3747e7a73929ba451ac2adb1f983",
     "path-analyser/dist/generated-tests/unassignClientFromGroup.feature.spec.ts": "2af022ff4443da4c07b322147a256701ba8c550697d1c1a49400c3f30ababc0c",
     "path-analyser/dist/generated-tests/unassignClientFromTenant.feature.spec.ts": "b739765890b9d95782cd1e981251025c0144ae5194a67b965aac2755d747fdce",
     "path-analyser/dist/generated-tests/unassignGroupFromTenant.feature.spec.ts": "29233a1a0cd340294fd1059b02cf04eb32a55bb085a7b0b35c1b7b9e9f8c39a6",

--- a/tests/regression/standalone-suite-imports.test.ts
+++ b/tests/regression/standalone-suite-imports.test.ts
@@ -36,6 +36,16 @@ const SUITES: readonly Suite[] = [
 
 const IMPORT_RE = /^\s*import\s[^'"]*['"]([^'"]+)['"]/gm;
 
+/**
+ * Directories under the suite root that must NOT be recursed into when
+ * collecting `*.spec.ts` files. These are produced by `npm install` /
+ * `playwright test` runs once a developer follows the README to run the
+ * standalone suite in place. Recursing into `node_modules/` in particular
+ * would pull in spec files shipped by transitive dependencies and cause
+ * false failures, as well as drastically slow the test.
+ */
+const SKIP_DIRS = new Set(['node_modules', 'playwright-report', 'test-results', '.git']);
+
 async function listSpecs(root: string): Promise<string[]> {
   const out: string[] = [];
   const stack = [root];
@@ -44,9 +54,12 @@ async function listSpecs(root: string): Promise<string[]> {
     if (!dir) continue;
     const entries = await fs.readdir(dir, { withFileTypes: true });
     for (const entry of entries) {
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) stack.push(full);
-      else if (entry.isFile() && entry.name.endsWith('.spec.ts')) out.push(full);
+      if (entry.isDirectory()) {
+        if (SKIP_DIRS.has(entry.name)) continue;
+        stack.push(path.join(dir, entry.name));
+      } else if (entry.isFile() && entry.name.endsWith('.spec.ts')) {
+        out.push(path.join(dir, entry.name));
+      }
     }
   }
   return out.sort();

--- a/tests/regression/standalone-suite-imports.test.ts
+++ b/tests/regression/standalone-suite-imports.test.ts
@@ -5,53 +5,73 @@ import { describe, expect, test } from 'vitest';
 /**
  * Class-of-defect guard test.
  *
- * Tracks issue #15: every emitted `*.spec.ts` in the request-validation
- * suite must resolve all its imports within the suite's own directory tree.
- * Imports must be either:
+ * Tracks issues #15 (request-validation) and #16 (path-analyser): every
+ * emitted `*.spec.ts` in either generator's output suite must resolve all
+ * its imports within the suite's own directory tree. Imports must be either:
  *   - bare module specifiers (e.g. `@playwright/test`)
- *   - relative paths that resolve to a file under `request-validation/generated/`
+ *   - relative paths that resolve to a file under the suite's root
  *
- * Catches the original defect (specs reaching back into the QA tree via
- * `../../../../utils/http`) and any future regression of the same shape
- * (e.g. someone reintroducing a hard-coded `../src/...` path).
+ * Catches the original defect (specs reaching back into the generator tree
+ * via `../../../../utils/http`) and any future regression of the same shape
+ * in either emitter.
  */
 
-const GENERATED_DIR = path.resolve(
-  import.meta.dirname,
-  '..',
-  '..',
-  'request-validation',
-  'generated',
-);
+const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
+
+interface Suite {
+  label: string;
+  root: string;
+}
+
+const SUITES: readonly Suite[] = [
+  {
+    label: 'request-validation',
+    root: path.join(REPO_ROOT, 'request-validation', 'generated'),
+  },
+  {
+    label: 'path-analyser',
+    root: path.join(REPO_ROOT, 'path-analyser', 'dist', 'generated-tests'),
+  },
+];
 
 const IMPORT_RE = /^\s*import\s[^'"]*['"]([^'"]+)['"]/gm;
 
-describe('emitted request-validation specs', () => {
-  test('every spec resolves all relative imports within request-validation/generated/', async () => {
-    if (!existsSync(GENERATED_DIR)) {
+async function listSpecs(root: string): Promise<string[]> {
+  const out: string[] = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    if (!dir) continue;
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (entry.isFile() && entry.name.endsWith('.spec.ts')) out.push(full);
+    }
+  }
+  return out.sort();
+}
+
+describe.each(SUITES)('emitted $label specs', ({ label, root }) => {
+  test(`every spec resolves all relative imports within ${label}/ suite root`, async () => {
+    if (!existsSync(root)) {
       throw new Error(
-        `request-validation/generated/ not found. Run \`npm run snapshot:regenerate\` to produce it before running this test.`,
+        `${label} suite directory not found at ${root}. ` +
+          `Run \`npm run snapshot:regenerate\` to produce it before running this test.`,
       );
     }
-    const entries = await fs.readdir(GENERATED_DIR);
-    const specs = entries.filter((n) => n.endsWith('.spec.ts'));
+    const specs = await listSpecs(root);
     expect(specs.length).toBeGreaterThan(0);
 
     const violations: string[] = [];
-    const suiteRoot = path.resolve(GENERATED_DIR);
+    const suiteRoot = path.resolve(root);
 
-    for (const spec of specs) {
-      const file = path.join(GENERATED_DIR, spec);
+    for (const file of specs) {
       const text = await fs.readFile(file, 'utf8');
       for (const match of text.matchAll(IMPORT_RE)) {
         const specifier = match[1];
-        // Bare module specifiers (e.g. @playwright/test) are fine — they're
-        // resolved by node_modules, not the filesystem layout of the suite.
         if (!specifier.startsWith('.') && !specifier.startsWith('/')) continue;
 
-        // Resolve the relative path against the spec's directory and verify
-        // it lands inside the suite root. Try common extensions because
-        // import specifiers may omit them.
         const baseResolved = path.resolve(path.dirname(file), specifier);
         const candidates = [
           baseResolved,
@@ -62,14 +82,15 @@ describe('emitted request-validation specs', () => {
         ];
         const resolved = candidates.find((c) => existsSync(c));
 
+        const rel = path.relative(suiteRoot, file);
         if (!resolved) {
-          violations.push(`${spec}: import "${specifier}" does not resolve to any file`);
+          violations.push(`${rel}: import "${specifier}" does not resolve to any file`);
           continue;
         }
-        const rel = path.relative(suiteRoot, resolved);
-        if (rel.startsWith('..') || path.isAbsolute(rel)) {
+        const relTarget = path.relative(suiteRoot, resolved);
+        if (relTarget.startsWith('..') || path.isAbsolute(relTarget)) {
           violations.push(
-            `${spec}: import "${specifier}" resolves outside the suite root (${rel})`,
+            `${rel}: import "${specifier}" resolves outside the suite root (${relTarget})`,
           );
         }
       }


### PR DESCRIPTION
Closes #16.

## What

After #13 vendored runtime helpers under `<outDir>/support/`, the path-analyser's emitted Playwright suite still wasn't runnable in place — no `package.json`, `playwright.config.ts`, `tsconfig.json`, `.env.example`, or `README.md`. Users had to fall back to the parent project's installed `@playwright/test`.

This PR retrofits the runnable-project scaffolding convention established by #15 (request-validation) onto the path-analyser emitter. The emitted suite is now a self-contained Playwright project:

```bash
cd path-analyser/dist/generated-tests
npm install
API_BASE_URL=http://localhost:8080/v2 npm test
```

## How

- New `path-analyser/templates/` directory with `package.json`, `playwright.config.ts`, `tsconfig.json`, `.env.example`, `README.md`.
- `materializeSupport()` extended to also copy these into `<outDir>/` after vendoring `support/`. Two new optional params: `projectTemplatesDir` (test override) and `overwriteRoot` (default `true`; `false` preserves user-edited root files but always refreshes `support/`).
- `defaultProjectTemplatesDir()` walks up from the module location looking for `templates/package.json`, so it resolves correctly under both tsx and dist.
- Each generator vendors its own templates directory — no shared scaffolding code (per #16's out-of-scope note).

## Class-of-defect guard

`tests/regression/standalone-suite-imports.test.ts` is generalized to scan both `request-validation/generated/` and `path-analyser/dist/generated-tests/`. Every emitted `*.spec.ts` in either suite must resolve all relative imports within its own suite root. The test now runs as 2 parametric cases.

## Tests

- `tests/codegen/materialize-support.test.ts` extended to 8 cases (root scaffolding, idempotency, `overwriteRoot=false`, `projectTemplatesDir` override, package.json contract).
- 48/48 tests passing locally; `npx tsc --noEmit -p path-analyser/tsconfig.json` clean; biome clean.

## Manual verification

Locally:
```bash
cd path-analyser/dist/generated-tests && npm install
```
installs cleanly. Running against a live Camunda is out of scope here (requires a server) but the structure matches what request-validation already ships.

## Out of scope

- Sharing scaffolding code between path-analyser and request-validation (per #16). Two ~60-line copies are acceptable until a third consumer appears.
- Test fixture seeding / global setup.