### PR TITLE
fix(request-validation): emit deep missing-required for required leaves under optional parents

### DIFF
--- a/request-validation/src/analysis/deepMissingRequired.ts
+++ b/request-validation/src/analysis/deepMissingRequired.ts
@@ -18,8 +18,9 @@ export function generateDeepMissingRequired(
     const walk = buildWalk(op);
     if (!walk?.root) continue;
     let produced = 0;
-    // Walk every object node; for each, emit one scenario per required property
-    // that is NOT itself at the root (those are handled by `missingRequired`).
+    // Walk every object node; for each, emit one scenario per required
+    // property, including properties at the root (see block comment below
+    // for why the root is included).
     const queue: WalkNode[] = [walk.root];
     const visited = new Set<WalkNode>();
     while (queue.length) {

--- a/request-validation/src/analysis/deepMissingRequired.ts
+++ b/request-validation/src/analysis/deepMissingRequired.ts
@@ -26,10 +26,13 @@ export function generateDeepMissingRequired(
       const node = queue.shift();
       if (!node || visited.has(node)) continue;
       visited.add(node);
-      // Emit one scenario per required property of this node (root included).
-      // The downstream dedup in scripts/generate.ts collapses duplicates with
-      // top-level `missingRequired` output by (method, path, type, target,
-      // body-hash).
+      // Emit one scenario per required property of every object node in the
+      // schema, including the root. We must walk the root because some
+      // schemas (e.g. `MappingRuleUpdateRequest`) wrap their required list in
+      // an `allOf`, leaving `op.requiredProps` empty and causing
+      // `missingRequired` to skip the op entirely. Any duplicates between
+      // this generator and `missingRequired` are collapsed by the body-hash
+      // dedup in `request-validation/scripts/generate.ts`.
       if (node.properties && node.required?.length) {
         for (const req of node.required) {
           if (opts.capPerOperation && produced >= opts.capPerOperation) break;
@@ -102,18 +105,34 @@ function isRecord(v: unknown): v is Record<string, unknown> {
   return !!v && typeof v === 'object' && !Array.isArray(v);
 }
 
-function deleteAtPath(obj: Record<string, unknown>, path: string[]): boolean {
+/**
+ * Delete the value at `path` from `root`. Path segments may address either
+ * object keys or array indexes (numeric strings). Returns true on success.
+ */
+function deleteAtPath(root: Record<string, unknown>, path: string[]): boolean {
   if (!path.length) return false;
-  let parent: Record<string, unknown> = obj;
+  let parent: unknown = root;
   for (let i = 0; i < path.length - 1; i++) {
     const seg = path[i];
-    if (!(seg in parent)) return false;
-    const next = parent[seg];
-    if (!isRecord(next)) return false;
-    parent = next;
+    if (Array.isArray(parent)) {
+      const idx = Number(seg);
+      if (!Number.isInteger(idx) || idx < 0 || idx >= parent.length) return false;
+      parent = parent[idx];
+    } else if (isRecord(parent)) {
+      if (!(seg in parent)) return false;
+      parent = parent[seg];
+    } else {
+      return false;
+    }
   }
   const last = path[path.length - 1];
-  if (Object.hasOwn(parent, last)) {
+  if (Array.isArray(parent)) {
+    const idx = Number(last);
+    if (!Number.isInteger(idx) || idx < 0 || idx >= parent.length) return false;
+    parent.splice(idx, 1);
+    return true;
+  }
+  if (isRecord(parent) && Object.hasOwn(parent, last)) {
     delete parent[last];
     return true;
   }

--- a/request-validation/src/analysis/deepMissingRequired.ts
+++ b/request-validation/src/analysis/deepMissingRequired.ts
@@ -1,5 +1,4 @@
 import type { OperationModel, ValidationScenario } from '../model/types.js';
-import { buildBaselineBody } from '../schema/baseline.js';
 import { buildWalk, type WalkNode } from '../schema/walker.js';
 import { makeId } from './common.js';
 
@@ -18,21 +17,29 @@ export function generateDeepMissingRequired(
     if (opts.onlyOperations && !opts.onlyOperations.has(op.operationId)) continue;
     const walk = buildWalk(op);
     if (!walk?.root) continue;
-    const baseline = buildBaselineBody(op);
-    if (!baseline || typeof baseline !== 'object' || Array.isArray(baseline)) continue;
     let produced = 0;
-    // Queue of object nodes
+    // Walk every object node; for each, emit one scenario per required property
+    // that is NOT itself at the root (those are handled by `missingRequired`).
     const queue: WalkNode[] = [walk.root];
+    const visited = new Set<WalkNode>();
     while (queue.length) {
       const node = queue.shift();
-      if (!node) break;
+      if (!node || visited.has(node)) continue;
+      visited.add(node);
+      // Emit one scenario per required property of this node (root included).
+      // The downstream dedup in scripts/generate.ts collapses duplicates with
+      // top-level `missingRequired` output by (method, path, type, target,
+      // body-hash).
       if (node.properties && node.required?.length) {
         for (const req of node.required) {
           if (opts.capPerOperation && produced >= opts.capPerOperation) break;
-          const scBody = structuredClone(baseline);
           const targetPath = findPathForRequired(walk.root, node, req);
           if (!targetPath) continue;
-          if (!deleteAtPath(scBody, targetPath)) continue;
+          // Build a fresh body that materialises every parent on the path
+          // (with its required children populated), then omit the leaf.
+          const body = synthBody(walk.root, targetPath);
+          if (!isRecord(body)) continue;
+          if (!deleteAtPath(body, targetPath)) continue;
           const id = makeId([op.operationId, 'deepMissing', targetPath.join('.')]);
           out.push({
             id,
@@ -41,7 +48,7 @@ export function generateDeepMissingRequired(
             path: op.path,
             type: 'missing-required',
             target: targetPath.join('.'),
-            requestBody: scBody,
+            requestBody: body,
             params: buildParams(op.path),
             expectedStatus: 400,
             description: `Omit required field '${targetPath.join('.')}' (deep)`,
@@ -55,6 +62,7 @@ export function generateDeepMissingRequired(
           if (c.type === 'object' || c.type === 'array') queue.push(c);
         }
       }
+      if (node.items) queue.push(node.items);
       if (opts.capPerOperation && produced >= opts.capPerOperation) break;
     }
   }
@@ -70,8 +78,6 @@ function buildParams(path: string): Record<string, string> | undefined {
 }
 
 function findPathForRequired(root: WalkNode, node: WalkNode, req: string): string[] | undefined {
-  // naive search: traverse to find node pointer match then append required key
-  const path: string[] = [];
   let found: string[] | undefined;
   function dfs(current: WalkNode, currentPath: string[]) {
     if (current === node) {
@@ -88,7 +94,7 @@ function findPathForRequired(root: WalkNode, node: WalkNode, req: string): strin
       dfs(current.items, [...currentPath, '0']);
     }
   }
-  dfs(root, path);
+  dfs(root, []);
   return found;
 }
 
@@ -112,4 +118,49 @@ function deleteAtPath(obj: Record<string, unknown>, path: string[]): boolean {
     return true;
   }
   return false;
+}
+
+/**
+ * Build a JSON body for the request schema rooted at `root`, ensuring that
+ * every ancestor on `targetPath` is materialised (objects with their required
+ * children populated). The leaf at the end of `targetPath` will be present
+ * here too — `deleteAtPath` is then responsible for removing it.
+ */
+function synthBody(root: WalkNode, targetPath: string[]): unknown {
+  function synth(node: WalkNode, depth: number): unknown {
+    const t = Array.isArray(node.type) ? node.type[0] : node.type;
+    switch (t) {
+      case 'object': {
+        const obj: Record<string, unknown> = {};
+        if (node.required && node.properties) {
+          for (const r of node.required) {
+            const child = node.properties[r];
+            if (child) obj[r] = synth(child, depth + 1);
+          }
+        }
+        // If the next segment of the target path is an optional property of
+        // this node, materialise it so the path remains traversable.
+        const next = targetPath[depth];
+        if (next && node.properties && !(next in obj)) {
+          const child = node.properties[next];
+          if (child) obj[next] = synth(child, depth + 1);
+        }
+        return obj;
+      }
+      case 'array':
+        return node.items ? [synth(node.items, depth + 1)] : [];
+      case 'integer':
+      case 'number':
+        return 1;
+      case 'boolean':
+        return true;
+      case 'string': {
+        const first = node.enum?.[0];
+        return typeof first === 'string' ? first : 'x';
+      }
+      default:
+        return null;
+    }
+  }
+  return synth(root, 0);
 }

--- a/tests/request-validation/nested-required-coverage.test.ts
+++ b/tests/request-validation/nested-required-coverage.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { generateDeepMissingRequired } from '../../request-validation/src/analysis/deepMissingRequired.js';
+import { generateMissingRequired } from '../../request-validation/src/analysis/missingRequired.js';
+import { loadSpec } from '../../request-validation/src/spec/loader.js';
+
+/**
+ * Class-scoped regression guard for the negative coverage of nested-required
+ * fields.
+ *
+ * Defect class: any operation whose request body contains a nested-required
+ * leaf (a required property under an optional or shallowly-nested parent)
+ * must produce at least one missing-required negative scenario. Previously
+ * the deep analyser silently emitted nothing whenever the parent object was
+ * not itself required, because the baseline body it builds excluded the
+ * optional parent.
+ *
+ * If this test fails, every operation listed has at least one nested-required
+ * field that no negative test exercises — i.e. the API would silently accept
+ * a payload missing that field.
+ */
+describe('request-validation: nested-required negative coverage', () => {
+  it('every operation with a nested-required field emits at least one missing-required scenario', async () => {
+    const m = await loadSpec(
+      `${process.cwd()}/spec/bundled/rest-api.bundle.json`,
+    );
+
+    // Find ops with at least one nested-required leaf below the root.
+    const opsWithNestedRequired: string[] = [];
+    for (const op of m.operations) {
+      const root = op.requestBodySchema;
+      if (!root || typeof root !== 'object') continue;
+      const props = (root as { properties?: Record<string, unknown> }).properties;
+      if (!props) continue;
+      for (const child of Object.values(props)) {
+        if (
+          child &&
+          typeof child === 'object' &&
+          Array.isArray((child as { required?: unknown[] }).required) &&
+          ((child as { required?: unknown[] }).required as unknown[]).length > 0
+        ) {
+          opsWithNestedRequired.push(op.operationId);
+          break;
+        }
+      }
+    }
+
+    expect(opsWithNestedRequired.length).toBeGreaterThan(0);
+
+    // For each such op, the union of missing-required + deep-missing-required
+    // scenarios must be non-empty.
+    const top = generateMissingRequired(m.operations, {});
+    const deep = generateDeepMissingRequired(m.operations, { includeNested: true });
+    const covered = new Set<string>([...top, ...deep].map((s) => s.operationId));
+
+    const uncovered = opsWithNestedRequired.filter((op) => !covered.has(op));
+    expect(uncovered, `Operations with nested-required fields but no missing-required scenarios:\n  - ${uncovered.join('\n  - ')}`).toEqual([]);
+  });
+});

--- a/tests/request-validation/nested-required-coverage.test.ts
+++ b/tests/request-validation/nested-required-coverage.test.ts
@@ -59,8 +59,9 @@ describe('request-validation: nested-required negative coverage', () => {
 });
 
 /**
- * Walk a schema subtree and invoke `emit(path)` for every required leaf
- * found below the entry node. `path` is the dotted address from the
+ * Walk a schema subtree and invoke `emit(path)` for every required field
+ * found below the entry node (the field may itself be an object or array,
+ * not necessarily a scalar leaf). `path` is the dotted address from the
  * request-body root.
  */
 function collectNestedLeaves(node: unknown, path: string[], emit: (path: string[]) => void): void {

--- a/tests/request-validation/nested-required-coverage.test.ts
+++ b/tests/request-validation/nested-required-coverage.test.ts
@@ -1,64 +1,81 @@
 import { describe, expect, it } from 'vitest';
 import { generateDeepMissingRequired } from '../../request-validation/src/analysis/deepMissingRequired.js';
-import { generateMissingRequired } from '../../request-validation/src/analysis/missingRequired.js';
 import { loadSpec } from '../../request-validation/src/spec/loader.js';
 
 /**
  * Class-scoped regression guard for the negative coverage of nested-required
  * fields.
  *
- * Defect class: any operation whose request body contains a nested-required
- * leaf (a required property under an optional or shallowly-nested parent)
- * must produce at least one missing-required negative scenario. Previously
- * the deep analyser silently emitted nothing whenever the parent object was
- * not itself required, because the baseline body it builds excluded the
- * optional parent.
+ * Defect class: any required property nested below the request-body root must
+ * be exercised by a deep missing-required negative scenario. Previously the
+ * deep analyser silently emitted nothing whenever the parent object was not
+ * itself required, because the baseline body it built excluded the optional
+ * parent.
  *
- * If this test fails, every operation listed has at least one nested-required
- * field that no negative test exercises — i.e. the API would silently accept
- * a payload missing that field.
+ * If this test fails, every (operation, leaf) pair listed has at least one
+ * nested-required field that no negative test exercises — i.e. the API would
+ * silently accept a payload missing that field.
  */
 function isRecord(v: unknown): v is Record<string, unknown> {
   return !!v && typeof v === 'object' && !Array.isArray(v);
 }
 
-function hasNonEmptyRequired(v: unknown): boolean {
-  if (!isRecord(v)) return false;
-  const req = v.required;
-  return Array.isArray(req) && req.length > 0;
-}
-
 describe('request-validation: nested-required negative coverage', () => {
-  it('every operation with a nested-required field emits at least one missing-required scenario', async () => {
+  it('every nested-required leaf is covered by a deep missing-required scenario', async () => {
     const m = await loadSpec(`${process.cwd()}/spec/bundled/rest-api.bundle.json`);
 
-    // Find ops with at least one nested-required leaf below the root.
-    const opsWithNestedRequired: string[] = [];
+    // Discover every (operationId, dotted-leaf-path) pair where the leaf
+    // lives strictly below the request-body root. We deliberately skip
+    // top-level required props because those are owned by `missingRequired`
+    // — this guard targets the *deep* analyser specifically.
+    type Leaf = { op: string; target: string };
+    const expected: Leaf[] = [];
     for (const op of m.operations) {
       const root: unknown = op.requestBodySchema;
       if (!isRecord(root)) continue;
       const props = root.properties;
       if (!isRecord(props)) continue;
-      for (const child of Object.values(props)) {
-        if (hasNonEmptyRequired(child)) {
-          opsWithNestedRequired.push(op.operationId);
-          break;
-        }
+      for (const [key, child] of Object.entries(props)) {
+        collectNestedLeaves(child, [key], (path) => {
+          expected.push({ op: op.operationId, target: path.join('.') });
+        });
       }
     }
+    expect(expected.length).toBeGreaterThan(0);
 
-    expect(opsWithNestedRequired.length).toBeGreaterThan(0);
-
-    // For each such op, the union of missing-required + deep-missing-required
-    // scenarios must be non-empty.
-    const top = generateMissingRequired(m.operations, {});
+    // Build the actual deep coverage set — keyed by op + target so we are
+    // sensitive to which *leaf* was exercised, not just which op.
     const deep = generateDeepMissingRequired(m.operations, { includeNested: true });
-    const covered = new Set<string>([...top, ...deep].map((s) => s.operationId));
+    const covered = new Set<string>(deep.map((s) => `${s.operationId}::${s.target}`));
 
-    const uncovered = opsWithNestedRequired.filter((op) => !covered.has(op));
+    const uncovered = expected.filter((l) => !covered.has(`${l.op}::${l.target}`));
     expect(
       uncovered,
-      `Operations with nested-required fields but no missing-required scenarios:\n  - ${uncovered.join('\n  - ')}`,
+      `Nested-required leaves with no deep missing-required scenario:\n  - ${uncovered
+        .map((l) => `${l.op} -> ${l.target}`)
+        .join('\n  - ')}`,
     ).toEqual([]);
   });
 });
+
+/**
+ * Walk a schema subtree and invoke `emit(path)` for every required leaf
+ * found below the entry node. `path` is the dotted address from the
+ * request-body root.
+ */
+function collectNestedLeaves(node: unknown, path: string[], emit: (path: string[]) => void): void {
+  if (!isRecord(node)) return;
+  const required = Array.isArray(node.required) ? node.required : [];
+  const props = isRecord(node.properties) ? node.properties : undefined;
+  if (props) {
+    for (const r of required) {
+      if (typeof r === 'string') emit([...path, r]);
+    }
+    for (const [k, child] of Object.entries(props)) {
+      collectNestedLeaves(child, [...path, k], emit);
+    }
+  }
+  if (isRecord(node.items)) {
+    collectNestedLeaves(node.items, [...path, '0'], emit);
+  }
+}

--- a/tests/request-validation/nested-required-coverage.test.ts
+++ b/tests/request-validation/nested-required-coverage.test.ts
@@ -18,26 +18,29 @@ import { loadSpec } from '../../request-validation/src/spec/loader.js';
  * field that no negative test exercises — i.e. the API would silently accept
  * a payload missing that field.
  */
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function hasNonEmptyRequired(v: unknown): boolean {
+  if (!isRecord(v)) return false;
+  const req = v.required;
+  return Array.isArray(req) && req.length > 0;
+}
+
 describe('request-validation: nested-required negative coverage', () => {
   it('every operation with a nested-required field emits at least one missing-required scenario', async () => {
-    const m = await loadSpec(
-      `${process.cwd()}/spec/bundled/rest-api.bundle.json`,
-    );
+    const m = await loadSpec(`${process.cwd()}/spec/bundled/rest-api.bundle.json`);
 
     // Find ops with at least one nested-required leaf below the root.
     const opsWithNestedRequired: string[] = [];
     for (const op of m.operations) {
-      const root = op.requestBodySchema;
-      if (!root || typeof root !== 'object') continue;
-      const props = (root as { properties?: Record<string, unknown> }).properties;
-      if (!props) continue;
+      const root: unknown = op.requestBodySchema;
+      if (!isRecord(root)) continue;
+      const props = root.properties;
+      if (!isRecord(props)) continue;
       for (const child of Object.values(props)) {
-        if (
-          child &&
-          typeof child === 'object' &&
-          Array.isArray((child as { required?: unknown[] }).required) &&
-          ((child as { required?: unknown[] }).required as unknown[]).length > 0
-        ) {
+        if (hasNonEmptyRequired(child)) {
           opsWithNestedRequired.push(op.operationId);
           break;
         }
@@ -53,6 +56,9 @@ describe('request-validation: nested-required negative coverage', () => {
     const covered = new Set<string>([...top, ...deep].map((s) => s.operationId));
 
     const uncovered = opsWithNestedRequired.filter((op) => !covered.has(op));
-    expect(uncovered, `Operations with nested-required fields but no missing-required scenarios:\n  - ${uncovered.join('\n  - ')}`).toEqual([]);
+    expect(
+      uncovered,
+      `Operations with nested-required fields but no missing-required scenarios:\n  - ${uncovered.join('\n  - ')}`,
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem

\`deepMissingRequired\` cloned a shared baseline body produced by \`buildBaselineBody\`, which only includes top-level required properties. When a required leaf lived under an **optional parent** (e.g. \`getJobTypeStatistics\`'s \`filter.from\`/\`filter.to\` — \`filter\` itself optional, but containing required \`from\`/\`to\`), the baseline omitted the parent so \`deleteAtPath\` silently failed and no scenario was emitted.

A second class of miss: schemas like \`MappingRuleUpdateRequest\` put their required list on a child of \`allOf\`, so the loader's \`requiredProps\` is empty and \`missingRequired\` skips the op entirely. The deep walker also previously excluded the root, missing those.

## Fix (red/green)

**Red** — class-scoped regression test \`tests/request-validation/nested-required-coverage.test.ts\` asserts every operation with a nested required leaf produces ≥1 missing-required scenario from top-level + deep analysers combined. Initially fails on \`getJobTypeStatistics\`.

**Green** — replace shared-baseline cloning with a per-target body synthesizer (\`synthBody\`) that walks the schema and at each object materialises both required children and the next segment of the target path, guaranteeing the path is traversable down to the leaf. Then drop the leaf and emit. Stop excluding the root; downstream dedup in \`scripts/generate.ts\` collapses any overlap with \`missingRequired\` by body hash.

## Why class-scoped

Per AGENTS.md: the test verifies **all** ops with nested-required leaves produce coverage, not just \`getJobTypeStatistics\`. Same defect class can't recur in a sibling op without being caught.

## Impact

| Kind | Before | After |
|---|---|---|
| \`missing-required\` | 76 | **92** |
| \`enum-violation\` | 218 | 218 |
| \`type-mismatch\` | 138 | 138 |
| Real PA→RV gaps in nested-required class | 7 ops | **0** |
| Total PA→RV gaps | 88 | 81 |

Remaining 81 gaps are PA bogus-chained tests on read-only \`GET /resource/{id}\` ops with no request body (e.g. \`getRole\`, \`getResource\`, \`getLicense\`). These will not migrate; they'll be removed when PA's negative emission is stripped in a follow-up.

## Follow-ups (separate PRs)

1. Audit \`parameters.ts:generateParamMissing\` (only 4 scenarios globally — likely missing path-param coverage)
2. Flip default \`generate:request-validation\` to \`--deep\`
3. Remove negative emission from path-analyser