### PR TITLE
docs(AGENTS.md): rename, delegate to central camunda/.github AGENTS.md, import shared discipline

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,5 +1,13 @@
 # AGENT.md
 
+> **Note:** This file extends a central Camunda AGENTS.md. Read and apply it before proceeding.
+>
+> **URL:** https://raw.githubusercontent.com/camunda/.github/refs/heads/main/AGENTS.md
+>
+> Treat the central file's contents as if they were written directly here.
+> The instructions below extend those guidelines and take precedence if there
+> is any conflict.
+
 Operational guide for AI coding agents working in this repository. Read this
 before making any change. For deeper background, see [README.md](README.md)
 (architecture, scripts, environment) and [CONTRIBUTING.md](CONTRIBUTING.md)
@@ -220,6 +228,73 @@ Mandatory for every behaviour change:
 Reviewers may ask you to demonstrate the red step (e.g. a separate commit
 or a clear PR description note).
 
+### Behaviour tests are the regression guard
+
+During a behaviour-preserving refactor, do **not** modify Layer-1 fixtures,
+Layer-2 chain assertions, or Layer-3 invariants. If a fixture or invariant
+fails, the production code is usually wrong — not the test. The whole
+point of the layered strategy is that named, hand-curated assertions
+encode preserved behaviour; rewriting them to match the new output erases
+the guard.
+
+If a change intentionally modifies observable behaviour (e.g. a planner
+chain shape, an emitter contract, or an extractor property), update the
+affected fixtures/invariants and explicitly document and justify the
+intended behaviour change in the PR.
+
+### Coverage analysis before a behaviour-preserving refactor (green/green)
+
+Before any non-trivial refactor of `path-analyser` or
+`semantic-graph-extractor`, audit whether the surface you're about to
+change is sufficiently guarded. A passing test suite is necessary but not
+sufficient — it only proves that *what is currently tested* still works.
+The risk of a refactor is the behaviour that nobody asserts.
+
+For each behaviour you intend to preserve, find or write the fixture or
+invariant that would fail if it changed. If the surface is unguarded,
+**add the missing fixture/invariant first, on the pre-refactor branch**,
+and prove it passes against the current implementation. This is the
+green/green discipline:
+
+1. **Green on the pre-refactor code** — proves the assertion encodes
+   preserved behaviour, not aspirational behaviour.
+2. **Green on the refactored code** — proves the refactor preserved it.
+
+Land the new guard fixtures in a separate PR off `main` and merge it
+before the refactor PR. A guard that lands together with the change it's
+supposed to guard has no recorded moment at which it passed against the
+old code.
+
+### There are no flaky tests
+
+Intermittent failures are either a **test defect** (race, unsynchronised
+readiness signal, timeout-as-correctness, wall-clock dependency, shared
+temp dir across runs, parallel-test interaction) or a **product defect**
+(race, missed signal, resource leak under load). Either way, an
+intermittent failure is a real defect that must be diagnosed and fixed
+before the change merges.
+
+Never: retry CI, mark the test `it.skip`, add `.retry()`, or describe the
+failure as "flaky" or "unrelated" in the PR description. "Re-run and
+hope" is a coping strategy, not engineering.
+
+When triaging:
+
+- Reproduce locally if possible (loops, resource pressure, timeout
+  reduction). If you can't reproduce, reason from first principles about
+  what could differ between local and CI (load, network, vitest worker
+  scheduling, fs semantics).
+- Common causes for this repo specifically: tests that race the spec
+  fetch, tests that depend on `**/generated/` output without first
+  running the pipeline, tests that share a temp dir without isolating
+  per-`it`, fixtures whose ordering depends on a non-deterministic
+  `TEST_SEED`.
+- In the fix commit, name "test defect" or "product defect" explicitly
+  and explain which signal the test was previously relying on vs the new
+  deterministic one.
+- Generous timeouts are safety nets, not correctness signals — comment
+  them so future maintainers don't tighten them back into a race.
+
 ## Commit conventions
 
 This repo follows [Conventional Commits](https://www.conventionalcommits.org/).
@@ -291,6 +366,15 @@ npm test
 For Layer-3 invariant changes you must run the pipeline first or the test
 file aborts with a "graph not found" / "scenarios directory not found"
 error.
+
+## Terminal commands (agent tooling)
+
+- Avoid heredocs (`<< EOF`) when running shell commands through an AI
+  agent or other automation tool — they don't work reliably in zsh on
+  macOS and produce confusing failures that look like syntax errors.
+- Prefer the agent's native file-editing tools for creating or modifying
+  files. Don't pipe content through `cat > file` from the shell.
+- Appending a single line with `echo` or `printf >> file` is fine.
 
 ## Boundaries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENT.md
+# AGENTS.md
 
 > **Note:** This file extends a central Camunda AGENTS.md. Read and apply it before proceeding.
 >


### PR DESCRIPTION
## Why

Two motivations:

1. **Adopt the central Camunda agents file.** [`camunda/.github/AGENTS.md`](https://raw.githubusercontent.com/camunda/.github/refs/heads/main/AGENTS.md) defines the shared baseline for AI coding agents across the org (role, change classification, tooling preconditions, build standards, defect discipline). [`camunda/c8ctl/AGENTS.md`](https://github.com/camunda/c8ctl/blob/main/AGENTS.md) already delegates to it with a top-of-file pointer; this PR adopts the same pattern here so agents working in this repo automatically pick up the org-wide rules without having to be told separately.
2. **Lift the cross-cutting discipline sections from c8ctl** that complement what we already have. After comparing the two files I found four sections in c8ctl that are not c8ctl-specific and apply directly to this repo's layered-fixture / red-green / class-scoped strategy.

## Changes

All changes are to the agents file only.

### 0. Rename `AGENT.md` → `AGENTS.md`

Renamed to match the org convention. The central Camunda file is `AGENTS.md` (plural), as is the equivalent in `camunda/c8ctl`. No other in-repo references needed updating; the H1 was updated alongside.

### 1. Top-of-file delegation to the central AGENTS.md

```md
> **Note:** This file extends a central Camunda AGENTS.md. Read and apply it before proceeding.
> **URL:** https://raw.githubusercontent.com/camunda/.github/refs/heads/main/AGENTS.md
> Treat the central file's contents as if they were written directly here.
> The instructions below extend those guidelines and take precedence if there is any conflict.
```

Same wording and precedence rule c8ctl uses.

### 2. New: "Behaviour tests are the regression guard" (under `## Bug-fix discipline`)

During a behaviour-preserving refactor, do **not** modify Layer-1 fixtures, Layer-2 chain assertions, or Layer-3 invariants. If they fail, the production code is usually wrong, not the test. The whole point of the layered strategy is that named, hand-curated assertions encode preserved behaviour; rewriting them to match the new output erases the guard.

### 3. New: "Coverage analysis before a behaviour-preserving refactor (green/green)"

Audit guarded surface first. For each behaviour you intend to preserve, find or write the fixture/invariant that would fail if it changed. If the surface is unguarded, **add the missing fixture/invariant first, on the pre-refactor branch**, and prove it passes against the current implementation. This is the green/green discipline:

1. **Green on the pre-refactor code** — proves the assertion encodes preserved behaviour, not aspirational behaviour.
2. **Green on the refactored code** — proves the refactor preserved it.

Land the new guard fixtures in a separate PR off `main` first.

### 4. New: "There are no flaky tests"

Intermittent failures are either a **test defect** (race, unsynchronised readiness signal, timeout-as-correctness, wall-clock dependency, shared temp dir, parallel-test interaction) or a **product defect** (race, missed signal, resource leak under load). Either way it's a real defect that must be diagnosed and fixed before merge. Never: retry CI, mark `it.skip`, add `.retry()`, or describe the failure as "flaky" or "unrelated".

Common causes called out specifically for this repo: tests that race the spec fetch, tests that depend on `**/generated/` output without first running the pipeline, tests that share a temp dir without isolating per-`it`, and fixtures whose ordering depends on a non-deterministic `TEST_SEED`.

### 5. New: "Terminal commands (agent tooling)"

Avoid heredocs (`<< EOF`) in zsh, prefer the agent's native file-editing tools, single-line `echo`/`printf >> file` is fine.

## What I deliberately did NOT lift from c8ctl

| c8ctl section | Reason for omitting |
|---|---|
| BPMN/DMN validation | This repo doesn't author or validate BPMN/DMN files. |
| Help-output flag scoping (`GLOBAL_FLAGS`) | c8ctl-specific CLI surface; no analogue here. |
| `test:integration --experimental-test-isolation=none` | Mitigation for `node:test` IPC bug ([nodejs/node#56802](https://github.com/nodejs/node/issues/56802)). This repo uses vitest, not `node:test`. |
| SDK gaps tracking (`.github/SDK_GAPS.md`) | c8ctl-specific. |
| Getter/setter and object-style-params TS preferences | Not adopted as house style here; introducing them via AGENTS.md without team agreement would be presumptuous. |
| Always-green-policy `npm test` invocation | The existing CI section already enforces this with the right command for this repo. |

## Verification

- `AGENTS.md` renders correctly on GitHub.
- All section headings remain unique.
- `grep` confirms no other in-repo file referenced `AGENT.md`.
- No breaking changes to existing rules — only additions, the rename, and the top-of-file delegation block.