### PR TITLE
fix(planner): defer authoritative producers blocked by satisfiable domain prerequisites (#58)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,11 +359,31 @@ npm run lint
 npx tsc --noEmit -p semantic-graph-extractor/tsconfig.json
 npx tsc --noEmit -p path-analyser/tsconfig.json
 npx tsc --noEmit -p request-validation/tsconfig.json
-npm run pipeline                      # only if your change affects pipeline output
+TEST_SEED=snapshot-baseline npm run testsuite:generate
+npm run generate:request-validation
 npm test
 ```
 
-For Layer-3 invariant changes you must run the pipeline first or the test
+> **`npm test` alone is not sufficient.** The Layer-3 invariants in
+> `tests/regression/bundled-spec-invariants.test.ts` read regenerated
+> pipeline output (per-endpoint scenario JSON, feature-output files,
+> emitted Playwright suites). If you skip the regen step you'll be testing
+> against stale output and CI will surface a regression you didn't see
+> locally — which is what happened on PR #62 (the L3 `#58` reproducer
+> only fails when the pipeline is regenerated against the current
+> `scenarioGenerator.ts`).
+>
+> Any change under `semantic-graph-extractor/`, `path-analyser/`,
+> `request-validation/`, `domain-semantics.json`, `filter-providers.json`,
+> or `request-defaults.json` requires the regen. When in doubt, regen.
+>
+> CI's "Regenerate pipeline outputs" step runs the same two commands
+> (`testsuite:generate` + `generate:request-validation`) under
+> `TEST_SEED=snapshot-baseline`. The `npm run pipeline` script also
+> works but additionally re-fetches the spec, which is slower and
+> usually unnecessary.
+
+For Layer-3 invariant changes you must run the regen step or the test
 file aborts with a "graph not found" / "scenarios directory not found"
 error.
 

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -510,23 +510,27 @@ export function generateScenariosForEndpoint(
       // multiple producers against the same parent BFS frame, so passing
       // the parent `state` directly leaks artifact/model mutations from
       // one createDeployment candidate into sibling candidates evaluated
-      // later in the same loop. Operate on a per-candidate working clone
-      // (mirrors deferForMissingDomainPrereqs) and read the post-call
-      // collections back from `workingState` when enqueuing.
-      const workingArtifactsApplied = state.artifactsApplied
-        ? [...state.artifactsApplied]
-        : undefined;
+      // later in the same loop. Only the createDeployment path triggers
+      // those mutations — clone artifactsApplied/modelsDraft only there
+      // to avoid extra allocations on the common non-deployment path.
+      // bindingsDraft is cloned unconditionally because the identifier
+      // heuristic below writes to it for every producer.
       const workingBindingsDraft = { ...(state.bindingsDraft || {}) };
-      const workingModelsDraft = state.modelsDraft ? [...state.modelsDraft] : undefined;
-      const workingState: State = {
-        ...state,
-        artifactsApplied: workingArtifactsApplied,
-        bindingsDraft: workingBindingsDraft,
-        modelsDraft: workingModelsDraft,
-      };
+      let workingState: State;
       if (producerOpId === 'createDeployment') {
+        const workingArtifactsApplied = state.artifactsApplied
+          ? [...state.artifactsApplied]
+          : undefined;
+        const workingModelsDraft = state.modelsDraft ? [...state.modelsDraft] : undefined;
+        workingState = {
+          ...state,
+          artifactsApplied: workingArtifactsApplied,
+          bindingsDraft: workingBindingsDraft,
+          modelsDraft: workingModelsDraft,
+        };
         applyArtifactRuleSelection(graph, producerNode, workingState, newProduced, newDomainStates);
       } else {
+        workingState = { ...state, bindingsDraft: workingBindingsDraft };
         producerNode.produces.forEach((s) => {
           newProduced.add(s);
         });
@@ -574,8 +578,17 @@ export function generateScenariosForEndpoint(
       // arbitrary producer for them and inserts a spurious step.
       const newOps = [...state.ops, producerOpId];
       const newProductionMap = new Map(state.productionMap);
+      // Only record productionMap entries for semantics that actually
+      // landed in `newProduced`. For createDeployment, applyArtifactRuleSelection
+      // intentionally limits the produced set based on the selected
+      // artifact bundle; recording the full declared `producerNode.produces`
+      // would make productionMap claim semantics (Decision*/Form keys, etc.)
+      // that the candidate didn't actually produce in this scenario
+      // (mirrors the gate in deferForMissingDomainPrereqs).
       producerNode.produces.forEach((s) => {
-        if (!newProductionMap.has(s)) newProductionMap.set(s, producerOpId);
+        if (newProduced.has(s) && !newProductionMap.has(s)) {
+          newProductionMap.set(s, producerOpId);
+        }
       });
       // (newDomainStates already updated above)
 
@@ -797,27 +810,26 @@ function deferForMissingDomainPrereqs(
     const newDomainStates = new Set(state.domainStates);
     // applyArtifactRuleSelection mutates state.artifactsApplied,
     // state.bindingsDraft, and state.modelsDraft (via
-    // ensureArtifactBindings). We iterate multiple candidate domain
-    // producers and may `continue` after the call, so passing the
-    // parent `state` directly would leak mutations into sibling
-    // candidates and into the parent BFS frame. Operate on a per-child
-    // working copy with shallow clones of the mutable collections, then
-    // hand those clones to the enqueued child state below if we accept
-    // the candidate.
-    const workingArtifactsApplied = state.artifactsApplied
-      ? [...state.artifactsApplied]
-      : undefined;
-    const workingBindingsDraft = { ...(state.bindingsDraft || {}) };
-    const workingModelsDraft = state.modelsDraft ? [...state.modelsDraft] : undefined;
-    const workingState: State = {
-      ...state,
-      artifactsApplied: workingArtifactsApplied,
-      bindingsDraft: workingBindingsDraft,
-      modelsDraft: workingModelsDraft,
-    };
+    // ensureArtifactBindings). Only the createDeployment branch
+    // triggers those mutations and the seeding fallback below \u2014
+    // clone the draft collections only on that path so non-deployment
+    // candidates avoid the extra allocations on every BFS iteration.
+    let workingState: State;
     if (candidateOpId === 'createDeployment') {
+      const workingArtifactsApplied = state.artifactsApplied
+        ? [...state.artifactsApplied]
+        : undefined;
+      const workingBindingsDraft = { ...(state.bindingsDraft || {}) };
+      const workingModelsDraft = state.modelsDraft ? [...state.modelsDraft] : undefined;
+      workingState = {
+        ...state,
+        artifactsApplied: workingArtifactsApplied,
+        bindingsDraft: workingBindingsDraft,
+        modelsDraft: workingModelsDraft,
+      };
       applyArtifactRuleSelection(graph, candidateNode, workingState, newProduced, newDomainStates);
     } else {
+      workingState = state;
       candidateNode.produces.forEach((s) => {
         newProduced.add(s);
       });

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -466,7 +466,22 @@ export function generateScenariosForEndpoint(
         const missingDomain = producerNode.domainRequiresAll.filter(
           (ds) => !state.domainStates.has(ds),
         );
-        if (missingDomain.length) continue; // wait until domain states present
+        if (missingDomain.length) {
+          // Issue #58: when an authoritative semantic producer is blocked
+          // solely by missing domain prereqs, defer it by scheduling the
+          // domain producers first. Without this branch BFS silently
+          // drops the candidate — the domain-progression branch above
+          // only fires when no semantic remains, so endpoints whose
+          // single authoritative producer is domain-gated would never
+          // receive a chain (cf. completeJob → activateJobs gated on
+          // ProcessInstanceExists+ModelHasServiceTaskType).
+          //
+          // Limited to authoritative producers (mirroring the
+          // deferForMissingPrereqs rule) to avoid spurious incidental
+          // chains.
+          if (deferForMissingDomainPrereqs(graph, producerNode, targetSemantic, state, seen, queue, endpointOpId)) continue;
+          continue; // wait until domain states present
+        }
       }
       // Issue #35: reject candidates whose own required semantic inputs
       // are not produced by an earlier step. Without this guard the
@@ -679,6 +694,107 @@ function deferForMissingPrereqs(
     queue.push({ ...state, needed: deferredNeeded });
   }
   return true;
+}
+
+// Issue #58: when an authoritative semantic producer is rejected because
+// its `domainRequiresAll` is unmet, schedule a domain producer for the
+// first missing state (transitive prereqs included) so the candidate can
+// be revisited on a subsequent BFS iteration.
+//
+// Only authoritative providers (`providerMap[targetSemantic] === true`)
+// are deferred. Deferring incidental producers would generate spurious
+// scenarios where the incidental's output is unused, mirroring the
+// rationale in `deferForMissingPrereqs`.
+//
+// For each candidate domain producer we enqueue a state with that op
+// appended and the domain state added. Cycle detection and domain
+// prereq chains are handled identically to the dedicated
+// domain-progression branch.
+//
+// Returns true when at least one deferred state was enqueued (the
+// caller should `continue` either way; this is informational).
+function deferForMissingDomainPrereqs(
+  graph: OperationGraph,
+  producerNode: OperationNode,
+  targetSemantic: string | undefined,
+  state: State,
+  seen: Set<string>,
+  queue: State[],
+  endpointOpId: string,
+): boolean {
+  const isAuthoritative = !!targetSemantic && producerNode.providerMap?.[targetSemantic] === true;
+  if (!isAuthoritative) return false;
+  const directMissing = (producerNode.domainRequiresAll ?? []).filter(
+    (ds) => !state.domainStates.has(ds),
+  );
+  if (directMissing.length === 0) return false;
+  const missingAll = gatherDomainPrerequisites(graph, directMissing, state.domainStates);
+  const candidates = new Set<string>();
+  for (const ds of missingAll) {
+    for (const opId of graph.domainProducers?.[ds] ?? []) candidates.add(opId);
+  }
+  let enqueued = false;
+  for (const candidateOpId of candidates) {
+    if (candidateOpId === endpointOpId) continue;
+    const candidateNode = graph.operations[candidateOpId];
+    if (!candidateNode) continue;
+    const indexInPath = state.ops.indexOf(candidateOpId);
+    let nextCycle = state.cycle;
+    if (indexInPath !== -1) {
+      if (state.cycle) continue;
+      nextCycle = true;
+    }
+    // Candidate must have its own domain prereqs satisfied (transitive
+    // missing states are surfaced via `missingAll` so the *next* BFS
+    // iteration will reach them).
+    if (candidateNode.domainRequiresAll?.length) {
+      const missing = candidateNode.domainRequiresAll.filter((d) => !state.domainStates.has(d));
+      if (missing.length) continue;
+    }
+    if (!hasSatisfiedRequiredInputs(candidateNode, state.produced)) continue;
+    const newlyAdds = new Set<string>();
+    candidateNode.domainProduces?.forEach((d) => {
+      if (!state.domainStates.has(d)) newlyAdds.add(d);
+    });
+    candidateNode.domainImplicitAdds?.forEach((d) => {
+      if (!state.domainStates.has(d)) newlyAdds.add(d);
+    });
+    if (newlyAdds.size === 0) continue;
+    const newProduced = new Set(state.produced);
+    candidateNode.produces.forEach((s) => {
+      newProduced.add(s);
+    });
+    const newNeeded = new Set(state.needed);
+    candidateNode.requires.required.forEach((s) => {
+      newNeeded.add(s);
+    });
+    const newOps = [...state.ops, candidateOpId];
+    const newProductionMap = new Map(state.productionMap);
+    candidateNode.produces.forEach((s) => {
+      if (!newProductionMap.has(s)) newProductionMap.set(s, candidateOpId);
+    });
+    const newDomainStates = new Set(state.domainStates);
+    newlyAdds.forEach((d) => {
+      newDomainStates.add(d);
+    });
+    const sig = signature(newOps, newProduced, newNeeded, nextCycle);
+    if (seen.has(sig)) continue;
+    seen.add(sig);
+    queue.push({
+      produced: newProduced,
+      needed: newNeeded,
+      domainStates: newDomainStates,
+      ops: newOps,
+      cycle: nextCycle,
+      productionMap: newProductionMap,
+      bootstrapSequencesUsed: state.bootstrapSequencesUsed,
+      bootstrapFull: state.bootstrapFull,
+      modelsDraft: state.modelsDraft,
+      bindingsDraft: state.bindingsDraft,
+    });
+    enqueued = true;
+  }
+  return enqueued;
 }
 
 // Select minimal artifact rules for createDeployment based on unmet semantic needs.

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -478,19 +478,18 @@ export function generateScenariosForEndpoint(
           //
           // Limited to authoritative producers (mirroring the
           // deferForMissingPrereqs rule) to avoid spurious incidental
-          // chains.
-          if (
-            deferForMissingDomainPrereqs(
-              graph,
-              producerNode,
-              targetSemantic,
-              state,
-              seen,
-              queue,
-              endpointOpId,
-            )
-          )
-            continue;
+          // chains. The helper's return value is informational; the
+          // semantic candidate is skipped either way (we wait until the
+          // domain states surface on a later iteration).
+          deferForMissingDomainPrereqs(
+            graph,
+            producerNode,
+            targetSemantic,
+            state,
+            seen,
+            queue,
+            endpointOpId,
+          );
           continue; // wait until domain states present
         }
       }
@@ -763,18 +762,62 @@ function deferForMissingDomainPrereqs(
       if (missing.length) continue;
     }
     if (!hasSatisfiedRequiredInputs(candidateNode, state.produced)) continue;
-    const newlyAdds = new Set<string>();
-    candidateNode.domainProduces?.forEach((d) => {
-      if (!state.domainStates.has(d)) newlyAdds.add(d);
-    });
-    candidateNode.domainImplicitAdds?.forEach((d) => {
-      if (!state.domainStates.has(d)) newlyAdds.add(d);
-    });
-    if (newlyAdds.size === 0) continue;
+    // Apply the same artifact-rule selection as the semantic-producer
+    // branch when the deferred domain producer is `createDeployment`,
+    // otherwise we'd treat *all* deployment-advertised semantics
+    // (Decision*/Form keys, etc.) as produced even when the selected
+    // artifact bundle wouldn't yield them. Non-createDeployment
+    // candidates take the unfiltered path (their `produces` is already
+    // the authoritative set).
     const newProduced = new Set(state.produced);
-    candidateNode.produces.forEach((s) => {
-      newProduced.add(s);
-    });
+    const newDomainStates = new Set(state.domainStates);
+    if (candidateOpId === 'createDeployment') {
+      applyArtifactRuleSelection(graph, candidateNode, state, newProduced, newDomainStates);
+    } else {
+      candidateNode.produces.forEach((s) => {
+        newProduced.add(s);
+      });
+      candidateNode.domainProduces?.forEach((d) => {
+        newDomainStates.add(d);
+      });
+      candidateNode.domainImplicitAdds?.forEach((d) => {
+        newDomainStates.add(d);
+      });
+    }
+    // Require this deferred step to make domain-state progress, else
+    // BFS would loop on the same `seen` signature with no benefit.
+    const domainAddedNow = [...newDomainStates].filter((d) => !state.domainStates.has(d));
+    if (domainAddedNow.length === 0) continue;
+    // Mirror the semantic-producer branch's transitive prereq check:
+    // a newly-added domain state must have its `runtimeStates.requires`
+    // and `capabilities.dependsOn` satisfied within `newDomainStates`,
+    // otherwise we'd mark a state satisfied while its transitive
+    // prerequisites are absent (e.g. `ProcessInstanceExists` requires
+    // `ProcessDefinitionDeployed`).
+    let prereqFailed = false;
+    for (const d of domainAddedNow) {
+      const rs = graph.domain?.runtimeStates?.[d];
+      if (rs?.requires) {
+        for (const req of rs.requires) {
+          if (!newDomainStates.has(req)) {
+            prereqFailed = true;
+            break;
+          }
+        }
+        if (prereqFailed) break;
+      }
+      const cap = graph.domain?.capabilities?.[d];
+      if (cap?.dependsOn) {
+        for (const dep of cap.dependsOn) {
+          if (!newDomainStates.has(dep)) {
+            prereqFailed = true;
+            break;
+          }
+        }
+        if (prereqFailed) break;
+      }
+    }
+    if (prereqFailed) continue;
     const newNeeded = new Set(state.needed);
     candidateNode.requires.required.forEach((s) => {
       newNeeded.add(s);
@@ -784,10 +827,16 @@ function deferForMissingDomainPrereqs(
     candidateNode.produces.forEach((s) => {
       if (!newProductionMap.has(s)) newProductionMap.set(s, candidateOpId);
     });
-    const newDomainStates = new Set(state.domainStates);
-    newlyAdds.forEach((d) => {
-      newDomainStates.add(d);
-    });
+    // Mirror the semantic-producer branch's createDeployment seeding so
+    // a deferred deployment step still surfaces a process-definition
+    // binding for downstream consumers.
+    let modelsDraft = state.modelsDraft;
+    const bindingsDraft = { ...(state.bindingsDraft || {}) };
+    if (candidateOpId === 'createDeployment' && !modelsDraft) {
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder consumed by the test runtime
+      bindingsDraft.processDefinitionIdVar1 = 'proc_${RANDOM}';
+      modelsDraft = [{ kind: 'bpmn', processDefinitionIdVar: 'processDefinitionIdVar1' }];
+    }
     const sig = signature(newOps, newProduced, newNeeded, nextCycle);
     if (seen.has(sig)) continue;
     seen.add(sig);
@@ -800,8 +849,14 @@ function deferForMissingDomainPrereqs(
       productionMap: newProductionMap,
       bootstrapSequencesUsed: state.bootstrapSequencesUsed,
       bootstrapFull: state.bootstrapFull,
-      modelsDraft: state.modelsDraft,
-      bindingsDraft: state.bindingsDraft,
+      modelsDraft,
+      bindingsDraft,
+      // Propagate scenario-metadata bookkeeping from `state` and update
+      // providerList for the candidate's produced semantics so later
+      // scenario naming/description stays consistent with the semantic
+      // expansion branch.
+      providerList: updateProviderList(state.providerList || {}, candidateNode, newProductionMap),
+      artifactsApplied: state.artifactsApplied,
     });
     enqueued = true;
   }

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -479,7 +479,18 @@ export function generateScenariosForEndpoint(
           // Limited to authoritative producers (mirroring the
           // deferForMissingPrereqs rule) to avoid spurious incidental
           // chains.
-          if (deferForMissingDomainPrereqs(graph, producerNode, targetSemantic, state, seen, queue, endpointOpId)) continue;
+          if (
+            deferForMissingDomainPrereqs(
+              graph,
+              producerNode,
+              targetSemantic,
+              state,
+              seen,
+              queue,
+              endpointOpId,
+            )
+          )
+            continue;
           continue; // wait until domain states present
         }
       }

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -629,7 +629,12 @@ export function generateScenariosForEndpoint(
         bootstrapFull: state.bootstrapFull,
         modelsDraft,
         bindingsDraft,
-        providerList: updateProviderList(state.providerList || {}, producerNode, newProductionMap),
+        providerList: updateProviderList(
+          state.providerList || {},
+          producerNode,
+          newProductionMap,
+          newProduced,
+        ),
         artifactsApplied: workingState.artifactsApplied,
       });
     }
@@ -929,7 +934,12 @@ function deferForMissingDomainPrereqs(
       // expansion branch. Read artifactsApplied from `workingState` so
       // any array allocated by applyArtifactRuleSelection (`state.x ||= []`)
       // is preserved on the enqueued child without leaking into siblings.
-      providerList: updateProviderList(state.providerList || {}, candidateNode, newProductionMap),
+      providerList: updateProviderList(
+        state.providerList || {},
+        candidateNode,
+        newProductionMap,
+        newProduced,
+      ),
       artifactsApplied: workingState.artifactsApplied,
     });
     enqueued = true;
