### PR TITLE
feat(validator): fail loud on invalid domain-semantics.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2516,6 +2516,15 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "optional-responses": {
       "version": "0.0.0",
       "dependencies": {
@@ -2526,7 +2535,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@playwright/test": "^1.54.2",
-        "yaml": "^2.5.0"
+        "yaml": "^2.5.0",
+        "zod": "^4.3.6"
       },
       "engines": {
         "node": ">=22.0.0"

--- a/path-analyser/package.json
+++ b/path-analyser/package.json
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "@playwright/test": "^1.54.2",
-    "yaml": "^2.5.0"
+    "yaml": "^2.5.0",
+    "zod": "^4.3.6"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/path-analyser/src/domainSemanticsValidator.ts
+++ b/path-analyser/src/domainSemanticsValidator.ts
@@ -7,9 +7,9 @@ import { z } from 'zod';
 //
 // The shape of `DomainSemantics` (in types.ts) describes *what* fields exist;
 // this module describes *which combinations of values are coherent* — the
-// cross-reference invariants between sections. Each invariant in the schema
-// is named (via `.refine(..., { params: { code } })`) so failures point
-// directly at the broken property rather than at a structural diff.
+// cross-reference invariants between sections. Each invariant is reported
+// from `superRefine` via `ctx.addIssue(..., { params: { invariant } })` so
+// failures point directly at the broken property rather than at a structural diff.
 //
 // Invariants encoded (all class-scoped — they reject the defect class, not
 // just one instance):
@@ -227,7 +227,10 @@ export interface DomainSemanticsValidationError {
 
 /**
  * Run all structural and cross-reference checks against `raw`. Returns the
- * empty array on success; otherwise returns one entry per violated invariant.
+ * empty array on success; otherwise returns one entry per Zod issue — a
+ * single invariant can produce multiple entries when several instances
+ * violate it (each entry carries the same `invariant` name but a distinct
+ * `message` identifying the offending property).
  *
  * The graphLoader calls this immediately after JSON.parse and throws if any
  * issues are returned. Tests can call it directly against synthetic

--- a/path-analyser/src/domainSemanticsValidator.ts
+++ b/path-analyser/src/domainSemanticsValidator.ts
@@ -1,0 +1,246 @@
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// path-analyser/src/domainSemanticsValidator.ts
+//
+// Load-time validator for path-analyser/domain-semantics.json.
+//
+// The shape of `DomainSemantics` (in types.ts) describes *what* fields exist;
+// this module describes *which combinations of values are coherent* — the
+// cross-reference invariants between sections. Each invariant in the schema
+// is named (via `.refine(..., { params: { code } })`) so failures point
+// directly at the broken property rather than at a structural diff.
+//
+// Invariants encoded (all class-scoped — they reject the defect class, not
+// just one instance):
+//
+//   1. artifactKindStateDeclared — every state in artifactKinds.*.producesStates
+//      is declared in runtimeStates ∪ capabilities.
+//   2. artifactKindWitnessDeclared — every key-shaped semantic type
+//      (artifactKinds.*.producesSemantics) declares a semanticTypes[T].witnesses
+//      edge.
+//   3. semanticTypeWitnessTargetResolves — every semanticTypes[T].witnesses
+//      target resolves to runtimeStates ∪ capabilities.
+//   4. semanticBindingTargetResolves — every valueBindings RHS of the form
+//      `semantic:X` references a declared semanticTypes entry.
+//   5. disjunctionNotWitnessRedundant — no disjunction group contains both a
+//      semantic type X and the state semanticTypes[X].witnesses.
+//   6. disjunctionMemberResolves — every disjunction member resolves to
+//      runtimeStates ∪ capabilities.
+//
+// The corresponding tests in tests/regression/ remain in place as
+// human-readable, hand-curated regression statements; this module promotes
+// them into a load-time gate inside graphLoader.
+// ---------------------------------------------------------------------------
+
+const SemanticTypeSpecSchema = z
+  .object({
+    witnesses: z.string().min(1).optional(),
+  })
+  .passthrough();
+
+const ArtifactKindSpecSchema = z
+  .object({
+    producesStates: z.array(z.string()).optional(),
+    producesSemantics: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+const OperationDomainRequirementsSchema = z
+  .object({
+    requires: z.array(z.string()).optional(),
+    disjunctions: z.array(z.array(z.string())).optional(),
+    implicitAdds: z.array(z.string()).optional(),
+    produces: z.array(z.string()).optional(),
+    valueBindings: z.record(z.string(), z.string()).optional(),
+  })
+  .passthrough();
+
+// Top-level shape — `passthrough` so unrelated fields (operationArtifactRules,
+// artifactFileKinds, semanticTypeToArtifactKind, identifiers, version, $schema)
+// flow through unmodified.
+const DomainSemanticsShape = z
+  .object({
+    runtimeStates: z.record(z.string(), z.unknown()).optional(),
+    capabilities: z.record(z.string(), z.unknown()).optional(),
+    semanticTypes: z.record(z.string(), SemanticTypeSpecSchema).optional(),
+    artifactKinds: z.record(z.string(), ArtifactKindSpecSchema).optional(),
+    operationRequirements: z.record(z.string(), OperationDomainRequirementsSchema).optional(),
+  })
+  .passthrough();
+
+type DomainSemanticsShape = z.infer<typeof DomainSemanticsShape>;
+
+interface CrossRefIssue {
+  code: string;
+  message: string;
+}
+
+// Helpers ---------------------------------------------------------------
+
+function declaredStates(d: DomainSemanticsShape): Set<string> {
+  return new Set([...Object.keys(d.runtimeStates ?? {}), ...Object.keys(d.capabilities ?? {})]);
+}
+
+function witnessOf(d: DomainSemanticsShape): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const [type, spec] of Object.entries(d.semanticTypes ?? {})) {
+    if (typeof spec.witnesses === 'string' && spec.witnesses.length > 0) {
+      m.set(type, spec.witnesses);
+    }
+  }
+  return m;
+}
+
+// Cross-reference invariants -------------------------------------------
+
+function checkArtifactKindStateDeclared(d: DomainSemanticsShape): CrossRefIssue[] {
+  const declared = declaredStates(d);
+  const issues: CrossRefIssue[] = [];
+  for (const [kind, spec] of Object.entries(d.artifactKinds ?? {})) {
+    for (const state of spec.producesStates ?? []) {
+      if (!declared.has(state)) {
+        issues.push({
+          code: 'artifactKindStateDeclared',
+          message: `artifactKinds.${kind}.producesStates references "${state}", which is not declared in runtimeStates or capabilities`,
+        });
+      }
+    }
+  }
+  return issues;
+}
+
+function checkArtifactKindWitnessDeclared(d: DomainSemanticsShape): CrossRefIssue[] {
+  const declared = d.semanticTypes ?? {};
+  const issues: CrossRefIssue[] = [];
+  for (const [kind, spec] of Object.entries(d.artifactKinds ?? {})) {
+    for (const type of spec.producesSemantics ?? []) {
+      const entry = declared[type];
+      if (!entry || typeof entry.witnesses !== 'string' || entry.witnesses.length === 0) {
+        issues.push({
+          code: 'artifactKindWitnessDeclared',
+          message: `artifactKinds.${kind}.producesSemantics references "${type}", which has no semanticTypes.${type}.witnesses declaration`,
+        });
+      }
+    }
+  }
+  return issues;
+}
+
+function checkSemanticTypeWitnessTargetResolves(d: DomainSemanticsShape): CrossRefIssue[] {
+  const declared = declaredStates(d);
+  const issues: CrossRefIssue[] = [];
+  for (const [type, spec] of Object.entries(d.semanticTypes ?? {})) {
+    const w = spec.witnesses;
+    if (typeof w !== 'string' || w.length === 0) continue;
+    if (!declared.has(w)) {
+      issues.push({
+        code: 'semanticTypeWitnessTargetResolves',
+        message: `semanticTypes.${type}.witnesses targets "${w}", which is not declared in runtimeStates or capabilities`,
+      });
+    }
+  }
+  return issues;
+}
+
+function checkSemanticBindingTargetResolves(d: DomainSemanticsShape): CrossRefIssue[] {
+  const declared = new Set(Object.keys(d.semanticTypes ?? {}));
+  const issues: CrossRefIssue[] = [];
+  for (const [op, req] of Object.entries(d.operationRequirements ?? {})) {
+    for (const [field, rhs] of Object.entries(req.valueBindings ?? {})) {
+      if (!rhs.startsWith('semantic:')) continue;
+      const ref = rhs.slice('semantic:'.length);
+      if (!declared.has(ref)) {
+        issues.push({
+          code: 'semanticBindingTargetResolves',
+          message: `operationRequirements.${op}.valueBindings["${field}"] references semantic type "${ref}", which is not declared in semanticTypes`,
+        });
+      }
+    }
+  }
+  return issues;
+}
+
+function checkDisjunctionNotWitnessRedundant(d: DomainSemanticsShape): CrossRefIssue[] {
+  const witness = witnessOf(d);
+  const issues: CrossRefIssue[] = [];
+  for (const [op, req] of Object.entries(d.operationRequirements ?? {})) {
+    for (const group of req.disjunctions ?? []) {
+      for (const member of group) {
+        const w = witness.get(member);
+        if (w && group.includes(w)) {
+          issues.push({
+            code: 'disjunctionNotWitnessRedundant',
+            message: `operationRequirements.${op}.disjunctions contains both semantic type "${member}" and its witnessed state "${w}" — collapse to requires: ["${w}"]`,
+          });
+        }
+      }
+    }
+  }
+  return issues;
+}
+
+function checkDisjunctionMemberResolves(d: DomainSemanticsShape): CrossRefIssue[] {
+  const declared = declaredStates(d);
+  const issues: CrossRefIssue[] = [];
+  for (const [op, req] of Object.entries(d.operationRequirements ?? {})) {
+    for (const group of req.disjunctions ?? []) {
+      for (const member of group) {
+        if (!declared.has(member)) {
+          issues.push({
+            code: 'disjunctionMemberResolves',
+            message: `operationRequirements.${op}.disjunctions references "${member}", which is not declared in runtimeStates or capabilities`,
+          });
+        }
+      }
+    }
+  }
+  return issues;
+}
+
+const CROSS_REF_CHECKS = [
+  checkArtifactKindStateDeclared,
+  checkArtifactKindWitnessDeclared,
+  checkSemanticTypeWitnessTargetResolves,
+  checkSemanticBindingTargetResolves,
+  checkDisjunctionNotWitnessRedundant,
+  checkDisjunctionMemberResolves,
+] as const;
+
+// Composed schema: structural shape + every cross-reference invariant.
+export const DomainSemanticsSchema = DomainSemanticsShape.superRefine((d, ctx) => {
+  for (const check of CROSS_REF_CHECKS) {
+    for (const issue of check(d)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: issue.message,
+        params: { invariant: issue.code },
+      });
+    }
+  }
+});
+
+export interface DomainSemanticsValidationError {
+  invariant: string;
+  message: string;
+}
+
+/**
+ * Run all structural and cross-reference checks against `raw`. Returns the
+ * empty array on success; otherwise returns one entry per violated invariant.
+ *
+ * The graphLoader calls this immediately after JSON.parse and throws if any
+ * issues are returned. Tests can call it directly against synthetic
+ * minimal-domain objects to verify each invariant in isolation.
+ */
+export function validateDomainSemantics(raw: unknown): DomainSemanticsValidationError[] {
+  const result = DomainSemanticsSchema.safeParse(raw);
+  if (result.success) return [];
+  return result.error.issues.map((issue) => {
+    const params = issue.code === 'custom' ? issue.params : undefined;
+    const invariantRaw =
+      params && typeof params === 'object' ? Reflect.get(params, 'invariant') : undefined;
+    const invariant = typeof invariantRaw === 'string' ? invariantRaw : 'shape';
+    return { invariant, message: issue.message };
+  });
+}

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -1,7 +1,15 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { parse as parseYaml } from 'yaml';
+import { validateDomainSemantics } from './domainSemanticsValidator.js';
 import type { BootstrapSequence, DomainSemantics, OperationGraph, OperationNode } from './types.js';
+
+class DomainSemanticsValidationFailure extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DomainSemanticsValidationFailure';
+  }
+}
 
 // Sibling semantic-graph-extractor package produces the operation dependency graph.
 const GRAPH_RELATIVE = '../semantic-graph-extractor/dist/output/operation-dependency-graph.json';
@@ -180,7 +188,15 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     const domainPath = path.resolve(baseDir, 'domain-semantics.json');
     const domainRaw = await readFile(domainPath, 'utf8');
     // biome-ignore lint/plugin: JSON.parse returns `any`; domain-semantics.json is the runtime contract.
-    domain = JSON.parse(domainRaw) as DomainSemantics;
+    const parsedDomain = JSON.parse(domainRaw) as DomainSemantics;
+    const issues = validateDomainSemantics(parsedDomain);
+    if (issues.length > 0) {
+      const detail = issues.map((i) => `  - [${i.invariant}] ${i.message}`).join('\n');
+      throw new DomainSemanticsValidationFailure(
+        `domain-semantics.json failed validation:\n${detail}`,
+      );
+    }
+    domain = parsedDomain;
     // debug: domain semantics sidecar loaded
     if (domain?.operationRequirements) {
       for (const [opId, req] of Object.entries(domain.operationRequirements)) {
@@ -274,8 +290,9 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
         }
       }
     }
