### PR TITLE
feat: implement semanticTypes.witnesses relation (#70)

### DIFF
--- a/path-analyser/domain-semantics.json
+++ b/path-analyser/domain-semantics.json
@@ -60,9 +60,9 @@
       "disjunctions": [["ProcessDefinitionKey", "ProcessDefinitionDeployed"]],
       "implicitAdds": ["ProcessInstanceExists"],
       "valueBindings": {
-  "request.processDefinitionId": "ProcessDefinitionDeployed.processDefinitionId",
-  "request.processDefinitionKey": "ProcessDefinitionKey.processDefinitionKey",
-  "response.processInstanceKey": "ProcessInstanceExists.processInstanceKey"
+        "request.processDefinitionId": "ProcessDefinitionDeployed.processDefinitionId",
+        "request.processDefinitionKey": "semantic:ProcessDefinitionKey",
+        "response.processInstanceKey": "semantic:ProcessInstanceKey"
       }
     },
     "activateJobs": {
@@ -84,7 +84,7 @@
     "createDeployment": {
       "valueBindings": {
         "response.deployments[].processDefinition.processDefinitionId": "ProcessDefinitionDeployed.processDefinitionId",
-        "response.deployments[].processDefinition.processDefinitionKey": "ProcessDefinitionKey.processDefinitionKey",
+        "response.deployments[].processDefinition.processDefinitionKey": "semantic:ProcessDefinitionKey",
         "response.deployments[].form.formKey": "FormDeployed.formKey"
       }
     },
@@ -131,6 +131,14 @@
     "DecisionDefinitionKey": "dmnDecision",
     "DecisionRequirementsKey": "dmnDrd",
     "FormKey": "form"
+  },
+  "semanticTypes": {
+    "ProcessDefinitionKey": { "witnesses": "ProcessDefinitionDeployed" },
+    "ProcessInstanceKey": { "witnesses": "ProcessInstanceExists" },
+    "DecisionDefinitionKey": { "witnesses": "DecisionDefinitionDeployed" },
+    "DecisionRequirementsKey": { "witnesses": "DecisionRequirementsDeployed" },
+    "FormKey": { "witnesses": "FormDeployed" },
+    "JobKey": { "witnesses": "JobAvailableForActivation" }
   },
   "operationArtifactRules": {
     "createDeployment": {

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -250,6 +250,21 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
         }
       }
     }
+    // #70: witness implication. Producing a value of semantic type T
+    // witnesses the existence of `semanticTypes[T].witnesses`. Surface
+    // every operation that produces T as a producer of the witnessed
+    // state. This unifies the typed-dataflow lens (bySemanticProducer)
+    // with the runtime-state lens (domainProducers).
+    if (domain?.semanticTypes) {
+      for (const [semanticType, spec] of Object.entries(domain.semanticTypes)) {
+        const witnessed = spec.witnesses;
+        if (typeof witnessed !== 'string' || witnessed.length === 0) continue;
+        const producers = bySemanticProducer[semanticType] ?? [];
+        for (const opId of producers) {
+          if (operations[opId]) addProducer(witnessed, opId);
+        }
+      }
+    }
   } catch {
     // ignore
   }

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -195,9 +195,18 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     // Build domainProducers
     const producers: Record<string, string[]> = {};
     domainProducers = producers;
