### PR TITLE
feat(testing): planner contract fixtures (refs #36)

### DIFF
--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -67,9 +67,10 @@ function opIdsOf(scenario: { operations: { operationId: string }[] }): string[] 
 // ---------------------------------------------------------------------------
 //
 // Two operations both produce ProcessDefinitionKey, but only
-// `createDeployment` is annotated provider:true. The planner must pick
-// the authoritative producer; the incidental search-style operation
-// should not appear in the resulting chain.
+// `createDeployment` is annotated provider:true. The planner must
+// prefer the authoritative producer for the first/canonical scenario;
+// additional scenarios may still be generated via the incidental
+// search-style operation (the contract is ordering, not suppression).
 const fixtureProviderPreference: OperationGraph = makeGraph([
   makeOp('createDeployment', {
     produces: ['ProcessDefinitionKey'],

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import { generateScenariosForEndpoint } from '../../../path-analyser/dist/src/scenarioGenerator.js';
+import type {
+  EndpointScenarioCollection,
+  OperationGraph,
+  OperationNode,
+} from '../../../path-analyser/dist/src/types.js';
+
+/**
+ * Planner contract fixtures — Layer 2 of the layered test strategy (#36).
+ *
+ * Each fixture is a hand-built minimal `OperationGraph` paired with a
+ * one-line assertion about the chain shape `generateScenariosForEndpoint`
+ * must produce. Failures point at one chain rule, not at hundreds of
+ * generated scenario files.
+ *
+ * Add a new fixture whenever a planner bug fix is observable at the
+ * chain level (e.g. "must include this op", "must NOT include this op",
+ * "providers preferred over incidental producers").
+ */
+
+interface NodeOpts {
+  required?: string[];
+  optional?: string[];
+  produces?: string[];
+  providerMap?: Record<string, boolean>;
+}
+
+function makeOp(operationId: string, opts: NodeOpts = {}): OperationNode {
+  return {
+    operationId,
+    method: 'POST',
+    path: `/${operationId}`,
+    requires: {
+      required: opts.required ?? [],
+      optional: opts.optional ?? [],
+    },
+    produces: opts.produces ?? [],
+    providerMap: opts.providerMap,
+  };
+}
+
+function makeGraph(nodes: OperationNode[]): OperationGraph {
+  const operations: Record<string, OperationNode> = {};
+  const bySemanticProducer: Record<string, string[]> = {};
+  for (const node of nodes) {
+    operations[node.operationId] = node;
+    for (const sem of node.produces) {
+      const list = bySemanticProducer[sem] ?? [];
+      list.push(node.operationId);
+      bySemanticProducer[sem] = list;
+    }
+  }
+  return { operations, bySemanticProducer };
+}
+
+function plan(graph: OperationGraph, endpointOpId: string): EndpointScenarioCollection {
+  return generateScenariosForEndpoint(graph, endpointOpId, { maxScenarios: 10 });
+}
+
+function opIdsOf(scenario: { operations: { operationId: string }[] }): string[] {
+  return scenario.operations.map((o) => o.operationId);
+}
+
+// ---------------------------------------------------------------------------
+// Fixture A: authoritative provider preferred over incidental producer (#34)
+// ---------------------------------------------------------------------------
+//
+// Two operations both produce ProcessDefinitionKey, but only
+// `createDeployment` is annotated provider:true. The planner must pick
+// the authoritative producer; the incidental search-style operation
+// should not appear in the resulting chain.
+const fixtureProviderPreference: OperationGraph = makeGraph([
+  makeOp('createDeployment', {
+    produces: ['ProcessDefinitionKey'],
+    providerMap: { ProcessDefinitionKey: true },
+  }),
+  makeOp('searchProcessDefinitions', {
+    produces: ['ProcessDefinitionKey'],
+    providerMap: { ProcessDefinitionKey: false },
+  }),
+  makeOp('createProcessInstance', {
+    required: ['ProcessDefinitionKey'],
+  }),
+]);
+
+// ---------------------------------------------------------------------------
+// Fixture B: optional types do NOT force pre-ops (#31, chain-level)
+// ---------------------------------------------------------------------------
+//
+// Endpoint requires ProcessDefinitionKey and optionally accepts ElementId.
+// The original #31 symptom in chain form: planner inserted a search-step
+// chain to source the "optional" type because it was wrongly classified
+// required. Optional types must remain opportunistic.
+const fixtureOptionalNoPreOp: OperationGraph = makeGraph([
+  makeOp('createDeployment', {
+    produces: ['ProcessDefinitionKey'],
+    providerMap: { ProcessDefinitionKey: true },
+  }),
+  makeOp('searchElementInstances', {
+    produces: ['ElementId'],
+    providerMap: { ElementId: true },
+  }),
+  makeOp('createProcessInstance', {
+    required: ['ProcessDefinitionKey'],
+    optional: ['ElementId'],
+  }),
+]);
+
+// ---------------------------------------------------------------------------
+// Fixture C: unsatisfied requirement surfaces explicitly
+// ---------------------------------------------------------------------------
+//
+// Endpoint requires a semantic type with no producer anywhere in the
+// graph. The planner must return a single `unsatisfied` scenario with
+// the missing type listed, not an empty collection or a silently-broken
+// chain.
+const fixtureUnsatisfied: OperationGraph = makeGraph([
+  makeOp('createProcessInstance', {
+    required: ['MissingType'],
+  }),
+]);
+
+// ---------------------------------------------------------------------------
+// Fixture D: trivial endpoint (no requirements) plans a one-op scenario
+// ---------------------------------------------------------------------------
+//
+// Endpoint with no required and no optional semantic types must produce
+// exactly one scenario containing only the endpoint itself. Locks in
+// the no-pre-op short-circuit path.
+const fixtureTrivial: OperationGraph = makeGraph([
+  makeOp('listTopology', {
+    produces: [],
+  }),
+]);
+
+describe('planner contracts: provider preference', () => {
+  it('first scenario uses the authoritative provider (#34)', () => {
+    // The planner explores both authoritative and incidental producers
+    // (BFS), but the authoritative producer must come first so it is the
+    // canonical scenario downstream consumers see. This is the chain-level
+    // mirror of the extractor `provider: true` flag.
+    const collection = plan(fixtureProviderPreference, 'createProcessInstance');
+    expect(collection.scenarios.length).toBeGreaterThan(0);
+    expect(opIdsOf(collection.scenarios[0])).toEqual(['createDeployment', 'createProcessInstance']);
+  });
+
+  it('productionMap attributes ProcessDefinitionKey to createDeployment in the first scenario (#34)', () => {
+    const collection = plan(fixtureProviderPreference, 'createProcessInstance');
+    expect(collection.scenarios[0].productionMap?.ProcessDefinitionKey).toBe('createDeployment');
+  });
+});
+
+describe('planner contracts: optional types stay opportunistic', () => {
+  it('does not insert a producer for the optional-only type (#31, chain-level)', () => {
+    const collection = plan(fixtureOptionalNoPreOp, 'createProcessInstance');
+    expect(collection.scenarios.length).toBeGreaterThan(0);
+    for (const scenario of collection.scenarios) {
+      const ops = opIdsOf(scenario);
+      expect(ops).not.toContain('searchElementInstances');
+    }
+  });
+
+  it('still includes the producer for the required type', () => {
+    const collection = plan(fixtureOptionalNoPreOp, 'createProcessInstance');
+    for (const scenario of collection.scenarios) {
+      expect(opIdsOf(scenario)).toContain('createDeployment');
+    }
+  });
+});
+
+describe('planner contracts: unsatisfied requirement', () => {
+  it('returns a single unsatisfied scenario listing the missing type', () => {
+    const collection = plan(fixtureUnsatisfied, 'createProcessInstance');
+    expect(collection.unsatisfied).toBe(true);
+    expect(collection.scenarios).toHaveLength(1);
+    const [scenario] = collection.scenarios;
+    expect(scenario.id).toBe('unsatisfied');
+    expect(scenario.missingSemanticTypes).toEqual(['MissingType']);
+  });
+});
+
+describe('planner contracts: trivial endpoint', () => {
+  it('plans exactly one scenario containing only the endpoint', () => {
+    const collection = plan(fixtureTrivial, 'listTopology');
+    expect(collection.scenarios).toHaveLength(1);
+    expect(opIdsOf(collection.scenarios[0])).toEqual(['listTopology']);
+  });
+});

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { generateScenariosForEndpoint } from '../../../path-analyser/dist/src/scenarioGenerator.js';
+import { generateScenariosForEndpoint } from '../../../path-analyser/src/scenarioGenerator.ts';
 import type {
   EndpointScenarioCollection,
   OperationGraph,
   OperationNode,
-} from '../../../path-analyser/dist/src/types.js';
+} from '../../../path-analyser/src/types.ts';
 
 /**
  * Planner contract fixtures — Layer 2 of the layered test strategy (#36).


### PR DESCRIPTION
Layer 2 of the layered test strategy in #36 (PR-C of A→B→C→D).

Adds [tests/fixtures/planner/planner-contracts.test.ts](tests/fixtures/planner/planner-contracts.test.ts) with four hand-built minimal `OperationGraph` fixtures, each paired with one-line chain-shape assertions on `generateScenariosForEndpoint`. Failures point at one chain rule, not at hundreds of generated scenario files.

| # | Fixture | Locks in |
|---|---|---|
| 1 | Provider preference | First/canonical scenario picks the authoritative producer over an incidental same-semantic producer (#34, chain-level). The contract is **ordering**, not suppression — additional scenarios via the incidental producer may still be generated. |
| 2 | Optional stays opportunistic | Planner does NOT insert a pre-op for an optional-only semantic type (#31, chain-level mirror of #42) |
| 3 | Unsatisfied requirement | Surfaces a single `unsatisfied` scenario listing the missing semantic type — not silent failure |
| 4 | Trivial endpoint | Endpoint with no requirements plans exactly one one-op scenario (short-circuit path) |

## Standing rule

A new planner bug fix should land with a graph fixture demonstrating the bug at chain level. PR-D under #36 ([#44](https://github.com/camunda/api-test-generator/pull/44)) codifies the rule in `CONTRIBUTING.md`.

## Imports

Imports come from `path-analyser/src/` directly, matching the convention used by other unit tests like [tests/codegen/cli-args.test.ts](tests/codegen/cli-args.test.ts). Vitest transforms TS source on the fly, so no pre-build of the planner workspace is required to run these fixtures.

## Verification

- 6 new tests pass: `npx vitest run tests/fixtures/planner`
- Lint clean: `npx biome check tests/fixtures/planner/`

## Roadmap (rest of #36)

- **PR-A** — done, in #41 (determinism quick win + bundled-spec invariants)
- **PR-B** — open in #42 (extractor construct fixtures)
- **PR-C (this PR)** — Layer 2: planner contract fixtures
- **PR-D** — open in #44 (delete `pipeline-snapshot.test.ts` + `pipeline-snapshot.json`, add CONTRIBUTING fixture-+-invariant rule)

Refs #36.