### PR TITLE
docs(request-validation): add stable/8.9 quickstart with c8ctl

### DIFF
--- a/request-validation/README.md
+++ b/request-validation/README.md
@@ -47,6 +47,32 @@ If you are not deep into the codebase, here is the 30‑second view:
 
 All generated scenarios currently expect 400; "stateful" follow-on semantic checks are out of scope here.
 
+### Quickstart: generate against `stable/8.9` and run against a local cluster
+
+End-to-end in five commands. Generates the request-validation suite from the upstream `stable/8.9` spec, starts a matching local Camunda cluster with [`c8ctl`](https://github.com/camunda/c8ctl), and runs the generated suite against it.
+
+```bash
+# 1. From the repo root: fetch the stable/8.9 spec and generate the suite.
+SPEC_REF=stable/8.9 npm run fetch-spec:ref
+npm run generate:request-validation
+
+# 2. Start a local Camunda 8.9 cluster (defaults to http://localhost:8080).
+c8ctl cluster start 8.9
+
+# 3. Install + run the generated suite in place.
+cd request-validation/generated
+npm install
+CORE_APPLICATION_URL=http://localhost:8080 npm test
+```
+
+The emitted suite is standalone (vendors its own `package.json`, `playwright.config.ts`, `tsconfig.json`, and `support/` helpers), so step 3 has no dependency on this generator project.
+
+Stop the cluster when you're done:
+
+```bash
+c8ctl cluster stop
+```
+
 ### Quick Start
 
 ```


### PR DESCRIPTION
Adds an end-to-end quickstart at the top of `request-validation/README.md` that walks through:

1. Generating the suite from the upstream `stable/8.9` spec (`SPEC_REF=stable/8.9 npm run fetch-spec:ref`)
2. Starting a matching local Camunda 8.9 cluster with `c8ctl cluster start 8.9`
3. Installing and running the standalone suite in place

Pulls the standalone-suite story (#15) and the [`c8ctl`](https://github.com/camunda/c8ctl) cluster lifecycle commands into a single five-command flow so users can go from clone to a passing run without piecing together commands from multiple READMEs.

Docs only — no code changes.