### PR TITLE
feat: BFS chain pipeline improvements — sidecar expansion, chain-graft fix, regression tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "testsuite:observe:run": "npm run codegen:playwright:all && npm run test:pw:path-analyser && npm run observe:aggregate",
     "observe:aggregate": "npm run build:analyser && node path-analyser/dist/src/scripts/aggregate-observations.js",
     "optional-responses": "node optional-responses/report.js",
+    "audit:sidecar": "npm run build:analyser && node path-analyser/dist/scripts/audit-sidecar.js",
     "pipeline": "npm run fetch-spec && npm run testsuite:generate && npm run generate:request-validation",
     "lint": "biome check",
     "lint:fix": "biome check --write",

--- a/path-analyser/domain-semantics.json
+++ b/path-analyser/domain-semantics.json
@@ -37,7 +37,68 @@
       "kind": "state",
       "parameters": ["jobType", "processDefinitionId"],
       "producedBy": ["activateJobs"],
-      "requires": ["ProcessInstanceExists", "ModelHasServiceTaskType"]
+      "$comment": "Conceptually requires ProcessInstanceExists+ModelHasServiceTaskType, but omitting 'requires' here avoids BFS domain-prereq deadlock. The semantic edges from createDeployment/createProcessInstance already enforce ordering."
+    },
+    "DecisionDefinitionDeployed": {
+      "kind": "state",
+      "parameter": "decisionDefinitionId",
+      "producedBy": ["createDeployment"]
+    },
+    "DecisionRequirementsDeployed": {
+      "kind": "state",
+      "parameter": "decisionRequirementsId",
+      "producedBy": ["createDeployment"]
+    },
+    "FormDeployed": {
+      "kind": "state",
+      "parameter": "formKey",
+      "producedBy": ["createDeployment"]
+    },
+    "TenantExists": {
+      "kind": "state",
+      "parameter": "tenantId",
+      "producedBy": ["createTenant"]
+    },
+    "UserExists": {
+      "kind": "state",
+      "parameter": "username",
+      "producedBy": ["createUser"]
+    },
+    "AuthorizationExists": {
+      "kind": "state",
+      "parameter": "authorizationKey",
+      "producedBy": ["createAuthorization"]
+    },
+    "BatchOperationExists": {
+      "kind": "state",
+      "parameter": "batchOperationKey",
+      "producedBy": [
+        "cancelProcessInstancesBatchOperation",
+        "deleteDecisionInstancesBatchOperation",
+        "deleteProcessInstancesBatchOperation"
+      ]
+    },
+    "DocumentExists": {
+      "kind": "state",
+      "parameter": "documentId",
+      "producedBy": ["createDocument", "createDocuments"]
+    },
+    "GlobalListenerExists": {
+      "kind": "state",
+      "parameter": "globalListenerId",
+      "producedBy": ["createGlobalTaskListener"]
+    },
+    "DecisionEvaluationExists": {
+      "kind": "state",
+      "parameter": "decisionEvaluationKey",
+      "producedBy": ["evaluateDecision"],
+      "requires": ["DecisionDefinitionDeployed"]
+    },
+    "IncidentExists": {
+      "kind": "state",
+      "parameter": "incidentKey",
+      "producedBy": [],
+      "$comment": "Incidents are produced when service tasks exhaust retries or workers fail. No automated happy-path producer. This is at the research boundary: cannot be derived from the spec alone — requires domain knowledge about how to trigger process failure."
     }
   },
   "operationRequirements": {
@@ -51,14 +112,14 @@
       }
     },
     "activateJobs": {
-      "requires": ["ProcessInstanceExists", "ModelHasServiceTaskType"],
+      "$comment": "activateJobs conceptually requires ProcessInstanceExists and ModelHasServiceTaskType, but these are tracked as domain annotation only to avoid blocking BFS semantic expansion for downstream consumers (completeJob, failJob, etc.)",
       "valueBindings": {
         "request.jobType": "ModelHasServiceTaskType.jobType"
       },
       "produces": ["JobAvailableForActivation"]
     },
     "searchJobs": {
-      "requires": ["ProcessInstanceExists", "ModelHasServiceTaskType"]
+      "$comment": "Conceptually requires ProcessInstanceExists+ModelHasServiceTaskType; omitted from domainRequiresAll to keep BFS unblocked."
     },
     "getUserTask": {
       "requires": ["ProcessInstanceExists"]
@@ -67,6 +128,8 @@
       "requires": ["ProcessInstanceExists"]
     },
     "createDeployment": {
+      "produces": ["DecisionDefinitionId"],
+      "$comment": "DecisionDefinitionId is present in deployment response as deployments[].decision.decisionDefinitionId but not picked up by the extractor; explicitly declared here.",
       "valueBindings": {
         "response.deployments[].processDefinition.processDefinitionId": "ProcessDefinitionDeployed.processDefinitionId",
         "response.deployments[].processDefinition.processDefinitionKey": "ProcessDefinitionKey.processDefinitionKey",
@@ -75,6 +138,282 @@
     },
     "searchProcessDefinitions": {
       "disjunctions": [["ProcessDefinitionKey", "ProcessDefinitionDeployed"]]
+    },
+    "getProcessDefinition": {
+      "disjunctions": [["ProcessDefinitionKey", "ProcessDefinitionDeployed"]]
+    },
+    "getProcessDefinitionXML": {
+      "disjunctions": [["ProcessDefinitionKey", "ProcessDefinitionDeployed"]]
+    },
+    "getProcessDefinitionStatistics": {
+      "disjunctions": [["ProcessDefinitionKey", "ProcessDefinitionDeployed"]]
+    },
+    "getStartProcessForm": {
+      "disjunctions": [["ProcessDefinitionKey", "ProcessDefinitionDeployed"]]
+    },
+    "getProcessDefinitionInstanceVersionStatistics": {
+      "requires": ["ProcessDefinitionDeployed"]
+    },
+    "migrateProcessInstancesBatchOperation": {
+      "disjunctions": [["ProcessDefinitionKey", "ProcessDefinitionDeployed"]]
+    },
+    "cancelProcessInstance": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "deleteProcessInstance": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "getProcessInstance": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "modifyProcessInstance": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "resolveProcessInstanceIncidents": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "searchProcessInstanceIncidents": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "getProcessInstanceCallHierarchy": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "getProcessInstanceSequenceFlows": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "getProcessInstanceStatistics": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "migrateProcessInstance": {
+      "requires": ["ProcessInstanceExists"],
+      "disjunctions": [["ProcessDefinitionKey", "ProcessDefinitionDeployed"]]
+    },
+    "assignUserTask": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "completeUserTask": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "unassignUserTask": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "updateUserTask": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "getUserTaskForm": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "searchUserTaskAuditLogs": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "searchUserTaskEffectiveVariables": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "searchUserTaskVariables": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "completeJob": {
+      "$comment": "Semantic edge activateJobs->completeJob via JobKey already enforces activateJobs prerequisite; domain state JobAvailableForActivation omitted from requires to avoid BFS circular deadlock."
+    },
+    "failJob": {
+      "$comment": "Same as completeJob — JobKey semantic edge provides the activateJobs prerequisite."
+    },
+    "throwJobError": {
+      "$comment": "Same as completeJob — JobKey semantic edge provides the activateJobs prerequisite."
+    },
+    "updateJob": {
+      "$comment": "Same as completeJob — JobKey semantic edge provides the activateJobs prerequisite."
+    },
+    "evaluateDecision": {
+      "requires": ["DecisionDefinitionDeployed"],
+      "implicitAdds": ["DecisionEvaluationExists"]
+    },
+    "getDecisionDefinition": {
+      "requires": ["DecisionDefinitionDeployed"]
+    },
+    "getDecisionDefinitionXML": {
+      "requires": ["DecisionDefinitionDeployed"]
+    },
+    "getDecisionRequirements": {
+      "requires": ["DecisionRequirementsDeployed"]
+    },
+    "getDecisionRequirementsXML": {
+      "requires": ["DecisionRequirementsDeployed"]
+    },
+    "deleteDecisionInstance": {
+      "requires": ["DecisionEvaluationExists"]
+    },
+    "getDecisionInstance": {
+      "requires": ["DecisionEvaluationExists"]
+    },
+    "getTenant": {
+      "requires": ["TenantExists"]
+    },
+    "updateTenant": {
+      "requires": ["TenantExists"]
+    },
+    "deleteTenant": {
+      "requires": ["TenantExists"]
+    },
+    "assignClientToTenant": {
+      "requires": ["TenantExists"]
+    },
+    "assignGroupToTenant": {
+      "requires": ["TenantExists"]
+    },
+    "assignMappingRuleToTenant": {
+      "requires": ["TenantExists"]
+    },
+    "assignRoleToTenant": {
+      "requires": ["TenantExists"]
+    },
+    "assignUserToTenant": {
+      "requires": ["TenantExists", "UserExists"]
+    },
+    "unassignClientFromTenant": {
+      "requires": ["TenantExists"]
+    },
+    "unassignGroupFromTenant": {
+      "requires": ["TenantExists"]
+    },
+    "unassignMappingRuleFromTenant": {
+      "requires": ["TenantExists"]
+    },
+    "unassignRoleFromTenant": {
+      "requires": ["TenantExists"]
+    },
+    "unassignUserFromTenant": {
+      "requires": ["TenantExists", "UserExists"]
+    },
+    "searchClientsForTenant": {
+      "requires": ["TenantExists"]
+    },
+    "searchGroupIdsForTenant": {
+      "requires": ["TenantExists"]
+    },
+    "searchMappingRulesForTenant": {
+      "requires": ["TenantExists"]
+    },
+    "searchRolesForTenant": {
+      "requires": ["TenantExists"]
+    },
+    "searchUsersForTenant": {
+      "requires": ["TenantExists"]
+    },
+    "getTenantClusterVariable": {
+      "requires": ["TenantExists"]
+    },
+    "createTenantClusterVariable": {
+      "requires": ["TenantExists"]
+    },
+    "deleteTenantClusterVariable": {
+      "requires": ["TenantExists"]
+    },
+    "getUser": {
+      "requires": ["UserExists"]
+    },
+    "updateUser": {
+      "requires": ["UserExists"]
+    },
+    "deleteUser": {
+      "requires": ["UserExists"]
+    },
+    "assignRoleToUser": {
+      "requires": ["UserExists"]
+    },
+    "unassignRoleFromUser": {
+      "requires": ["UserExists"]
+    },
+    "assignUserToGroup": {
+      "requires": ["UserExists"]
+    },
+    "unassignUserFromGroup": {
+      "requires": ["UserExists"]
+    },
+    "activateAdHocSubProcessActivities": {
+      "requires": ["ProcessInstanceExists"],
+      "$comment": "Also requires the BPMN to have an ad-hoc sub-process element. Cannot be fully derived from the spec alone — domain knowledge required about BPMN model structure."
+    },
+    "createElementInstanceVariables": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "getElementInstance": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "searchElementInstanceIncidents": {
+      "requires": ["ProcessInstanceExists"]
+    },
+    "getIncident": {
+      "requires": ["IncidentExists"],
+      "$comment": "IncidentExists cannot be established via happy-path API calls. Requires a process to fail (e.g. service task exhausting retries). This is the research boundary: encode in test fixtures manually."
+    },
+    "resolveIncident": {
+      "requires": ["IncidentExists"],
+      "$comment": "Same as getIncident: requires a failed process. Cannot be auto-derived."
+    },
+    "getAuthorization": {
+      "requires": ["AuthorizationExists"]
+    },
+    "updateAuthorization": {
+      "requires": ["AuthorizationExists"]
+    },
+    "deleteAuthorization": {
+      "requires": ["AuthorizationExists"]
+    },
+    "getBatchOperation": {
+      "requires": ["BatchOperationExists"]
+    },
+    "cancelBatchOperation": {
+      "requires": ["BatchOperationExists"]
+    },
+    "resumeBatchOperation": {
+      "requires": ["BatchOperationExists"]
+    },
+    "suspendBatchOperation": {
+      "requires": ["BatchOperationExists"]
+    },
+    "createDocumentLink": {
+      "requires": ["DocumentExists"]
+    },
+    "getDocument": {
+      "requires": ["DocumentExists"]
+    },
+    "deleteDocument": {
+      "requires": ["DocumentExists"]
+    },
+    "createGlobalTaskListener": {
+      "$comment": "createGlobalTaskListener appears to take a user-provided listenerId (PUT-style idempotent create). The graph marks it as requiring GlobalListenerId because the path/body parameter has that semantic type, but no prior operation produces it — the ID is caller-generated. Treating as no domain state precondition.",
+      "implicitAdds": ["GlobalListenerExists"]
+    },
+    "getGlobalTaskListener": {
+      "requires": ["GlobalListenerExists"]
+    },
+    "updateGlobalTaskListener": {
+      "requires": ["GlobalListenerExists"]
+    },
+    "deleteGlobalTaskListener": {
+      "requires": ["GlobalListenerExists"]
+    },
+    "getAuditLog": {
+      "$comment": "AuditLogKey is obtained by searching audit logs. Any state-changing operation produces audit log entries. Treating as requiring at least one prior state-changing operation (modelled loosely as ProcessInstanceExists for test chain building).",
+      "requires": ["ProcessInstanceExists"]
+    },
+    "getVariable": {
+      "$comment": "VariableKey is available on any running process instance that has set variables.",
+      "requires": ["ProcessInstanceExists"]
+    },
+    "getResource": {
+      "$comment": "ResourceKey is produced by createDeployment. Resources are deployed BPMN/DMN/form artifacts.",
+      "requires": ["ProcessDefinitionDeployed"]
+    },
+    "getResourceContent": {
+      "requires": ["ProcessDefinitionDeployed"]
+    },
+    "deleteResource": {
+      "requires": ["ProcessDefinitionDeployed"]
+    },
+    "updateTenantClusterVariable": {
+      "requires": ["TenantExists"]
     }
   },
   "artifactKinds": {

--- a/path-analyser/package.json
+++ b/path-analyser/package.json
@@ -16,6 +16,7 @@
     "observe:aggregate": "npm run build && node dist/src/scripts/aggregate-observations.js",
     "observe:run": "npm run codegen:playwright:all && npm run test:pw && npm run observe:aggregate",
     "validate:providers": "npm run build && node dist/scripts/validate-providers.js",
+    "audit:sidecar": "npm run build && node dist/scripts/audit-sidecar.js",
     "debug:canonical": "npm run build && node dist/src/scripts/debug-canonical.js",
     "clean": "rimraf dist || rm -rf dist",
     "regenerate": "npm run clean && npm run build && npm run generate:scenarios && npm run codegen:playwright:all"

--- a/path-analyser/scripts/audit-sidecar.ts
+++ b/path-analyser/scripts/audit-sidecar.ts
@@ -1,0 +1,101 @@
+/**
+ * Sidecar audit script.
+ *
+ * Cross-references the operation dependency graph against domain-semantics.json
+ * and reports every operation that has no `operationRequirements` entry but
+ * has non-trivial semantic dependencies — i.e., the operations where a human
+ * must decide whether domain state preconditions need encoding in the sidecar.
+ *
+ * Run via:
+ *   npm run audit:sidecar -w path-analyser
+ *
+ * Output sections:
+ *   [GAP]  — has required semantic types in graph but no sidecar entry
+ *   [OK]   — either has a sidecar entry, or has no required semantic types
+ *   [ENTRY]— entry-point operation (no required semantics, no sidecar needed)
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadGraph } from '../src/graphLoader.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+interface DomainSemantics {
+  operationRequirements?: Record<string, unknown>;
+}
+
+async function main() {
+  const baseDir = process.cwd().endsWith('path-analyser')
+    ? process.cwd()
+    : path.resolve(process.cwd(), 'path-analyser');
+
+  const graph = await loadGraph(baseDir);
+  const sidecarPath = path.resolve(baseDir, 'domain-semantics.json');
+  // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+  const sidecar = JSON.parse(readFileSync(sidecarPath, 'utf8')) as DomainSemantics;
+  const covered = new Set(Object.keys(sidecar.operationRequirements ?? {}));
+
+  const ops = Object.values(graph.operations);
+
+  const gaps: string[] = [];
+  const entryPoints: string[] = [];
+  const ok: string[] = [];
+
+  for (const op of ops) {
+    const hasRequired = op.requires.required.length > 0;
+    const hasSidecar = covered.has(op.operationId);
+    const hasDomainRequired = (op.domainRequiresAll ?? []).length > 0;
+
+    if (hasSidecar) {
+      ok.push(op.operationId);
+    } else if (!hasRequired && !hasDomainRequired) {
+      entryPoints.push(op.operationId);
+    } else {
+      gaps.push(`${op.operationId}  [requires: ${op.requires.required.join(', ')}]`);
+    }
+  }
+
+  gaps.sort();
+  entryPoints.sort();
+  ok.sort();
+
+  console.log('=== Sidecar Audit ===\n');
+  console.log(`Total operations in graph : ${ops.length}`);
+  console.log(`Covered by sidecar        : ${ok.length}`);
+  console.log(`Entry points (no needs)   : ${entryPoints.length}`);
+  console.log(`GAPS (missing sidecar)    : ${gaps.length}\n`);
+
+  if (gaps.length > 0) {
+    console.log('--- GAP: operations with required semantics but no sidecar entry ---');
+    for (const g of gaps) console.log(`  [GAP]   ${g}`);
+    console.log('');
+  }
+
+  console.log('--- OK: operations covered by sidecar ---');
+  for (const o of ok) console.log(`  [OK]    ${o}`);
+  console.log('');
+
+  console.log('--- ENTRY: entry-point operations (no sidecar entry needed) ---');
+  for (const e of entryPoints) console.log(`  [ENTRY] ${e}`);
+  console.log('');
+
+  if (gaps.length > 0) {
+    console.log(
+      `Action required: add operationRequirements entries for the ${gaps.length} GAP operation(s) above.`,
+    );
+    console.log(
+      'For each GAP, determine whether it requires a domain state precondition (encode in sidecar)',
+    );
+    console.log('or whether the semantic type dependency from the graph is sufficient on its own.');
+    process.exit(1);
+  } else {
+    console.log('All operations with semantic dependencies are covered by the sidecar.');
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -230,7 +230,15 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     if (domain?.operationRequirements) {
       for (const [opId, spec] of Object.entries(domain.operationRequirements)) {
         if (!operations[opId]) continue;
-        for (const st of spec.produces ?? []) addProducer(st, opId);
+        for (const st of spec.produces ?? []) {
+          addProducer(st, opId);
+          // Also register as a semantic producer so BFS semantic expansion can use it
+          if (!bySemanticProducer[st]) bySemanticProducer[st] = [];
+          if (!bySemanticProducer[st].includes(opId)) bySemanticProducer[st].push(opId);
+          // And add to the operation's produces list so BFS can track production
+          const node = operations[opId];
+          if (node && !node.produces.includes(st)) node.produces.push(st);
+        }
         for (const st of spec.implicitAdds ?? []) addProducer(st, opId);
       }
     }

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -127,24 +127,28 @@ async function main() {
       integrationCandidates
         .filter((sc) => sc.operations.length > 1)
         .sort((a, b) => a.operations.length - b.operations.length)[0] || integrationCandidates[0];
+
+    // Graft integration chain onto feature scenarios regardless of whether a response shape exists.
+    // Operations returning 204 (no body) have no `resp`, but still need their prerequisite chain.
+    const isSearchLikeOp =
+      (op.method.toUpperCase() === 'POST' && /\/search$/.test(op.path)) ||
+      /search/i.test(op.operationId) ||
+      op.operationId === 'activateJobs';
+    for (const s of featureCollection.scenarios) {
+      const isEmptyNeg = s.expectedResult && s.expectedResult.kind === 'empty';
+      const skipGraft = isSearchLikeOp && isEmptyNeg;
+      if (
+        !skipGraft &&
+        chainSource &&
+        s.operations.length === 1 &&
+        chainSource.operations.length > 1
+      ) {
+        s.operations = chainSource.operations.map((o) => ({ ...o }));
+      }
+    }
+
     if (resp) {
       for (const s of featureCollection.scenarios) {
-        // Graft chain if available and feature scenario currently only has endpoint op
-        // Special-case: for search-like empty-negative, skip grafting to produce an empty result without prerequisites
-        const isSearchLikeOp =
-          (op.method.toUpperCase() === 'POST' && /\/search$/.test(op.path)) ||
-          /search/i.test(op.operationId) ||
-          op.operationId === 'activateJobs';
-        const isEmptyNeg = s.expectedResult && s.expectedResult.kind === 'empty';
-        const skipGraft = isSearchLikeOp && isEmptyNeg;
-        if (
-          !skipGraft &&
-          chainSource &&
-          s.operations.length === 1 &&
-          chainSource.operations.length > 1
-        ) {
-          s.operations = chainSource.operations.map((o) => ({ ...o }));
-        }
         s.responseShapeSemantics = resp.producedSemantics || undefined;
         s.responseShapeFields = resp.fields.map((f) => ({
           name: f.name,

--- a/semantic-graph-extractor/index.ts
+++ b/semantic-graph-extractor/index.ts
@@ -35,13 +35,15 @@ export class SemanticGraphExtractor {
   async extractGraph(specPath: string): Promise<OperationDependencyGraph> {
     console.log(`Loading OpenAPI specification from: ${specPath}`);
 
-    // Load and parse the OpenAPI spec
+    // Load and parse the OpenAPI spec.
+    // The bundled output (rest-api.bundle.json) is plain JSON; fall back to
+    // YAML parsing only for .yaml / .yml sources so the extractor works with
+    // both the legacy single-file YAML and the bundled JSON format.
     const specContent = fs.readFileSync(specPath, 'utf8');
-    // yaml.load() returns `unknown`; this is the runtime contract boundary
-    // where we trust the on-disk spec to conform to the OpenAPISpec interface.
-    // Downstream analyzers tolerate missing fields gracefully.
-    // biome-ignore lint/plugin: runtime contract boundary for parsed YAML
-    const spec = yaml.load(specContent) as OpenAPISpec;
+    // biome-ignore lint/plugin: runtime contract boundary for parsed input
+    const spec = (
+      specPath.endsWith('.json') ? JSON.parse(specContent) : yaml.load(specContent)
+    ) as OpenAPISpec;
 
     console.log(`Analyzing semantic types and operations...`);
 

--- a/tests/fixtures/extractor/extractor-graph.test.ts
+++ b/tests/fixtures/extractor/extractor-graph.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Graph-pipeline fixtures for the semantic-graph extractor.
+ *
+ * These tests exercise the full extraction pipeline — JSON parsing, graph
+ * construction and edge derivation — using small hand-crafted bundled-JSON
+ * specs. Each test isolates ONE property of the pipeline so a failure
+ * names a single broken behaviour.
+ *
+ * The fixture specs below mirror the format emitted by camunda-schema-bundler
+ * (i.e., plain JSON with all $refs resolved), which is what SemanticGraphExtractor
+ * now parses via JSON.parse() rather than yaml.load().
+ */
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { GraphBuilder } from '../../../semantic-graph-extractor/graph-builder.ts';
+import { SemanticGraphExtractor } from '../../../semantic-graph-extractor/index.ts';
+import { SchemaAnalyzer } from '../../../semantic-graph-extractor/schema-analyzer.ts';
+import type { OpenAPISpec } from '../../../semantic-graph-extractor/types.ts';
+
+// ---------------------------------------------------------------------------
+// Fixture: minimal bundled JSON spec with two operations sharing one
+// semantic type. `provideKey` produces ProcessDefinitionKey in its response;
+// `consumeKey` requires ProcessDefinitionKey in its request body.
+//
+// `components.schemas` is populated to mirror the real camunda-schema-bundler
+// output format — extractSemanticTypes() only reads from components.schemas,
+// not from inline path schemas.
+// ---------------------------------------------------------------------------
+const fixtureTwoOpGraph: OpenAPISpec = {
+  openapi: '3.0.3',
+  info: { title: 'fixture-two-op-graph', version: '0.0.0' },
+  components: {
+    schemas: {
+      ProcessDefinitionKey: {
+        type: 'string',
+        'x-semantic-type': 'ProcessDefinitionKey',
+        description: 'Unique key identifying a process definition',
+      },
+    },
+  },
+  paths: {
+    '/definitions': {
+      post: {
+        operationId: 'provideKey',
+        responses: {
+          '200': {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    processDefinitionKey: {
+                      type: 'string',
+                      'x-semantic-type': 'ProcessDefinitionKey',
+                      'x-semantic-provider': true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/instances': {
+      post: {
+        operationId: 'consumeKey',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['processDefinitionKey'],
+                properties: {
+                  processDefinitionKey: {
+                    type: 'string',
+                    'x-semantic-type': 'ProcessDefinitionKey',
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: { '200': { description: 'ok' } },
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Fixture: two independent operations with NO shared semantic type.
+// Zero edges expected between them.
+// ---------------------------------------------------------------------------
+const fixtureNoSharedType: OpenAPISpec = {
+  openapi: '3.0.3',
+  info: { title: 'fixture-no-shared-type', version: '0.0.0' },
+  paths: {
+    '/a': {
+      get: {
+        operationId: 'opA',
+        parameters: [
+          {
+            name: 'jobKey',
+            in: 'query',
+            schema: { type: 'string', 'x-semantic-type': 'JobKey' },
+          },
+        ],
+        responses: { '200': { description: 'ok' } },
+      },
+    },
+    '/b': {
+      post: {
+        operationId: 'opB',
+        responses: {
+          '200': {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    processDefinitionKey: {
+                      type: 'string',
+                      'x-semantic-type': 'ProcessDefinitionKey',
+                      'x-semantic-provider': true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function buildGraphFrom(spec: OpenAPISpec) {
+  const analyzer = new SchemaAnalyzer();
+  const semanticTypes = analyzer.extractSemanticTypes(spec);
+  const operations = analyzer.extractOperations(spec);
+  return new GraphBuilder().buildDependencyGraph(operations, semanticTypes);
+}
+
+// ---------------------------------------------------------------------------
+// Tests: GraphBuilder edge creation
+// ---------------------------------------------------------------------------
+describe('GraphBuilder: edge creation from semantic type relationships', () => {
+  it('creates an edge from producer to consumer when they share a semantic type', () => {
+    const graph = buildGraphFrom(fixtureTwoOpGraph);
+
+    const edge = graph.edges.find(
+      (e) => e.sourceOperationId === 'provideKey' && e.targetOperationId === 'consumeKey',
+    );
+    expect(edge, 'expected edge provideKey → consumeKey').toBeDefined();
+    expect(edge?.semanticType).toBe('ProcessDefinitionKey');
+  });
+
+  it('does NOT create a reverse edge from consumer to producer', () => {
+    const graph = buildGraphFrom(fixtureTwoOpGraph);
+
+    const reverseEdge = graph.edges.find(
+      (e) => e.sourceOperationId === 'consumeKey' && e.targetOperationId === 'provideKey',
+    );
+    expect(reverseEdge, 'reverse edge must not exist').toBeUndefined();
+  });
+
+  it('creates zero edges when no semantic type is shared between operations', () => {
+    const graph = buildGraphFrom(fixtureNoSharedType);
+    expect(graph.edges).toHaveLength(0);
+  });
+
+  it('includes both operations in the graph regardless of edge count', () => {
+    const graph = buildGraphFrom(fixtureNoSharedType);
+    expect(graph.operations.has('opA')).toBe(true);
+    expect(graph.operations.has('opB')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: SemanticGraphExtractor.extractGraph() — JSON vs YAML parsing
+// ---------------------------------------------------------------------------
+describe('SemanticGraphExtractor.extractGraph(): JSON input parsing', () => {
+  it('parses a .json spec file using JSON.parse (not yaml.load)', async () => {
+    const tmpPath = join(tmpdir(), 'fixture-two-op-graph.json');
+    writeFileSync(tmpPath, JSON.stringify(fixtureTwoOpGraph));
+
+    const extractor = new SemanticGraphExtractor();
+    const graph = await extractor.extractGraph(tmpPath);
+
+    // If JSON.parse failed silently and returned an empty spec, operations
+    // would be empty. Assert we got real content.
+    expect(graph.operations.size).toBe(2);
+    expect(graph.semanticTypes.size).toBeGreaterThanOrEqual(1);
+  });
+
+  it('extracts the correct edge from a JSON fixture via the full pipeline', async () => {
+    const tmpPath = join(tmpdir(), 'fixture-two-op-graph-edges.json');
+    writeFileSync(tmpPath, JSON.stringify(fixtureTwoOpGraph));
+
+    const extractor = new SemanticGraphExtractor();
+    const graph = await extractor.extractGraph(tmpPath);
+
+    const edge = graph.edges.find(
+      (e) => e.sourceOperationId === 'provideKey' && e.targetOperationId === 'consumeKey',
+    );
+    expect(edge, 'expected edge provideKey → consumeKey via full pipeline').toBeDefined();
+    expect(edge?.semanticType).toBe('ProcessDefinitionKey');
+  });
+
+  it('parses a .yaml spec string path without error', async () => {
+    // Verify the YAML fallback path still works for callers using legacy .yaml sources.
+    const yaml = require('js-yaml');
+    const yamlContent = yaml.dump(fixtureTwoOpGraph);
+    const tmpPath = join(tmpdir(), 'fixture-two-op-graph.yaml');
+    writeFileSync(tmpPath, yamlContent);
+
+    const extractor = new SemanticGraphExtractor();
+    const graph = await extractor.extractGraph(tmpPath);
+
+    expect(graph.operations.size).toBe(2);
+  });
+});

--- a/tests/regression/scenario-chain-invariants.test.ts
+++ b/tests/regression/scenario-chain-invariants.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Scenario-chain invariants — Layer 3 extension of the layered test strategy.
+ *
+ * These tests lock in properties of the BFS-generated scenario chains so that:
+ *   1. Known-correct chains cannot be silently broken by sidecar or graph changes.
+ *   2. The chain-grafting fix (no-response-body endpoints) is regression-guarded.
+ *   3. The sidecar population completeness (zero-gap audit) is enforced as a test.
+ *
+ * Prerequisites: the pipeline must have been generated.
+ *   npm run testsuite:generate   (or npm run pipeline)
+ */
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const FEATURE_OUTPUT_DIR = join(REPO_ROOT, 'path-analyser', 'dist', 'feature-output');
+const RAW_OUTPUT_DIR = join(REPO_ROOT, 'path-analyser', 'dist', 'output');
+
+interface OperationRef {
+  operationId: string;
+}
+interface ScenarioEntry {
+  id: string;
+  operations: OperationRef[];
+  domainStatesRequired?: string[];
+  expectedResult?: { kind: string };
+}
+interface ScenarioCollection {
+  endpoint: { operationId: string };
+  scenarios: ScenarioEntry[];
+  unsatisfied?: boolean;
+}
+
+function loadFeatureScenarios(filename: string): ScenarioCollection {
+  const p = join(FEATURE_OUTPUT_DIR, filename);
+  if (!existsSync(p)) {
+    throw new Error(
+      `Feature scenario file not found at ${p}. Run 'npm run testsuite:generate' first.`,
+    );
+  }
+  // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+  return JSON.parse(readFileSync(p, 'utf8')) as ScenarioCollection;
+}
+
+function loadRawScenarios(filename: string): ScenarioCollection {
+  const p = join(RAW_OUTPUT_DIR, filename);
+  if (!existsSync(p)) {
+    throw new Error(`Raw scenario file not found at ${p}. Run 'npm run testsuite:generate' first.`);
+  }
+  // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+  return JSON.parse(readFileSync(p, 'utf8')) as ScenarioCollection;
+}
+
+// ---------------------------------------------------------------------------
+// BFS domain-state gating: key chains that require domain state prerequisites
+// ---------------------------------------------------------------------------
+describe('scenario-chain invariants: BFS domain-state chains', () => {
+  it('cancelProcessInstance raw scenario chain includes createDeployment and createProcessInstance', () => {
+    const col = loadRawScenarios(
+      'post--process-instances--{processInstanceKey}--cancellation-scenarios.json',
+    );
+    const mainScenario = col.scenarios.find(
+      (s) => s.id !== 'unsatisfied' && s.operations.length > 1,
+    );
+    expect(mainScenario, 'expected at least one multi-op scenario').toBeDefined();
+    // biome-ignore lint/style/noNonNullAssertion: mainScenario asserted by preceding expect().toBeDefined()
+    const opIds = mainScenario!.operations.map((o) => o.operationId);
+    expect(opIds).toContain('createDeployment');
+    expect(opIds).toContain('createProcessInstance');
+    // createDeployment must precede createProcessInstance
+    expect(opIds.indexOf('createDeployment')).toBeLessThan(opIds.indexOf('createProcessInstance'));
+    // createProcessInstance must precede cancelProcessInstance
+    expect(opIds.indexOf('createProcessInstance')).toBeLessThan(
+      opIds.indexOf('cancelProcessInstance'),
+    );
+  });
+
+  it('cancelProcessInstance domain state is declared as ProcessInstanceExists', () => {
+    const col = loadRawScenarios(
+      'post--process-instances--{processInstanceKey}--cancellation-scenarios.json',
+    );
+    const mainScenario = col.scenarios.find(
+      (s) => s.id !== 'unsatisfied' && s.operations.length > 1,
+    );
+    expect(mainScenario?.domainStatesRequired).toContain('ProcessInstanceExists');
+  });
+
+  it('completeJob raw scenario chain includes activateJobs as a prerequisite', () => {
+    const col = loadRawScenarios('post--jobs--{jobKey}--completion-scenarios.json');
+    expect(col.scenarios.length).toBeGreaterThan(0);
+    const satisfiedScenario = col.scenarios.find(
+      (s) => s.id !== 'unsatisfied' && s.operations.length > 1,
+    );
+    if (!satisfiedScenario) {
+      // If all scenarios are unsatisfied, that itself is a regression signal
+      expect(col.unsatisfied, 'completeJob must not be permanently unsatisfied').toBe(false);
+      return;
+    }
+    const opIds = satisfiedScenario.operations.map((o) => o.operationId);
+    expect(opIds).toContain('activateJobs');
+    expect(opIds.indexOf('activateJobs')).toBeLessThan(opIds.indexOf('completeJob'));
+  });
+
+  it('evaluateDecision raw scenario chain includes createDeployment as a prerequisite', () => {
+    // evaluateDecision requires DecisionDefinitionDeployed (new sidecar state)
+    const files = existsSync(RAW_OUTPUT_DIR)
+      ? readdirSync(RAW_OUTPUT_DIR).filter(
+          (f) => f.includes('evaluation') && f.includes('decision'),
+        )
+      : [];
+    if (files.length === 0) {
+      throw new Error(
+        'No evaluateDecision scenario file found. Run npm run testsuite:generate first.',
+      );
+    }
+    const col = loadRawScenarios(files[0]);
+    const satisfiedScenario = col.scenarios.find(
+      (s) => s.id !== 'unsatisfied' && s.operations.length > 1,
+    );
+    if (!satisfiedScenario) return; // unsatisfied is informational only for this operation
+    const opIds = satisfiedScenario.operations.map((o) => o.operationId);
+    expect(opIds).toContain('createDeployment');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chain-grafting fix: no-response-body endpoints must get the chain in feature output
+// ---------------------------------------------------------------------------
+describe('scenario-chain invariants: chain graft for no-body endpoints', () => {
+  it('cancelProcessInstance feature scenario includes createDeployment (chain grafted despite no response body)', () => {
+    const col = loadFeatureScenarios(
+      'post--process-instances--{processInstanceKey}--cancellation-scenarios.json',
+    );
+    const mainScenario = col.scenarios[0];
+    expect(mainScenario, 'expected at least one feature scenario').toBeDefined();
+    const opIds = mainScenario.operations.map((o) => o.operationId);
+    expect(
+      opIds,
+      'cancelProcessInstance feature scenario must include createDeployment (chain graft should have fired)',
+    ).toContain('createDeployment');
+  });
+
+  it('deleteProcessInstance feature scenario includes createDeployment', () => {
+    const col = loadFeatureScenarios(
+      'post--process-instances--{processInstanceKey}--deletion-scenarios.json',
+    );
+    const mainScenario = col.scenarios[0];
+    expect(mainScenario).toBeDefined();
+    const opIds = mainScenario.operations.map((o) => o.operationId);
+    expect(opIds).toContain('createDeployment');
+  });
+
+  it('search-like empty-negative scenarios are NOT grafted with a prerequisite chain', () => {
+    // The search-like empty-negative is intentionally standalone (expects empty result set)
+    const col = loadFeatureScenarios('post--process-instances--search-scenarios.json');
+    const emptyNeg = col.scenarios.find(
+      (s) => s.id.startsWith('feature-') && s.expectedResult?.kind === 'empty',
+    );
+    if (!emptyNeg) return; // no empty-negative variant for this endpoint, skip
+    // Empty-negative should be a standalone call (1 operation only)
+    expect(
+      emptyNeg.operations,
+      'empty-negative scenario must not include setup operations',
+    ).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createDeployment chain: existing invariant from bundled-spec-invariants (mirrored here for chain focus)
+// ---------------------------------------------------------------------------
+describe('scenario-chain invariants: createProcessInstance chain integrity', () => {
+  it('every createProcessInstance feature scenario includes createDeployment', () => {
+    const col = loadFeatureScenarios('post--process-instances-scenarios.json');
+    expect(col.scenarios.length).toBeGreaterThan(0);
+    const offenders = col.scenarios
+      .map((s) => ({ id: s.id, ops: s.operations.map((o) => o.operationId) }))
+      .filter((s) => s.ops.length > 1 && !s.ops.includes('createDeployment'));
+    expect(
+      offenders,
+      'all multi-op createProcessInstance scenarios must include createDeployment',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #46

## What changed

See the linked issue (#46) for full problem descriptions. In brief:

| # | Change | File(s) |
|---|--------|---------|
| 1 | Fix extractor to use `JSON.parse()` for `.json` specs (not `yaml.load()`) | `semantic-graph-extractor/index.ts` |
| 2 | Update spec-pin to current bundled spec (183 ops, 35 semantic types, commit `770d14c`) | `tests/regression/spec-pin.json` |
| 3 | Add extractor fixture tests (7 tests: graph pipeline, JSON/YAML parsing) | `tests/fixtures/extractor/extractor-graph.test.ts` *(new)* |
| 4 | Add `audit:sidecar` script — exits non-zero if any sidecar gaps exist | `path-analyser/scripts/audit-sidecar.ts` *(new)*, `path-analyser/package.json`, `package.json` |
| 5 | Expand `domain-semantics.json`: 11 new runtime states, 89 new operationRequirements | `path-analyser/domain-semantics.json` |
| 6 | Fix chain-graft silent skip for 204 No Content endpoints | `path-analyser/src/index.ts` |
| 7 | Fix graphLoader: sidecar `produces` → `bySemanticProducer` + `op.produces` | `path-analyser/src/graphLoader.ts` |
| 8 | Fix sidecar BFS deadlocks (`activateJobs`, `evaluateDecision` chains) | `path-analyser/domain-semantics.json` |
| 9 | Add scenario-chain-invariants regression tests (8 tests) | `tests/regression/scenario-chain-invariants.test.ts` *(new)* |

## Test results

```
Test Files  15 passed (15)
     Tests  84 passed (84)
```

## How to verify

```bash
npm install
npm run fetch-spec           # or export SPEC_REF=770d14c5c112... && npm run fetch-spec:ref
npm run extract-graph
npm run generate:scenarios
npm test
npm run audit:sidecar        # should exit 0 — 0 gaps
```

## Key behaviour fixes

**Chain-graft fix**: `cancelProcessInstance`, `deleteProcessInstance` and similar 204-response endpoints now correctly include the full prerequisite chain (`createDeployment → createProcessInstance → cancelProcessInstance`) in feature scenarios.

**evaluateDecision / completeJob**: These endpoints now generate valid BFS chains. Previously they returned 0 scenarios due to circular domain-state prereq deadlocks.

## Known limitations

- `IncidentExists` has no automated producer — requires manual test fixture engineering (process failure scenarios). Documented as the research boundary in `domain-semantics.json`.
- `DecisionDefinitionId` emitted via sidecar workaround; upstream extractor should be enhanced to read `deployments[].decision.decisionDefinitionId` directly from deployment response schema.