### PR TITLE
fix(planner): graft prerequisite chain for endpoints without a response shape

### DIFF
--- a/path-analyser/src/extractSchemas.ts
+++ b/path-analyser/src/extractSchemas.ts
@@ -61,16 +61,29 @@ export async function extractResponseAndRequestVariants(baseDir: string, semanti
   const doc = YAML.parse(raw) as OpenAPISchemaObject;
   const responses: ResponseShapeSummary[] = [];
   const requestGroups: RequestOneOfGroupSummary[] = [];
+  // Per-operation success status map. Populated for every operation that
+  // declares a 2xx (200/201/204) response, even when there is no JSON body.
+  // Used by the request-plan builder to assert the correct HTTP status for
+  // each step (final and prerequisite). 204 No-Content endpoints in
+  // particular have no JSON shape but must still be asserted as 204.
+  const successStatusByOp: Record<string, number> = {};
 
   const paths = doc.paths || {};
   for (const [, methods] of Object.entries(paths)) {
     for (const [, op] of Object.entries(methods || {})) {
       if (!op?.operationId) continue;
       const operationId = op.operationId;
-      // Response extraction: take first 200 json schema if present
+      // Pick the first 2xx response declared by the operation (200/201/204).
+      // We record `successStatusByOp[operationId]` for every such operation,
+      // even when it has no JSON body (e.g. 204 No-Content), so that the
+      // request-plan builder can assert the correct HTTP status. The JSON
+      // schema parsing below only runs when there *is* a JSON body — hence
+      // an operation can be present in `successStatusByOp` without producing
+      // an entry in `responses`.
       const successCode = Object.keys(op.responses || {}).find((c) =>
         ['200', '201', '204'].includes(c),
       );
+      if (successCode) successStatusByOp[operationId] = Number(successCode);
       const success = successCode ? op.responses?.[successCode] : undefined;
       const ctSchemas: { ct: string; schema: JsonSchema }[] = [];
       if (success?.content) {
@@ -188,7 +201,7 @@ export async function extractResponseAndRequestVariants(baseDir: string, semanti
     requestIndex.byOperation[g.operationId] ||= [];
     requestIndex.byOperation[g.operationId].push(g);
   }
-  return { responses, requestIndex };
+  return { responses, requestIndex, successStatusByOp };
 }
 
 function flattenTopLevelFields(
@@ -342,7 +355,7 @@ function refName(ref: string): string {
 }
 
 export async function writeExtractionOutputs(baseDir: string, semanticTypes: string[]) {
-  const { responses, requestIndex } = await extractResponseAndRequestVariants(
+  const { responses, requestIndex, successStatusByOp } = await extractResponseAndRequestVariants(
     baseDir,
     semanticTypes,
   );
@@ -358,7 +371,7 @@ export async function writeExtractionOutputs(baseDir: string, semanticTypes: str
     JSON.stringify(requestIndex, null, 2),
     'utf8',
   );
-  return { responses, requestIndex };
+  return { responses, requestIndex, successStatusByOp };
 }
 
 function toPascalCase(name: string): string {

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -291,6 +291,33 @@ function normalizeOp(opId: string, op: RawOp): OperationNode {
 
   // providerMap already built above; if still empty leave as undefined later
 
+  // Pass through responseSemanticTypes (per status code -> array of
+  // {semanticType, fieldPath, ...}). The path-analyser request-plan builder
+  // uses these to emit per-step extracts on prerequisite producer steps so
+  // grafted chains actually populate downstream URL placeholder vars.
+  const normalizedResponseSemanticTypes: Record<
+    string,
+    { semanticType: string; fieldPath: string; required?: boolean }[]
+  > = {};
+  if (op.responseSemanticTypes && typeof op.responseSemanticTypes === 'object') {
+    for (const [status, arr] of Object.entries(op.responseSemanticTypes)) {
+      if (!Array.isArray(arr)) continue;
+      const entries: { semanticType: string; fieldPath: string; required?: boolean }[] = [];
+      for (const entry of arr) {
+        const st: unknown = entry?.semanticType;
+        const fp: unknown = entry?.fieldPath;
+        if (typeof st === 'string' && typeof fp === 'string') {
+          entries.push({
+            semanticType: st,
+            fieldPath: fp,
+            required: typeof entry?.required === 'boolean' ? entry.required : undefined,
+          });
+        }
+      }
+      if (entries.length) normalizedResponseSemanticTypes[status] = entries;
+    }
+  }
+
   return {
     operationId: op.operationId ?? op.id ?? op.name ?? opId,
     method: (op.method ?? op.httpMethod ?? op.verb ?? 'GET').toUpperCase(),
@@ -303,6 +330,9 @@ function normalizeOp(opId: string, op: RawOp): OperationNode {
       op.eventuallyConsistent === true || op['x-eventually-consistent'] === true,
     operationMetadata: op.operationMetadata || undefined,
     conditionalIdempotency: op.conditionalIdempotency || undefined,
+    responseSemanticTypes: Object.keys(normalizedResponseSemanticTypes).length
+      ? normalizedResponseSemanticTypes
+      : undefined,
   };
 }
 

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -63,7 +63,10 @@ async function main() {
   }
   // Extract response shapes & request variants (oneOf groups)
   const semanticTypes = Object.keys(graph.bySemanticProducer || {});
-  const { requestIndex, responses } = await writeExtractionOutputs(baseDir, semanticTypes);
+  const { requestIndex, responses, successStatusByOp } = await writeExtractionOutputs(
+    baseDir,
+    semanticTypes,
+  );
   const responseByOp: Record<string, ResponseShapeSummary> = {};
   for (const r of responses) responseByOp[r.operationId] = r;
 
@@ -92,7 +95,9 @@ async function main() {
 
   for (const op of Object.values(graph.operations)) {
     // Generate scenarios for every endpoint, even if it has no semantic requirements.
-    const collection = generateScenariosForEndpoint(graph, op.operationId, { maxScenarios: 20 });
+    const collection = generateScenariosForEndpoint(graph, op.operationId, {
+      maxScenarios: 20,
+    });
     // Augment scenarios with response shape
     const resp = responseByOp[op.operationId];
     if (resp) {
@@ -107,7 +112,14 @@ async function main() {
         }));
         if (resp.nestedSlices) s.responseNestedSlices = resp.nestedSlices;
         if (resp.nestedItems) s.responseArrayItemFields = resp.nestedItems;
-        s.requestPlan = buildRequestPlan(s, resp, graph, canonical, requestIndex.byOperation);
+        s.requestPlan = buildRequestPlan(
+          s,
+          resp,
+          graph,
+          canonical,
+          requestIndex.byOperation,
+          successStatusByOp,
+        );
       }
     }
     const fileName = normalizeEndpointFileName(op.method, op.path);
@@ -127,24 +139,32 @@ async function main() {
       integrationCandidates
         .filter((sc) => sc.operations.length > 1)
         .sort((a, b) => a.operations.length - b.operations.length)[0] || integrationCandidates[0];
-    if (resp) {
-      for (const s of featureCollection.scenarios) {
-        // Graft chain if available and feature scenario currently only has endpoint op
-        // Special-case: for search-like empty-negative, skip grafting to produce an empty result without prerequisites
-        const isSearchLikeOp =
-          (op.method.toUpperCase() === 'POST' && /\/search$/.test(op.path)) ||
-          /search/i.test(op.operationId) ||
-          op.operationId === 'activateJobs';
-        const isEmptyNeg = s.expectedResult && s.expectedResult.kind === 'empty';
-        const skipGraft = isSearchLikeOp && isEmptyNeg;
-        if (
-          !skipGraft &&
-          chainSource &&
-          s.operations.length === 1 &&
-          chainSource.operations.length > 1
-        ) {
-          s.operations = chainSource.operations.map((o) => ({ ...o }));
-        }
+    // The chain-graft + requestPlan synthesis must run for every endpoint,
+    // not just those with a response shape. Operations with a
+    // 204 No-Content response (cancelProcessInstance, completeJob,
+    // resolveIncident, deleteRole, deleteUser, …) used to fall into the
+    // `if (resp)` branch's else and be left as a single-step scenario, which
+    // the emitter then rendered with literal `${var}` placeholders in URLs.
+    // The response-shape assignments below are still gated on `resp` because
+    // they have no meaning when the response body is empty.
+    for (const s of featureCollection.scenarios) {
+      // Graft chain if available and feature scenario currently only has endpoint op
+      // Special-case: for search-like empty-negative, skip grafting to produce an empty result without prerequisites
+      const isSearchLikeOp =
+        (op.method.toUpperCase() === 'POST' && /\/search$/.test(op.path)) ||
+        /search/i.test(op.operationId) ||
+        op.operationId === 'activateJobs';
+      const isEmptyNeg = s.expectedResult && s.expectedResult.kind === 'empty';
+      const skipGraft = isSearchLikeOp && isEmptyNeg;
+      if (
+        !skipGraft &&
+        chainSource &&
+        s.operations.length === 1 &&
+        chainSource.operations.length > 1
+      ) {
+        s.operations = chainSource.operations.map((o) => ({ ...o }));
+      }
+      if (resp) {
         s.responseShapeSemantics = resp.producedSemantics || undefined;
         s.responseShapeFields = resp.fields.map((f) => ({
           name: f.name,
@@ -155,33 +175,40 @@ async function main() {
         }));
         if (resp.nestedSlices) s.responseNestedSlices = resp.nestedSlices;
         if (resp.nestedItems) s.responseArrayItemFields = resp.nestedItems;
-        s.requestPlan = buildRequestPlan(s, resp, graph, canonical, requestIndex.byOperation);
-        // Validation: for JSON requests with oneOf groups, non-negative scenarios must set exactly one variant's required keys
-        try {
-          const final = s.requestPlan?.[s.requestPlan.length - 1];
-          const groups = requestIndex.byOperation[op.operationId] || [];
-          const isError = s.expectedResult && s.expectedResult.kind === 'error';
-          if (final?.bodyKind === 'json' && final?.bodyTemplate && groups.length && !isError) {
-            const presentKeys = new Set(Object.keys(final.bodyTemplate));
-            for (const g of groups) {
-              // Count variants whose required keys are fully present in the body
-              const hits = g.variants.filter((v) => v.required.every((k) => presentKeys.has(k)));
-              // Deduplicate by required set (some variants only differ by discriminator value but share the same required keys)
-              const uniqByReq = new Map<string, (typeof hits)[number]>();
-              for (const v of hits) {
-                const key = [...v.required].sort().join('|');
-                if (!uniqByReq.has(key)) uniqByReq.set(key, v);
-              }
-              const uniqCount = uniqByReq.size;
-              if (uniqCount !== 1) {
-                throw new Error(
-                  `oneOf validation failed for ${op.operationId} group '${g.groupId}': expected exactly 1 variant's required keys present, found ${uniqCount}`,
-                );
-              }
+      }
+      s.requestPlan = buildRequestPlan(
+        s,
+        resp,
+        graph,
+        canonical,
+        requestIndex.byOperation,
+        successStatusByOp,
+      );
+      // Validation: for JSON requests with oneOf groups, non-negative scenarios must set exactly one variant's required keys
+      try {
+        const final = s.requestPlan?.[s.requestPlan.length - 1];
+        const groups = requestIndex.byOperation[op.operationId] || [];
+        const isError = s.expectedResult && s.expectedResult.kind === 'error';
+        if (final?.bodyKind === 'json' && final?.bodyTemplate && groups.length && !isError) {
+          const presentKeys = new Set(Object.keys(final.bodyTemplate));
+          for (const g of groups) {
+            // Count variants whose required keys are fully present in the body
+            const hits = g.variants.filter((v) => v.required.every((k) => presentKeys.has(k)));
+            // Deduplicate by required set (some variants only differ by discriminator value but share the same required keys)
+            const uniqByReq = new Map<string, (typeof hits)[number]>();
+            for (const v of hits) {
+              const key = [...v.required].sort().join('|');
+              if (!uniqByReq.has(key)) uniqByReq.set(key, v);
+            }
+            const uniqCount = uniqByReq.size;
+            if (uniqCount !== 1) {
+              throw new Error(
+                `oneOf validation failed for ${op.operationId} group '${g.groupId}': expected exactly 1 variant's required keys present, found ${uniqCount}`,
+              );
             }
           }
-        } catch {}
-      }
+        }
+      } catch {}
     }
     // Collect artifact references from feature scenarios (multipart files)
     try {
@@ -274,6 +301,7 @@ function buildRequestPlan(
   graph: OperationGraph,
   canonical: Record<string, CanonicalShape>,
   requestGroupsIndex: Record<string, RequestOneOfGroupSummary[]>,
+  successStatusByOp: Record<string, number>,
 ): RequestStep[] {
   const steps: RequestStep[] = [];
   // Each operation becomes a step; final step uses response shape for extraction
@@ -284,7 +312,14 @@ function buildRequestPlan(
       operationId: opRef.operationId,
       method: opRef.method,
       pathTemplate: opRef.path,
-      expect: { status: determineExpectedStatus(scenario, resp, isFinal) },
+      expect: {
+        status: determineExpectedStatus(
+          scenario,
+          resp,
+          isFinal,
+          successStatusByOp[opRef.operationId],
+        ),
+      },
     };
     // Domain valueBindings driven response extraction (non-final steps included)
     const opDom = graph.domain?.operationRequirements?.[opRef.operationId];
@@ -339,6 +374,39 @@ function buildRequestPlan(
       }
       if (extract.length) step.extract = (step.extract || []).concat(extract);
     }
+    // Non-final producer steps: emit semantic-labeled extracts using the
+    // dependency graph's `responseSemanticTypes` (which captures nested
+    // fieldPaths like `metadata.processInstanceKey`, unlike
+    // `extractSchemas.flattenTopLevelFields` which only sees top-level).
+    // Without this, a grafted prerequisite chain could exist but never
+    // populate the URL var, leaving `${...Var}` literally in the emitted
+    // URL.
+    if (!isFinal) {
+      const stepNode = graph.operations[opRef.operationId];
+      const stepSuccess = successStatusByOp[opRef.operationId];
+      const responseEntries = stepNode?.responseSemanticTypes?.[String(stepSuccess)] ?? [];
+      if (responseEntries.length) {
+        const extract: { fieldPath: string; bind: string; semantic?: string }[] = [];
+        const existingBinds = new Set((step.extract ?? []).map((e) => e.bind));
+        for (const entry of responseEntries) {
+          const bind = `${camelCase(entry.semanticType)}Var`;
+          if (existingBinds.has(bind)) continue;
+          // semantic-graph-extractor emits array item paths with `[]`
+          // markers (schema-analyzer.ts: `${fieldPath}[]`). The Playwright
+          // emitter's accessor builder expects numeric indices, so
+          // normalise to first-element access — same convention used for
+          // domainBinding extracts above.
+          const fieldPath = entry.fieldPath.replace(/\[\]/g, '[0]');
+          extract.push({
+            fieldPath,
+            bind,
+            semantic: entry.semanticType,
+          });
+          existingBinds.add(bind);
+        }
+        if (extract.length) step.extract = (step.extract || []).concat(extract);
+      }
+    }
     steps.push(step);
     // If this is the final step and scenario has duplicateTest, append a duplicate invocation
     if (isFinal && scenario.duplicateTest) {
@@ -362,6 +430,7 @@ function determineExpectedStatus(
   scenario: EndpointScenario,
   resp: ResponseShapeSummary | undefined,
   isFinal: boolean,
+  opSuccessStatus: number | undefined,
 ): number {
   if (
     isFinal &&
@@ -372,7 +441,13 @@ function determineExpectedStatus(
     const n = Number(scenario.expectedResult.code);
     if (!Number.isNaN(n)) return n;
   }
-  return resp?.successStatus || (isFinal ? 200 : 200);
+  // Prefer the operation's own declared success status for every step
+  // (covers 204 endpoints, and prerequisite steps whose status differs
+  // from the final step). Only the final step falls back to the
+  // endpoint response shape's `successStatus`; non-final steps fall
+  // back directly to 200 because `resp` describes the final endpoint,
+  // not the prerequisite.
+  return opSuccessStatus ?? (isFinal ? (resp?.successStatus ?? 200) : 200);
 }
 
 function _synthesizeBodyTemplate(scenario: EndpointScenario, opRef: OperationRef) {
@@ -410,7 +485,10 @@ type RequestBodyPlan =
   | { kind: 'json'; template: Record<string, unknown> }
   | {
       kind: 'multipart';
-      template: { fields: Record<string, string>; files: Record<string, string> };
+      template: {
+        fields: Record<string, string>;
+        files: Record<string, string>;
+      };
       expectedSlices: string[];
     };
 
@@ -631,7 +709,10 @@ function buildRequestBodyFromCanonical(
   if (chosenCt === 'multipart/form-data') {
     // Represent multipart template as { fields: Record<string,string>, files: Record<string,string> }
     // Detect array of binaries: look for paths matching resources[] with type string/binary
-    const template: { fields: Record<string, string>; files: Record<string, string> } = {
+    const template: {
+      fields: Record<string, string>;
+      files: Record<string, string>;
+    } = {
       fields: {},
       files: {},
     };

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -33,6 +33,14 @@ export interface OperationNode extends OperationRef {
     duplicatePolicy: string; // e.g. ignore
     appliesWhen: string; // e.g. key-present
   };
+  // Response semantic-type entries keyed by status code, sourced from the
+  // semantic-graph extractor. Each entry captures the field path (which may
+  // be nested, e.g. `metadata.processInstanceKey`) and the semantic type
+  // produced by that field on a 2xx response.
+  responseSemanticTypes?: Record<
+    string,
+    { semanticType: string; fieldPath: string; required?: boolean }[]
+  >;
 }
 
 export interface OperationGraph {

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -29,6 +29,7 @@ const GRAPH_PATH = join(
   'operation-dependency-graph.json',
 );
 const SCENARIOS_DIR = join(REPO_ROOT, 'path-analyser', 'dist', 'output');
+const FEATURE_SCENARIOS_DIR = join(REPO_ROOT, 'path-analyser', 'dist', 'feature-output');
 const GENERATED_TESTS_DIR = join(REPO_ROOT, 'path-analyser', 'dist', 'generated-tests');
 
 interface SemanticTypeEntry {
@@ -185,7 +186,12 @@ describe('bundled-spec invariants: planner output', () => {
         `Scenarios directory not found at ${SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
       );
     }
-    const offenders: { file: string; scenario: string; step: string; missing: string[] }[] = [];
+    const offenders: {
+      file: string;
+      scenario: string;
+      step: string;
+      missing: string[];
+    }[] = [];
     for (const f of readdirSync(SCENARIOS_DIR)) {
       if (!f.endsWith('-scenarios.json')) continue;
       // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
@@ -207,7 +213,12 @@ describe('bundled-spec invariants: planner output', () => {
           }
           const missing = req.filter((s) => !produced.has(s));
           if (missing.length) {
-            offenders.push({ file: f, scenario: sc.id, step: ref.operationId, missing });
+            offenders.push({
+              file: f,
+              scenario: sc.id,
+              step: ref.operationId,
+              missing,
+            });
           }
           for (const [statusCode, entries] of Object.entries(opNode.responseSemanticTypes ?? {})) {
             // Mirror semantic-graph-extractor/graph-builder.ts
@@ -217,6 +228,177 @@ describe('bundled-spec invariants: planner output', () => {
             if (!statusCode.startsWith('2') && !statusCode.startsWith('3')) continue;
             for (const e of entries) produced.add(e.semanticType);
           }
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('every feature-output scenario binds or chains every {placeholder} whose path parameter has a recognised semanticType', () => {
+    // Class-scoped guard for the "un-extracted ${var} in URL" defect family:
+    // when an endpoint's response analyser produces no shape (typically for
+    // 204 No-Content operations like cancelProcessInstance, completeJob,
+    // resolveIncident, deleteRole, deleteUser, …), the feature-coverage
+    // pipeline previously skipped the chain-graft + requestPlan step, leaving
+    // a single-step scenario for an endpoint with required path parameters.
+    // The emitter then rendered URLs like `/process-instances/${processInstanceKey}/cancellation`
+    // — the literal placeholder, never substituted at runtime.
+    //
+    // Scope: only path placeholders whose parameter on the dependency graph
+    // carries a `semanticType`. That excludes:
+    //   - Bug B (admin-entity IDs lacking upstream `x-semantic-type` —
+    //     roles/groups/mapping-rules/global cluster variables/resources):
+    //     the parameter has no `semanticType`, so no producer is recognised.
+    //   - The Bug A class itself is operations whose placeholders DO have
+    //     recognised semantic types but whose chain was previously dropped.
+    // Bug B will land its own invariant once we add the upstream x-semantic-type
+    // tags (or the local domain-semantics fallback). Bug C (BFS empty-chain
+    // for semanticised endpoints) is already separately surfaced by other
+    // planner invariants and will get its own named guard with its fix.
+    //
+    // Invariant: for every feature-output scenario, every `{x}` in the
+    // endpoint path whose parameter has a `semanticType` set must be either
+    // (a) bound via `scenario.bindings.xVar`, or (b) covered by at least
+    // one earlier step in `scenario.operations[]`.
+    if (!existsSync(FEATURE_SCENARIOS_DIR)) {
+      throw new Error(
+        `Feature-output directory not found at ${FEATURE_SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+      );
+    }
+    if (!existsSync(SCENARIOS_DIR)) {
+      throw new Error(
+        `Planner scenarios directory not found at ${SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+      );
+    }
+    const graph = loadGraph();
+    const opByKey = new Map<string, OperationNode>();
+    for (const op of graph.operations) {
+      opByKey.set(`${op.method.toUpperCase()} ${op.path}`, op);
+    }
+    interface FeatureScenarioFile {
+      endpoint: { operationId: string; method: string; path: string };
+      scenarios: {
+        id: string;
+        operations: { operationId: string }[];
+        bindings?: Record<string, unknown>;
+        requestPlan?: {
+          operationId: string;
+          extract?: { fieldPath: string; bind: string; semantic?: string }[];
+        }[];
+      }[];
+    }
+    interface PlannerScenarioFile {
+      scenarios: { missingSemanticTypes?: string[] }[];
+    }
+    const offenders: {
+      file: string;
+      scenario: string;
+      placeholders: string[];
+    }[] = [];
+    for (const f of readdirSync(FEATURE_SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      const plannerPath = join(SCENARIOS_DIR, f);
+      // The pipeline emits one planner-scenarios file per feature-scenarios
+      // file (same normalised filename). A missing companion is a pipeline
+      // bug — fail fast rather than silently skip and mask it.
+      if (!existsSync(plannerPath)) {
+        throw new Error(
+          `Missing planner scenario file for feature scenario ${relative(
+            REPO_ROOT,
+            join(FEATURE_SCENARIOS_DIR, f),
+          )}; expected ${relative(REPO_ROOT, plannerPath)}`,
+        );
+      }
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const planner = JSON.parse(readFileSync(plannerPath, 'utf8')) as PlannerScenarioFile;
+      // Out-of-scope: Bug C class — BFS could not produce a fully-satisfied
+      // chain for this endpoint (every scenario has unmet semantic
+      // prerequisites, e.g. ResourceKey has no producer). The BFS may still
+      // emit a single "unsatisfied" scenario, so we filter on satisfaction
+      // rather than non-emptiness. Tracked separately; will get its own
+      // named guard with its fix.
+      const hasSatisfiedChain = (planner.scenarios ?? []).some(
+        (s) => !s.missingSemanticTypes || s.missingSemanticTypes.length === 0,
+      );
+      if (!hasSatisfiedChain) continue;
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const file = JSON.parse(
+        readFileSync(join(FEATURE_SCENARIOS_DIR, f), 'utf8'),
+      ) as FeatureScenarioFile;
+      const placeholders = [...file.endpoint.path.matchAll(/\{([^}]+)\}/g)].map((m) => m[1]);
+      if (placeholders.length === 0) continue;
+      const endpointKey = `${file.endpoint.method.toUpperCase()} ${file.endpoint.path}`;
+      const node = opByKey.get(endpointKey);
+      // A missing dependency-graph node for an endpoint that has a
+      // feature-output file is a graph/feature-output mismatch (or an
+      // endpoint-keying bug) — fail fast rather than silently skip.
+      if (!node) {
+        throw new Error(
+          `Missing dependency-graph node for endpoint ${endpointKey} referenced by feature scenario ${f}. This indicates a graph/feature-output mismatch or endpoint-keying bug.`,
+        );
+      }
+      // Out-of-scope: Bug B (placeholder parameter lacks `semanticType`,
+      // i.e. upstream `x-semantic-type` is missing). Tracked separately;
+      // will get its own named guard with its fix.
+      const parameters = node.parameters ?? [];
+      const pathParameters = parameters.filter((p) => p.location === 'path');
+      // If the path has placeholders but the graph node has no path
+      // parameters at all, that is a graph/extractor bug — fail fast.
+      if (pathParameters.length === 0) {
+        throw new Error(
+          `Dependency-graph node for endpoint ${endpointKey} referenced by feature scenario ${f} has path placeholders (${placeholders.join(', ')}) but no path parameters on the node. This indicates a graph extraction or endpoint-keying bug.`,
+        );
+      }
+      const inScope = placeholders.filter((ph) => {
+        const param = parameters.find((p) => p.name === ph && p.location === 'path');
+        return Boolean(param?.semanticType);
+      });
+      if (inScope.length === 0) continue;
+      for (const sc of file.scenarios) {
+        const bindings = sc.bindings ?? {};
+        // Mirror the Playwright emitter's URL templating, which references
+        // `ctx.<camelCase(placeholder)>Var` (see
+        // path-analyser/src/codegen/playwright/emitter.ts buildUrlExpression).
+        // Lowering only the first char keeps existing lowerCamelCase
+        // placeholders untouched while normalising any future PascalCase
+        // ones, so the invariant cannot false-fail on casing alone.
+        const placeholderVarName = (ph: string) => `${ph.charAt(0).toLowerCase()}${ph.slice(1)}Var`;
+        // Collect every variable name that an earlier step in the request
+        // plan actually `extract`s. Mere presence of a multi-step chain is
+        // not sufficient — the chain must produce the binding the URL
+        // template needs, otherwise `${...Var}` would still leak into the
+        // emitted URL at runtime.
+        const lastOpId = sc.operations[sc.operations.length - 1]?.operationId;
+        const producedByEarlierStep = new Set<string>();
+        for (const step of sc.requestPlan ?? []) {
+          if (step.operationId === lastOpId) break;
+          for (const e of step.extract ?? []) producedByEarlierStep.add(e.bind);
+        }
+        // Mirror the emitter's substitution semantics: `buildUrlExpression`
+        // uses `ctx.<var>Var || '${placeholder}'`, so a binding that is
+        // falsy (`null`, `''`, `0`, `false`) or the `__PENDING__` sentinel
+        // (which the emitter only seeds for body/multipart template vars,
+        // not URL placeholders) would still leak `${...Var}` into the URL
+        // at runtime. Treat such bindings as unsatisfied.
+        const isUsableBinding = (v: unknown) =>
+          v !== undefined &&
+          v !== null &&
+          v !== '' &&
+          v !== '__PENDING__' &&
+          v !== 0 &&
+          v !== false;
+        const unsatisfied = inScope.filter((ph) => {
+          const varName = placeholderVarName(ph);
+          if (isUsableBinding(bindings[varName])) return false;
+          if (producedByEarlierStep.has(varName)) return false;
+          return true;
+        });
+        if (unsatisfied.length) {
+          offenders.push({
+            file: f,
+            scenario: sc.id,
+            placeholders: unsatisfied,
+          });
         }
       }
     }


### PR DESCRIPTION
## Summary

Generated Playwright tests for endpoints with a 204 No-Content response (e.g. `cancelProcessInstance`, `completeJob`, `resolveIncident`, `deleteUser`, `deleteRole`) were rendered with **literal `${var}` placeholders** in their URLs, never substituted at runtime. Example:

```
fetch(`${baseURL}/process-instances/${processInstanceKey}/cancellation`, …)
```

## Root cause (Bug A)

In [path-analyser/src/index.ts](path-analyser/src/index.ts), the feature-coverage pipeline synthesised the prerequisite chain (graft) and the `requestPlan` only inside an `if (resp)` branch. Operations whose response analyser produced no shape (typically 204 responses) fell into the else and kept a single-step scenario, even though their path required parameters that an upstream operation (e.g. `createProcessInstance` for `processInstanceKey`) would have produced.

## Fix

Three coordinated changes — all needed for the URL var to actually reach the runtime:

1. **Lift chain-graft + `buildRequestPlan` out of `if (resp)`** so 204 endpoints get their prerequisite chain. The response-shape assignments (`responseShapeSemantics`, `responseShapeFields`, `nestedSlices`, `nestedItems`) remain gated on `resp` because they have no meaning when the response body is empty.
2. **Emit response extracts on non-final producer steps** from `OperationNode.responseSemanticTypes` (threaded through from the dependency graph). Without this, the grafted chain exists but never populates the URL var, because `extractSchemas.flattenTopLevelFields` only sees top-level fields and misses nested paths like `metadata.processInstanceKey`. Array markers `[]` are normalised to `[0]` to match the emitter's accessor convention (and the existing `domainBinding` extraction in the same file).
3. **Per-step success status correctness** via a new `successStatusByOp` map populated by `extractSchemas.ts` for every 200/201/204 op (even ones with no JSON body). `determineExpectedStatus` prefers the operation's own status; only the final step falls back to `resp?.successStatus`, so e.g. a 204 final endpoint can no longer leak its status onto a 200 prerequisite.

## Regression guard

Added a class-scoped Layer-3 invariant in [tests/regression/bundled-spec-invariants.test.ts](tests/regression/bundled-spec-invariants.test.ts):

> Every feature-output scenario whose endpoint path has `{placeholders}` either binds them via `scenario.bindings.xVar`, or has a prerequisite step in `requestPlan` that **actually `extract`s** the value — for every placeholder whose path parameter has a recognised `semanticType` on the dependency graph.

The invariant mirrors the Playwright emitter on two axes so it cannot false-pass or false-fail:

- **Casing**: derives the var name as `camelCase(placeholder) + 'Var'` (matches `buildUrlExpression`).
- **Substitution semantics**: a binding only counts as satisfied when it is truthy and not `__PENDING__` (matches `ctx.<var>Var || '${placeholder}'`; URL placeholders are never seeded with `__PENDING__`).

Scope is deliberately narrowed to placeholders with a recognised `semanticType` so the invariant captures **the Bug A defect class**, not other defect classes:

- **Out of scope — Bug B**: admin-entity IDs whose upstream schemas lack `x-semantic-type` (`roleId`, `groupId`, `mappingRuleId`, `AuthorizationKey`, `name` on global cluster variables, `resourceKey`). The planner cannot match a producer for those today; will land its own named invariant alongside the upstream `x-semantic-type` PR on `camunda/camunda` (or a local domain-semantics fallback).
- **Out of scope — Bug C**: endpoints where BFS could not produce a fully-satisfied chain even though a `semanticType` is known. Tracked separately; will land its own named invariant alongside the planner fix.

Both follow-ups will reuse the same test scaffolding here. The invariant also fails fast (rather than silently skipping) on missing planner files, missing graph nodes, or missing path parameters — these would mask pipeline mismatches.

## Behaviour delta on the pinned bundled spec

123 broken Playwright tests → 0 in scope of Bug A (the residual 108 split into Bug B and Bug C buckets, each guarded by their own forthcoming invariant).

## Verification

- `npm run lint` — clean
- `npx tsc --noEmit` for all three workspace tsconfigs — clean
- `npm test` — **74/74 passed** (was 73/73 before; the new `#bug-A` invariant is the +1 and it is green)
- `npm run testsuite:generate` succeeds and emits 183 endpoint suites against the spec pinned in `tests/regression/spec-pin.json`
- Spot-check: `cancelProcessInstance` now asserts status 204; `createDocument → getProcessInstance` chain extracts `processInstanceKeyVar:metadata.processInstanceKey` so the URL substitutes correctly.

## AGENTS.md compliance

- Red → green → class-scoped: invariant was first written failing on the pre-fix tree (123 offenders), the fix turned it green, and the assertion is scoped to the defect family rather than a single instance.
- No flaky / known-failing tests: the invariant lands green, with explicit out-of-scope filters documenting the deferred Bug B and Bug C classes.
- No `as T` outside imports / `as const`; runtime contract boundaries for parsed JSON use `// biome-ignore lint/plugin: runtime contract boundary for parsed JSON`.
