### PR TITLE
feat(testing): determinism quick win + bundled-spec invariants harness (refs #36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,40 @@ narrowing, or `satisfies` instead — and only suppress with
 
 ## Regression Testing
 
-The pipeline emits 396 generated files (semantic graph, scenario JSON,
-Playwright tests, validation tests). To guard against accidental drift
-during refactoring, `npm test` runs a SHA-256 snapshot comparison against
-a captured baseline (`tests/regression/pipeline-snapshot.json`).
+The pipeline emits hundreds of generated files (semantic graph, scenario JSON,
+Playwright tests, validation tests). The regression strategy is **layered**
+(see #36):
+
+- **Layer 1 — extractor construct fixtures.** Hand-curated minimal OpenAPI
+  snippets in `tests/fixtures/extractor/` paired with property assertions.
+  *(coming soon)*
+- **Layer 2 — planner contract fixtures.** Tiny dependency-graph fixtures in
+  `tests/fixtures/planner/` paired with chain-shape assertions. *(coming soon)*
+- **Layer 3 — bundled-spec invariants** ([tests/regression/bundled-spec-invariants.test.ts](tests/regression/bundled-spec-invariants.test.ts)).
+  Named, human-readable invariants over the real bundled spec. Each `it`
+  block is one regression statement.
+- **Layer 4 — end-to-end snapshot** ([tests/regression/pipeline-snapshot.test.ts](tests/regression/pipeline-snapshot.test.ts)).
+  SHA-256 snapshot comparison against a captured baseline. Slated for removal
+  once Layers 1–3 cover the high-value regressions.
+
+### Determinism
+
+Generator output is byte-reproducible **by default**. The seeding module
+(`path-analyser/src/codegen/support/seeding.ts`) uses `TEST_SEED` to seed all
+`deterministicSuffix(...)` calls; if unset, it falls back to the constant
+`'snapshot-baseline'`, so `npm run pipeline` produces identical output across
+runs and machines without needing `TEST_SEED` to be set explicitly.
+
+To opt out (for example, when generating a one-off suite for live-broker
+exploration where unique-per-run identifiers are useful), set:
+
+```bash
+TEST_SEED=random npm run pipeline
+```
+
+Any other non-empty value is treated as a custom deterministic seed.
+
+### Snapshot workflow
 
 **Workflow:**
 

--- a/path-analyser/src/codegen/support/seeding.ts
+++ b/path-analyser/src/codegen/support/seeding.ts
@@ -52,18 +52,34 @@ function mulberry32(a: number) {
   };
 }
 
+/**
+ * Resolve the active seed string. Determinism is the default — generator
+ * output is byte-reproducible across runs and machines unless the caller
+ * explicitly opts out by setting `TEST_SEED=random`.
+ *
+ * - unset / `'snapshot-baseline'` (the default): deterministic.
+ * - any other non-empty string: deterministic (seeded by that string).
+ * - `'random'`: nondeterministic (`Math.random()` fallback). Used only
+ *   when explicitly requested for live-broker exploration.
+ */
+const DEFAULT_SEED = 'snapshot-baseline';
+function resolveSeed(): { seed: string; random: boolean } {
+  const raw = process.env.TEST_SEED;
+  if (raw === 'random') return { seed: '', random: true };
+  return { seed: raw && raw.length > 0 ? raw : DEFAULT_SEED, random: false };
+}
+
 const globalEnv: SeedEnv = (() => {
-  const seedStr = process.env.TEST_SEED;
-  const deterministic = !!seedStr;
+  const { seed: seedStr, random } = resolveSeed();
   let seedNum = 0;
-  if (seedStr) {
+  if (random) {
+    seedNum = Date.now() ^ (Math.random() * 0xffffffff);
+  } else {
     // hash string to 32-bit int
     for (let i = 0; i < seedStr.length; i++)
       seedNum = (Math.imul(31, seedNum) + seedStr.charCodeAt(i)) | 0;
-  } else {
-    seedNum = Date.now() ^ (Math.random() * 0xffffffff);
   }
-  const rand = deterministic ? mulberry32(seedNum >>> 0) : Math.random;
+  const rand = random ? Math.random : mulberry32(seedNum >>> 0);
   const counters = new Map<string, number>();
   const env: SeedEnv = {
     random: () => rand().toString(36).slice(2),
@@ -72,8 +88,8 @@ const globalEnv: SeedEnv = (() => {
       counters.set(bucket, v);
       return v;
     },
-    runId: deterministic ? `det-${seedStr}` : `rt-${Date.now().toString(36)}`,
-    deterministic,
+    runId: random ? `rt-${Date.now().toString(36)}` : `det-${seedStr}`,
+    deterministic: !random,
   };
   return env;
 })();
@@ -81,24 +97,23 @@ const globalEnv: SeedEnv = (() => {
 /**
  * Short suffix for test fixture identifiers (e.g. `tenantId_5l5k`).
  *
- * When `TEST_SEED` is set, the suffix is derived deterministically from the
- * input `key` via FNV-1a hash, so repeated pipeline runs produce identical
- * output regardless of call ordering across modules. When `TEST_SEED` is
- * unset, falls back to `Math.random()` to preserve historical uniqueness.
+ * Deterministic by default: the suffix is derived from the input `key`
+ * via FNV-1a hash, mixed with the active seed (`TEST_SEED` or its default
+ * `'snapshot-baseline'`). Repeated pipeline runs produce identical output
+ * regardless of call ordering across modules.
  *
- * Pass a stable, unique `key` (e.g. the variable name plus a discriminator)
- * for reproducible output; reuse the same key only when collisions are OK.
+ * Pass `TEST_SEED=random` to force `Math.random()` fallback (only useful
+ * for live-broker exploration where unique-per-run ids are desired).
  */
 export function deterministicSuffix(key: string, length = 4): string {
-  if (!process.env.TEST_SEED) {
+  const { seed, random } = resolveSeed();
+  if (random) {
     return Math.random()
       .toString(36)
       .slice(2, 2 + length);
   }
-  // FNV-1a 32-bit hash, seeded by TEST_SEED so different runs give different
-  // (but reproducible) suffixes.
+  // FNV-1a 32-bit hash, seeded by the resolved seed.
   let h = 0x811c9dc5;
-  const seed = process.env.TEST_SEED;
   for (let i = 0; i < seed.length; i++) {
     h ^= seed.charCodeAt(i);
     h = Math.imul(h, 0x01000193);

--- a/request-validation/scripts/generate.ts
+++ b/request-validation/scripts/generate.ts
@@ -106,10 +106,13 @@ async function main() {
   console.log(`[generate] Using spec from ${source}: ${specPath}`);
   const model = await loadSpec(specPath);
   const specCommit: string | undefined = specProvenance;
-  // When TEST_SEED is set, use a stable placeholder so generator output is byte-reproducible.
-  const generationTimestamp = process.env.TEST_SEED
-    ? `seeded:${process.env.TEST_SEED}`
-    : new Date().toISOString();
+  // When TEST_SEED is set (or left at the default), use a stable placeholder
+  // so generator output is byte-reproducible. Set TEST_SEED=random to opt in
+  // to a real wall-clock timestamp.
+  const generationTimestamp =
+    process.env.TEST_SEED === 'random'
+      ? new Date().toISOString()
+      : `seeded:${process.env.TEST_SEED || 'snapshot-baseline'}`;
   const scenarios: ValidationScenario[] = [];
   // --only filters by scenario kind across the entire generator (base AND deep).
   // Without --only, all kinds permitted by the active mode (deep on/off) run.

--- a/semantic-graph-extractor/index.ts
+++ b/semantic-graph-extractor/index.ts
@@ -109,9 +109,13 @@ export class SemanticGraphExtractor {
       semanticTypes: Array.from(graph.semanticTypes.values()),
       edges: graph.edges,
       metadata: {
-        extractedAt: process.env.TEST_SEED
-          ? `seeded:${process.env.TEST_SEED}`
-          : new Date().toISOString(),
+        // Use a deterministic placeholder by default so generated artifacts
+        // are byte-reproducible. Set TEST_SEED=random to opt in to a real
+        // wall-clock timestamp (only useful for live-broker exploration).
+        extractedAt:
+          process.env.TEST_SEED === 'random'
+            ? new Date().toISOString()
+            : `seeded:${process.env.TEST_SEED || 'snapshot-baseline'}`,
         totalOperations: graph.operations.size,
         totalSemanticTypes: graph.semanticTypes.size,
         totalDependencies: graph.edges.length,

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -1,0 +1,179 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Bundled-spec invariants — Layer 3 of the layered test strategy (#36).
+ *
+ * Each `it` block is a single, named regression statement of the form
+ * "X must hold for the bundled spec output". Failures point at one
+ * named property, not at 412 hashed files.
+ *
+ * The invariants here lock in behaviours we have already proven correct
+ * against the real bundled spec (see #31, #32, #33, #34). Add a new
+ * invariant whenever a bug fix is observable at the graph or chain
+ * level; remove an invariant whenever the property it asserts is
+ * deliberately revoked.
+ *
+ * Prerequisites: the pipeline must have been generated. CI runs
+ * `npm run pipeline` before `npm test`; locally you can run
+ * `npm run testsuite:generate` first.
+ */
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const GRAPH_PATH = join(
+  REPO_ROOT,
+  'semantic-graph-extractor',
+  'dist',
+  'output',
+  'operation-dependency-graph.json',
+);
+const SCENARIOS_DIR = join(REPO_ROOT, 'path-analyser', 'dist', 'output');
+const GENERATED_TESTS_DIR = join(REPO_ROOT, 'path-analyser', 'dist', 'generated-tests');
+
+interface SemanticTypeEntry {
+  semanticType: string;
+  fieldPath: string;
+  required: boolean;
+  provider: boolean;
+}
+interface OperationNode {
+  operationId: string;
+  method: string;
+  path: string;
+  requestBodySemanticTypes?: SemanticTypeEntry[];
+  responseSemanticTypes?: Record<string, SemanticTypeEntry[]>;
+}
+interface DependencyGraph {
+  operations: OperationNode[];
+}
+interface ScenarioFile {
+  endpoint: { operationId: string };
+  requiredSemanticTypes: string[];
+  scenarios: { id: string; operations: { operationId: string }[] }[];
+}
+
+let cachedGraph: DependencyGraph | undefined;
+function loadGraph(): DependencyGraph {
+  if (cachedGraph) return cachedGraph;
+  if (!existsSync(GRAPH_PATH)) {
+    throw new Error(
+      `Dependency graph not found at ${GRAPH_PATH}. Run 'npm run extract-graph' first.`,
+    );
+  }
+  // biome-ignore lint/plugin: runtime contract boundary for parsed JSON; downstream property accesses tolerate malformed entries
+  cachedGraph = JSON.parse(readFileSync(GRAPH_PATH, 'utf8')) as DependencyGraph;
+  return cachedGraph;
+}
+
+function findOperation(opId: string): OperationNode {
+  const op = loadGraph().operations.find((o) => o.operationId === opId);
+  if (!op) throw new Error(`Operation ${opId} not found in dependency graph`);
+  return op;
+}
+
+function requiredSemanticTypesOf(opId: string): string[] {
+  const op = findOperation(opId);
+  const set = new Set<string>();
+  for (const e of op.requestBodySemanticTypes ?? []) {
+    if (e.required) set.add(e.semanticType);
+  }
+  return [...set].sort();
+}
+
+function providersOf(opId: string): string[] {
+  const op = findOperation(opId);
+  const set = new Set<string>();
+  for (const entries of Object.values(op.responseSemanticTypes ?? {})) {
+    for (const e of entries) if (e.provider) set.add(e.semanticType);
+  }
+  return [...set].sort();
+}
+
+function loadScenarioFile(filename: string): ScenarioFile {
+  const p = join(SCENARIOS_DIR, filename);
+  // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+  return JSON.parse(readFileSync(p, 'utf8')) as ScenarioFile;
+}
+
+describe('bundled-spec invariants: extractor classification', () => {
+  it('createProcessInstance required semantic types are exactly {ProcessDefinitionId, ProcessDefinitionKey} (#31/#32)', () => {
+    // Locks in ancestor-required tracking: ElementId nested under the
+    // optional `startInstructions[]` parent must NOT be required.
+    expect(requiredSemanticTypesOf('createProcessInstance')).toEqual([
+      'ProcessDefinitionId',
+      'ProcessDefinitionKey',
+    ]);
+  });
+
+  it('createProcessInstance.startInstructions[].elementId is classified optional (#31)', () => {
+    // Direct field-level lock-in: this is the leaf the original bug demoted.
+    const op = findOperation('createProcessInstance');
+    const node = op.requestBodySemanticTypes?.find(
+      (e) => e.fieldPath === 'startInstructions[].elementId',
+    );
+    expect(
+      node,
+      'startInstructions[].elementId must be present in extracted semantics',
+    ).toBeDefined();
+    expect(node?.required).toBe(false);
+  });
+
+  it('createDeployment provides the full {ProcessDefinitionKey, ProcessDefinitionId, DecisionDefinitionKey, DecisionRequirementsKey, FormKey} provider set (#34)', () => {
+    // Locks in `x-semantic-provider` array-form recognition: the response
+    // payload uses array-form `x-semantic-provider` on `deployments[].*`,
+    // and #34 made the inheritedProvider flag thread through the nested
+    // object subtrees so every listed key is flagged provider:true.
+    expect(providersOf('createDeployment')).toEqual([
+      'DecisionDefinitionKey',
+      'DecisionRequirementsKey',
+      'FormKey',
+      'ProcessDefinitionId',
+      'ProcessDefinitionKey',
+    ]);
+  });
+});
+
+describe('bundled-spec invariants: planner output', () => {
+  it('every createProcessInstance scenario includes createDeployment as a prerequisite (#32)', () => {
+    // Locks in #32: ProcessDefinitionKey/Id must always be sourced from
+    // createDeployment, the canonical authoritative provider. Tightening
+    // this further (e.g. "is the FIRST step") is blocked by #35
+    // (spurious intermediate steps), which can prepend an unrelated GET
+    // for an eventually-consistent variant. Tighten when #35 lands.
+    const scen = loadScenarioFile('post--process-instances-scenarios.json');
+    expect(scen.scenarios.length).toBeGreaterThan(0);
+    const offenders = scen.scenarios
+      .map((s) => ({ id: s.id, ops: s.operations.map((o) => o.operationId) }))
+      .filter((s) => !s.ops.includes('createDeployment'));
+    expect(offenders).toEqual([]);
+  });
+
+  it('no createProcessInstance scenario calls searchElementInstances (#31)', () => {
+    // The original symptom of #31: the planner inserted a search-step
+    // chain because ElementId was wrongly required. Ancestor-required
+    // tracking removed that branch.
+    const scen = loadScenarioFile('post--process-instances-scenarios.json');
+    const offenders = scen.scenarios
+      .map((s) => ({ id: s.id, ops: s.operations.map((o) => o.operationId) }))
+      .filter((s) => s.ops.includes('searchElementInstances'));
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('bundled-spec invariants: emitted Playwright suite', () => {
+  it('no generated test contains a stray __invalidEnum sentinel object (#39)', () => {
+    // Layer-3 mirror of the targeted enum-violation test in
+    // tests/request-validation/. Catches any future analyser that
+    // re-introduces the same sentinel-leak pattern.
+    const offenders: string[] = [];
+    for (const f of readdirSync(GENERATED_TESTS_DIR)) {
+      if (!f.endsWith('.spec.ts')) continue;
+      const src = readFileSync(join(GENERATED_TESTS_DIR, f), 'utf8');
+      if (src.includes('__invalidEnum')) {
+        offenders.push(relative(REPO_ROOT, join(GENERATED_TESTS_DIR, f)));
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -20,7 +20,7 @@ import { describe, expect, it } from 'vitest';
  * `npm run testsuite:generate` first.
  */
 
-const REPO_ROOT = join(__dirname, '..', '..');
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
 const GRAPH_PATH = join(
   REPO_ROOT,
   'semantic-graph-extractor',
@@ -92,6 +92,11 @@ function providersOf(opId: string): string[] {
 
 function loadScenarioFile(filename: string): ScenarioFile {
   const p = join(SCENARIOS_DIR, filename);
+  if (!existsSync(p)) {
+    throw new Error(
+      `Scenario file not found at ${p}. Run 'npm run testsuite:generate' (or 'npm run pipeline') first.`,
+    );
+  }
   // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
   return JSON.parse(readFileSync(p, 'utf8')) as ScenarioFile;
 }
@@ -166,6 +171,11 @@ describe('bundled-spec invariants: emitted Playwright suite', () => {
     // Layer-3 mirror of the targeted enum-violation test in
     // tests/request-validation/. Catches any future analyser that
     // re-introduces the same sentinel-leak pattern.
+    if (!existsSync(GENERATED_TESTS_DIR)) {
+      throw new Error(
+        `Generated tests directory not found at ${GENERATED_TESTS_DIR}. Run 'npm run testsuite:generate' (or 'npm run pipeline') first.`,
+      );
+    }
     const offenders: string[] = [];
     for (const f of readdirSync(GENERATED_TESTS_DIR)) {
       if (!f.endsWith('.spec.ts')) continue;

--- a/tests/regression/pipeline-snapshot.json
+++ b/tests/regression/pipeline-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-27T04:08:43.347Z",
+  "generatedAt": "2026-04-27T04:24:35.346Z",
   "fileCount": 422,
   "trees": [
     "semantic-graph-extractor/dist/output",
@@ -172,7 +172,7 @@
     "path-analyser/dist/generated-tests/support/env.ts": "accc60237367bc4199bffa128cb81974871b63b9d5e36ca33f7fd28e1ad49c22",
     "path-analyser/dist/generated-tests/support/recorder.ts": "abe8049c2523e83e62a59047cd04d29dd353889b2d20c6ff407ebe6ed52ff12a",
     "path-analyser/dist/generated-tests/support/seed-rules.json": "5819f41d4a789c4af66b9953cd35b0705af515cc72ec922a9765857f15f14f2d",
-    "path-analyser/dist/generated-tests/support/seeding.ts": "931b97cedddf6711e11546fb15797b3aac1982bb0fe9cd86423feae6e94f6cdc",
+    "path-analyser/dist/generated-tests/support/seeding.ts": "10eff69c154a4690a485871f39026d44041d9d77a8fa76a92043c287648d11c4",
     "path-analyser/dist/generated-tests/suspendBatchOperation.feature.spec.ts": "c29992502fdd09ac55536192278487aeb6a9f3eedc6e05023f88a5e65f634179",
     "path-analyser/dist/generated-tests/throwJobError.feature.spec.ts": "2289f6b26259a08cc4a25ba9e01344042d5a59c8e7ca6bd7b1bb8eca61a14dfe",
     "path-analyser/dist/generated-tests/tsconfig.json": "4cbe5253520faab8eaee005058db1cb5a36c3747e7a73929ba451ac2adb1f983",


### PR DESCRIPTION
First installment of the layered test strategy in #36. Two pieces:

## 1. Determinism quick win (Layer 4)

The seeding module previously fell back to `Math.random()` when `TEST_SEED` was unset. That caused snapshots to pass locally and fail on CI (or vice versa) depending on whether the contributor prefixed every generation command with `TEST_SEED=snapshot-baseline` — a recurring papercut on #32 and #34.

**Determinism is now the default.** [path-analyser/src/codegen/support/seeding.ts](path-analyser/src/codegen/support/seeding.ts):
- unset `TEST_SEED` → resolves to `'snapshot-baseline'`
- any other non-empty value → custom deterministic seed
- `TEST_SEED=random` → explicit opt-in to `Math.random()` (only useful for live-broker exploration)

Same semantics mirrored in [semantic-graph-extractor/index.ts](semantic-graph-extractor/index.ts) and [request-validation/scripts/generate.ts](request-validation/scripts/generate.ts) timestamp emitters. `snapshot:regenerate` keeps its explicit prefix (no-op now, but documents intent).

**Verified:** `npm run testsuite:generate` with no `TEST_SEED` now produces a byte-identical `createProcessInstance.feature.spec.ts` to a seeded run.

## 2. Bundled-spec invariants harness (Layer 3)

New file [tests/regression/bundled-spec-invariants.test.ts](tests/regression/bundled-spec-invariants.test.ts) — 6 named, human-readable invariants over the real bundled spec output. Each `it` block is a one-line regression statement:

| # | Invariant | Locks in |
|---|---|---|
| 1 | `createProcessInstance` required semantic types are exactly `{ProcessDefinitionId, ProcessDefinitionKey}` | #31/#32 ancestor-required tracking |
| 2 | `createProcessInstance.startInstructions[].elementId` is classified optional | #31 direct field-level |
| 3 | `createDeployment` provides `{ProcessDefinitionKey, .Id, DecisionDefinitionKey, DecisionRequirementsKey, FormKey}` | #34 array-form `x-semantic-provider` inheritance |
| 4 | Every `createProcessInstance` scenario includes `createDeployment` as a prerequisite | #32 (tightening this blocked by #35) |
| 5 | No `createProcessInstance` scenario calls `searchElementInstances` | #31 original symptom |
| 6 | No generated test contains a stray `__invalidEnum` sentinel object | #39 (bundled-spec mirror) |

Runs alongside the existing snapshot test for now; PR-D under #36 will delete the snapshot once Layers 1–2 land.

## Documentation

[README.md](README.md) regression section now describes the layered strategy and the `TEST_SEED=random` opt-out.

## Verification

- 56/56 vitest pass (+6 new invariants)
- Pipeline output byte-identical with and without `TEST_SEED`
- Lint clean

## Roadmap (rest of #36)

- **PR-B** — Layer 1: extractor construct-fixture harness (4+ fixtures backfilling #31, #32-review, #33, #34-review)
- **PR-C** — Layer 2: planner contract-fixture harness (2+ graph fixtures)
- **PR-D** — delete `pipeline-snapshot.test.ts` + `pipeline-snapshot.json`, add CONTRIBUTING fixture-+-invariant rule

Refs #36.