### PR TITLE
fix: declare missing runtime states (FormDeployed + DMN deployed states) (#66)

### DIFF
--- a/path-analyser/domain-semantics.json
+++ b/path-analyser/domain-semantics.json
@@ -38,6 +38,21 @@
       "parameters": ["jobType", "processDefinitionId"],
       "producedBy": ["activateJobs"],
       "requires": ["ProcessInstanceExists", "ModelHasServiceTaskType"]
+    },
+    "FormDeployed": {
+      "kind": "state",
+      "parameter": "formKey",
+      "producedBy": ["createDeployment"]
+    },
+    "DecisionDefinitionDeployed": {
+      "kind": "state",
+      "parameter": "decisionDefinitionId",
+      "producedBy": ["createDeployment"]
+    },
+    "DecisionRequirementsDeployed": {
+      "kind": "state",
+      "parameter": "decisionRequirementsId",
+      "producedBy": ["createDeployment"]
     }
   },
   "operationRequirements": {

--- a/tests/regression/artifact-produces-states-declared.test.ts
+++ b/tests/regression/artifact-produces-states-declared.test.ts
@@ -1,0 +1,42 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+interface ArtifactKindSpec {
+  producesStates?: string[];
+}
+interface RuntimeStateSpec {
+  kind: 'state';
+}
+interface DomainSemantics {
+  artifactKinds?: Record<string, ArtifactKindSpec>;
+  runtimeStates?: Record<string, RuntimeStateSpec>;
+  capabilities?: Record<string, unknown>;
+}
+
+describe('domain-semantics.json — artifactKinds.producesStates declarations', () => {
+  it('every state claimed by an artifact kind must be declared in runtimeStates or capabilities (#66 — FormDeployed defect class, also catches DMN)', async () => {
+    const file = path.resolve(import.meta.dirname, '../../path-analyser/domain-semantics.json');
+    const raw = await readFile(file, 'utf8');
+    // biome-ignore lint/plugin: domain-semantics.json is the runtime contract.
+    const domain = JSON.parse(raw) as DomainSemantics;
+
+    const declaredInRuntime = Object.keys(domain.runtimeStates ?? {});
+    const declaredInCapabilities = Object.keys(domain.capabilities ?? {});
+    const declaredStates = new Set([...declaredInRuntime, ...declaredInCapabilities]);
+
+    const claimedByArtifacts: { artifactKind: string; state: string }[] = [];
+    for (const [artifactKind, spec] of Object.entries(domain.artifactKinds ?? {})) {
+      for (const state of spec.producesStates ?? []) {
+        claimedByArtifacts.push({ artifactKind, state });
+      }
+    }
+
+    const undeclared = claimedByArtifacts.filter(({ state }) => !declaredStates.has(state));
+
+    expect(
+      undeclared,
+      `artifactKinds claim producesStates that are not declared in runtimeStates or capabilities: ${JSON.stringify(undeclared, null, 2)}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
First sub-task of #66.

## Problem

Three artifact kinds in \`path-analyser/domain-semantics.json\` claim \`producesStates\` that were never declared in \`runtimeStates\`:

| artifactKind | claimed state | declared? |
|---|---|---|
| \`form\` | \`FormDeployed\` | ❌ |
| \`dmnDecision\` | \`DecisionDefinitionDeployed\` | ❌ |
| \`dmnDrd\` | \`DecisionRequirementsDeployed\` | ❌ |

The loader and BFS already tracked these strings as states (via \`enumerateRuleStates\` reading \`artifactKinds.producesStates\`), so behaviour was unchanged — but the modelling was a lie. Downstream invariants (and a future schema validator) can't rely on every claimed state being defined.

The original spike (#60) flagged \`FormDeployed\` only, because that was the one with a value-binding referencing it. The class-scoped regression test in this PR surfaced **two more instances** of the same defect class — DMN had no value bindings, so the spike's narrower lens missed them. This is exactly the AGENTS.md class-scoped-test discipline catching a sibling defect.

## Fix

Add three \`runtimeStates\` entries (15-line addition). Parameter choices:

- \`FormDeployed.formKey\` matches the existing value-binding \`response.deployments[].form.formKey: \"FormDeployed.formKey\"\` in \`createDeployment\` (no other consumers, so this is the only constraint).
- \`DecisionDefinitionDeployed.decisionDefinitionId\` and \`DecisionRequirementsDeployed.decisionRequirementsId\` follow the \`ProcessDefinitionDeployed.processDefinitionId\` convention — parameter is the lowercase-first \`identifierType\` from the matching artifactKind.

## Tests

Red/green split into two commits per AGENTS.md:

1. \`test: add class-scoped guard for artifactKind producesStates declarations\` — fails on \`main\` with all 3 undeclared states listed.
2. \`fix: declare missing runtime states ...\` — minimal data fix that turns the test green.

The new test asserts the broader rule (every \`producesStates\` entry must resolve to a declared \`runtimeStates\` or \`capabilities\` entry), so any future regression on a new artifact kind is caught.

## Pre-push checks

- \`npm run lint\`: clean
- \`tsc --noEmit\` per workspace (3 projects): clean
- \`testsuite:generate\` + \`generate:request-validation\`: clean
- \`npm test\`: 90/90 passing across 16 files
- **No snapshot drift** — the planner already enumerated these states from \`artifactKinds.producesStates\`; declaring them changes the schema, not the planner output.

## Tracking

Refs #66. Three of the four remaining defects from the spike still open in the tracking issue:

- [ ] \`createDeployment\` value-binding RHS uses semantic type \`ProcessDefinitionKey\` as a runtime state (req+resp)
- [ ] \`createProcessInstance\` parameter mismatch with \`ProcessInstanceExists\` binding
- [ ] Modelling cleanups (Zod schema validator, vocabulary alignment, parity check in CI)