-  } catch {
-    // ignore
+  } catch (err) {
+    if (err instanceof DomainSemanticsValidationFailure) throw err;
+    // ignore: sidecar absent or unreadable — domain analysis disabled
   }
 
   return { operations, bySemanticProducer, bootstrapSequences, domain, domainProducers };

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -292,7 +292,17 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     }
   } catch (err) {
     if (err instanceof DomainSemanticsValidationFailure) throw err;
-    // ignore: sidecar absent or unreadable — domain analysis disabled
+    if (err instanceof SyntaxError) {
+      throw new DomainSemanticsValidationFailure(
+        `domain-semantics.json is not valid JSON: ${err.message}`,
+      );
+    }
+    if (err instanceof Error && 'code' in err && err.code !== 'ENOENT') {
+      throw new DomainSemanticsValidationFailure(
+        `Failed to load domain-semantics.json: ${err.message}`,
+      );
+    }
+    // ENOENT or non-Error throw: sidecar absent — domain analysis disabled
   }
 
   return { operations, bySemanticProducer, bootstrapSequences, domain, domainProducers };

--- a/tests/fixtures/loader/graphloader-sidecar.test.ts
+++ b/tests/fixtures/loader/graphloader-sidecar.test.ts
@@ -152,3 +152,45 @@ describe('graphLoader: sidecar-declared produces (#56)', () => {
     expect(g.operations.opOne?.produces.filter((s) => s === 'Foo').length).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Class-scoped guard: load-time "fail loud" invariant for an unreadable
+// or malformed domain-semantics.json. A missing sidecar (ENOENT) must
+// continue to disable domain analysis silently, but anything else — bad
+// JSON, permissions error, validator failure — must surface as a thrown
+// DomainSemanticsValidationFailure rather than be swallowed.
+// ---------------------------------------------------------------------------
+describe('graphLoader: domain-semantics.json fail-loud invariant', () => {
+  it('does not throw when domain-semantics.json is absent (ENOENT is tolerated)', async () => {
+    writeFileSync(
+      join(graphDir, 'operation-dependency-graph.json'),
+      JSON.stringify({ operations: [{ operationId: 'op', method: 'GET', path: '/x' }] }),
+    );
+    // intentionally do NOT write domain-semantics.json
+    await expect(loadGraph(baseDir)).resolves.toBeDefined();
+  });
+
+  it('throws DomainSemanticsValidationFailure when domain-semantics.json is malformed JSON', async () => {
+    writeFileSync(
+      join(graphDir, 'operation-dependency-graph.json'),
+      JSON.stringify({ operations: [{ operationId: 'op', method: 'GET', path: '/x' }] }),
+    );
+    writeFileSync(join(baseDir, 'domain-semantics.json'), '{ this is not valid json');
+    await expect(loadGraph(baseDir)).rejects.toThrow(/domain-semantics\.json is not valid JSON/);
+  });
+
+  it('throws DomainSemanticsValidationFailure when domain-semantics.json fails validation', async () => {
+    writeFileSync(
+      join(graphDir, 'operation-dependency-graph.json'),
+      JSON.stringify({ operations: [{ operationId: 'op', method: 'GET', path: '/x' }] }),
+    );
+    writeFileSync(
+      join(baseDir, 'domain-semantics.json'),
+      JSON.stringify({
+        runtimeStates: { Known: {} },
+        artifactKinds: { kindA: { producesStates: ['UndeclaredState'] } },
+      }),
+    );
+    await expect(loadGraph(baseDir)).rejects.toThrow(/artifactKindStateDeclared/);
+  });
+});

--- a/tests/regression/domain-semantics-validator.test.ts
+++ b/tests/regression/domain-semantics-validator.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { validateDomainSemantics } from '../../path-analyser/src/domainSemanticsValidator.ts';
+
+// ---------------------------------------------------------------------------
+// Class-scoped guards for path-analyser/src/domainSemanticsValidator.ts.
+//
+// Each `it` block constructs a minimal synthetic DomainSemantics object that
+// violates exactly one invariant, then asserts the validator reports that
+// invariant by name. Companion test for each existing regression test that
+// asserts the same invariants over the real sidecar file.
+//
+// If the validator's catalogue of invariants ever shrinks, these tests fail
+// and call out the gap explicitly rather than allowing a load-time defect to
+// escape into runtime.
+// ---------------------------------------------------------------------------
+
+describe('validateDomainSemantics', () => {
+  it('accepts an empty domain', () => {
+    expect(validateDomainSemantics({})).toEqual([]);
+  });
+
+  it('reports artifactKindStateDeclared when producesStates is undeclared', () => {
+    const errs = validateDomainSemantics({
+      runtimeStates: { Known: {} },
+      artifactKinds: {
+        kindA: { producesStates: ['Unknown'] },
+      },
+    });
+    expect(errs.map((e) => e.invariant)).toContain('artifactKindStateDeclared');
+    expect(errs.find((e) => e.invariant === 'artifactKindStateDeclared')?.message).toContain(
+      'Unknown',
+    );
+  });
+
+  it('reports artifactKindWitnessDeclared when a key-shaped semantic type has no witnesses edge', () => {
+    const errs = validateDomainSemantics({
+      runtimeStates: { Known: {} },
+      semanticTypes: {
+        SomeKey: {}, // declared but no witnesses edge
+      },
+      artifactKinds: {
+        kindA: { producesSemantics: ['SomeKey'] },
+      },
+    });
+    expect(errs.map((e) => e.invariant)).toContain('artifactKindWitnessDeclared');
+  });
+
+  it('reports artifactKindWitnessDeclared when the semantic type is missing entirely', () => {
+    const errs = validateDomainSemantics({
+      runtimeStates: { Known: {} },
+      artifactKinds: {
+        kindA: { producesSemantics: ['MissingKey'] },
+      },
+    });
+    expect(errs.map((e) => e.invariant)).toContain('artifactKindWitnessDeclared');
+  });
+
+  it('reports semanticTypeWitnessTargetResolves when witnesses target is undeclared', () => {
+    const errs = validateDomainSemantics({
+      runtimeStates: { Known: {} },
+      semanticTypes: {
+        SomeKey: { witnesses: 'NotAState' },
+      },
+    });
+    expect(errs.map((e) => e.invariant)).toContain('semanticTypeWitnessTargetResolves');
+  });
+
+  it('reports semanticBindingTargetResolves when valueBindings RHS references a missing semantic type', () => {
+    const errs = validateDomainSemantics({
+      runtimeStates: { Known: {} },
+      operationRequirements: {
+        someOp: {
+          valueBindings: { 'request.foo': 'semantic:MissingKey' },
+        },
+      },
+    });
+    expect(errs.map((e) => e.invariant)).toContain('semanticBindingTargetResolves');
+  });
+
+  it('does not report semanticBindingTargetResolves for legacy state.parameter RHS', () => {
+    const errs = validateDomainSemantics({
+      runtimeStates: { Known: {} },
+      operationRequirements: {
+        someOp: {
+          valueBindings: { 'request.foo': 'Known.id' },
+        },
+      },
+    });
+    expect(errs.map((e) => e.invariant)).not.toContain('semanticBindingTargetResolves');
+  });
+
+  it('reports disjunctionNotWitnessRedundant when a disjunction contains both X and witnesses(X)', () => {
+    const errs = validateDomainSemantics({
+      runtimeStates: { ProcessDefinitionDeployed: {} },
+      semanticTypes: {
+        ProcessDefinitionKey: { witnesses: 'ProcessDefinitionDeployed' },
+      },
+      operationRequirements: {
+        createProcessInstance: {
+          disjunctions: [['ProcessDefinitionKey', 'ProcessDefinitionDeployed']],
+        },
+      },
+    });
+    expect(errs.map((e) => e.invariant)).toContain('disjunctionNotWitnessRedundant');
+  });
+
+  it('reports disjunctionMemberResolves when a disjunction member is undeclared', () => {
+    const errs = validateDomainSemantics({
+      runtimeStates: { Known: {} },
+      operationRequirements: {
+        someOp: {
+          disjunctions: [['Known', 'AlsoUnknown']],
+        },
+      },
+    });
+    expect(errs.map((e) => e.invariant)).toContain('disjunctionMemberResolves');
+  });
+
+  it('accepts the real path-analyser/domain-semantics.json', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const file = path.resolve(import.meta.dirname, '../../path-analyser/domain-semantics.json');
+    const raw = await fs.readFile(file, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    expect(validateDomainSemantics(parsed)).toEqual([]);
+  });
+});

--- a/tests/regression/domain-semantics-validator.test.ts
+++ b/tests/regression/domain-semantics-validator.test.ts
@@ -92,6 +92,9 @@ describe('validateDomainSemantics', () => {
   it('reports disjunctionNotWitnessRedundant when a disjunction contains both X and witnesses(X)', () => {
     const errs = validateDomainSemantics({
       runtimeStates: { ProcessDefinitionDeployed: {} },
+      // Declare ProcessDefinitionKey as a capability so disjunctionMemberResolves
+      // doesn't also fire — this fixture must violate exactly one invariant.
+      capabilities: { ProcessDefinitionKey: {} },
       semanticTypes: {
         ProcessDefinitionKey: { witnesses: 'ProcessDefinitionDeployed' },
       },
@@ -102,6 +105,7 @@ describe('validateDomainSemantics', () => {
       },
     });
     expect(errs.map((e) => e.invariant)).toContain('disjunctionNotWitnessRedundant');
+    expect(errs.map((e) => e.invariant)).not.toContain('disjunctionMemberResolves');
   });
 
   it('reports disjunctionMemberResolves when a disjunction member is undeclared', () => {


### PR DESCRIPTION
## Summary

Promotes the cross-reference invariants tested in `tests/regression/` into a load-time gate inside `graphLoader.ts`. The sidecar `path-analyser/domain-semantics.json` is now validated on every load via Zod, with named invariants pointing directly at the broken property.

## What changes

- New `path-analyser/src/domainSemanticsValidator.ts` exposes `validateDomainSemantics(raw)` returning a list of named issues.
- `graphLoader.ts` calls it immediately after `JSON.parse` and throws a tagged `DomainSemanticsValidationFailure` (re-thrown out of the existing `catch {}` so a missing sidecar is still tolerated, but an invalid one fails loud).
- New `tests/regression/domain-semantics-validator.test.ts` drives each invariant in isolation against synthetic minimal-domain objects.

## Invariants enforced

| Code | What it asserts |
|---|---|
| `artifactKindStateDeclared` | every `artifactKinds.*.producesStates` is declared in `runtimeStates` or `capabilities` |
| `artifactKindWitnessDeclared` | every key-shaped `artifactKinds.*.producesSemantics` has a `semanticTypes[T].witnesses` edge |
| `semanticTypeWitnessTargetResolves` | every `semanticTypes[T].witnesses` target resolves |
| `semanticBindingTargetResolves` | every `valueBindings` RHS of the form `semantic:X` references a declared semantic type |
| `disjunctionNotWitnessRedundant` | no disjunction contains both X and `semanticTypes[X].witnesses` |
| `disjunctionMemberResolves` | every disjunction member resolves |

The existing `artifact-produces-states-declared`, `semantic-types-witnesses`, and `disjunctions-vs-witnesses` regression tests stay in place as a second layer.

## Stacked on

This PR is stacked on #72 (disjunction cleanup). Merge order: #71 → #72 → this.

Refs #66
