### PR TITLE
fix(extractor): use JSON.parse() for .json specs, YAML only for .yaml/.yml

### DIFF
--- a/semantic-graph-extractor/index.ts
+++ b/semantic-graph-extractor/index.ts
@@ -36,14 +36,24 @@ export class SemanticGraphExtractor {
     console.log(`Loading OpenAPI specification from: ${specPath}`);
 
     // Load and parse the OpenAPI spec.
-    // The bundled output (rest-api.bundle.json) is plain JSON; fall back to
-    // YAML parsing only for .yaml / .yml sources so the extractor works with
-    // both the legacy single-file YAML and the bundled JSON format.
+    // The bundled output (rest-api.bundle.json) is plain JSON; YAML parsing
+    // is reserved for legacy .yaml / .yml sources. Unknown extensions are
+    // rejected explicitly so a typo'd path can't silently fall through to
+    // a parser that happens to tolerate the input.
     const specContent = fs.readFileSync(specPath, 'utf8');
+    const ext = path.extname(specPath).toLowerCase();
+    let parsed: unknown;
+    if (ext === '.json') {
+      parsed = JSON.parse(specContent);
+    } else if (ext === '.yaml' || ext === '.yml') {
+      parsed = yaml.load(specContent);
+    } else {
+      throw new Error(
+        `Unsupported spec file extension '${ext || '(none)'}' for ${specPath}; expected .json, .yaml, or .yml`,
+      );
+    }
     // biome-ignore lint/plugin: runtime contract boundary for parsed input
-    const spec = (
-      specPath.endsWith('.json') ? JSON.parse(specContent) : yaml.load(specContent)
-    ) as OpenAPISpec;
+    const spec = parsed as OpenAPISpec;
 
     console.log(`Analyzing semantic types and operations...`);
 

--- a/semantic-graph-extractor/index.ts
+++ b/semantic-graph-extractor/index.ts
@@ -35,13 +35,15 @@ export class SemanticGraphExtractor {
   async extractGraph(specPath: string): Promise<OperationDependencyGraph> {
     console.log(`Loading OpenAPI specification from: ${specPath}`);
 
-    // Load and parse the OpenAPI spec
+    // Load and parse the OpenAPI spec.
+    // The bundled output (rest-api.bundle.json) is plain JSON; fall back to
+    // YAML parsing only for .yaml / .yml sources so the extractor works with
+    // both the legacy single-file YAML and the bundled JSON format.
     const specContent = fs.readFileSync(specPath, 'utf8');
-    // yaml.load() returns `unknown`; this is the runtime contract boundary
-    // where we trust the on-disk spec to conform to the OpenAPISpec interface.
-    // Downstream analyzers tolerate missing fields gracefully.
-    // biome-ignore lint/plugin: runtime contract boundary for parsed YAML
-    const spec = yaml.load(specContent) as OpenAPISpec;
+    // biome-ignore lint/plugin: runtime contract boundary for parsed input
+    const spec = (
+      specPath.endsWith('.json') ? JSON.parse(specContent) : yaml.load(specContent)
+    ) as OpenAPISpec;
 
     console.log(`Analyzing semantic types and operations...`);
 

--- a/tests/fixtures/extractor/extractor-graph.test.ts
+++ b/tests/fixtures/extractor/extractor-graph.test.ts
@@ -10,14 +10,28 @@
  * (i.e., plain JSON with all $refs resolved), which is what SemanticGraphExtractor
  * now parses via JSON.parse() rather than yaml.load().
  */
-import { writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import * as yaml from 'js-yaml';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GraphBuilder } from '../../../semantic-graph-extractor/graph-builder.ts';
 import { SemanticGraphExtractor } from '../../../semantic-graph-extractor/index.ts';
 import { SchemaAnalyzer } from '../../../semantic-graph-extractor/schema-analyzer.ts';
 import type { OpenAPISpec } from '../../../semantic-graph-extractor/types.ts';
+
+// Mock the js-yaml `load` export so we can assert which parser the
+// production code routed to. ESM module namespaces are not spy-able
+// (vitest issue), so the only reliable way to observe the call is to
+// replace the export at module-load time. `dump` is preserved so the
+// test still produces real YAML strings to feed back to the extractor.
+vi.mock('js-yaml', async () => {
+  const actual = await vi.importActual<typeof import('js-yaml')>('js-yaml');
+  return {
+    ...actual,
+    load: vi.fn(actual.load),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Fixture: minimal bundled JSON spec with two operations sharing one
@@ -188,21 +202,37 @@ describe('GraphBuilder: edge creation from semantic type relationships', () => {
 // Tests: SemanticGraphExtractor.extractGraph() — JSON vs YAML parsing
 // ---------------------------------------------------------------------------
 describe('SemanticGraphExtractor.extractGraph(): JSON input parsing', () => {
-  it('parses a .json spec file using JSON.parse (not yaml.load)', async () => {
-    const tmpPath = join(tmpdir(), 'fixture-two-op-graph.json');
+  // Each test gets its own temp dir so parallel vitest workers don't
+  // collide on fixed filenames under os.tmpdir() and stale files don't
+  // accumulate between runs.
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'extractor-graph-'));
+    vi.mocked(yaml.load).mockClear();
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('parses a .json spec file using JSON.parse and not yaml.load', async () => {
+    const tmpPath = join(tmpDir, 'fixture-two-op-graph.json');
     writeFileSync(tmpPath, JSON.stringify(fixtureTwoOpGraph));
 
     const extractor = new SemanticGraphExtractor();
     const graph = await extractor.extractGraph(tmpPath);
 
-    // If JSON.parse failed silently and returned an empty spec, operations
-    // would be empty. Assert we got real content.
+    // If the extractor regressed to YAML-parsing JSON inputs, yaml.load
+    // would be called and this assertion would fail — guarding the
+    // contract independently of the parsed output (yaml.load happens to
+    // handle JSON text, so output equality alone cannot detect the
+    // regression).
+    expect(yaml.load).not.toHaveBeenCalled();
     expect(graph.operations.size).toBe(2);
     expect(graph.semanticTypes.size).toBeGreaterThanOrEqual(1);
   });
 
   it('extracts the correct edge from a JSON fixture via the full pipeline', async () => {
-    const tmpPath = join(tmpdir(), 'fixture-two-op-graph-edges.json');
+    const tmpPath = join(tmpDir, 'fixture-two-op-graph-edges.json');
     writeFileSync(tmpPath, JSON.stringify(fixtureTwoOpGraph));
 
     const extractor = new SemanticGraphExtractor();
@@ -215,16 +245,28 @@ describe('SemanticGraphExtractor.extractGraph(): JSON input parsing', () => {
     expect(edge?.semanticType).toBe('ProcessDefinitionKey');
   });
 
-  it('parses a .yaml spec string path without error', async () => {
-    // Verify the YAML fallback path still works for callers using legacy .yaml sources.
-    const yaml = require('js-yaml');
+  it('parses a .yaml spec via yaml.load (legacy fallback)', async () => {
     const yamlContent = yaml.dump(fixtureTwoOpGraph);
-    const tmpPath = join(tmpdir(), 'fixture-two-op-graph.yaml');
+    const tmpPath = join(tmpDir, 'fixture-two-op-graph.yaml');
     writeFileSync(tmpPath, yamlContent);
 
     const extractor = new SemanticGraphExtractor();
     const graph = await extractor.extractGraph(tmpPath);
 
+    // Symmetric with the .json case: assert yaml.load was actually
+    // exercised for the .yaml path so the routing is observably correct
+    // in both directions.
+    expect(yaml.load).toHaveBeenCalledTimes(1);
     expect(graph.operations.size).toBe(2);
+  });
+
+  it('throws on an unsupported spec extension instead of silently parsing', async () => {
+    const tmpPath = join(tmpDir, 'fixture.txt');
+    writeFileSync(tmpPath, JSON.stringify(fixtureTwoOpGraph));
+
+    const extractor = new SemanticGraphExtractor();
+    await expect(extractor.extractGraph(tmpPath)).rejects.toThrow(
+      /Unsupported spec file extension/,
+    );
   });
 });

--- a/tests/fixtures/extractor/extractor-graph.test.ts
+++ b/tests/fixtures/extractor/extractor-graph.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Graph-pipeline fixtures for the semantic-graph extractor.
+ *
+ * These tests exercise the full extraction pipeline — JSON parsing, graph
+ * construction and edge derivation — using small hand-crafted bundled-JSON
+ * specs. Each test isolates ONE property of the pipeline so a failure
+ * names a single broken behaviour.
+ *
+ * The fixture specs below mirror the format emitted by camunda-schema-bundler
+ * (i.e., plain JSON with all $refs resolved), which is what SemanticGraphExtractor
+ * now parses via JSON.parse() rather than yaml.load().
+ */
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { GraphBuilder } from '../../../semantic-graph-extractor/graph-builder.ts';
+import { SemanticGraphExtractor } from '../../../semantic-graph-extractor/index.ts';
+import { SchemaAnalyzer } from '../../../semantic-graph-extractor/schema-analyzer.ts';
+import type { OpenAPISpec } from '../../../semantic-graph-extractor/types.ts';
+
+// ---------------------------------------------------------------------------
+// Fixture: minimal bundled JSON spec with two operations sharing one
+// semantic type. `provideKey` produces ProcessDefinitionKey in its response;
+// `consumeKey` requires ProcessDefinitionKey in its request body.
+//
+// `components.schemas` is populated to mirror the real camunda-schema-bundler
+// output format — extractSemanticTypes() only reads from components.schemas,
+// not from inline path schemas.
+// ---------------------------------------------------------------------------
+const fixtureTwoOpGraph: OpenAPISpec = {
+  openapi: '3.0.3',
+  info: { title: 'fixture-two-op-graph', version: '0.0.0' },
+  components: {
+    schemas: {
+      ProcessDefinitionKey: {
+        type: 'string',
+        'x-semantic-type': 'ProcessDefinitionKey',
+        description: 'Unique key identifying a process definition',
+      },
+    },
+  },
+  paths: {
+    '/definitions': {
+      post: {
+        operationId: 'provideKey',
+        responses: {
+          '200': {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    processDefinitionKey: {
+                      type: 'string',
+                      'x-semantic-type': 'ProcessDefinitionKey',
+                      'x-semantic-provider': true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/instances': {
+      post: {
+        operationId: 'consumeKey',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['processDefinitionKey'],
+                properties: {
+                  processDefinitionKey: {
+                    type: 'string',
+                    'x-semantic-type': 'ProcessDefinitionKey',
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: { '200': { description: 'ok' } },
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Fixture: two independent operations with NO shared semantic type.
+// Zero edges expected between them.
+// ---------------------------------------------------------------------------
+const fixtureNoSharedType: OpenAPISpec = {
+  openapi: '3.0.3',
+  info: { title: 'fixture-no-shared-type', version: '0.0.0' },
+  paths: {
+    '/a': {
+      get: {
+        operationId: 'opA',
+        parameters: [
+          {
+            name: 'jobKey',
+            in: 'query',
+            schema: { type: 'string', 'x-semantic-type': 'JobKey' },
+          },
+        ],
+        responses: { '200': { description: 'ok' } },
+      },
+    },
+    '/b': {
+      post: {
+        operationId: 'opB',
+        responses: {
+          '200': {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    processDefinitionKey: {
+                      type: 'string',
+                      'x-semantic-type': 'ProcessDefinitionKey',
+                      'x-semantic-provider': true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function buildGraphFrom(spec: OpenAPISpec) {
+  const analyzer = new SchemaAnalyzer();
+  const semanticTypes = analyzer.extractSemanticTypes(spec);
+  const operations = analyzer.extractOperations(spec);
+  return new GraphBuilder().buildDependencyGraph(operations, semanticTypes);
+}
+
+// ---------------------------------------------------------------------------
+// Tests: GraphBuilder edge creation
+// ---------------------------------------------------------------------------
+describe('GraphBuilder: edge creation from semantic type relationships', () => {
+  it('creates an edge from producer to consumer when they share a semantic type', () => {
+    const graph = buildGraphFrom(fixtureTwoOpGraph);
+
+    const edge = graph.edges.find(
+      (e) => e.sourceOperationId === 'provideKey' && e.targetOperationId === 'consumeKey',
+    );
+    expect(edge, 'expected edge provideKey → consumeKey').toBeDefined();
+    expect(edge?.semanticType).toBe('ProcessDefinitionKey');
+  });
+
+  it('does NOT create a reverse edge from consumer to producer', () => {
+    const graph = buildGraphFrom(fixtureTwoOpGraph);
+
+    const reverseEdge = graph.edges.find(
+      (e) => e.sourceOperationId === 'consumeKey' && e.targetOperationId === 'provideKey',
+    );
+    expect(reverseEdge, 'reverse edge must not exist').toBeUndefined();
+  });
+
+  it('creates zero edges when no semantic type is shared between operations', () => {
+    const graph = buildGraphFrom(fixtureNoSharedType);
+    expect(graph.edges).toHaveLength(0);
+  });
+
+  it('includes both operations in the graph regardless of edge count', () => {
+    const graph = buildGraphFrom(fixtureNoSharedType);
+    expect(graph.operations.has('opA')).toBe(true);
+    expect(graph.operations.has('opB')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: SemanticGraphExtractor.extractGraph() — JSON vs YAML parsing
+// ---------------------------------------------------------------------------
+describe('SemanticGraphExtractor.extractGraph(): JSON input parsing', () => {
+  it('parses a .json spec file using JSON.parse (not yaml.load)', async () => {
+    const tmpPath = join(tmpdir(), 'fixture-two-op-graph.json');
+    writeFileSync(tmpPath, JSON.stringify(fixtureTwoOpGraph));
+
+    const extractor = new SemanticGraphExtractor();
+    const graph = await extractor.extractGraph(tmpPath);
+
+    // If JSON.parse failed silently and returned an empty spec, operations
+    // would be empty. Assert we got real content.
+    expect(graph.operations.size).toBe(2);
+    expect(graph.semanticTypes.size).toBeGreaterThanOrEqual(1);
+  });
+
+  it('extracts the correct edge from a JSON fixture via the full pipeline', async () => {
+    const tmpPath = join(tmpdir(), 'fixture-two-op-graph-edges.json');
+    writeFileSync(tmpPath, JSON.stringify(fixtureTwoOpGraph));
+
+    const extractor = new SemanticGraphExtractor();
+    const graph = await extractor.extractGraph(tmpPath);
+
+    const edge = graph.edges.find(
+      (e) => e.sourceOperationId === 'provideKey' && e.targetOperationId === 'consumeKey',
+    );
+    expect(edge, 'expected edge provideKey → consumeKey via full pipeline').toBeDefined();
+    expect(edge?.semanticType).toBe('ProcessDefinitionKey');
+  });
+
+  it('parses a .yaml spec string path without error', async () => {
+    // Verify the YAML fallback path still works for callers using legacy .yaml sources.
+    const yaml = require('js-yaml');
+    const yamlContent = yaml.dump(fixtureTwoOpGraph);
+    const tmpPath = join(tmpdir(), 'fixture-two-op-graph.yaml');
+    writeFileSync(tmpPath, yamlContent);
+
+    const extractor = new SemanticGraphExtractor();
+    const graph = await extractor.extractGraph(tmpPath);
+
+    expect(graph.operations.size).toBe(2);
+  });
+});


### PR DESCRIPTION
Takeover of part 1/3 of #47 (original author: @johnOC03), rebased on main and split per reviewer request.

## What changed
- `semantic-graph-extractor/index.ts` — switch to `JSON.parse()` when the spec file extension is `.json`; keep `yaml.load()` as a fallback for `.yaml`/`.yml` sources so the extractor handles both the bundled JSON output and legacy YAML inputs.
- `tests/fixtures/extractor/extractor-graph.test.ts` (new) — 7 fixture tests covering GraphBuilder edge creation + `extractGraph()` JSON / YAML parsing paths.

## Why
The bundled spec is plain JSON. `yaml.load()` happens to handle JSON-as-YAML but silently discards JSON-specific differences and adds an unnecessary YAML parse pass. This isolates the parser concern.

## Verification
```
npm run lint
npx vitest run tests/fixtures/extractor/extractor-graph.test.ts   # 7/7 passed
```

## Notes
- Parts 2/3 (chain-graft + graphLoader) and 3/3 (domain-semantics expansion + audit script) will follow as separate PRs.
- Original PR #47 will be closed once the three takeover PRs land.

Closes part of #46.