+    // Dedup at the writer: every callsite (runtimeStates.producedBy,
+    // capabilities.producedBy, identifiers.boundBy, operationRequirements.
+    // produces / implicitAdds, the #70 witness implication) funnels through
+    // here, so guarding once prevents duplicate (state, opId) pairs from any
+    // current or future caller. Without this, an opId that satisfies a state
+    // through more than one channel (e.g. createDeployment producing
+    // ProcessDefinitionDeployed both directly and via the
+    // ProcessDefinitionKey → ProcessDefinitionDeployed witness edge) would
+    // appear multiple times in domainProducers[state].
     const addProducer = (state: string, opId: string) => {
       const list = producers[state] ?? [];
-      list.push(opId);
+      if (!list.includes(opId)) list.push(opId);
       producers[state] = list;
       const node = operations[opId];
       if (node) {

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -528,16 +528,18 @@ function buildRequestBodyFromCanonical(
     }
   } catch {}
   const requiredFields = nodes.filter((n) => n.required && !n.path.includes('[]'));
-  // Bindings map from domain valueBindings (request.* -> state.parameter)
+  // Bindings map from domain valueBindings (request.* -> parameter name).
+  // Two RHS grammars are supported:
+  //   1. `state.parameter`        — legacy form; parameter name is the leaf of the RHS.
+  //   2. `semantic:<SemanticType>` — witness form (#70); parameter name is the leaf
+  //      of the LHS field-path, since the typed-dataflow lens replaces the
+  //      state.parameter pair.
   const opDom = graph.domain?.operationRequirements?.[opId];
   const bindingMap: Record<string, string> = {};
   if (opDom?.valueBindings) {
     for (const [k, v] of Object.entries<string>(opDom.valueBindings)) {
       if (k.startsWith('request.')) {
         const raw = k.slice('request.'.length);
-        // #70: under the new grammar `semantic:<SemanticType>`, the parameter
-        // name is derived from the LHS field-path leaf instead of from the
-        // RHS state.parameter pair.
         const param = v.startsWith('semantic:')
           ? (raw.split('.').pop() ?? '')
           : (v.split('.').pop() ?? '');

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -329,9 +329,14 @@ function buildRequestPlan(
         if (!k.startsWith('response.')) continue; // only handle response mappings here
         const fieldPathRaw = k.slice('response.'.length); // canonical path with [] markers
         const norm = fieldPathRaw.replace(/\[\]/g, '[0]'); // first element access for arrays
-        // Determine target variable name based on parameter portion after last '.' in mapping (state.parameter)
+        // #70: under the new grammar `semantic:<SemanticType>`, the binding
+        // variable is derived from the LHS field-path leaf instead of from
+        // the RHS state.parameter pair (which the typed-dataflow lens replaces).
         const mapping = v;
-        const paramPart = mapping.split('.').pop() ?? '';
+        const isSemantic = mapping.startsWith('semantic:');
+        const paramPart = isSemantic
+          ? (fieldPathRaw.split('.').pop() ?? '')
+          : (mapping.split('.').pop() ?? '');
         let bind = `${camelCase(paramPart)}Var`;
         if (k.endsWith('$key')) {
           // explicit key semantic mapping
@@ -530,7 +535,13 @@ function buildRequestBodyFromCanonical(
     for (const [k, v] of Object.entries<string>(opDom.valueBindings)) {
       if (k.startsWith('request.')) {
         const raw = k.slice('request.'.length);
-        bindingMap[raw] = v.split('.').pop() ?? ''; // take parameter name
+        // #70: under the new grammar `semantic:<SemanticType>`, the parameter
+        // name is derived from the LHS field-path leaf instead of from the
+        // RHS state.parameter pair.
+        const param = v.startsWith('semantic:')
+          ? (raw.split('.').pop() ?? '')
+          : (v.split('.').pop() ?? '');
+        bindingMap[raw] = param;
       }
     }
   }

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -248,6 +248,18 @@ export interface DomainSemantics {
   semanticTypeToArtifactKind?: Record<string, string>;
   operationArtifactRules?: Record<string, OperationArtifactRuleSpec>;
   artifactFileKinds?: Record<string, string[]>; // extension -> artifactKind[]
+  // #70: declarative witness edges from semantic types (key-shaped values)
+  // to the runtime states or capabilities they imply. Producing a value of
+  // semantic type T witnesses the existence of state `semanticTypes[T].witnesses`.
+  // The loader uses this to populate domainProducers from bySemanticProducer.
+  semanticTypes?: Record<string, SemanticTypeSpec>;
+}
+
+export interface SemanticTypeSpec {
+  // Name of a runtimeStates or capabilities entry that this semantic type's
+  // value implies the existence of. Required for key-shaped semantic types
+  // (those listed in artifactKinds.*.producesSemantics).
+  witnesses?: string;
 }
 
 export interface IdentifierSpec {

--- a/tests/regression/semantic-types-witnesses.test.ts
+++ b/tests/regression/semantic-types-witnesses.test.ts
@@ -94,4 +94,31 @@ describe('domain-semantics.json — semanticTypes.witnesses relation (#70)', () 
       `valueBindings reference semanticTypes that are not declared: ${JSON.stringify(dangling, null, 2)}`,
     ).toEqual([]);
   });
+
+  // Class-scoped guard: no domainProducers[state] entry should contain duplicate
+  // opIds. The witness implication (semanticTypes[T].witnesses) re-adds every
+  // producer of T as a producer of the witnessed state, which previously
+  // double-counted any opId that already produced the witnessed state via
+  // runtimeStates.producedBy / capabilities.producedBy /
+  // operationRequirements.produces. addProducer() now dedups at the writer so
+  // every current AND future callsite is covered.
+  it('domainProducers contains no duplicate opIds per state (witness merge dedup)', async () => {
+    const { loadGraph } = await import('../../path-analyser/src/graphLoader.ts');
+    const baseDir = path.resolve(import.meta.dirname, '../../path-analyser');
+    const graph = await loadGraph(baseDir);
+
+    const dupes: { state: string; opId: string; count: number }[] = [];
+    for (const [state, opIds] of Object.entries(graph.domainProducers ?? {})) {
+      const counts = new Map<string, number>();
+      for (const opId of opIds) counts.set(opId, (counts.get(opId) ?? 0) + 1);
+      for (const [opId, count] of counts) {
+        if (count > 1) dupes.push({ state, opId, count });
+      }
+    }
+
+    expect(
+      dupes,
+      `domainProducers must not contain duplicate opIds per state: ${JSON.stringify(dupes, null, 2)}`,
+    ).toEqual([]);
+  });
 });

--- a/tests/regression/semantic-types-witnesses.test.ts
+++ b/tests/regression/semantic-types-witnesses.test.ts
@@ -1,0 +1,97 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+interface ArtifactKindSpec {
+  producesStates?: string[];
+  producesSemantics?: string[];
+}
+interface OperationDomainRequirements {
+  valueBindings?: Record<string, string>;
+}
+interface SemanticTypeSpec {
+  witnesses?: string;
+}
+interface DomainSemantics {
+  artifactKinds?: Record<string, ArtifactKindSpec>;
+  runtimeStates?: Record<string, unknown>;
+  capabilities?: Record<string, unknown>;
+  operationRequirements?: Record<string, OperationDomainRequirements>;
+  semanticTypes?: Record<string, SemanticTypeSpec>;
+}
+
+async function loadDomain(): Promise<DomainSemantics> {
+  const file = path.resolve(import.meta.dirname, '../../path-analyser/domain-semantics.json');
+  const raw = await readFile(file, 'utf8');
+  // biome-ignore lint/plugin: domain-semantics.json is the runtime contract.
+  return JSON.parse(raw) as DomainSemantics;
+}
+
+describe('domain-semantics.json — semanticTypes.witnesses relation (#70)', () => {
+  it('every key-shaped semantic type (artifactKinds.*.producesSemantics) must declare a witnesses edge', async () => {
+    const domain = await loadDomain();
+
+    const declaredSemanticTypes = domain.semanticTypes ?? {};
+
+    const keyShaped: { artifactKind: string; semanticType: string }[] = [];
+    for (const [artifactKind, spec] of Object.entries(domain.artifactKinds ?? {})) {
+      for (const semanticType of spec.producesSemantics ?? []) {
+        keyShaped.push({ artifactKind, semanticType });
+      }
+    }
+
+    const missingWitness = keyShaped.filter(({ semanticType }) => {
+      const entry = declaredSemanticTypes[semanticType];
+      return !entry || typeof entry.witnesses !== 'string' || entry.witnesses.length === 0;
+    });
+
+    expect(
+      missingWitness,
+      `key-shaped semantic types are missing a semanticTypes[<type>].witnesses declaration: ${JSON.stringify(missingWitness, null, 2)}`,
+    ).toEqual([]);
+  });
+
+  it('every semanticTypes[X].witnesses target must resolve to a declared runtimeState or capability', async () => {
+    const domain = await loadDomain();
+
+    const declaredStates = new Set([
+      ...Object.keys(domain.runtimeStates ?? {}),
+      ...Object.keys(domain.capabilities ?? {}),
+    ]);
+
+    const dangling: { semanticType: string; witnesses: string }[] = [];
+    for (const [semanticType, spec] of Object.entries(domain.semanticTypes ?? {})) {
+      const w = spec.witnesses;
+      if (typeof w !== 'string' || w.length === 0) continue;
+      if (!declaredStates.has(w)) dangling.push({ semanticType, witnesses: w });
+    }
+
+    expect(
+      dangling,
+      `semanticTypes.witnesses targets do not resolve to any runtimeStates or capabilities entry: ${JSON.stringify(dangling, null, 2)}`,
+    ).toEqual([]);
+  });
+
+  it('every valueBindings RHS of the form "semantic:X" must reference a declared semanticType', async () => {
+    const domain = await loadDomain();
+
+    const declaredSemanticTypes = new Set(Object.keys(domain.semanticTypes ?? {}));
+
+    const dangling: { operationId: string; field: string; rhs: string }[] = [];
+    for (const [operationId, req] of Object.entries(domain.operationRequirements ?? {})) {
+      const bindings = req.valueBindings ?? {};
+      for (const [field, rhs] of Object.entries(bindings)) {
+        if (!rhs.startsWith('semantic:')) continue;
+        const ref = rhs.slice('semantic:'.length);
+        if (!declaredSemanticTypes.has(ref)) {
+          dangling.push({ operationId, field, rhs });
+        }
+      }
+    }
+
+    expect(
+      dangling,
+      `valueBindings reference semanticTypes that are not declared: ${JSON.stringify(dangling, null, 2)}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #70.

Stacked on #67 (declares the runtimeStates this PR's witness edges target). Merge #67 first, then rebase this onto main.

## Summary

Introduces a first-class declarative edge from semantic types to the runtime states or capabilities they witness. Producing a value of semantic type `T` witnesses the existence of `semanticTypes[T].witnesses`. The loader now uses this to flow the typed-dataflow lens (`bySemanticProducer`) into the runtime-state lens (`domainProducers`).

## Modelling changes (`path-analyser/domain-semantics.json`)

- New top-level `semanticTypes` block with six witness edges:
  - `ProcessDefinitionKey` → `ProcessDefinitionDeployed`
  - `ProcessInstanceKey` → `ProcessInstanceExists`
  - `DecisionDefinitionKey` → `DecisionDefinitionDeployed`
  - `DecisionRequirementsKey` → `DecisionRequirementsDeployed`
  - `FormKey` → `FormDeployed`
  - `JobKey` → `JobAvailableForActivation`
- New value-binding grammar: `semantic:<SemanticType>`. Three previously broken bindings now use it:
  - `createDeployment.response.deployments[].processDefinition.processDefinitionKey`
  - `createProcessInstance.request.processDefinitionKey`
  - `createProcessInstance.response.processInstanceKey`

  Under the old grammar these RHSs (`ProcessDefinitionKey.processDefinitionKey` and `ProcessInstanceExists.processInstanceKey`) silently no-opped — the `state.parameter` pair did not resolve to anything in `runtimeStates` or `capabilities`. The witness lens makes them coherent.

## Code changes

- `types.ts`: extend `DomainSemantics` with `semanticTypes?: Record<string, { witnesses?: string }>`.
- `graphLoader.ts`: after building `domainProducers` from the existing declarations, walk `semanticTypes.*.witnesses` and merge `bySemanticProducer[T]` into `domainProducers[witnessedState]`.
- `index.ts`: when a `valueBindings` RHS starts with `semantic:`, derive the binding-variable / parameter name from the LHS field-path leaf instead of from the RHS state.parameter pair.

## Class-scoped invariants (red test committed first)

`tests/regression/semantic-types-witnesses.test.ts` enforces:

1. Every entry in `artifactKinds.*.producesSemantics` must declare a `witnesses` edge.
2. Every `semanticTypes[X].witnesses` target must resolve to a declared `runtimeStates` or `capabilities` entry.
3. Every `valueBindings` RHS of the form `semantic:X` must reference a declared semanticType.

## Validation

- All 93 tests pass.
- No pipeline-snapshot drift (planner already enumerated the witnessed states via `artifactKinds.producesStates` after #67).
- Lint, all three `tsc --noEmit` projects, `testsuite:generate`, and `generate:request-validation` all clean.

## Unblocks (Refs #66)

- Three broken bindings are now coherent (PR-side-effect).
- `createProcessInstance.disjunctions` cleanup falls out automatically once consumers prefer the witness edge over the disjunction.
- A future Zod validator can use witness invariants directly.
