### PR TITLE
fix(graph-loader): surface sidecar-declared 'produces' to semantic BFS

### DIFF
--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -234,6 +234,22 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
         for (const st of spec.implicitAdds ?? []) addProducer(st, opId);
       }
     }
+    // #56: surface sidecar-declared `produces` into the semantic-BFS-visible
+    // structures (op.produces and bySemanticProducer). Without this step the
+    // sidecar entry only updates `domainProduces` / `domainProducers`, which
+    // are used by the runtime-state planner but invisible to semantic BFS.
+    if (domain?.operationRequirements) {
+      for (const [opId, spec] of Object.entries(domain.operationRequirements)) {
+        const node = operations[opId];
+        if (!node) continue;
+        for (const st of spec.produces ?? []) {
+          if (!node.produces.includes(st)) node.produces.push(st);
+          const list = bySemanticProducer[st] ?? [];
+          if (!list.includes(opId)) list.push(opId);
+          bySemanticProducer[st] = list;
+        }
+      }
+    }
   } catch {
     // ignore
   }

--- a/tests/fixtures/loader/graphloader-sidecar.test.ts
+++ b/tests/fixtures/loader/graphloader-sidecar.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Loader fixtures for graphLoader sidecar handling — issue #56.
+ *
+ * Each fixture builds a tiny on-disk layout mimicking the path-analyser
+ * baseDir contract (a sibling `semantic-graph-extractor/dist/output/`
+ * directory holding the dependency graph, plus a `domain-semantics.json`
+ * inside the baseDir), then calls `loadGraph()` and asserts on the
+ * returned `OperationGraph`.
+ *
+ * The first fixture pins the regression for #56: a sidecar-declared
+ * `domain.operationRequirements[opId].produces` must surface in
+ * `bySemanticProducer` and `operations[opId].produces`, otherwise
+ * semantic BFS cannot use it.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadGraph } from '../../../path-analyser/src/graphLoader.ts';
+
+interface SidecarLayout {
+  graph: Record<string, unknown>;
+  domain: Record<string, unknown>;
+}
+
+let workdir: string;
+let baseDir: string;
+let graphDir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'graphloader-fixture-'));
+  baseDir = join(workdir, 'path-analyser');
+  graphDir = join(workdir, 'semantic-graph-extractor', 'dist', 'output');
+  mkdirSync(baseDir, { recursive: true });
+  mkdirSync(graphDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+function writeLayout(layout: SidecarLayout): void {
+  writeFileSync(join(graphDir, 'operation-dependency-graph.json'), JSON.stringify(layout.graph));
+  writeFileSync(join(baseDir, 'domain-semantics.json'), JSON.stringify(layout.domain));
+}
+
+// ---------------------------------------------------------------------------
+// Fixture #56 — sidecar `produces` must surface in BFS-visible maps.
+// ---------------------------------------------------------------------------
+describe('graphLoader: sidecar-declared produces (#56)', () => {
+  it('registers sidecar produces in bySemanticProducer so semantic BFS can find them', async () => {
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'producerOp',
+            method: 'POST',
+            path: '/producer',
+          },
+          {
+            operationId: 'consumerOp',
+            method: 'POST',
+            path: '/consumer',
+          },
+        ],
+      },
+      domain: {
+        operationRequirements: {
+          producerOp: {
+            produces: ['Foo'],
+          },
+        },
+      },
+    });
+    const g = await loadGraph(baseDir);
+    expect(
+      g.bySemanticProducer.Foo,
+      'sidecar producer must be registered for semantic BFS',
+    ).toEqual(['producerOp']);
+  });
+
+  it("registers sidecar produces on the operation's own produces list", async () => {
+    writeLayout({
+      graph: {
+        operations: [{ operationId: 'producerOp', method: 'POST', path: '/producer' }],
+      },
+      domain: {
+        operationRequirements: {
+          producerOp: {
+            produces: ['Foo'],
+          },
+        },
+      },
+    });
+    const g = await loadGraph(baseDir);
+    expect(g.operations.producerOp?.produces).toContain('Foo');
+  });
+
+  it('preserves an existing extractor-derived producer when the sidecar declares the same semantic', async () => {
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'extractorProducer',
+            method: 'POST',
+            path: '/extractor',
+            responseSemanticTypes: {
+              '200': [{ semanticType: 'Foo', fieldPath: 'foo', provider: true }],
+            },
+          },
+          { operationId: 'sidecarProducer', method: 'POST', path: '/sidecar' },
+        ],
+      },
+      domain: {
+        operationRequirements: {
+          sidecarProducer: {
+            produces: ['Foo'],
+          },
+        },
+      },
+    });
+    const g = await loadGraph(baseDir);
+    expect(g.bySemanticProducer.Foo).toEqual(
+      expect.arrayContaining(['extractorProducer', 'sidecarProducer']),
+    );
+  });
+
+  it('does not duplicate a producer if the sidecar redundantly declares an extractor-derived semantic', async () => {
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'opOne',
+            method: 'POST',
+            path: '/one',
+            responseSemanticTypes: {
+              '200': [{ semanticType: 'Foo', fieldPath: 'foo', provider: true }],
+            },
+          },
+        ],
+      },
+      domain: {
+        operationRequirements: {
+          opOne: {
+            produces: ['Foo'],
+          },
+        },
+      },
+    });
+    const g = await loadGraph(baseDir);
+    expect(g.bySemanticProducer.Foo).toEqual(['opOne']);
+    expect(g.operations.opOne?.produces.filter((s) => s === 'Foo').length).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #56.

## Summary

`domain.operationRequirements[opId].produces` was wired into `domainProducers` / `node.domainProduces` (consumed by the runtime-state planner) but **not** into `bySemanticProducer` / `OperationNode.produces` (consumed by the semantic BFS in `scenarioGenerator.ts`). A sidecar-only producer was therefore invisible to semantic BFS, so a sidecar entry like

```json
{ "operationRequirements": { "createDeployment": { "produces": ["DecisionDefinitionId"] } } }
```

would not let `evaluateDecision` chain back to `createDeployment` via that semantic.

## Fix

In `graphLoader.ts`, after the existing domain-producer wiring, append each sidecar `produces` entry into `bySemanticProducer[st]` and `operations[opId].produces` when not already present.

## Red/green

A new Layer-1 loader fixture `tests/fixtures/loader/graphloader-sidecar.test.ts` pins four properties:
1. sidecar producer registered in `bySemanticProducer`
2. sidecar producer appended to `operations[opId].produces`
3. extractor-derived producer is preserved alongside a sidecar producer for the same semantic
4. duplicate registration is suppressed when sidecar redundantly declares an extractor-derived semantic

Properties (1)–(3) failed on `main` against the new fixture; (4) was already correct. All four pass after the fix. Full suite: 78/78.

## Scope

This change is necessary but not sufficient for #58 — none of the four deadlocked endpoints are unblocked by it on the current pinned spec, because no sidecar `produces` entry currently targets the missing semantics. It removes one obstacle so the #58 fix can rely on sidecar-augmented producers.

## Credit

Original observation by @johnOC03 in the closed PR #47 (commit `256e202`).