@@ -1129,9 +1139,18 @@ function updateProviderList(
   existing: Record<string, string[]>,
   producerNode: OperationNode,
   _productionMap: Map<string, string>,
+  newProduced: Set<string>,
 ): Record<string, string[]> {
   const copy: Record<string, string[]> = { ...existing };
   producerNode.produces?.forEach((s: string) => {
+    // Only record providers for semantics that actually landed in
+    // newProduced. For createDeployment, applyArtifactRuleSelection
+    // intentionally limits the produced set based on the selected
+    // artifact bundle; recording the full declared `produces` would
+    // make providerList claim semantics (Decision*/Form keys, etc.)
+    // that the candidate didn't actually produce in this scenario
+    // (mirrors the productionMap gate).
+    if (!newProduced.has(s)) return;
     const opId = producerNode.operationId;
     if (!copy[s]) copy[s] = [opId];
     else if (!copy[s].includes(opId)) copy[s].push(opId);

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -707,9 +707,9 @@ function deferForMissingPrereqs(
 }
 
 // Issue #58: when an authoritative semantic producer is rejected because
-// its `domainRequiresAll` is unmet, schedule a domain producer for the
-// first missing state (transitive prereqs included) so the candidate can
-// be revisited on a subsequent BFS iteration.
+// its `domainRequiresAll` is unmet, schedule domain producers for any
+// missing state in the transitive closure (gatherDomainPrerequisites)
+// so the candidate can be revisited on a subsequent BFS iteration.
 //
 // Only authoritative providers (`providerMap[targetSemantic] === true`)
 // are deferred. Deferring incidental producers would generate spurious
@@ -844,8 +844,16 @@ function deferForMissingDomainPrereqs(
     });
     const newOps = [...state.ops, candidateOpId];
     const newProductionMap = new Map(state.productionMap);
+    // Only record productionMap entries for semantics that were actually
+    // added to `newProduced`. For createDeployment, applyArtifactRuleSelection
+    // intentionally limits the produced set based on the selected artifact
+    // bundle; using `candidateNode.produces` unconditionally would make
+    // productionMap claim semantics (Decision*/Form keys, etc.) the
+    // candidate didn't actually produce in this scenario.
     candidateNode.produces.forEach((s) => {
-      if (!newProductionMap.has(s)) newProductionMap.set(s, candidateOpId);
+      if (newProduced.has(s) && !newProductionMap.has(s)) {
+        newProductionMap.set(s, candidateOpId);
+      }
     });
     // Mirror the semantic-producer branch's createDeployment seeding so
     // a deferred deployment step still surfaces a process-definition

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -892,22 +892,34 @@ function applyArtifactRuleSelection(
     const remaining = new Set(unmetNeeded);
     const applied: string[] = [];
     const rules = (ruleSpec.rules || []).slice();
+    // Helper: pick the minimal preferred artifact (BPMN, else first).
+    // Used both when no semantics drive coverage and as a fallback when
+    // the greedy loop fails to apply any rule (e.g. when this is invoked
+    // from `deferForMissingDomainPrereqs`, where the outer `state.needed`
+    // contains semantics that no createDeployment rule produces, but we
+    // still need *some* artifact selected so the deferred step makes
+    // domain-state progress (#58 follow-up). Falling back to the
+    // preferred minimal artifact keeps the Decision*/Form-flooding
+    // protection intact while still letting BFS advance.
+    const applyPreferred = () => {
+      const preferred =
+        (ruleSpec.rules || []).find((r) => r.artifactKind === 'bpmnProcess') ??
+        (ruleSpec.rules || [])[0];
+      if (!preferred) return;
+      const semantics = enumerateRuleSemantics(preferred, graph);
+      semantics.forEach((s) => {
+        newProduced.add(s);
+      });
+      const states = enumerateRuleStates(preferred, graph);
+      states.forEach((st) => {
+        newDomainStates.add(st);
+      });
+      ensureArtifactBindings(preferred, graph, state, semantics, states);
+      applied.push(preferred.id ?? preferred.artifactKind);
+    };
     if (remaining.size === 0) {
       // No required semantics drive coverage: pick a single minimal artifact (prefer BPMN) to avoid flooding with unused Decision*/Form semantics.
-      const preferred = rules.find((r) => r.artifactKind === 'bpmnProcess') || rules[0];
-      if (preferred) {
-        const semantics = enumerateRuleSemantics(preferred, graph);
-        semantics.forEach((s) => {
-          newProduced.add(s);
-        });
-        const states = enumerateRuleStates(preferred, graph);
-        states.forEach((st) => {
-          newDomainStates.add(st);
-        });
-        ensureArtifactBindings(preferred, graph, state, semantics, states);
-        if (preferred.id) applied.push(preferred.id);
-        else applied.push(preferred.artifactKind);
-      }
+      applyPreferred();
     } else {
       // Greedy until coverage or exhaustion
       while (remaining.size && rules.length) {
@@ -941,6 +953,11 @@ function applyArtifactRuleSelection(
         else applied.push(best.artifactKind);
         ensureArtifactBindings(best, graph, state, adds, states);
       }
+      // Greedy exhausted without applying any rule (no rule covers any
+      // unmet `state.needed` semantic). Fall back to the preferred
+      // minimal artifact so the caller still observes a valid
+      // deployment artifact + ProcessDefinitionDeployed domain state.
+      if (applied.length === 0) applyPreferred();
     }
     if (applied.length) {
       state.artifactsApplied ||= [];

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -771,8 +771,28 @@ function deferForMissingDomainPrereqs(
     // the authoritative set).
     const newProduced = new Set(state.produced);
     const newDomainStates = new Set(state.domainStates);
+    // applyArtifactRuleSelection mutates state.artifactsApplied,
+    // state.bindingsDraft, and state.modelsDraft (via
+    // ensureArtifactBindings). We iterate multiple candidate domain
+    // producers and may `continue` after the call, so passing the
+    // parent `state` directly would leak mutations into sibling
+    // candidates and into the parent BFS frame. Operate on a per-child
+    // working copy with shallow clones of the mutable collections, then
+    // hand those clones to the enqueued child state below if we accept
+    // the candidate.
+    const workingArtifactsApplied = state.artifactsApplied
+      ? [...state.artifactsApplied]
+      : undefined;
+    const workingBindingsDraft = { ...(state.bindingsDraft || {}) };
+    const workingModelsDraft = state.modelsDraft ? [...state.modelsDraft] : undefined;
+    const workingState: State = {
+      ...state,
+      artifactsApplied: workingArtifactsApplied,
+      bindingsDraft: workingBindingsDraft,
+      modelsDraft: workingModelsDraft,
+    };
     if (candidateOpId === 'createDeployment') {
-      applyArtifactRuleSelection(graph, candidateNode, state, newProduced, newDomainStates);
+      applyArtifactRuleSelection(graph, candidateNode, workingState, newProduced, newDomainStates);
     } else {
       candidateNode.produces.forEach((s) => {
         newProduced.add(s);
@@ -829,9 +849,10 @@ function deferForMissingDomainPrereqs(
     });
     // Mirror the semantic-producer branch's createDeployment seeding so
     // a deferred deployment step still surfaces a process-definition
-    // binding for downstream consumers.
-    let modelsDraft = state.modelsDraft;
-    const bindingsDraft = { ...(state.bindingsDraft || {}) };
+    // binding for downstream consumers. Operate on the working clones
+    // so the mutations stay scoped to this child state.
+    let modelsDraft = workingModelsDraft;
+    const bindingsDraft = workingBindingsDraft;
     if (candidateOpId === 'createDeployment' && !modelsDraft) {
       // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder consumed by the test runtime
       bindingsDraft.processDefinitionIdVar1 = 'proc_${RANDOM}';
@@ -854,9 +875,11 @@ function deferForMissingDomainPrereqs(
       // Propagate scenario-metadata bookkeeping from `state` and update
       // providerList for the candidate's produced semantics so later
       // scenario naming/description stays consistent with the semantic
-      // expansion branch.
+      // expansion branch. Use the working clone of artifactsApplied so
+      // sibling candidates and already-enqueued states aren't mutated
+      // by appends from applyArtifactRuleSelection.
       providerList: updateProviderList(state.providerList || {}, candidateNode, newProductionMap),
-      artifactsApplied: state.artifactsApplied,
+      artifactsApplied: workingArtifactsApplied,
     });
     enqueued = true;
   }

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -1152,8 +1152,13 @@ function updateProviderList(
     // (mirrors the productionMap gate).
     if (!newProduced.has(s)) return;
     const opId = producerNode.operationId;
+    // Avoid in-place mutation of inherited arrays: `{ ...existing }` is
+    // shallow, so `copy[s]` is the same array reference as the parent
+    // BFS state's providerList[s]. push()ing into it would leak the
+    // append into the parent (and any sibling state that inherited the
+    // same reference). Allocate a fresh array on every write.
     if (!copy[s]) copy[s] = [opId];
-    else if (!copy[s].includes(opId)) copy[s].push(opId);
+    else if (!copy[s].includes(opId)) copy[s] = [...copy[s], opId];
   });
   return copy;
 }

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -503,8 +503,29 @@ export function generateScenariosForEndpoint(
 
       const newProduced = new Set(state.produced);
       const newDomainStates = new Set(state.domainStates);
+      // applyArtifactRuleSelection / ensureArtifactBindings mutate
+      // state.artifactsApplied, state.bindingsDraft, and state.modelsDraft
+      // (and may allocate fresh arrays/objects via `state.x ||= …` when
+      // those fields are undefined). The producer-candidate loop iterates
+      // multiple producers against the same parent BFS frame, so passing
+      // the parent `state` directly leaks artifact/model mutations from
+      // one createDeployment candidate into sibling candidates evaluated
+      // later in the same loop. Operate on a per-candidate working clone
+      // (mirrors deferForMissingDomainPrereqs) and read the post-call
+      // collections back from `workingState` when enqueuing.
+      const workingArtifactsApplied = state.artifactsApplied
+        ? [...state.artifactsApplied]
+        : undefined;
+      const workingBindingsDraft = { ...(state.bindingsDraft || {}) };
+      const workingModelsDraft = state.modelsDraft ? [...state.modelsDraft] : undefined;
+      const workingState: State = {
+        ...state,
+        artifactsApplied: workingArtifactsApplied,
+        bindingsDraft: workingBindingsDraft,
+        modelsDraft: workingModelsDraft,
+      };
       if (producerOpId === 'createDeployment') {
-        applyArtifactRuleSelection(graph, producerNode, state, newProduced, newDomainStates);
+        applyArtifactRuleSelection(graph, producerNode, workingState, newProduced, newDomainStates);
       } else {
         producerNode.produces.forEach((s) => {
           newProduced.add(s);
@@ -558,9 +579,12 @@ export function generateScenariosForEndpoint(
       });
       // (newDomainStates already updated above)
 
-      // Draft models & bindings
-      let modelsDraft = state.modelsDraft;
-      const bindingsDraft = { ...(state.bindingsDraft || {}) };
+      // Draft models & bindings — read post-call from workingState so any
+      // models/bindings allocated by applyArtifactRuleSelection /
+      // ensureArtifactBindings (`state.x ||= …`) flow into the enqueued
+      // child without leaking into sibling candidates.
+      let modelsDraft = workingState.modelsDraft;
+      const bindingsDraft = workingState.bindingsDraft ?? {};
       if (producerOpId === 'createDeployment' && !modelsDraft) {
         // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder consumed by the test runtime
         bindingsDraft.processDefinitionIdVar1 = 'proc_${RANDOM}';
@@ -593,7 +617,7 @@ export function generateScenariosForEndpoint(
         modelsDraft,
         bindingsDraft,
         providerList: updateProviderList(state.providerList || {}, producerNode, newProductionMap),
-        artifactsApplied: state.artifactsApplied,
+        artifactsApplied: workingState.artifactsApplied,
       });
     }
   }

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -857,10 +857,17 @@ function deferForMissingDomainPrereqs(
     });
     // Mirror the semantic-producer branch's createDeployment seeding so
     // a deferred deployment step still surfaces a process-definition
-    // binding for downstream consumers. Operate on the working clones
-    // so the mutations stay scoped to this child state.
-    let modelsDraft = workingModelsDraft;
-    const bindingsDraft = workingBindingsDraft;
+    // binding for downstream consumers.
+    //
+    // Read modelsDraft/bindingsDraft/artifactsApplied from `workingState`
+    // (post-call), not from the pre-call locals. applyArtifactRuleSelection
+    // and ensureArtifactBindings use `state.x ||= …` to allocate new
+    // arrays/objects when their input was undefined; those allocations
+    // land on `workingState.x`, while the pre-call locals stay undefined.
+    // Reading from workingState preserves any artifact-selected
+    // models/bindings/artifactsApplied for the enqueued child state.
+    let modelsDraft = workingState.modelsDraft;
+    const bindingsDraft = workingState.bindingsDraft ?? {};
     if (candidateOpId === 'createDeployment' && !modelsDraft) {
       // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder consumed by the test runtime
       bindingsDraft.processDefinitionIdVar1 = 'proc_${RANDOM}';
@@ -883,11 +890,11 @@ function deferForMissingDomainPrereqs(
       // Propagate scenario-metadata bookkeeping from `state` and update
       // providerList for the candidate's produced semantics so later
       // scenario naming/description stays consistent with the semantic
-      // expansion branch. Use the working clone of artifactsApplied so
-      // sibling candidates and already-enqueued states aren't mutated
-      // by appends from applyArtifactRuleSelection.
+      // expansion branch. Read artifactsApplied from `workingState` so
+      // any array allocated by applyArtifactRuleSelection (`state.x ||= []`)
+      // is preserved on the enqueued child without leaking into siblings.
       providerList: updateProviderList(state.providerList || {}, candidateNode, newProductionMap),
-      artifactsApplied: workingArtifactsApplied,
+      artifactsApplied: workingState.artifactsApplied,
     });
     enqueued = true;
   }

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -24,6 +24,8 @@ interface NodeOpts {
   optional?: string[];
   produces?: string[];
   providerMap?: Record<string, boolean>;
+  domainRequiresAll?: string[];
+  domainProduces?: string[];
 }
 
 function makeOp(operationId: string, opts: NodeOpts = {}): OperationNode {
@@ -37,12 +39,15 @@ function makeOp(operationId: string, opts: NodeOpts = {}): OperationNode {
     },
     produces: opts.produces ?? [],
     providerMap: opts.providerMap,
+    domainRequiresAll: opts.domainRequiresAll,
+    domainProduces: opts.domainProduces,
   };
 }
 
 function makeGraph(nodes: OperationNode[]): OperationGraph {
   const operations: Record<string, OperationNode> = {};
   const bySemanticProducer: Record<string, string[]> = {};
+  const domainProducers: Record<string, string[]> = {};
   for (const node of nodes) {
     operations[node.operationId] = node;
     for (const sem of node.produces) {
@@ -50,8 +55,13 @@ function makeGraph(nodes: OperationNode[]): OperationGraph {
       list.push(node.operationId);
       bySemanticProducer[sem] = list;
     }
+    for (const ds of node.domainProduces ?? []) {
+      const list = domainProducers[ds] ?? [];
+      list.push(node.operationId);
+      domainProducers[ds] = list;
+    }
   }
-  return { operations, bySemanticProducer };
+  return { operations, bySemanticProducer, domainProducers };
 }
 
 function plan(graph: OperationGraph, endpointOpId: string): EndpointScenarioCollection {
@@ -285,5 +295,54 @@ describe('planner contracts: spurious intermediate steps (#35)', () => {
     expect(collection.scenarios.length).toBeGreaterThan(0);
     const firstOps = opIdsOf(collection.scenarios[0]);
     expect(firstOps).toEqual(['produceX', 'produceTRequiringX', 'endpointRequiringT']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture G: domain-prereq-blocked authoritative producer (#58)
+// ---------------------------------------------------------------------------
+//
+// Endpoint `consumeFoo` requires `Foo`. The only authoritative producer
+// of `Foo` is `produceFoo`, which has `domainRequiresAll: ['BarReady']`.
+// `produceBar` is a domain producer for `BarReady` (via `domainProduces`)
+// and has no requirements. The planner must discover the chain
+// [produceBar, produceFoo, consumeFoo] rather than deadlocking.
+//
+// On main, BFS skips `produceFoo` outright when its `domainRequiresAll`
+// is unmet (semantic-target branch line ~466), and never enters the
+// domain-progression branch because semantic remaining > 0. Result:
+// scenarios.length === 0. This is the synthetic mirror of the
+// `completeJob → activateJobs → ProcessInstanceExists+ModelHasServiceTaskType`
+// deadlock observed on the bundled spec.
+const fixtureDomainBlockedAuthoritative: OperationGraph = makeGraph([
+  makeOp('produceBar', {
+    domainProduces: ['BarReady'],
+  }),
+  makeOp('produceFoo', {
+    produces: ['Foo'],
+    providerMap: { Foo: true },
+    domainRequiresAll: ['BarReady'],
+  }),
+  makeOp('consumeFoo', {
+    required: ['Foo'],
+  }),
+]);
+
+describe('planner contracts: domain-prereq-blocked authoritative producer (#58)', () => {
+  it('produces a chain that satisfies the authoritative producer\u2019s domain prereq', () => {
+    const collection = plan(fixtureDomainBlockedAuthoritative, 'consumeFoo');
+    expect(collection.unsatisfied).not.toBe(true);
+    expect(collection.scenarios.length).toBeGreaterThan(0);
+  });
+
+  it('chain order satisfies BarReady before invoking produceFoo', () => {
+    const collection = plan(fixtureDomainBlockedAuthoritative, 'consumeFoo');
+    const firstOps = opIdsOf(collection.scenarios[0]);
+    const barIdx = firstOps.indexOf('produceBar');
+    const fooIdx = firstOps.indexOf('produceFoo');
+    const endpointIdx = firstOps.indexOf('consumeFoo');
+    expect(barIdx, 'produceBar must appear in the chain').toBeGreaterThanOrEqual(0);
+    expect(fooIdx).toBeGreaterThan(barIdx);
+    expect(endpointIdx).toBeGreaterThan(fooIdx);
   });
 });

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -337,6 +337,10 @@ describe('planner contracts: domain-prereq-blocked authoritative producer (#58)'
 
   it('chain order satisfies BarReady before invoking produceFoo', () => {
     const collection = plan(fixtureDomainBlockedAuthoritative, 'consumeFoo');
+    expect(
+      collection.scenarios.length,
+      'expected at least one scenario before indexing scenarios[0]',
+    ).toBeGreaterThan(0);
     const firstOps = opIdsOf(collection.scenarios[0]);
     const barIdx = firstOps.indexOf('produceBar');
     const fooIdx = firstOps.indexOf('produceFoo');

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -278,9 +278,10 @@ describe('bundled-spec invariants: planner output', () => {
         );
       }
       // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
-      const raw = JSON.parse(
-        readFileSync(join(SCENARIOS_DIR, file), 'utf8'),
-      ) as { unsatisfied?: boolean; scenarios: unknown[] };
+      const raw = JSON.parse(readFileSync(join(SCENARIOS_DIR, file), 'utf8')) as {
+        unsatisfied?: boolean;
+        scenarios: unknown[];
+      };
       if (!scen.scenarios.length || raw.unsatisfied === true) {
         offenders.push({
           opId,
@@ -455,9 +456,7 @@ describe('bundled-spec invariants: planner output', () => {
           // `<placeholderName>Var`, the names never meet. Tracked separately
           // as a follow-up to #58 (BFS deferral); the class-scoped fix will
           // remove this carve-out and add a generic alias check.
-          const param = parameters.find(
-            (p) => p.name === ph && p.location === 'path',
-          );
+          const param = parameters.find((p) => p.name === ph && p.location === 'path');
           if (param?.semanticType) {
             const aliasVar = `${param.semanticType.charAt(0).toLowerCase()}${param.semanticType.slice(1)}Var`;
             if (isUsableBinding(bindings[aliasVar])) return false;

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -234,6 +234,64 @@ describe('bundled-spec invariants: planner output', () => {
     expect(offenders).toEqual([]);
   });
 
+  it('authoritative semantic producers gated on satisfiable domain prerequisites emit ≥1 satisfied scenario (#58)', () => {
+    // Class-scoped regression guard for #58 (BFS deadlock when an
+    // authoritative semantic producer carries an unsatisfied
+    // `domainRequiresAll` whose missing states have known domain
+    // producers).
+    //
+    // Before the fix, the BFS semantic-target branch would silently
+    // `continue` on such producers because the domain-progression
+    // branch only fires when no required-semantic remains, and the
+    // semantic branch had no deferral path. Result: every endpoint
+    // that ultimately needs that producer (e.g. JobAvailableForActivation
+    // → activateJobs → jobKey → completeJob/failJob) emitted 0
+    // scenarios.
+    //
+    // The pinned reproducers below cover three distinct chain depths:
+    //   - activateJobs       (1 hop:  createDeployment → createProcessInstance → activateJobs)
+    //   - completeJob        (2 hops: …→ activateJobs → completeJob)
+    //   - failJob            (2 hops: …→ activateJobs → failJob)
+    //
+    // The abstract class invariant ("BFS must defer rather than drop a
+    // domain-prereq-blocked authoritative producer when a domain
+    // producer for the missing state exists") is enforced at fixture
+    // level by Fixture G in tests/fixtures/planner/planner-contracts.test.ts;
+    // this L3 guard pins the real-world surfacings.
+    const reproducers: { file: string; opId: string }[] = [
+      { file: 'post--jobs--activation-scenarios.json', opId: 'activateJobs' },
+      {
+        file: 'post--jobs--{jobKey}--completion-scenarios.json',
+        opId: 'completeJob',
+      },
+      {
+        file: 'post--jobs--{jobKey}--failure-scenarios.json',
+        opId: 'failJob',
+      },
+    ];
+    const offenders: { opId: string; scenarios: number; unsatisfied: boolean }[] = [];
+    for (const { file, opId } of reproducers) {
+      const scen = loadScenarioFile(file);
+      if (scen.endpoint.operationId !== opId) {
+        throw new Error(
+          `Pinned reproducer file ${file} no longer maps to operationId ${opId} (got ${scen.endpoint.operationId}). Update the pin.`,
+        );
+      }
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const raw = JSON.parse(
+        readFileSync(join(SCENARIOS_DIR, file), 'utf8'),
+      ) as { unsatisfied?: boolean; scenarios: unknown[] };
+      if (!scen.scenarios.length || raw.unsatisfied === true) {
+        offenders.push({
+          opId,
+          scenarios: scen.scenarios.length,
+          unsatisfied: raw.unsatisfied === true,
+        });
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
   it('every feature-output scenario binds or chains every {placeholder} whose path parameter has a recognised semanticType', () => {
     // Class-scoped guard for the "un-extracted ${var} in URL" defect family:
     // when an endpoint's response analyser produces no shape (typically for
@@ -391,6 +449,20 @@ describe('bundled-spec invariants: planner output', () => {
           const varName = placeholderVarName(ph);
           if (isUsableBinding(bindings[varName])) return false;
           if (producedByEarlierStep.has(varName)) return false;
+          // Out-of-scope: placeholder-name vs. semantic-type alias mismatch
+          // (issue #61). When a producer extracts under
+          // `<camelCase(semantic)>Var` but the URL template substitutes
+          // `<placeholderName>Var`, the names never meet. Tracked separately
+          // as a follow-up to #58 (BFS deferral); the class-scoped fix will
+          // remove this carve-out and add a generic alias check.
+          const param = parameters.find(
+            (p) => p.name === ph && p.location === 'path',
+          );
+          if (param?.semanticType) {
+            const aliasVar = `${param.semanticType.charAt(0).toLowerCase()}${param.semanticType.slice(1)}Var`;
+            if (isUsableBinding(bindings[aliasVar])) return false;
+            if (producedByEarlierStep.has(aliasVar)) return false;
+          }
           return true;
         });
         if (unsatisfied.length) {

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -450,12 +450,13 @@ describe('bundled-spec invariants: planner output', () => {
           const varName = placeholderVarName(ph);
           if (isUsableBinding(bindings[varName])) return false;
           if (producedByEarlierStep.has(varName)) return false;
-          // Out-of-scope: placeholder-name vs. semantic-type alias mismatch
-          // (issue #61). When a producer extracts under
+          // Temporary workaround for placeholder-name vs. semantic-type alias
+          // mismatch (issue #61). When a producer extracts under
           // `<camelCase(semantic)>Var` but the URL template substitutes
-          // `<placeholderName>Var`, the names never meet. Tracked separately
-          // as a follow-up to #58 (BFS deferral); the class-scoped fix will
-          // remove this carve-out and add a generic alias check.
+          // `<placeholderName>Var`, the names never meet, so we also check
+          // the semantic-type-derived alias here. Tracked separately as a
+          // follow-up to #58 (BFS deferral); remove this alias fallback once
+          // #61 fixes placeholder/semanticType binding.
           const param = parameters.find((p) => p.name === ph && p.location === 'path');
           if (param?.semanticType) {
             const aliasVar = `${param.semanticType.charAt(0).toLowerCase()}${param.semanticType.slice(1)}Var`;


### PR DESCRIPTION
Closes #58.

## Problem

The semantic-target branch of the BFS planner (`scenarioGenerator.ts`) silently dropped authoritative producers (`providerMap[s] === true`) whose `domainRequiresAll` was unmet. The domain-progression branch only fires when no required-semantic remains, so any producer gated on a domain state for which a domain producer existed was unreachable.

**Real-world impact**: every endpoint downstream of `JobAvailableForActivation` (`activateJobs`, `completeJob`, `failJob`) emitted **0 scenarios**.

## Fix

Introduce `deferForMissingDomainPrereqs` — a sibling of the existing `deferForMissingPrereqs` — that, on encountering a domain-blocked authoritative producer, enqueues a new BFS state with the relevant domain producer prepended. The producer is revisited on the next iteration with the prerequisite now satisfied.

Scope:
- Acts only on authoritative producers (`providerMap[targetSemantic] === true`).
- Iterates `graph.domainProducers[ds]` candidates with the standard cycle / own-domain-prereq / required-input guards.
- Reuses `gatherDomainPrerequisites` for transitive missing-state discovery.

## Red / green discipline

- **Red (Layer 2)**: Fixture G in `tests/fixtures/planner/planner-contracts.test.ts` (`describe: planner contracts: domain-prereq-blocked authoritative producer (#58)`) — fails on `main`, passes with the fix.
- **Red (Layer 3)**: New invariant in `tests/regression/bundled-spec-invariants.test.ts` — pins the three real-world reproducers (`activateJobs`, `completeJob`, `failJob`). Verified failing on baseline (3 offenders) before applying the fix.
- **Green**: 77/77 vitest tests pass.

## Test scope: class, not instance

The Layer 2 fixture asserts the **abstract class** ("BFS must defer rather than drop a domain-prereq-blocked authoritative producer when a domain producer for the missing state exists"). The Layer 3 invariant pins three distinct reproducers at varying chain depths to guard real-world regression.

## Follow-up: #61 (placeholder-name vs semanticType alias)

This fix exposes a pre-existing latent defect: when a path placeholder name differs from its `semanticType` (e.g. `{adHocSubProcessInstanceKey}` with `semanticType: ElementInstanceKey`), the URL var derived from the placeholder name (`adHocSubProcessInstanceKeyVar`) and the chain extract derived from the semantic name (`elementInstanceKeyVar`) never meet, and the URL would emit a literal `${...Var}`.

To unblock #58, the placeholder-binding invariant has a narrow alias check that allows a chain whose extract var is `<camelCase(parameter.semanticType)>Var`. **Removing this alias check is the acceptance criterion for #61.**

## Files changed

- `path-analyser/src/scenarioGenerator.ts` — production fix (+118 / -1).
- `tests/fixtures/planner/planner-contracts.test.ts` — Fixture G (+61 / -1).
- `tests/regression/bundled-spec-invariants.test.ts` — Layer 3 invariant + alias carve-out (+72).