### PR TITLE
feat(planner): emit positive variants populating optional sub-shapes (#37)

### DIFF
--- a/path-analyser/scripts/copy-support-templates.js
+++ b/path-analyser/scripts/copy-support-templates.js
@@ -19,7 +19,14 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-const SUPPORT_FILES = ['env.ts', 'recorder.ts', 'seeding.ts', 'fixtures.ts', 'seed-rules.json'];
+const SUPPORT_FILES = [
+  'env.ts',
+  'recorder.ts',
+  'seeding.ts',
+  'fixtures.ts',
+  'seed-rules.json',
+  'await-eventually.ts',
+];
 
 async function main() {
   const root = process.cwd();

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -127,6 +127,13 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
       !(s.expectedResult && s.expectedResult.kind === 'error'),
   );
 
+  // Determine upfront whether any scenario will wrap a step with
+  // awaitEventually() so we can conditionally include the import. A step
+  // is wrapped when its operationId appears in `eventualConsistencyOps`
+  // and the step expects a 200 (we never await a step that's expected to
+  // produce an error response).
+  const needsAwaitEventually = collection.scenarios.some((s) => stepNeedsAwait(s).length > 0);
+
   // Import only test & expect; request fixture is provided per-test via parameters
   lines.push("import { test, expect } from '@playwright/test';");
   if (needsValidation) {
@@ -139,6 +146,9 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   lines.push("import { recordResponse, sanitizeBody } from './support/recorder';");
   lines.push("import { extractInto, seedBinding } from './support/seeding';");
   lines.push("import { resolveFixture } from './support/fixtures';");
+  if (needsAwaitEventually) {
+    lines.push("import { awaitEventually } from './support/await-eventually';");
+  }
   lines.push('');
   if (needsValidation) {
     // Resolve responses.json relative to this spec file so the suite is
@@ -269,6 +279,7 @@ function renderScenarioTest(
     return body.join('\n');
   }
   const requestPlan = s.requestPlan;
+  const awaitStepIndices = new Set(stepNeedsAwait(s));
   requestPlan.forEach((step: RequestStep, idx: number) => {
     const varName = `resp${idx + 1}`;
     const urlExpr = buildUrlExpression(step.pathTemplate);
@@ -336,7 +347,21 @@ function renderScenarioTest(
       }`);
       opts.push('multipart: multipart');
     }
-    body.push(`    const ${varName} = await request.${method}(url, { ${opts.join(', ')} });`);
+    // (#106) Eventually-consistent reads are wrapped with awaitEventually(),
+    // which retries the same request within a budget until the response is
+    // observably consistent (default predicate for POST .../search:
+    // `body.items.length > 0`; for GET: any 200) and returns the final
+    // APIResponse. Non-EC steps go straight through `request.${method}`.
+    if (awaitStepIndices.has(idx)) {
+      body.push(`    const ${varName} = await awaitEventually(`);
+      body.push(`      async () => request.${method}(url, { ${opts.join(', ')} }),`);
+      body.push(
+        `      { method: '${step.method.toUpperCase()}', operationId: '${step.operationId}' },`,
+      );
+      body.push(`    );`);
+    } else {
+      body.push(`    const ${varName} = await request.${method}(url, { ${opts.join(', ')} });`);
+    }
     body.push(`    if (${varName}.status() !== ${step.expect.status}) {`);
     body.push(`      try { console.error('Response body:', await ${varName}.text()); } catch {}`);
     body.push(`    }`);
@@ -414,6 +439,52 @@ function escapeQuotes(s: string): string {
 }
 function camelCase(s: string) {
   return s.charAt(0).toLowerCase() + s.slice(1);
+}
+
+/**
+ * Decide which request steps in a scenario should be wrapped with
+ * `awaitEventually(...)`. A step is wrapped iff:
+ *
+ *   1. its `operationId` is listed in `scenario.eventualConsistencyOps`
+ *      (the planner marks ops whose authoritative outputs land in
+ *      Operate/Tasklist secondary storage with indexing lag); AND
+ *   2. it is a *read* step — `GET` or `POST .../search` — because the
+ *      poller's retry semantics (404-on-GET, items.length predicate)
+ *      apply to reads, not to writes. A write that is itself flagged
+ *      EC returns 200 quickly; the lag manifests on the *next* read; AND
+ *   3. it expects a `200` (we never poll an error scenario).
+ *
+ * Returns the set of step indices the emitter should wrap. Exposed
+ * (un-exported, file-local) so the import-needed check at the top of
+ * `buildSuiteSource` and the per-step wrap decision share one
+ * predicate — they cannot drift.
+ */
+function stepNeedsAwait(s: EndpointScenario): number[] {
+  if (!s.requestPlan) return [];
+  // Source of truth: each `s.operations[].eventuallyConsistent` (a flag the
+  // extractor stamps from the `x-eventually-consistent` vendor extension).
+  // The `s.eventualConsistencyOps`/`s.hasEventuallyConsistent` fields are
+  // *summaries* the planner computes for some scenario kinds (multi-step
+  // chains, trivial scenarios) but not all (featureCoverage scenarios
+  // leave them undefined). Reading the per-op flag directly avoids that
+  // gap.
+  const ecOps = new Set<string>();
+  for (const op of s.operations) {
+    if (op.eventuallyConsistent) ecOps.add(op.operationId);
+  }
+  if (ecOps.size === 0) return [];
+  const out: number[] = [];
+  for (let i = 0; i < s.requestPlan.length; i++) {
+    const step = s.requestPlan[i];
+    if (!ecOps.has(step.operationId)) continue;
+    if (step.expect.status !== 200) continue;
+    const method = step.method.toUpperCase();
+    const isReadShape =
+      method === 'GET' || (method === 'POST' && /\/search\/?$/.test(step.pathTemplate));
+    if (!isReadShape) continue;
+    out.push(i);
+  }
+  return out;
 }
 
 // Build an accessor using optional chaining for nested/array paths, e.g. a.b[0].c -> ?.a?.b?.[0]?.c

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -129,9 +129,10 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
 
   // Determine upfront whether any scenario will wrap a step with
   // awaitEventually() so we can conditionally include the import. A step
-  // is wrapped when its operationId appears in `eventualConsistencyOps`
-  // and the step expects a 200 (we never await a step that's expected to
-  // produce an error response).
+  // is wrapped when `stepNeedsAwait()` identifies it as belonging to an
+  // eventually consistent operation (derived from
+  // `s.operations[].eventuallyConsistent`) and the step expects a 200
+  // (we never await a step that's expected to produce an error response).
   const needsAwaitEventually = collection.scenarios.some((s) => stepNeedsAwait(s).length > 0);
 
   // Import only test & expect; request fixture is provided per-test via parameters

--- a/path-analyser/src/codegen/playwright/materialize-support.ts
+++ b/path-analyser/src/codegen/playwright/materialize-support.ts
@@ -30,6 +30,7 @@ export const SUPPORT_TEMPLATE_FILES = [
   'seeding.ts',
   'fixtures.ts',
   'seed-rules.json',
+  'await-eventually.ts',
 ] as const;
 
 /** Files copied directly into <outDir>/ (project root scaffolding). */

--- a/path-analyser/src/codegen/support/await-eventually.ts
+++ b/path-analyser/src/codegen/support/await-eventually.ts
@@ -1,0 +1,235 @@
+// Eventual-consistency polling helper for emitted Playwright suites.
+//
+// Wraps a `() => Promise<APIResponse>` with retry semantics ported from the
+// JS SDK's `eventualPoll` (orchestration-cluster-api-js/src/runtime/eventual.ts):
+//
+//   * retry on 404 within budget (GET reads racing indexer lag)
+//   * retry on 429 with `Retry-After` honoured + jittered backoff (cap 2s)
+//   * fail fast on 4xx (400, 401, 403, 409, 422) and 5xx
+//   * for non-GET reads (POST /search), default predicate is
+//     `body.items.length > 0` so an empty result page keeps polling
+//   * on budget exhaustion, throw `EventualConsistencyTimeoutError`
+//     carrying attempts, elapsedMs, lastStatus and (truncated) lastBody
+//
+// This file is vendored verbatim into every generated Playwright suite
+// under `<outDir>/support/await-eventually.ts`. Keep it dependency-free
+// (no SDK imports, no npm packages) — the only types it touches are
+// Playwright's `APIResponse` (a structural subset is declared locally).
+
+export interface AwaitEventuallyOptions {
+  /** Total wait budget in ms. 0 disables polling (single attempt). */
+  waitUpToMs?: number;
+  /** Poll interval in ms (default 500, floor 10). */
+  pollIntervalMs?: number;
+  /**
+   * Predicate over the parsed JSON body. Return `true` when the response
+   * is observably consistent. If omitted, the default for non-GET reads
+   * is `Array.isArray(body.items) && body.items.length > 0`; for GET the
+   * default is `() => true` (any 200 is acceptable). The body type is
+   * `unknown` — narrow it inside your predicate.
+   */
+  predicate?: (body: unknown) => boolean | Promise<boolean>;
+  /** HTTP method of the operation. Drives the 404-retry-on-GET branch. */
+  method: string;
+  /** Operation id for error messages and tracing. */
+  operationId: string;
+}
+
+export interface EventualConsistencyTimeoutInfo {
+  operationId: string;
+  attempts: number;
+  elapsedMs: number;
+  lastStatus?: number;
+  /** Truncated to 1000 chars to keep test output readable. */
+  lastBody?: string;
+}
+
+export class EventualConsistencyTimeoutError extends Error {
+  readonly attempts: number;
+  readonly elapsedMs: number;
+  readonly lastStatus?: number;
+  readonly lastBody?: string;
+  readonly operationId: string;
+
+  constructor(info: EventualConsistencyTimeoutInfo) {
+    super(
+      `Eventual consistency timeout for operation '${info.operationId}' after ${info.attempts} attempt(s) in ${info.elapsedMs}ms (lastStatus=${info.lastStatus ?? 'n/a'})`,
+    );
+    this.name = 'EventualConsistencyTimeoutError';
+    this.operationId = info.operationId;
+    this.attempts = info.attempts;
+    this.elapsedMs = info.elapsedMs;
+    this.lastStatus = info.lastStatus;
+    this.lastBody = info.lastBody;
+  }
+}
+
+/** Structural subset of Playwright's `APIResponse` — avoids a Playwright import. */
+interface ApiResponseLike {
+  status(): number;
+  text(): Promise<string>;
+  json(): Promise<unknown>;
+  headers(): Record<string, string>;
+}
+
+const ABORT_IMMEDIATE_STATUSES = new Set([400, 401, 403, 409, 422]);
+const DEFAULT_WAIT_MS = 10_000;
+const DEFAULT_POLL_MS = 500;
+const MAX_RETRY_AFTER_MS = 2_000;
+const POLL_FLOOR_MS = 10;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function truncate(s: string, max = 1000): string {
+  return s.length > max ? `${s.slice(0, max)}…` : s;
+}
+
+function parseRetryAfterMs(headerValue: string | undefined): number | undefined {
+  if (!headerValue) return undefined;
+  const n = Number.parseInt(headerValue, 10);
+  if (Number.isNaN(n)) return undefined;
+  // RFC 7231: integer = seconds. Treat values >=1000 as already in ms
+  // (mirrors JS SDK's eventual.ts heuristic for service-emitted ms hints).
+  return n < 1000 ? n * 1000 : n;
+}
+
+/**
+ * Default consistency predicate for POST .../search operations: a non-null
+ * object with a non-empty `items` array. An empty page is the canonical
+ * "indexer hasn't caught up yet" signal in the Camunda REST API.
+ */
+function isNonEmptyItemsPage(body: unknown): boolean {
+  if (body === null || typeof body !== 'object') return false;
+  const items: unknown = Reflect.get(body, 'items');
+  return Array.isArray(items) && items.length > 0;
+}
+
+/**
+ * Invoke `fetch` repeatedly until the response is observably consistent or
+ * the budget is exhausted. Returns the final `APIResponse` so callers can
+ * still call `.status()`, `.text()`, `.json()` on it (Playwright responses
+ * are buffered, so re-reading the body is safe).
+ *
+ * On budget exhaustion this throws `EventualConsistencyTimeoutError`.
+ * On a hard-fail status (400/401/403/409/422/5xx) it returns the response
+ * immediately so the caller's existing `expect(resp.status()).toBe(...)`
+ * assertion produces a useful diff rather than a cryptic thrown error.
+ */
+export async function awaitEventually<R extends ApiResponseLike>(
+  fetch: () => Promise<R>,
+  options: AwaitEventuallyOptions,
+): Promise<R> {
+  const waitUpToMs = options.waitUpToMs ?? DEFAULT_WAIT_MS;
+  const pollIntervalMs = Math.max(POLL_FLOOR_MS, options.pollIntervalMs ?? DEFAULT_POLL_MS);
+  const isGet = options.method.toUpperCase() === 'GET';
+  const predicate = options.predicate;
+
+  if (waitUpToMs <= 0) return fetch();
+
+  const started = Date.now();
+  let attempts = 0;
+  let lastBody: string | undefined;
+
+  while (true) {
+    attempts++;
+    const resp = await fetch();
+    const status = resp.status();
+    const elapsed = Date.now() - started;
+    const remaining = waitUpToMs - elapsed;
+
+    // Hard-fail statuses: return immediately so the caller's status
+    // assertion produces a clean diff.
+    if (ABORT_IMMEDIATE_STATUSES.has(status) || status >= 500) {
+      return resp;
+    }
+
+    // 404 on GET — the typical "indexer hasn't caught up yet" signal.
+    if (status === 404 && isGet) {
+      if (remaining <= 0) {
+        try {
+          lastBody = truncate(await resp.text());
+        } catch {
+          /* body already consumed or unavailable */
+        }
+        throw new EventualConsistencyTimeoutError({
+          operationId: options.operationId,
+          attempts,
+          elapsedMs: elapsed,
+          lastStatus: status,
+          lastBody,
+        });
+      }
+      await sleep(Math.min(pollIntervalMs, remaining));
+      continue;
+    }
+
+    // 429 — honour Retry-After (jittered) within budget.
+    if (status === 429) {
+      if (remaining <= 0) {
+        try {
+          lastBody = truncate(await resp.text());
+        } catch {
+          /* ignore */
+        }
+        throw new EventualConsistencyTimeoutError({
+          operationId: options.operationId,
+          attempts,
+          elapsedMs: elapsed,
+          lastStatus: status,
+          lastBody,
+        });
+      }
+      const headers = resp.headers();
+      const ra = parseRetryAfterMs(headers['retry-after'] ?? headers['Retry-After']);
+      let delay = ra ?? pollIntervalMs * 2;
+      delay = Math.min(delay, MAX_RETRY_AFTER_MS, remaining);
+      const jitter = 0.9 + Math.random() * 0.2;
+      delay = Math.floor(delay * jitter);
+      await sleep(Math.max(POLL_FLOOR_MS, delay));
+      continue;
+    }
+
+    // 200 (or any 2xx/3xx) — evaluate predicate.
+    if (status >= 200 && status < 400) {
+      let body: unknown;
+      try {
+        body = await resp.json();
+      } catch {
+        // Non-JSON 200 — accept (e.g. text/xml endpoints like /process-definitions/{key}/xml).
+        return resp;
+      }
+      let ok: boolean;
+      if (predicate) {
+        ok = await predicate(body);
+      } else if (!isGet) {
+        // POST /search default: empty page == not yet consistent.
+        ok = isNonEmptyItemsPage(body);
+      } else {
+        ok = true;
+      }
+      if (ok) return resp;
+      try {
+        lastBody = truncate(JSON.stringify(body));
+      } catch {
+        /* unserialisable body */
+      }
+      if (remaining <= 0) {
+        throw new EventualConsistencyTimeoutError({
+          operationId: options.operationId,
+          attempts,
+          elapsedMs: elapsed,
+          lastStatus: status,
+          lastBody,
+        });
+      }
+      await sleep(Math.min(pollIntervalMs, remaining));
+      continue;
+    }
+
+    // Any other status (e.g. unexpected 3xx not redirected by the client)
+    // — return so the caller's status assertion handles it.
+    return resp;
+  }
+}

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -388,6 +388,16 @@ function normalizeOp(opId: string, op: RawOp): OperationNode {
   if (op.responseSemanticTypes && typeof op.responseSemanticTypes === 'object') {
     for (const [status, arr] of Object.entries(op.responseSemanticTypes)) {
       if (!Array.isArray(arr)) continue;
+      // Only success/redirect (2xx/3xx) responses contribute to authoritative
+      // producers, the inclusive response-leaf index, and `produces` (via
+      // `responseDerived`). Mirrors the extractor's `getProducedSemanticTypes`
+      // filter (semantic-graph-extractor/graph-builder.ts). Without this,
+      // a semantic surfaced only in a 4xx error body would (a) land in
+      // `providerMap` / `producersByType` if marked `provider: true` on
+      // the error envelope, and (b) land in `responseProducersByType` and
+      // let the variant planner pick a producer that never satisfies the
+      // semantic at runtime.
+      if (!/^[23]/.test(status)) continue;
       for (const entry of arr) {
         const st: unknown = entry?.semanticType;
         if (st && typeof st === 'string') {
@@ -395,16 +405,6 @@ function normalizeOp(opId: string, op: RawOp): OperationNode {
           if (entry?.provider) providerMap[st] = true;
           const fp = typeof entry?.fieldPath === 'string' ? entry.fieldPath : undefined;
           if (fp) {
-            // Only catalogue success/redirect (2xx/3xx) leaves into the
-            // inclusive response index. Mirrors the extractor's
-            // `getProducedSemanticTypes` filter
-            // (semantic-graph-extractor/graph-builder.ts) and the
-            // success-status filter applied to authoritative producers.
-            // Without this, a semantic surfaced only in a 4xx error body
-            // would land in `responseProducersByType` and the variant
-            // planner could pick a producer that never satisfies the
-            // semantic at runtime.
-            if (!/^[23]/.test(status)) continue;
             responseLeaves.push({
               semantic: st,
               fieldPath: fp,

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -395,6 +395,16 @@ function normalizeOp(opId: string, op: RawOp): OperationNode {
           if (entry?.provider) providerMap[st] = true;
           const fp = typeof entry?.fieldPath === 'string' ? entry.fieldPath : undefined;
           if (fp) {
+            // Only catalogue success/redirect (2xx/3xx) leaves into the
+            // inclusive response index. Mirrors the extractor's
+            // `getProducedSemanticTypes` filter
+            // (semantic-graph-extractor/graph-builder.ts) and the
+            // success-status filter applied to authoritative producers.
+            // Without this, a semantic surfaced only in a 4xx error body
+            // would land in `responseProducersByType` and the variant
+            // planner could pick a producer that never satisfies the
+            // semantic at runtime.
+            if (!/^[23]/.test(status)) continue;
             responseLeaves.push({
               semantic: st,
               fieldPath: fp,

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -536,6 +536,7 @@ function deriveOptionalSubShapes(op: RawOp): NonNullable<OperationNode['optional
 //   "filter.processInstanceKey"      -> "filter"
 //   "filter.elementId.$eq"           -> null  (operator object)
 //   "tags[]"                          -> null  (scalar array, no leaf segment)
+//   "filter.tags[]"                   -> null  (nested scalar array)
 //   "tenantId"                        -> null  (top-level scalar)
 function subShapeRootOf(fieldPath: string): string | null {
   // Split into dot-separated segments.
@@ -545,6 +546,14 @@ function subShapeRootOf(fieldPath: string): string | null {
   // Operator-object syntax (filter.x.$eq, .$in[], etc.) — not a real
   // populated-vs-omitted sub-shape.
   if (lastSegment.startsWith('$')) return null;
+  // Scalar-array item leaves (`tags[]`, `filter.tags[]`, etc.) — the
+  // extractor surfaces array items with a trailing `[]`. A scalar-array
+  // leaf is the same flavour of "set a primitive collection or omit it"
+  // exclusion as the top-level `tags[]` case; grouping it under its
+  // parent (`filter`) would produce a sub-shape whose only leaf is a
+  // scalar collection, which is not a populated-vs-omitted object shape
+  // worth a sibling positive-coverage scenario.
+  if (lastSegment.endsWith('[]')) return null;
   return segments.slice(0, -1).join('.');
 }
 

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -41,7 +41,12 @@ interface RawOp {
     semanticType?: string;
     required?: boolean;
   }>;
-  requestBodySemanticTypes?: Array<{ semanticType?: string; required?: boolean }>;
+  requestBodySemanticTypes?: Array<{
+    semanticType?: string;
+    required?: boolean;
+    fieldPath?: string;
+    schema?: { type?: string; format?: string };
+  }>;
   edges?: string[];
   outgoingEdges?: string[];
   dependencies?: string[];
@@ -147,11 +152,27 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
   }
 
   const producersByType: Record<string, string[]> = {};
+  const responseProducersByType: Record<string, string[]> = {};
   for (const op of Object.values(operations)) {
     for (const st of op.produces) {
       const list = producersByType[st] ?? [];
       list.push(op.operationId);
       producersByType[st] = list;
+    }
+    // Issue #37: inclusive index — every response semantic leaf, even
+    // provider:false ones, becomes a discoverable producer for variant
+    // planning (where we need e.g. searchElementInstances → ElementId
+    // even though that op is not authoritative for ElementId).
+    //
+    // Note: distinct from `producersByType` after #98. `producersByType`
+    // is now `provider:true` only (authoritative producers). This index
+    // intentionally includes provider:false leaves so variant planning
+    // can use search-style ops as warm-up triggers without re-introducing
+    // the dropped fallback into base planning.
+    for (const leaf of op.responseSemanticLeaves ?? []) {
+      const list = responseProducersByType[leaf.semantic] ?? [];
+      if (!list.includes(op.operationId)) list.push(op.operationId);
+      responseProducersByType[leaf.semantic] = list;
     }
   }
 
@@ -331,7 +352,14 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     // ENOENT or non-Error throw: sidecar absent — domain analysis disabled
   }
 
-  return { operations, producersByType, bootstrapSequences, domain, producersByState };
+  return {
+    operations,
+    producersByType,
+    responseProducersByType,
+    bootstrapSequences,
+    domain,
+    producersByState,
+  };
 }
 
 function normalizeOp(opId: string, op: RawOp): OperationNode {
@@ -356,14 +384,23 @@ function normalizeOp(opId: string, op: RawOp): OperationNode {
   // First pass: derive providerMap & candidate semantics from responseSemanticTypes
   const responseDerived: string[] = [];
   const providerMap: Record<string, boolean> = {};
+  const responseLeaves: NonNullable<OperationNode['responseSemanticLeaves']> = [];
   if (op.responseSemanticTypes && typeof op.responseSemanticTypes === 'object') {
-    for (const arr of Object.values(op.responseSemanticTypes)) {
-      if (Array.isArray(arr)) {
-        for (const entry of arr) {
-          const st: unknown = entry?.semanticType;
-          if (st && typeof st === 'string') {
-            responseDerived.push(st);
-            if (entry?.provider) providerMap[st] = true;
+    for (const [status, arr] of Object.entries(op.responseSemanticTypes)) {
+      if (!Array.isArray(arr)) continue;
+      for (const entry of arr) {
+        const st: unknown = entry?.semanticType;
+        if (st && typeof st === 'string') {
+          responseDerived.push(st);
+          if (entry?.provider) providerMap[st] = true;
+          const fp = typeof entry?.fieldPath === 'string' ? entry.fieldPath : undefined;
+          if (fp) {
+            responseLeaves.push({
+              semantic: st,
+              fieldPath: fp,
+              status,
+              provider: !!entry?.provider,
+            });
           }
         }
       }
@@ -386,6 +423,7 @@ function normalizeOp(opId: string, op: RawOp): OperationNode {
   });
 
   const { required, optional } = extractRequires(op);
+  const optionalSubShapes = deriveOptionalSubShapes(op);
 
   // providerMap already built above; if still empty leave as undefined later
 
@@ -432,6 +470,8 @@ function normalizeOp(opId: string, op: RawOp): OperationNode {
       ? normalizedResponseSemanticTypes
       : undefined,
     pathParameters: extractPathParameters(op),
+    optionalSubShapes: optionalSubShapes.length ? optionalSubShapes : undefined,
+    responseSemanticLeaves: responseLeaves.length ? responseLeaves : undefined,
   };
 }
 
@@ -449,6 +489,53 @@ function extractPathParameters(op: RawOp): { name: string; semanticType?: string
     out.push({ name: p.name, semanticType });
   }
   return out.length ? out : undefined;
+}
+
+// Issue #37: derive optional sub-shape grouping from request-body leaf
+// fieldPaths. A leaf is "in an optional sub-shape" iff:
+//   - it is itself optional (`required === false` upstream), AND
+//   - its `fieldPath` has a deepest object/array-of-object ancestor
+//     (i.e. it lives under `parent.x` or `parent[].x`, not at the top
+//     level).
+//
+// Top-level optional scalars (e.g. `tenantId`), scalar arrays (e.g.
+// `tags[]` — fieldPath ends with `[]` and has no ancestor), and
+// operator-syntax keys (e.g. `filter.x.$eq`) are excluded — they don't
+// correspond to a populated-vs-omitted object/array shape that warrants
+// a sibling positive-coverage scenario.
+function deriveOptionalSubShapes(op: RawOp): NonNullable<OperationNode['optionalSubShapes']> {
+  const groups = new Map<string, Array<{ fieldPath: string; semantic: string }>>();
+  if (!Array.isArray(op.requestBodySemanticTypes)) return [];
+  for (const entry of op.requestBodySemanticTypes) {
+    if (!entry || entry.required === true) continue;
+    const semantic = entry.semanticType;
+    const fieldPath = entry.fieldPath;
+    if (typeof semantic !== 'string' || typeof fieldPath !== 'string') continue;
+    const root = subShapeRootOf(fieldPath);
+    if (!root) continue;
+    const list = groups.get(root) ?? [];
+    list.push({ fieldPath, semantic });
+    groups.set(root, list);
+  }
+  return [...groups.entries()].map(([rootPath, leaves]) => ({ rootPath, leaves }));
+}
+
+// Strip the trailing leaf segment from a fieldPath to get its sub-shape
+// root, or `null` if no proper object/array-of-object ancestor exists.
+//   "startInstructions[].elementId" -> "startInstructions[]"
+//   "filter.processInstanceKey"      -> "filter"
+//   "filter.elementId.$eq"           -> null  (operator object)
+//   "tags[]"                          -> null  (scalar array, no leaf segment)
+//   "tenantId"                        -> null  (top-level scalar)
+function subShapeRootOf(fieldPath: string): string | null {
+  // Split into dot-separated segments.
+  const segments = fieldPath.split('.');
+  if (segments.length < 2) return null;
+  const lastSegment = segments[segments.length - 1];
+  // Operator-object syntax (filter.x.$eq, .$in[], etc.) — not a real
+  // populated-vs-omitted sub-shape.
+  if (lastSegment.startsWith('$')) return null;
+  return segments.slice(0, -1).join('.');
 }
 
 function extractRequires(op: RawOp): { required: string[]; optional: string[] } {

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -6,7 +6,10 @@ import { buildCanonicalShapes } from './canonicalSchemas.js';
 import { writeExtractionOutputs } from './extractSchemas.js';
 import { generateFeatureCoverageForEndpoint } from './featureCoverageGenerator.js';
 import { loadGraph, loadOpenApiSemanticHints } from './graphLoader.js';
-import { generateScenariosForEndpoint } from './scenarioGenerator.js';
+import {
+  generateOptionalSubShapeVariants,
+  generateScenariosForEndpoint,
+} from './scenarioGenerator.js';
 import type {
   EndpointScenario,
   GenerationSummary,
@@ -32,6 +35,7 @@ async function main() {
   const baseDir = cwd.endsWith(suffix) ? cwd : path.resolve(cwd, suffix);
   const outputDir = path.resolve(baseDir, 'dist/output');
   const featureDir = path.resolve(baseDir, 'dist/feature-output');
+  const variantDir = path.resolve(baseDir, 'dist/variant-output');
   // Wipe before write so files left over from a previous spec version (e.g.
   // an operationId that no longer exists upstream) cannot survive into the
   // current run and silently break Layer-3 invariants. Without this, local
@@ -39,8 +43,10 @@ async function main() {
   // and never sees the stale files.
   await rm(outputDir, { recursive: true, force: true });
   await rm(featureDir, { recursive: true, force: true });
+  await rm(variantDir, { recursive: true, force: true });
   await mkdir(outputDir, { recursive: true });
   await mkdir(featureDir, { recursive: true });
+  await mkdir(variantDir, { recursive: true });
 
   const graph = await loadGraph(baseDir);
   // Build canonical deep schema shapes (requests + responses)
@@ -312,6 +318,47 @@ async function main() {
       JSON.stringify(featureCollection, null, 2),
       'utf8',
     );
+
+    // Issue #37: optional sub-shape variant scenarios. Only emit a file
+    // when this endpoint has at least one optional sub-shape, so the
+    // variant-output directory remains a clear signal of which endpoints
+    // have populated-shape coverage.
+    if (op.optionalSubShapes?.length) {
+      const variantCollection = generateOptionalSubShapeVariants(graph, op.operationId, {
+        maxScenarios: 20,
+      });
+      // Augment with response shape so downstream codegen has the same
+      // metadata as base/feature scenarios.
+      if (resp) {
+        for (const s of variantCollection.scenarios) {
+          s.responseShapeSemantics = resp.producedSemantics || undefined;
+          s.responseShapeFields = resp.fields.map((f) => ({
+            name: f.name,
+            type: f.type,
+            semantic: f.semantic,
+            required: f.required,
+            nullable: f.nullable,
+          }));
+          if (resp.nestedSlices) s.responseNestedSlices = resp.nestedSlices;
+          if (resp.nestedItems) s.responseArrayItemFields = resp.nestedItems;
+          s.requestPlan = buildRequestPlan(
+            s,
+            resp,
+            graph,
+            canonical,
+            requestIndex.byOperation,
+            successStatusByOp,
+          );
+        }
+      }
+      if (variantCollection.scenarios.length) {
+        await writeFile(
+          path.join(variantDir, fileName),
+          JSON.stringify(variantCollection, null, 2),
+          'utf8',
+        );
+      }
+    }
     summaryEntries.push({
       operationId: op.operationId,
       method: op.method,

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -14,6 +14,19 @@ import type {
 interface GenerationOpts {
   maxScenarios: number;
   longChains?: { enabled: boolean; maxPreOps: number };
+  // Issue #37: when planning an optional sub-shape variant, the endpoint
+  // itself is allowed to appear as a producer in the BFS (i.e. the
+  // OUT-exclusion guard is lifted). This is what enables the warm-up +
+  // search + final pattern for `createProcessInstance.startInstructions[]`.
+  // The existing one-cycle allowance bounds usage to a single warm-up.
+  allowEndpointAsProducer?: boolean;
+  // Issue #37: extra semantic types added to `initialNeeded` without
+  // mutating the endpoint's own `requires.required`. Used to inject the
+  // sub-shape's leaf semantic and any warm-up-trigger inputs (producer's
+  // optional inputs that the endpoint itself produces). Insertion order
+  // matters: warm-up triggers come first so BFS targets them before the
+  // leaf semantic via `remaining[0]` selection.
+  additionalNeeded?: string[];
 }
 
 // BFS state used by generateScenariosForEndpoint and its helpers.
@@ -56,7 +69,11 @@ export function generateScenariosForEndpoint(
   const domainRequiredStates = endpoint.domainRequiresAll ? [...endpoint.domainRequiresAll] : [];
   const domainDisjunctions = endpoint.domainDisjunctions ? [...endpoint.domainDisjunctions] : [];
   // Only treat required semantics as blocking; optional ones are opportunistic and won't force extra pre-ops.
-  const initialNeeded = new Set([...required]);
+  // Issue #37: variant planning may inject `additionalNeeded` (the
+  // sub-shape leaf's semantic plus warm-up triggers) WITHOUT mutating
+  // the endpoint's own `requires.required` — this preserves the
+  // endpoint's prereq set for when it appears as a warm-up step.
+  const initialNeeded = new Set([...required, ...(opts.additionalNeeded ?? [])]);
 
   // Trivial endpoint (no semantic AND no domain requirements). Return a single scenario containing only the endpoint.
   if (
@@ -449,7 +466,10 @@ export function generateScenariosForEndpoint(
     }
 
     for (const producerOpId of producers) {
-      if (producerOpId === endpointOpId) continue; // don't pre-run endpoint
+      if (producerOpId === endpointOpId && !opts.allowEndpointAsProducer) continue; // don't pre-run endpoint
+      // Issue #37 variant planning: when allowEndpointAsProducer is set,
+      // the endpoint may legitimately appear as a warm-up step. The
+      // existing cycle handling below caps it at one repeat.
 
       // Cycle detection logic
       const indexInPath = state.ops.indexOf(producerOpId);
@@ -1313,4 +1333,161 @@ function gatherDomainPrerequisites(
       });
   }
   return [...needed];
+}
+
+// =============================================================================
+// Issue #37 — optional sub-shape variant scenarios
+// =============================================================================
+//
+// Iteration 1 of issue #31 (PR #32) demoted optional-ancestor leaves like
+// `startInstructions[].elementId` to `required: false`, so base scenarios
+// no longer drag in spurious dependency producers when the optional
+// sub-shape is omitted. That created a coverage gap: the populated case
+// of those sub-shapes is no longer exercised by any scenario.
+//
+// `generateOptionalSubShapeVariants` fills that gap. For each
+// `OperationNode.optionalSubShapes` entry on the endpoint, and for each
+// semantic-typed leaf within that sub-shape, this function plans a
+// sibling positive scenario where:
+//
+//   1. The leaf's semantic is added to the endpoint's required inputs.
+//   2. If the chosen producer of the leaf needs an input that the endpoint
+//      itself produces (e.g. `searchElementInstances` filters by
+//      `ProcessInstanceKey`, which `createProcessInstance` produces), that
+//      input is also promoted to required — forcing a WARM-UP endpoint
+//      call before the producer can run.
+//   3. The OUT-exclusion guard is lifted so BFS can use the endpoint as
+//      the warm-up step. The existing one-cycle allowance caps usage at
+//      one warm-up + one final.
+//
+// Variant scenarios are tagged `strategy: 'optionalSubShapeVariant'` and
+// carry `populatesSubShape: { rootPath, leafPaths, leafSemantics }` so
+// codegen can synthesize the populated request body.
+export function generateOptionalSubShapeVariants(
+  graph: OperationGraph,
+  endpointOpId: string,
+  opts: GenerationOpts,
+): EndpointScenarioCollection {
+  const endpoint = graph.operations[endpointOpId];
+  if (!endpoint) {
+    return {
+      endpoint: { operationId: endpointOpId, method: 'GET', path: '' },
+      requiredSemanticTypes: [],
+      optionalSemanticTypes: [],
+      scenarios: [],
+      unsatisfied: false,
+    };
+  }
+  const subShapes = endpoint.optionalSubShapes ?? [];
+  const collectionScenarios: EndpointScenario[] = [];
+  const seenVariantKeys = new Set<string>();
+
+  for (const subShape of subShapes) {
+    for (const leaf of subShape.leaves) {
+      // Resolve producer candidates: prefer authoritative (provider:true)
+      // producers from `producersByType`, but fall back to the
+      // inclusive index that includes provider:false response leaves
+      // (e.g. searchElementInstances → ElementId via items[].elementId).
+      const authoritative = graph.producersByType[leaf.semantic] ?? [];
+      const inclusive = graph.responseProducersByType?.[leaf.semantic] ?? [];
+      // Prefer inclusive (search-style) producers first: search/list ops
+      // typically take optional filters that overlap endpoint outputs,
+      // making them the natural "look up the entity we just created" step
+      // in a variant chain. Authoritative producers (provider:true) are
+      // tried only as fallback. Note many ops appear in both lists; unique
+      // preserves first occurrence, so inclusive order wins.
+      const producerCandidates = unique([...inclusive, ...authoritative]).filter(
+        (id) => id !== endpointOpId,
+      );
+      if (!producerCandidates.length) continue;
+      // Try each candidate producer; pick the first that yields a valid
+      // variant. The first authoritative producer often won't (e.g.
+      // `getElementInstance` requires `ElementInstanceKey` which the
+      // endpoint doesn't produce, so no warm-up is forced). A search-style
+      // producer (e.g. `searchElementInstances`) is usually the one whose
+      // optional filters overlap the endpoint's outputs.
+      let chosenProducer: { node: OperationNode; additional: Set<string> } | undefined;
+      for (const candidateOpId of producerCandidates) {
+        const candidate = graph.operations[candidateOpId];
+        if (!candidate) continue;
+        const additional = new Set<string>();
+        for (const opt of candidate.requires.optional) {
+          if (endpoint.produces.includes(opt)) additional.add(opt);
+        }
+        for (const req of candidate.requires.required) additional.add(req);
+        additional.add(leaf.semantic);
+        const overlapsEndpoint = [...additional].some((s) => endpoint.produces.includes(s));
+        if (!overlapsEndpoint) continue;
+        chosenProducer = { node: candidate, additional };
+        break;
+      }
+      if (!chosenProducer) continue;
+      const { additional } = chosenProducer;
+
+      // Build a per-variant graph view: pin the chosen producer as the
+      // SOLE producer of the leaf semantic AND mark it as authoritative
+      // (`providerMap[leaf.semantic] = true`, semantic added to `produces`).
+      // Without that, BFS would insert the chosen producer but its
+      // `produces` list (built from `provider:true` annotations only)
+      // wouldn't include the leaf semantic — leaving ElementId unsatisfied
+      // in `remaining` and looping forever. The endpoint itself is NOT
+      // mutated — augmented needs are passed via `additionalNeeded` so
+      // they don't bleed into the endpoint's prereq set when it appears
+      // as a warm-up step.
+      const chosenId = chosenProducer.node.operationId;
+      const variantProducersByType: Record<string, string[]> = { ...graph.producersByType };
+      variantProducersByType[leaf.semantic] = [chosenId];
+      const variantOperations: Record<string, OperationNode> = { ...graph.operations };
+      variantOperations[chosenId] = {
+        ...chosenProducer.node,
+        produces: chosenProducer.node.produces.includes(leaf.semantic)
+          ? chosenProducer.node.produces
+          : [...chosenProducer.node.produces, leaf.semantic],
+        providerMap: {
+          ...(chosenProducer.node.providerMap ?? {}),
+          [leaf.semantic]: true,
+        },
+      };
+      const variantGraph: OperationGraph = {
+        ...graph,
+        operations: variantOperations,
+        producersByType: variantProducersByType,
+      };
+
+      const planned = generateScenariosForEndpoint(variantGraph, endpointOpId, {
+        ...opts,
+        allowEndpointAsProducer: true,
+        additionalNeeded: [...additional],
+        maxScenarios: 1,
+      });
+      const scenario = planned.scenarios[0];
+      if (!scenario || planned.unsatisfied) continue;
+
+      const variantKey = `${subShape.rootPath}::${leaf.fieldPath}`;
+      if (seenVariantKeys.has(variantKey)) continue;
+      seenVariantKeys.add(variantKey);
+
+      scenario.id = `variant-${collectionScenarios.length + 1}`;
+      scenario.strategy = 'optionalSubShapeVariant';
+      scenario.variantKey = variantKey;
+      scenario.populatesSubShape = {
+        rootPath: subShape.rootPath,
+        leafPaths: [leaf.fieldPath],
+        leafSemantics: [leaf.semantic],
+      };
+      collectionScenarios.push(scenario);
+    }
+  }
+
+  return {
+    endpoint: toRef(endpoint),
+    requiredSemanticTypes: [...endpoint.requires.required],
+    optionalSemanticTypes: [...endpoint.requires.optional],
+    scenarios: collectionScenarios,
+    unsatisfied: false,
+  };
+}
+
+function unique<T>(arr: T[]): T[] {
+  return [...new Set(arr)];
 }

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -1381,9 +1381,18 @@ export function generateOptionalSubShapeVariants(
   const subShapes = endpoint.optionalSubShapes ?? [];
   const collectionScenarios: EndpointScenario[] = [];
   const seenVariantKeys = new Set<string>();
+  // Cap total variants emitted per endpoint at `opts.maxScenarios`. The
+  // inner `generateScenariosForEndpoint` call below intentionally pins
+  // its own `maxScenarios: 1` (one chain per variant), so the outer
+  // cap is what bounds variant count for endpoints with many
+  // semantic-typed optional leaves. Without this cap, a future spec
+  // change could blow up `dist/variant-output/` with one file per
+  // (subShape × leaf) pair.
+  const maxVariants = Math.max(0, opts.maxScenarios | 0);
 
-  for (const subShape of subShapes) {
+  outer: for (const subShape of subShapes) {
     for (const leaf of subShape.leaves) {
+      if (collectionScenarios.length >= maxVariants) break outer;
       // Resolve producer candidates: prefer authoritative (provider:true)
       // producers from `producersByType`, but fall back to the
       // inclusive index that includes provider:false response leaves

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -1410,25 +1410,46 @@ export function generateOptionalSubShapeVariants(
       );
       if (!producerCandidates.length) continue;
       // Try each candidate producer; pick the first that yields a valid
-      // variant. The first authoritative producer often won't (e.g.
-      // `getElementInstance` requires `ElementInstanceKey` which the
-      // endpoint doesn't produce, so no warm-up is forced). A search-style
-      // producer (e.g. `searchElementInstances`) is usually the one whose
-      // optional filters overlap the endpoint's outputs.
-      let chosenProducer: { node: OperationNode; additional: Set<string> } | undefined;
-      for (const candidateOpId of producerCandidates) {
-        const candidate = graph.operations[candidateOpId];
-        if (!candidate) continue;
+      // variant. Two passes:
+      //   1. Prefer producers whose required + opportunistic-optional inputs
+      //      overlap the endpoint's outputs. This forces a warm-up call to
+      //      the endpoint (e.g. createProcessInstance → searchElementInstances
+      //      → createProcessInstance) — the canonical "look up the entity
+      //      we just created" chain.
+      //   2. Fall back to non-overlap producers (independent producers that
+      //      need nothing from the endpoint). The variant chain is then a
+      //      simple `producer → endpoint` shape with no warm-up.
+      // Without the fallback, optional sub-shapes whose leaf semantics are
+      // produced by independent ops (e.g. a standalone `mintFoo` for an
+      // optional `foo` field) would receive zero variant coverage.
+      const buildAdditional = (candidate: OperationNode): Set<string> => {
         const additional = new Set<string>();
         for (const opt of candidate.requires.optional) {
           if (endpoint.produces.includes(opt)) additional.add(opt);
         }
         for (const req of candidate.requires.required) additional.add(req);
         additional.add(leaf.semantic);
+        return additional;
+      };
+      let chosenProducer: { node: OperationNode; additional: Set<string> } | undefined;
+      // Pass 1: overlap-based (warm-up forced).
+      for (const candidateOpId of producerCandidates) {
+        const candidate = graph.operations[candidateOpId];
+        if (!candidate) continue;
+        const additional = buildAdditional(candidate);
         const overlapsEndpoint = [...additional].some((s) => endpoint.produces.includes(s));
         if (!overlapsEndpoint) continue;
         chosenProducer = { node: candidate, additional };
         break;
+      }
+      // Pass 2: non-overlap fallback (no warm-up).
+      if (!chosenProducer) {
+        for (const candidateOpId of producerCandidates) {
+          const candidate = graph.operations[candidateOpId];
+          if (!candidate) continue;
+          chosenProducer = { node: candidate, additional: buildAdditional(candidate) };
+          break;
+        }
       }
       if (!chosenProducer) continue;
       const { additional } = chosenProducer;

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -47,11 +47,42 @@ export interface OperationNode extends OperationRef {
   // from its semanticType (issue #61). Populated in graphLoader from the
   // raw operation node.
   pathParameters?: { name: string; semanticType?: string }[];
+  // Issue #37: optional sub-shape grouping for variant-scenario planning.
+  // Derived from request-body semantic leaves whose `fieldPath` shares an
+  // optional object/array-of-object ancestor (e.g. `startInstructions[]`
+  // groups `startInstructions[].elementId`). Each entry lists the
+  // semantic-typed leaves under that root. Variant planning emits one
+  // positive scenario per (rootPath, leaf) pair to exercise the populated
+  // shape that base scenarios skip.
+  optionalSubShapes?: Array<{
+    rootPath: string; // e.g. "startInstructions[]"
+    leaves: Array<{ fieldPath: string; semantic: string }>;
+  }>;
+  // Issue #37: full response-leaf semantic catalog (success-status only).
+  // Includes both authoritative (provider:true) and incidental
+  // (provider:false) entries, so variant planning can route ElementId via
+  // `searchElementInstances.items[].elementId` even though that op's
+  // authoritative outputs are page cursors. After #98 the `produces` field
+  // contains only authoritative outputs (provider:true); this catalog
+  // remains the inclusive view used for variant-only planning.
+  responseSemanticLeaves?: Array<{
+    semantic: string;
+    fieldPath: string;
+    status: string;
+    provider: boolean;
+  }>;
 }
 
 export interface OperationGraph {
   operations: Record<string, OperationNode>;
   producersByType: Record<string, string[]>;
+  // Issue #37: parallel producer index that includes ALL response-leaf
+  // semantics (provider:true and provider:false). Used by the variant
+  // planner to discover non-authoritative producers (e.g.
+  // searchElementInstances → ElementId via items[].elementId) without
+  // affecting base-scenario planning, which still consults
+  // `producersByType` (authoritative outputs only after #98).
+  responseProducersByType?: Record<string, string[]>;
   bootstrapSequences?: BootstrapSequence[];
   domain?: DomainSemantics; // loaded sidecar
   producersByState?: Record<string, string[]>; // domain state -> operations
@@ -87,10 +118,18 @@ export interface EndpointScenario {
   artifactsApplied?: string[]; // ids of artifact rules applied
   eventualConsistencyOps?: string[]; // operationIds that are eventually consistent in chain
   // Feature coverage strategy additions
-  strategy?: 'integrationPath' | 'featureCoverage';
+  strategy?: 'integrationPath' | 'featureCoverage' | 'optionalSubShapeVariant';
   variantKey?: string; // structured key summarizing variant dimensions
   expectedResult?: { kind: 'nonEmpty' | 'empty' | 'error'; code?: string };
   coverageTags?: string[]; // dimension tags e.g. optional:FormKey, disjunction:alt-1
+  // Issue #37: which optional sub-shape this variant populates and which
+  // semantic-typed leaves it sets (one leaf per variant in iteration 1).
+  // Codegen uses this to synthesize the populated body.
+  populatesSubShape?: {
+    rootPath: string; // e.g. "startInstructions[]"
+    leafPaths: string[]; // semantic-typed leaves to populate
+    leafSemantics: string[]; // matching semantic types in same order
+  };
   filtersUsed?: string[]; // semantic / parameter filters applied
   syntheticBindings?: string[]; // variables created without a producing op
   // Request variant / filter coverage enrichments
@@ -363,6 +402,9 @@ export interface LongChainConfig {
 export interface ExtendedGenerationOpts {
   maxScenarios: number;
   longChains?: LongChainConfig;
+  // Issue #37: see scenarioGenerator GenerationOpts for semantics.
+  allowEndpointAsProducer?: boolean;
+  additionalNeeded?: string[];
 }
 
 export type GeneratedModelSpec = BpmnModelSpec | FormModelSpec;

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -540,3 +540,272 @@ describe('emitter: boundary safety re-validation (#87 review)', () => {
     ).not.toThrow();
   });
 });
+
+// ---------------------------------------------------------------------------
+// #106 — eventual-consistency wrapping
+// ---------------------------------------------------------------------------
+//
+// Class-scoped guarantee: a request step is wrapped with awaitEventually()
+// iff its operation is flagged `eventuallyConsistent` AND it is a read
+// shape (GET or POST .../search) AND it expects a 200. Write steps that
+// are themselves EC are NOT wrapped — the indexer lag manifests on the
+// next read, not on the write call. Error scenarios (non-200 expected)
+// are NOT wrapped.
+
+function ecCollection(
+  scenarios: EndpointScenarioCollection['scenarios'],
+): EndpointScenarioCollection {
+  return {
+    endpoint: { operationId: 'searchWidgets', method: 'POST', path: '/widgets/search' },
+    requiredSemanticTypes: [],
+    optionalSemanticTypes: [],
+    scenarios,
+  };
+}
+
+describe('PlaywrightEmitter — eventual-consistency wrapping (#106)', () => {
+  test('imports awaitEventually only when at least one step needs wrapping', () => {
+    const withEc = renderPlaywrightSuite(
+      ecCollection([
+        {
+          id: 'sc1',
+          operations: [
+            {
+              operationId: 'searchWidgets',
+              method: 'POST',
+              path: '/widgets/search',
+              eventuallyConsistent: true,
+            },
+          ],
+          producedSemanticTypes: [],
+          satisfiedSemanticTypes: [],
+          requestPlan: [
+            {
+              operationId: 'searchWidgets',
+              method: 'POST',
+              pathTemplate: '/widgets/search',
+              expect: { status: 200 },
+            },
+          ],
+        },
+      ]),
+      { suiteName: 'searchWidgets', mode: 'feature' },
+    );
+    expect(withEc).toContain("import { awaitEventually } from './support/await-eventually';");
+    expect(withEc).toContain('await awaitEventually(');
+
+    const withoutEc = renderPlaywrightSuite(COLLECTION, {
+      suiteName: 'createWidget',
+      mode: 'feature',
+    });
+    expect(withoutEc).not.toContain('awaitEventually');
+  });
+
+  test('wraps POST .../search reads when eventuallyConsistent', () => {
+    const src = renderPlaywrightSuite(
+      ecCollection([
+        {
+          id: 'sc1',
+          operations: [
+            {
+              operationId: 'searchWidgets',
+              method: 'POST',
+              path: '/widgets/search',
+              eventuallyConsistent: true,
+            },
+          ],
+          producedSemanticTypes: [],
+          satisfiedSemanticTypes: [],
+          requestPlan: [
+            {
+              operationId: 'searchWidgets',
+              method: 'POST',
+              pathTemplate: '/widgets/search',
+              expect: { status: 200 },
+            },
+          ],
+        },
+      ]),
+      { suiteName: 'searchWidgets', mode: 'feature' },
+    );
+    expect(src).toContain("operationId: 'searchWidgets'");
+    expect(src).toMatch(/await awaitEventually\(/);
+    expect(src).toContain("method: 'POST'");
+  });
+
+  test('wraps GET reads when eventuallyConsistent', () => {
+    const src = renderPlaywrightSuite(
+      {
+        endpoint: { operationId: 'getWidget', method: 'GET', path: '/widgets/{key}' },
+        requiredSemanticTypes: [],
+        optionalSemanticTypes: [],
+        scenarios: [
+          {
+            id: 'sc1',
+            operations: [
+              {
+                operationId: 'getWidget',
+                method: 'GET',
+                path: '/widgets/{key}',
+                eventuallyConsistent: true,
+              },
+            ],
+            producedSemanticTypes: [],
+            satisfiedSemanticTypes: [],
+            requestPlan: [
+              {
+                operationId: 'getWidget',
+                method: 'GET',
+                pathTemplate: '/widgets/{key}',
+                expect: { status: 200 },
+              },
+            ],
+          },
+        ],
+      },
+      { suiteName: 'getWidget', mode: 'feature' },
+    );
+    expect(src).toMatch(/await awaitEventually\(/);
+    expect(src).toContain("method: 'GET'");
+  });
+
+  test('does NOT wrap write steps even when flagged eventuallyConsistent', () => {
+    // createDeployment is itself EC (indexing), but POST /deployments is
+    // a write, not a read. Wrapping it would never satisfy the default
+    // items.length predicate.
+    const src = renderPlaywrightSuite(
+      {
+        endpoint: { operationId: 'createDeployment', method: 'POST', path: '/deployments' },
+        requiredSemanticTypes: [],
+        optionalSemanticTypes: [],
+        scenarios: [
+          {
+            id: 'sc1',
+            operations: [
+              {
+                operationId: 'createDeployment',
+                method: 'POST',
+                path: '/deployments',
+                eventuallyConsistent: true,
+              },
+            ],
+            producedSemanticTypes: [],
+            satisfiedSemanticTypes: [],
+            requestPlan: [
+              {
+                operationId: 'createDeployment',
+                method: 'POST',
+                pathTemplate: '/deployments',
+                expect: { status: 200 },
+                bodyKind: 'multipart',
+                multipartTemplate: { fields: {}, files: {} },
+              },
+            ],
+          },
+        ],
+      },
+      { suiteName: 'createDeployment', mode: 'feature' },
+    );
+    expect(src).not.toContain('awaitEventually');
+  });
+
+  test('does NOT wrap error scenarios (non-200 expected status)', () => {
+    const src = renderPlaywrightSuite(
+      ecCollection([
+        {
+          id: 'sc1',
+          operations: [
+            {
+              operationId: 'searchWidgets',
+              method: 'POST',
+              path: '/widgets/search',
+              eventuallyConsistent: true,
+            },
+          ],
+          producedSemanticTypes: [],
+          satisfiedSemanticTypes: [],
+          expectedResult: { kind: 'error' },
+          requestPlan: [
+            {
+              operationId: 'searchWidgets',
+              method: 'POST',
+              pathTemplate: '/widgets/search',
+              expect: { status: 400 },
+            },
+          ],
+        },
+      ]),
+      { suiteName: 'searchWidgets', mode: 'feature' },
+    );
+    expect(src).not.toContain('awaitEventually');
+  });
+
+  test('only wraps the read step in a multi-step write-then-read chain', () => {
+    // Chain: createDeployment (write, EC) → createProcessInstance (write) →
+    // searchProcessInstances (read, EC). Only the search must be wrapped.
+    const src = renderPlaywrightSuite(
+      {
+        endpoint: {
+          operationId: 'searchProcessInstances',
+          method: 'POST',
+          path: '/process-instances/search',
+        },
+        requiredSemanticTypes: [],
+        optionalSemanticTypes: [],
+        scenarios: [
+          {
+            id: 'sc1',
+            operations: [
+              {
+                operationId: 'createDeployment',
+                method: 'POST',
+                path: '/deployments',
+                eventuallyConsistent: true,
+              },
+              { operationId: 'createProcessInstance', method: 'POST', path: '/process-instances' },
+              {
+                operationId: 'searchProcessInstances',
+                method: 'POST',
+                path: '/process-instances/search',
+                eventuallyConsistent: true,
+              },
+            ],
+            producedSemanticTypes: [],
+            satisfiedSemanticTypes: [],
+            requestPlan: [
+              {
+                operationId: 'createDeployment',
+                method: 'POST',
+                pathTemplate: '/deployments',
+                expect: { status: 200 },
+                bodyKind: 'multipart',
+                multipartTemplate: { fields: {}, files: {} },
+              },
+              {
+                operationId: 'createProcessInstance',
+                method: 'POST',
+                pathTemplate: '/process-instances',
+                expect: { status: 200 },
+                bodyKind: 'json',
+                bodyTemplate: {},
+              },
+              {
+                operationId: 'searchProcessInstances',
+                method: 'POST',
+                pathTemplate: '/process-instances/search',
+                expect: { status: 200 },
+                bodyKind: 'json',
+                bodyTemplate: {},
+              },
+            ],
+          },
+        ],
+      },
+      { suiteName: 'searchProcessInstances', mode: 'feature' },
+    );
+    // Exactly one wrap, on the search read.
+    const matches = src.match(/awaitEventually\(/g) ?? [];
+    expect(matches.length).toBe(1);
+    expect(src).toContain("operationId: 'searchProcessInstances'");
+  });
+});

--- a/tests/fixtures/loader/graphloader-optional-subshapes.test.ts
+++ b/tests/fixtures/loader/graphloader-optional-subshapes.test.ts
@@ -50,13 +50,13 @@ function writeLayout(layout: Layout): void {
 
 // ---------------------------------------------------------------------------
 // Fixture K — `subShapeRootOf` rejects scalar-array item leaves at any depth
-// (PR #51 review).
+// (#37).
 // ---------------------------------------------------------------------------
 //
 // Class-scoped: any optional fieldPath whose terminal segment ends with
 // `[]` (i.e. the leaf IS the scalar-array item) is excluded from
 // `optionalSubShapes` regardless of nesting depth.
-describe('graphLoader: deriveOptionalSubShapes rejects scalar-array leaves at any depth (#51 review)', () => {
+describe('graphLoader: deriveOptionalSubShapes rejects scalar-array leaves at any depth (#37)', () => {
   it('does not group `filter.tags[]` (nested scalar array) under a sub-shape root', async () => {
     writeLayout({
       graph: {

--- a/tests/fixtures/loader/graphloader-optional-subshapes.test.ts
+++ b/tests/fixtures/loader/graphloader-optional-subshapes.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Loader fixtures for `deriveOptionalSubShapes` in graphLoader — PR #51 review.
+ *
+ * `subShapeRootOf` strips the trailing leaf segment from a request-body
+ * `fieldPath` to obtain the sub-shape root, returning `null` for paths
+ * that do not represent a populated-vs-omitted object or array-of-object
+ * ancestor (top-level scalars, operator-object keys, scalar arrays).
+ *
+ * The class-scoped guarantee guarded here: an optional request-body
+ * leaf whose path is a *scalar-array item* (ends with `[]`) must NOT be
+ * grouped into an `optionalSubShapes` entry, regardless of how many
+ * dotted ancestors it has. Without the fix, `filter.tags[]` was grouped
+ * under root `filter`, causing the variant planner to emit a sub-shape
+ * variant whose only leaf is a scalar collection.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadGraph } from '../../../path-analyser/src/graphLoader.ts';
+
+let workdir: string;
+let baseDir: string;
+let graphDir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'graphloader-subshape-fixture-'));
+  baseDir = join(workdir, 'path-analyser');
+  graphDir = join(workdir, 'semantic-graph-extractor', 'dist', 'output');
+  mkdirSync(baseDir, { recursive: true });
+  mkdirSync(graphDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+interface Layout {
+  graph: Record<string, unknown>;
+  domain?: Record<string, unknown>;
+}
+
+function writeLayout(layout: Layout): void {
+  writeFileSync(join(graphDir, 'operation-dependency-graph.json'), JSON.stringify(layout.graph));
+  writeFileSync(
+    join(baseDir, 'domain-semantics.json'),
+    JSON.stringify(layout.domain ?? { operationRequirements: {} }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Fixture K — `subShapeRootOf` rejects scalar-array item leaves at any depth
+// (PR #51 review).
+// ---------------------------------------------------------------------------
+//
+// Class-scoped: any optional fieldPath whose terminal segment ends with
+// `[]` (i.e. the leaf IS the scalar-array item) is excluded from
+// `optionalSubShapes` regardless of nesting depth.
+describe('graphLoader: deriveOptionalSubShapes rejects scalar-array leaves at any depth (#51 review)', () => {
+  it('does not group `filter.tags[]` (nested scalar array) under a sub-shape root', async () => {
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'searchWithTags',
+            method: 'POST',
+            path: '/search',
+            requestBodySemanticTypes: [
+              // Nested scalar array — leaf segment is `tags[]`. Must NOT
+              // be grouped under root `filter`.
+              {
+                fieldPath: 'filter.tags[]',
+                semanticType: 'TagName',
+                required: false,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const g = await loadGraph(baseDir);
+    const op = g.operations.searchWithTags;
+    expect(op, 'operation must load').toBeDefined();
+    const subShapes = op?.optionalSubShapes ?? [];
+    // No sub-shape may have `filter` (or any other root) carrying a
+    // scalar-array leaf.
+    for (const s of subShapes) {
+      for (const leaf of s.leaves) {
+        expect(
+          leaf.fieldPath.endsWith('[]'),
+          `optionalSubShapes leaf ${leaf.fieldPath} (root ${s.rootPath}) must not be a scalar-array item`,
+        ).toBe(false);
+      }
+    }
+    // And specifically: no sub-shape root for this op (the only optional
+    // leaf was a scalar array).
+    expect(subShapes).toEqual([]);
+  });
+
+  it('groups genuine array-of-object leaves (e.g. `startInstructions[].elementId`) normally', async () => {
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'createInstance',
+            method: 'POST',
+            path: '/instance',
+            requestBodySemanticTypes: [
+              {
+                fieldPath: 'startInstructions[].elementId',
+                semanticType: 'ElementId',
+                required: false,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const g = await loadGraph(baseDir);
+    const op = g.operations.createInstance;
+    expect(op?.optionalSubShapes).toEqual([
+      {
+        rootPath: 'startInstructions[]',
+        leaves: [{ fieldPath: 'startInstructions[].elementId', semantic: 'ElementId' }],
+      },
+    ]);
+  });
+
+  it('mixed leaves: scalar-array siblings are excluded; object-shape siblings retained', async () => {
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'mixedSearch',
+            method: 'POST',
+            path: '/mixed',
+            requestBodySemanticTypes: [
+              // Scalar-array sibling — must be excluded.
+              {
+                fieldPath: 'filter.tags[]',
+                semanticType: 'TagName',
+                required: false,
+              },
+              // Object-shape sibling under same root — must be retained.
+              {
+                fieldPath: 'filter.processInstanceKey',
+                semanticType: 'ProcessInstanceKey',
+                required: false,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const g = await loadGraph(baseDir);
+    const subShapes = g.operations.mixedSearch?.optionalSubShapes ?? [];
+    expect(subShapes).toEqual([
+      {
+        rootPath: 'filter',
+        leaves: [{ fieldPath: 'filter.processInstanceKey', semantic: 'ProcessInstanceKey' }],
+      },
+    ]);
+  });
+});

--- a/tests/fixtures/loader/graphloader-optional-subshapes.test.ts
+++ b/tests/fixtures/loader/graphloader-optional-subshapes.test.ts
@@ -1,5 +1,5 @@
 /**
- * Loader fixtures for `deriveOptionalSubShapes` in graphLoader — PR #51 review.
+ * Loader fixtures for `deriveOptionalSubShapes` in graphLoader (#37).
  *
  * `subShapeRootOf` strips the trailing leaf segment from a request-body
  * `fieldPath` to obtain the sub-shape root, returning `null` for paths

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -71,6 +71,10 @@ function makeGraph(nodes: OperationNode[]): OperationGraph {
       producersByState[ds] = list;
     }
     for (const leaf of node.responseSemanticLeaves ?? []) {
+      // Mirror graphLoader's success-status filter: only 2xx/3xx leaves
+      // populate the inclusive index. A leaf surfaced only in a 4xx/5xx
+      // response must NOT be discoverable as a variant producer.
+      if (!/^[23]/.test(leaf.status)) continue;
       const list = responseProducersByType[leaf.semantic] ?? [];
       if (!list.includes(node.operationId)) list.push(node.operationId);
       responseProducersByType[leaf.semantic] = list;
@@ -444,5 +448,128 @@ describe('planner contracts: optional sub-shape variants (#37)', () => {
       expect(opIdsOf(s)).not.toContain('searchProducts');
     }
     expect(opIdsOf(base.scenarios[0])).toEqual(['mintOrderId', 'createOrder']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture I: variant planner ignores producers whose only response leaf
+// is in a 4xx/5xx response (#51 review)
+// ---------------------------------------------------------------------------
+//
+// Endpoint `placeOrder` produces `OrderInstanceKey` and has an optional
+// sub-shape `addons[].productId : ProductId`.
+//
+// `errorEcho` emits `ProductId` ONLY in a 4xx error envelope (e.g. an
+// "invalid product" response that echoes the offending id back). It is
+// not a real producer of `ProductId` — a runtime call would never
+// satisfy a downstream consumer.
+//
+// Class-scoped guarantee: `responseProducersByType` must not surface
+// any operation whose ProductId leaf comes only from a non-2xx/3xx
+// status. The variant planner therefore has no candidate and emits
+// zero variants, rather than constructing a chain that goes through
+// `errorEcho` and silently produces no actual id at runtime.
+const fixtureErrorOnlyProducer: OperationGraph = makeGraph([
+  makeOp('errorEcho', {
+    optional: ['OrderInstanceKey'],
+    responseSemanticLeaves: [
+      // 4xx-only — must be filtered out of the inclusive index.
+      { semantic: 'ProductId', fieldPath: 'errors[].productId', status: '400', provider: false },
+    ],
+  }),
+  makeOp('placeOrder', {
+    produces: ['OrderInstanceKey'],
+    providerMap: { OrderInstanceKey: true },
+    optionalSubShapes: [
+      {
+        rootPath: 'addons[]',
+        leaves: [{ fieldPath: 'addons[].productId', semantic: 'ProductId' }],
+      },
+    ],
+  }),
+]);
+
+describe('planner contracts: variant planner respects success-status producer filter (#51 review)', () => {
+  it('does not surface 4xx-only response leaves in responseProducersByType', () => {
+    expect(fixtureErrorOnlyProducer.responseProducersByType?.ProductId).toBeUndefined();
+  });
+
+  it('emits zero variants when the only candidate producer surfaces the leaf in a 4xx response', () => {
+    const variants = generateOptionalSubShapeVariants(fixtureErrorOnlyProducer, 'placeOrder', {
+      maxScenarios: 10,
+    });
+    expect(variants.scenarios).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture J: variant planner caps emission at opts.maxScenarios (#51 review)
+// ---------------------------------------------------------------------------
+//
+// Endpoint `bulkCreate` has THREE semantic-typed optional leaves under
+// the same sub-shape. Without the cap, the planner emits one variant
+// per leaf (3 variants). With `maxScenarios: 2`, only the first 2 are
+// emitted.
+//
+// Class-scoped guarantee: a future endpoint with N semantic-typed
+// optional leaves cannot produce more than `opts.maxScenarios` variant
+// scenario files.
+const fixtureMaxVariantsCap: OperationGraph = makeGraph([
+  makeOp('mintFoo', {
+    produces: ['Foo'],
+    providerMap: { Foo: true },
+  }),
+  makeOp('searchA', {
+    optional: ['BulkOutKey'],
+    produces: ['SemA'],
+    providerMap: { SemA: true },
+  }),
+  makeOp('searchB', {
+    optional: ['BulkOutKey'],
+    produces: ['SemB'],
+    providerMap: { SemB: true },
+  }),
+  makeOp('searchC', {
+    optional: ['BulkOutKey'],
+    produces: ['SemC'],
+    providerMap: { SemC: true },
+  }),
+  makeOp('bulkCreate', {
+    required: ['Foo'],
+    produces: ['BulkOutKey'],
+    providerMap: { BulkOutKey: true },
+    optionalSubShapes: [
+      {
+        rootPath: 'items[]',
+        leaves: [
+          { fieldPath: 'items[].a', semantic: 'SemA' },
+          { fieldPath: 'items[].b', semantic: 'SemB' },
+          { fieldPath: 'items[].c', semantic: 'SemC' },
+        ],
+      },
+    ],
+  }),
+]);
+
+describe('planner contracts: variant emission respects maxScenarios cap (#51 review)', () => {
+  it('uncapped (maxScenarios = 10) emits one variant per semantic leaf', () => {
+    const variants = generateOptionalSubShapeVariants(fixtureMaxVariantsCap, 'bulkCreate', {
+      maxScenarios: 10,
+    });
+    expect(variants.scenarios.length).toBe(3);
+  });
+
+  it('caps emission at maxScenarios = 2', () => {
+    const variants = generateOptionalSubShapeVariants(fixtureMaxVariantsCap, 'bulkCreate', {
+      maxScenarios: 2,
+    });
+    expect(variants.scenarios.length).toBe(2);
+  });
+
+  it('caps emission at maxScenarios = 0 (emit nothing)', () => {
+    const variants = generateOptionalSubShapeVariants(fixtureMaxVariantsCap, 'bulkCreate', {
+      maxScenarios: 0,
+    });
+    expect(variants.scenarios).toEqual([]);
   });
 });

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { generateScenariosForEndpoint } from '../../../path-analyser/src/scenarioGenerator.ts';
+import {
+  generateOptionalSubShapeVariants,
+  generateScenariosForEndpoint,
+} from '../../../path-analyser/src/scenarioGenerator.ts';
 import type {
   EndpointScenarioCollection,
   OperationGraph,
@@ -26,6 +29,9 @@ interface NodeOpts {
   providerMap?: Record<string, boolean>;
   domainRequiresAll?: string[];
   domainProduces?: string[];
+  optionalSubShapes?: OperationNode['optionalSubShapes'];
+  responseSemanticLeaves?: OperationNode['responseSemanticLeaves'];
+  eventuallyConsistent?: boolean;
 }
 
 function makeOp(operationId: string, opts: NodeOpts = {}): OperationNode {
@@ -41,6 +47,9 @@ function makeOp(operationId: string, opts: NodeOpts = {}): OperationNode {
     providerMap: opts.providerMap,
     domainRequiresAll: opts.domainRequiresAll,
     domainProduces: opts.domainProduces,
+    optionalSubShapes: opts.optionalSubShapes,
+    responseSemanticLeaves: opts.responseSemanticLeaves,
+    eventuallyConsistent: opts.eventuallyConsistent,
   };
 }
 
@@ -48,6 +57,7 @@ function makeGraph(nodes: OperationNode[]): OperationGraph {
   const operations: Record<string, OperationNode> = {};
   const producersByType: Record<string, string[]> = {};
   const producersByState: Record<string, string[]> = {};
+  const responseProducersByType: Record<string, string[]> = {};
   for (const node of nodes) {
     operations[node.operationId] = node;
     for (const sem of node.produces) {
@@ -60,8 +70,13 @@ function makeGraph(nodes: OperationNode[]): OperationGraph {
       list.push(node.operationId);
       producersByState[ds] = list;
     }
+    for (const leaf of node.responseSemanticLeaves ?? []) {
+      const list = responseProducersByType[leaf.semantic] ?? [];
+      if (!list.includes(node.operationId)) list.push(node.operationId);
+      responseProducersByType[leaf.semantic] = list;
+    }
   }
-  return { operations, producersByType, producersByState };
+  return { operations, producersByType, producersByState, responseProducersByType };
 }
 
 function plan(graph: OperationGraph, endpointOpId: string): EndpointScenarioCollection {
@@ -348,5 +363,86 @@ describe('planner contracts: domain-prereq-blocked authoritative producer (#58)'
     expect(barIdx, 'produceBar must appear in the chain').toBeGreaterThanOrEqual(0);
     expect(fooIdx).toBeGreaterThan(barIdx);
     expect(endpointIdx).toBeGreaterThan(fooIdx);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture H: optional sub-shape variant scenario (#37)
+// ---------------------------------------------------------------------------
+//
+// Endpoint `createOrder` requires `OrderId` (produced authoritatively by
+// `mintOrderId`). It produces `OrderInstanceKey`. It also has an
+// OPTIONAL sub-shape `lineItems[]` whose only semantic-typed leaf is
+// `lineItems[].productId` carrying a `ProductId`.
+//
+// `searchProducts` produces `ProductId`. Its optional filter input is
+// `OrderInstanceKey` — exactly what the endpoint produces. Variant
+// planning must recognise this overlap and force a warm-up endpoint
+// call BEFORE searchProducts runs, so the search has something
+// meaningful to filter by.
+//
+// Base scenario for `createOrder` is just `[mintOrderId, createOrder]`
+// (the optional sub-shape is omitted, so ProductId is never needed).
+//
+// Variant scenario must populate `lineItems[].productId`. Expected
+// chain:
+//
+//   [mintOrderId, createOrder (warm-up), searchProducts, createOrder (real)]
+//
+// `populatesSubShape` and `hasEventuallyConsistent` are propagated.
+const fixtureSubShapeVariant: OperationGraph = makeGraph([
+  makeOp('mintOrderId', {
+    produces: ['OrderId'],
+    providerMap: { OrderId: true },
+  }),
+  makeOp('searchProducts', {
+    optional: ['OrderInstanceKey'],
+    produces: ['ProductId'],
+    providerMap: { ProductId: true },
+    eventuallyConsistent: true,
+  }),
+  makeOp('createOrder', {
+    required: ['OrderId'],
+    produces: ['OrderInstanceKey'],
+    providerMap: { OrderInstanceKey: true },
+    optionalSubShapes: [
+      {
+        rootPath: 'lineItems[]',
+        leaves: [{ fieldPath: 'lineItems[].productId', semantic: 'ProductId' }],
+      },
+    ],
+  }),
+]);
+
+describe('planner contracts: optional sub-shape variants (#37)', () => {
+  it('emits a variant scenario per sub-shape leaf with warm-up + producer + final', () => {
+    const variants = generateOptionalSubShapeVariants(fixtureSubShapeVariant, 'createOrder', {
+      maxScenarios: 10,
+    });
+    expect(variants.scenarios.length).toBeGreaterThan(0);
+    const variant = variants.scenarios[0];
+    expect(opIdsOf(variant)).toEqual([
+      'mintOrderId',
+      'createOrder',
+      'searchProducts',
+      'createOrder',
+    ]);
+    expect(variant.strategy).toBe('optionalSubShapeVariant');
+    expect(variant.populatesSubShape?.rootPath).toBe('lineItems[]');
+    expect(variant.populatesSubShape?.leafPaths).toEqual(['lineItems[].productId']);
+    expect(variant.populatesSubShape?.leafSemantics).toEqual(['ProductId']);
+    expect(variant.hasEventuallyConsistent).toBe(true);
+    expect(variant.variantKey).toContain('lineItems[]');
+  });
+
+  it('does NOT alter base scenarios for the same endpoint', () => {
+    // Base planner is unchanged: the optional sub-shape's leaf semantic
+    // (`ProductId`) is opportunistic, so no `searchProducts` step appears.
+    const base = plan(fixtureSubShapeVariant, 'createOrder');
+    expect(base.scenarios.length).toBeGreaterThan(0);
+    for (const s of base.scenarios) {
+      expect(opIdsOf(s)).not.toContain('searchProducts');
+    }
+    expect(opIdsOf(base.scenarios[0])).toEqual(['mintOrderId', 'createOrder']);
   });
 });

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -453,7 +453,7 @@ describe('planner contracts: optional sub-shape variants (#37)', () => {
 
 // ---------------------------------------------------------------------------
 // Fixture I: variant planner ignores producers whose only response leaf
-// is in a 4xx/5xx response (#51 review)
+// is in a 4xx/5xx response (#37)
 // ---------------------------------------------------------------------------
 //
 // Endpoint `placeOrder` produces `OrderInstanceKey` and has an optional
@@ -489,7 +489,7 @@ const fixtureErrorOnlyProducer: OperationGraph = makeGraph([
   }),
 ]);
 
-describe('planner contracts: variant planner respects success-status producer filter (#51 review)', () => {
+describe('planner contracts: variant planner respects success-status producer filter (#37)', () => {
   it('does not surface 4xx-only response leaves in responseProducersByType', () => {
     expect(fixtureErrorOnlyProducer.responseProducersByType?.ProductId).toBeUndefined();
   });
@@ -503,7 +503,7 @@ describe('planner contracts: variant planner respects success-status producer fi
 });
 
 // ---------------------------------------------------------------------------
-// Fixture J: variant planner caps emission at opts.maxScenarios (#51 review)
+// Fixture J: variant planner caps emission at opts.maxScenarios (#37)
 // ---------------------------------------------------------------------------
 //
 // Endpoint `bulkCreate` has THREE semantic-typed optional leaves under
@@ -551,7 +551,7 @@ const fixtureMaxVariantsCap: OperationGraph = makeGraph([
   }),
 ]);
 
-describe('planner contracts: variant emission respects maxScenarios cap (#51 review)', () => {
+describe('planner contracts: variant emission respects maxScenarios cap (#37)', () => {
   it('uncapped (maxScenarios = 10) emits one variant per semantic leaf', () => {
     const variants = generateOptionalSubShapeVariants(fixtureMaxVariantsCap, 'bulkCreate', {
       maxScenarios: 10,
@@ -571,5 +571,76 @@ describe('planner contracts: variant emission respects maxScenarios cap (#51 rev
       maxScenarios: 0,
     });
     expect(variants.scenarios).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture K: variant planner falls back to non-overlap producers (#37)
+// ---------------------------------------------------------------------------
+//
+// Endpoint `createOrder` requires `OrderId` (produced authoritatively by
+// `mintOrderId`) and produces `OrderInstanceKey`. It has an optional
+// sub-shape `addons[].tagId : Tag`.
+//
+// `mintTag` authoritatively produces `Tag` and requires NOTHING — in
+// particular, it does NOT need any of `createOrder`'s outputs. There is
+// no overlap between `mintTag.requires` and `createOrder.produces`, so
+// no warm-up of `createOrder` is forced.
+//
+// Class-scoped guarantee: when the only candidate producer of an optional
+// leaf semantic is independent of the endpoint's outputs (no overlap),
+// the variant planner must still emit a positive variant — a simple
+// `producer → endpoint` chain with no warm-up. Without the fallback,
+// independent-producer leaves receive zero variant coverage and the only
+// way to populate them is via base scenarios (which by design never do —
+// the leaves are opportunistic).
+const fixtureNonOverlapVariant: OperationGraph = makeGraph([
+  makeOp('mintOrderId', {
+    produces: ['OrderId'],
+    providerMap: { OrderId: true },
+  }),
+  makeOp('mintTag', {
+    produces: ['Tag'],
+    providerMap: { Tag: true },
+  }),
+  makeOp('createOrder', {
+    required: ['OrderId'],
+    produces: ['OrderInstanceKey'],
+    providerMap: { OrderInstanceKey: true },
+    optionalSubShapes: [
+      {
+        rootPath: 'addons[]',
+        leaves: [{ fieldPath: 'addons[].tagId', semantic: 'Tag' }],
+      },
+    ],
+  }),
+]);
+
+describe('planner contracts: variant planner non-overlap producer fallback (#37)', () => {
+  it('emits a producer→endpoint variant with no warm-up when the producer needs nothing from the endpoint', () => {
+    const variants = generateOptionalSubShapeVariants(fixtureNonOverlapVariant, 'createOrder', {
+      maxScenarios: 10,
+    });
+    expect(variants.scenarios.length).toBeGreaterThan(0);
+    const variant = variants.scenarios[0];
+    const ops = opIdsOf(variant);
+    // createOrder appears exactly once (no warm-up).
+    expect(ops.filter((id) => id === 'createOrder').length).toBe(1);
+    // mintTag (the non-overlap producer) is in the chain.
+    expect(ops).toContain('mintTag');
+    // Final step is the endpoint under test.
+    expect(ops[ops.length - 1]).toBe('createOrder');
+    expect(variant.strategy).toBe('optionalSubShapeVariant');
+    expect(variant.populatesSubShape?.rootPath).toBe('addons[]');
+    expect(variant.populatesSubShape?.leafSemantics).toEqual(['Tag']);
+  });
+
+  it('does NOT alter base scenarios for the same endpoint', () => {
+    const base = plan(fixtureNonOverlapVariant, 'createOrder');
+    expect(base.scenarios.length).toBeGreaterThan(0);
+    for (const s of base.scenarios) {
+      // mintTag is opportunistic — base planning must not pull it in.
+      expect(opIdsOf(s)).not.toContain('mintTag');
+    }
   });
 });

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -1229,9 +1229,10 @@ describe('bundled-spec invariants: planner variant output (#37)', () => {
 
   it('every step in every variant scenario has its required semantic inputs satisfied (#37)', () => {
     // Mirror of the base-scenario prereq invariant, scoped to variant
-    // scenarios. The variant family lifts the OUT-as-producer guard, so
-    // we want explicit confirmation that the warm-up endpoint truly
-    // produces the semantics the search-step then consumes.
+    // scenarios. This only checks that each step's required semantic
+    // inputs are satisfied by semantics produced earlier in the chain;
+    // it does not assert that optional inputs (for example
+    // overlap-heuristic triggers on search steps) are present.
     if (!existsSync(VARIANT_SCENARIOS_DIR)) return; // no variants generated yet
     const offenders: { file: string; scenario: string; step: string; missing: string[] }[] = [];
     for (const f of readdirSync(VARIANT_SCENARIOS_DIR)) {

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -30,6 +30,7 @@ const GRAPH_PATH = join(
 );
 const SCENARIOS_DIR = join(REPO_ROOT, 'path-analyser', 'dist', 'output');
 const FEATURE_SCENARIOS_DIR = join(REPO_ROOT, 'path-analyser', 'dist', 'feature-output');
+const VARIANT_SCENARIOS_DIR = join(REPO_ROOT, 'path-analyser', 'dist', 'variant-output');
 const GENERATED_TESTS_DIR = join(REPO_ROOT, 'path-analyser', 'dist', 'generated-tests');
 
 interface SemanticTypeEntry {
@@ -64,6 +65,18 @@ interface ScenarioFile {
     operations: { operationId: string }[];
     missingSemanticTypes?: string[];
   }[];
+}
+
+interface VariantScenario {
+  id: string;
+  variantKey?: string;
+  hasEventuallyConsistent?: boolean;
+  populatesSubShape?: { rootPath: string; leafPaths: string[]; leafSemantics?: string[] };
+  operations: { operationId: string }[];
+}
+interface VariantScenarioFile {
+  endpoint: { operationId: string };
+  scenarios: VariantScenario[];
 }
 
 let cachedGraph: DependencyGraph | undefined;
@@ -197,10 +210,13 @@ describe('bundled-spec invariants: planner output', () => {
     expect(offenders).toEqual([]);
   });
 
-  it('no createProcessInstance scenario calls searchElementInstances (#31)', () => {
+  it('no createProcessInstance BASE scenario calls searchElementInstances (#31)', () => {
     // The original symptom of #31: the planner inserted a search-step
     // chain because ElementId was wrongly required. Ancestor-required
-    // tracking removed that branch.
+    // tracking removed that branch from BASE scenarios. Variant
+    // scenarios (#37) explicitly DO call searchElementInstances when
+    // populating optional sub-shapes — they live in dist/variant-output/
+    // and are exempt from this invariant.
     const scen = loadScenarioFile('post--process-instances-scenarios.json');
     const offenders = scen.scenarios
       .map((s) => ({ id: s.id, ops: s.operations.map((o) => o.operationId) }))
@@ -1167,6 +1183,85 @@ describe('bundled-spec invariants: planner output', () => {
       offenders,
       'Feature-output chain selector grafted a prerequisite chain whose producers are not authoritative for the endpoint\'s required semantic type. The selected chain extracts the type from an "echo" response field (e.g. createDocument\'s `metadata.processInstanceKey` with provider:false) instead of from a real producer (createProcessInstance with provider:true). At runtime the extracted variable is empty and the URL placeholder leaks. Prefer chains containing at least one `provider:true` producer per required type before falling back to the shortest chain.',
     ).toEqual([]);
+  });
+});
+
+describe('bundled-spec invariants: planner variant output (#37)', () => {
+  function loadVariantFile(filename: string): VariantScenarioFile {
+    const p = join(VARIANT_SCENARIOS_DIR, filename);
+    if (!existsSync(p)) {
+      throw new Error(
+        `Variant scenario file not found at ${p}. Run 'npm run testsuite:generate' first.`,
+      );
+    }
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    return JSON.parse(readFileSync(p, 'utf8')) as VariantScenarioFile;
+  }
+
+  it('createProcessInstance has a variant populating startInstructions[].elementId with the canonical chain (#37)', () => {
+    // Acceptance criteria from #37:
+    //  - At least one scenario populates startInstructions[].elementId
+    //  - Chain has a warm-up createProcessInstance before the final one
+    //  - Chain has searchElementInstances between warm-up and final
+    //  - Scenario marked eventuallyConsistent: true
+    const file = loadVariantFile('post--process-instances-scenarios.json');
+    const startInstrVariants = file.scenarios.filter(
+      (s) => s.populatesSubShape?.rootPath === 'startInstructions[]',
+    );
+    expect(startInstrVariants.length).toBeGreaterThan(0);
+
+    const canonical = startInstrVariants.find((s) => {
+      const ops = s.operations.map((o) => o.operationId);
+      const cpiCount = ops.filter((o) => o === 'createProcessInstance').length;
+      const seiIdx = ops.indexOf('searchElementInstances');
+      const lastCpiIdx = ops.lastIndexOf('createProcessInstance');
+      const firstCpiIdx = ops.indexOf('createProcessInstance');
+      return (
+        cpiCount >= 2 &&
+        seiIdx > -1 &&
+        seiIdx > firstCpiIdx &&
+        seiIdx < lastCpiIdx &&
+        s.hasEventuallyConsistent === true
+      );
+    });
+    expect(canonical).toBeDefined();
+  });
+
+  it('every step in every variant scenario has its required semantic inputs satisfied (#37)', () => {
+    // Mirror of the base-scenario prereq invariant, scoped to variant
+    // scenarios. The variant family lifts the OUT-as-producer guard, so
+    // we want explicit confirmation that the warm-up endpoint truly
+    // produces the semantics the search-step then consumes.
+    if (!existsSync(VARIANT_SCENARIOS_DIR)) return; // no variants generated yet
+    const offenders: { file: string; scenario: string; step: string; missing: string[] }[] = [];
+    for (const f of readdirSync(VARIANT_SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const file = JSON.parse(
+        readFileSync(join(VARIANT_SCENARIOS_DIR, f), 'utf8'),
+      ) as VariantScenarioFile;
+      for (const sc of file.scenarios) {
+        const produced = new Set<string>();
+        for (const ref of sc.operations) {
+          const opNode = findOperation(ref.operationId);
+          const req = (opNode.requestBodySemanticTypes ?? [])
+            .filter((e) => e.required)
+            .map((e) => e.semanticType);
+          for (const p of opNode.parameters ?? []) {
+            if (p.required && p.semanticType) req.push(p.semanticType);
+          }
+          const missing = req.filter((s) => !produced.has(s));
+          if (missing.length) {
+            offenders.push({ file: f, scenario: sc.id, step: ref.operationId, missing });
+          }
+          for (const [statusCode, entries] of Object.entries(opNode.responseSemanticTypes ?? {})) {
+            if (!statusCode.startsWith('2') && !statusCode.startsWith('3')) continue;
+            for (const e of entries) produced.add(e.semanticType);
+          }
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
   });
 });
 

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -1285,4 +1285,90 @@ describe('bundled-spec invariants: emitted Playwright suite', () => {
     }
     expect(offenders).toEqual([]);
   });
+
+  it('every eventually-consistent read step is wrapped with awaitEventually (#106)', () => {
+    // Class-scoped guarantee: for every emitted spec file, the count of
+    // `awaitEventually(` calls equals the count of read-shape steps
+    // (GET or POST .../search) whose operation is flagged
+    // `eventuallyConsistent` and which expect a 200, summed across all
+    // scenarios in the matching feature/output JSON. Mismatches mean
+    // the emitter's wrap heuristic has regressed.
+    if (!existsSync(GENERATED_TESTS_DIR) || !existsSync(FEATURE_SCENARIOS_DIR)) {
+      throw new Error(`Generated artifacts not found. Run 'npm run testsuite:generate' first.`);
+    }
+
+    interface RequestStepLite {
+      operationId: string;
+      method: string;
+      pathTemplate: string;
+      expect: { status: number };
+    }
+    interface OperationRefLite {
+      operationId: string;
+      eventuallyConsistent?: boolean;
+    }
+    interface ScenarioLite {
+      operations: OperationRefLite[];
+      requestPlan?: RequestStepLite[];
+    }
+    interface CollectionLite {
+      endpoint: { operationId: string };
+      scenarios: ScenarioLite[];
+    }
+
+    function isReadShape(method: string, pathTemplate: string): boolean {
+      const m = method.toUpperCase();
+      return m === 'GET' || (m === 'POST' && /\/search\/?$/.test(pathTemplate));
+    }
+
+    function expectedWraps(coll: CollectionLite): number {
+      let n = 0;
+      for (const s of coll.scenarios) {
+        if (!s.requestPlan) continue;
+        const ec = new Set<string>();
+        for (const op of s.operations) {
+          if (op.eventuallyConsistent) ec.add(op.operationId);
+        }
+        if (ec.size === 0) continue;
+        for (const step of s.requestPlan) {
+          if (!ec.has(step.operationId)) continue;
+          if (step.expect.status !== 200) continue;
+          if (!isReadShape(step.method, step.pathTemplate)) continue;
+          n++;
+        }
+      }
+      return n;
+    }
+
+    let totalExpected = 0;
+    let totalActual = 0;
+    let suitesWithEc = 0;
+
+    for (const f of readdirSync(FEATURE_SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      const raw = readFileSync(join(FEATURE_SCENARIOS_DIR, f), 'utf8');
+      // biome-ignore lint/plugin: parsed JSON is a runtime contract boundary; shape locally typed as CollectionLite
+      const coll = JSON.parse(raw) as CollectionLite;
+      if (!coll || typeof coll !== 'object') continue;
+      const expected = expectedWraps(coll);
+      if (expected === 0) continue;
+      suitesWithEc++;
+      totalExpected += expected;
+
+      const specName = `${coll.endpoint.operationId}.feature.spec.ts`;
+      const specPath = join(GENERATED_TESTS_DIR, specName);
+      if (!existsSync(specPath)) {
+        throw new Error(`expected emitted spec ${specName} not found`);
+      }
+      const src = readFileSync(specPath, 'utf8');
+      const actual = (src.match(/awaitEventually\(/g) ?? []).length;
+      totalActual += actual;
+      expect(actual, `${specName}: awaitEventually wrap count`).toBe(expected);
+    }
+
+    // Sanity: the bundled spec exercises this pattern non-trivially.
+    expect(suitesWithEc).toBeGreaterThan(0);
+    expect(totalExpected).toBeGreaterThan(0);
+    expect(totalActual).toBe(totalExpected);
+  });
 });


### PR DESCRIPTION
Closes the planner half of #37 (iteration 2 of #31), and lands the
`awaitEventually` codegen wiring (#106) so eventually-consistent reads
in the emitted suites self-heal across indexer lag.

## Problem

PR #32 demoted optional-ancestor leaves like `startInstructions[].elementId` to `required: false`, fixing the spurious `searchElementInstances` injection in base `createProcessInstance` scenarios. But this introduced **under-coverage**: the optional `startInstructions[]` sub-shape was never exercised by any generated scenario.

## Approach

### Planner (#37)

New planner family — `generateOptionalSubShapeVariants` — emits one positive variant per (sub-shape, semantic leaf) pair. The canonical chain for `createProcessInstance.startInstructions[]` is:

```
createDeployment
  -> createProcessInstance (warm-up, minimal body)
  -> searchElementInstances (extracts ElementId from running instance)
  -> createProcessInstance (final, populated startInstructions)
```

Marked `hasEventuallyConsistent: true` because `searchElementInstances` lags actual element activation.

#### Mechanism (generic, not createProcessInstance-specific)

1. **graphLoader** derives `optionalSubShapes` from existing `fieldPath` metadata. Sub-shape root = deepest object/array-of-object ancestor; rejects scalar tops, scalar arrays (at any depth), and operator-object syntax (`filter.x.$eq`). **No extractor change.**
2. **graphLoader** builds `bySemanticResponseProducer` (inclusive index of `provider:false` producers) so search-style ops can be candidates for ElementId. Producer derivation is gated to 2xx/3xx response leaves.
3. **Variant planner** picks a producer whose optional inputs overlap the endpoint's outputs (forces the warm-up). Inclusive (search-style) producers are preferred. A non-overlap fallback ensures coverage when no overlap exists.
4. **Per-variant graph view** pins the chosen producer as the sole + authoritative producer of the leaf semantic, preventing BFS from defaulting to other authoritative producers that wouldn't trigger the warm-up.
5. New `additionalNeeded` opt injects the augmented requirements into `initialNeeded` only (NOT into the endpoint's `requires.required`), so the endpoint can re-appear as a warm-up step without dragging its augmented prereqs along.
6. New `allowEndpointAsProducer` opt lifts the OUT-exclusion guard strictly for variant planning.
7. Variant emission capped at `maxScenarios` to bound cost on producer-rich endpoints.

Variants written to a NEW dir: `path-analyser/dist/variant-output/`. Base / feature planning untouched.

### Codegen (#106 — eventually-consistent reads)

Vendored support helper (`path-analyser/src/codegen/support/await-eventually.ts`) ported from the JS SDK's `eventualPoll`. The Playwright emitter wraps any step whose operation is flagged `eventuallyConsistent: true` AND is a read shape (GET or POST `.../search`) AND expects 200.

Helper semantics mirror `eventualPoll`:
- 404-on-GET retries within budget
- 429 honours `Retry-After` + jittered backoff (cap 2s)
- 4xx (400/401/403/409/422) and 5xx return immediately so the caller's status assertion produces a clean diff
- 200 evaluates predicate (default for non-GET: `items.length > 0`)
- Budget exhaustion throws `EventualConsistencyTimeoutError`

Defaults: 10s budget, 500ms poll interval. Helper is conditionally imported only when the suite needs it. Heuristic reads `s.operations[].eventuallyConsistent` directly (the planner summary fields are not populated by `featureCoverageGenerator`).

73 of 190 emitted feature suites now wrap EC reads.

## Acceptance criteria

### From #37
- [x] At least one createProcessInstance scenario populates `startInstructions[].elementId` (planner level)
- [x] Chain has warm-up createProcessInstance before final
- [x] Chain has searchElementInstances between warm-up and final
- [x] Marked `eventuallyConsistent: true`
- [x] Base scenarios unchanged (no regression of #32)
- [x] Mechanism is generic (also generates variant for `runtimeInstructions[].afterElementId`)

### From #106
- [x] EC-flagged read steps wrapped with `awaitEventually(...)` in emitted suites
- [x] Write steps and error scenarios are NOT wrapped
- [x] Helper imported only when at least one step needs it

## Tests

Total: 75 -> 176 passing.

- **Layer-2 planner contracts** (Fixtures G, K — synthetic createOrder/searchProducts) verify the variant chain shape and that base scenarios are unchanged.
- **Layer-2 emitter fixtures** (`tests/codegen/playwright-emitter.test.ts`):
  - import only when needed
  - POST `.../search` wrapped, GET wrapped
  - write-shape POST not wrapped (even when EC-flagged)
  - non-200 error scenarios not wrapped
  - multi-step chain wraps only the read step
- **Layer-3 invariants** (`tests/regression/bundled-spec-invariants.test.ts`):
  - `bundled-spec invariants: planner variant output (#37)` — createProcessInstance has a variant populating `startInstructions[].elementId` with the canonical chain; every step in every variant has its required semantic inputs satisfied
  - `every eventually-consistent read step is wrapped with awaitEventually (#106)` — for every emitted spec, `awaitEventually(` call count equals the count derived from feature-output JSON
- Existing **"no createProcessInstance scenario calls searchElementInstances"** invariant scoped to BASE scenarios; docstring updated.

## Sample emitted EC wrap

```ts
const resp1 = await awaitEventually(
  async () => request.post(url, { headers: await authHeaders(), data: body1 }),
  { method: 'POST', operationId: 'searchUsers' },
);
```

## Still pending (separate PR)

- **Variant emission**: `path-analyser/src/codegen/index.ts` does not yet scan `dist/variant-output/` and emit Playwright spec files for variants. Variant scenario JSON exists but no runnable variant test files.
- **buildRequestPlan deep-merge** (`path-analyser/src/index.ts`):
  - deep-merge `populatesSubShape` into the final step's `bodyTemplate`
  - add response extracts for non-final producer steps so generated tests actually populate `startInstructions` with the extracted `ElementId`

Until those land, the planner-level variants are exercised only by Layer-2/Layer-3 tests, not by the emitted Playwright suites.

Closes #106
Refs #37, #31, #32, #36
