### PR TITLE
refactor(graph): align vocabulary — producersByState / producersByType

### DIFF
--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -144,12 +144,12 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     }
   }
 
-  const bySemanticProducer: Record<string, string[]> = {};
+  const producersByType: Record<string, string[]> = {};
   for (const op of Object.values(operations)) {
     for (const st of op.produces) {
-      const list = bySemanticProducer[st] ?? [];
+      const list = producersByType[st] ?? [];
       list.push(op.operationId);
-      bySemanticProducer[st] = list;
+      producersByType[st] = list;
     }
   }
 
@@ -183,7 +183,7 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
 
   // Domain sidecar load (optional)
   let domain: DomainSemantics | undefined;
-  let domainProducers: Record<string, string[]> | undefined;
+  let producersByState: Record<string, string[]> | undefined;
   try {
     const domainPath = path.resolve(baseDir, 'domain-semantics.json');
     const domainRaw = await readFile(domainPath, 'utf8');
@@ -208,9 +208,9 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
         if (req.implicitAdds) node.domainImplicitAdds = req.implicitAdds;
       }
     }
-    // Build domainProducers
+    // Build producersByState
     const producers: Record<string, string[]> = {};
-    domainProducers = producers;
+    producersByState = producers;
     // Dedup at the writer: every callsite (runtimeStates.producedBy,
     // capabilities.producedBy, identifiers.boundBy, operationRequirements.
     // produces / implicitAdds, the #70 witness implication) funnels through
@@ -219,7 +219,7 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     // through more than one channel (e.g. createDeployment producing
     // ProcessDefinitionDeployed both directly and via the
     // ProcessDefinitionKey → ProcessDefinitionDeployed witness edge) would
-    // appear multiple times in domainProducers[state].
+    // appear multiple times in producersByState[state].
     const addProducer = (state: string, opId: string) => {
       const list = producers[state] ?? [];
       if (!list.includes(opId)) list.push(opId);
@@ -260,8 +260,8 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
       }
     }
     // #56: surface sidecar-declared `produces` into the semantic-BFS-visible
-    // structures (op.produces and bySemanticProducer). Without this step the
-    // sidecar entry only updates `domainProduces` / `domainProducers`, which
+    // structures (op.produces and producersByType). Without this step the
+    // sidecar entry only updates `domainProduces` / `producersByState`, which
     // are used by the runtime-state planner but invisible to semantic BFS.
     if (domain?.operationRequirements) {
       for (const [opId, spec] of Object.entries(domain.operationRequirements)) {
@@ -269,22 +269,22 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
         if (!node) continue;
         for (const st of spec.produces ?? []) {
           if (!node.produces.includes(st)) node.produces.push(st);
-          const list = bySemanticProducer[st] ?? [];
+          const list = producersByType[st] ?? [];
           if (!list.includes(opId)) list.push(opId);
-          bySemanticProducer[st] = list;
+          producersByType[st] = list;
         }
       }
     }
     // #70: witness implication. Producing a value of semantic type T
     // witnesses the existence of `semanticTypes[T].witnesses`. Surface
     // every operation that produces T as a producer of the witnessed
-    // state. This unifies the typed-dataflow lens (bySemanticProducer)
-    // with the runtime-state lens (domainProducers).
+    // state. This unifies the typed-dataflow lens (producersByType)
+    // with the runtime-state lens (producersByState).
     if (domain?.semanticTypes) {
       for (const [semanticType, spec] of Object.entries(domain.semanticTypes)) {
         const witnessed = spec.witnesses;
         if (typeof witnessed !== 'string' || witnessed.length === 0) continue;
-        const producers = bySemanticProducer[semanticType] ?? [];
+        const producers = producersByType[semanticType] ?? [];
         for (const opId of producers) {
           if (operations[opId]) addProducer(witnessed, opId);
         }
@@ -305,7 +305,7 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     // ENOENT or non-Error throw: sidecar absent — domain analysis disabled
   }
 
-  return { operations, bySemanticProducer, bootstrapSequences, domain, domainProducers };
+  return { operations, producersByType, bootstrapSequences, domain, producersByState };
 }
 
 function normalizeOp(opId: string, op: RawOp): OperationNode {

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -62,7 +62,7 @@ async function main() {
     throw new Error(msg);
   }
   // Extract response shapes & request variants (oneOf groups)
-  const semanticTypes = Object.keys(graph.bySemanticProducer || {});
+  const semanticTypes = Object.keys(graph.producersByType || {});
   const { requestIndex, responses, successStatusByOp } = await writeExtractionOutputs(
     baseDir,
     semanticTypes,

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -86,7 +86,7 @@ export function generateScenariosForEndpoint(
   // Determine impossible semantic types (no producer anywhere, excluding endpoint self-production)
   const missing: string[] = [];
   for (const st of initialNeeded) {
-    if (!graph.bySemanticProducer[st] || graph.bySemanticProducer[st].length === 0) {
+    if (!graph.producersByType[st] || graph.producersByType[st].length === 0) {
       if (!endpoint.produces.includes(st)) missing.push(st);
     }
   }
@@ -317,13 +317,13 @@ export function generateScenariosForEndpoint(
       );
       const domainCandidates = new Set<string>();
       for (const d of missingDomainAll)
-        (graph.domainProducers?.[d] || []).forEach((opId) => {
+        (graph.producersByState?.[d] || []).forEach((opId) => {
           domainCandidates.add(opId);
         });
       for (const group of unmetDisjunctions) {
         // union producers for each member
         for (const member of group)
-          (graph.domainProducers?.[member] || []).forEach((opId) => {
+          (graph.producersByState?.[member] || []).forEach((opId) => {
             domainCandidates.add(opId);
           });
       }
@@ -427,7 +427,7 @@ export function generateScenariosForEndpoint(
 
     // Choose a semantic type to target next
     const targetSemantic = remaining[0];
-    let producers: string[] = targetSemantic ? graph.bySemanticProducer[targetSemantic] || [] : [];
+    let producers: string[] = targetSemantic ? graph.producersByType[targetSemantic] || [] : [];
 
     // Provider preference & incidental suppression
     if (targetSemantic) {
@@ -783,7 +783,7 @@ function deferForMissingDomainPrereqs(
   const missingAll = gatherDomainPrerequisites(graph, directMissing, state.domainStates);
   const candidates = new Set<string>();
   for (const ds of missingAll) {
-    for (const opId of graph.domainProducers?.[ds] ?? []) candidates.add(opId);
+    for (const opId of graph.producersByState?.[ds] ?? []) candidates.add(opId);
   }
   let enqueued = false;
   for (const candidateOpId of candidates) {

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -45,10 +45,10 @@ export interface OperationNode extends OperationRef {
 
 export interface OperationGraph {
   operations: Record<string, OperationNode>;
-  bySemanticProducer: Record<string, string[]>;
+  producersByType: Record<string, string[]>;
   bootstrapSequences?: BootstrapSequence[];
   domain?: DomainSemantics; // loaded sidecar
-  domainProducers?: Record<string, string[]>; // domain state -> operations
+  producersByState?: Record<string, string[]>; // domain state -> operations
 }
 
 export interface BootstrapSequence {
@@ -251,7 +251,7 @@ export interface DomainSemantics {
   // #70: declarative witness edges from semantic types (key-shaped values)
   // to the runtime states or capabilities they imply. Producing a value of
   // semantic type T witnesses the existence of state `semanticTypes[T].witnesses`.
-  // The loader uses this to populate domainProducers from bySemanticProducer.
+  // The loader uses this to populate producersByState from producersByType.
   semanticTypes?: Record<string, SemanticTypeSpec>;
 }
 

--- a/tests/fixtures/loader/graphloader-sidecar.test.ts
+++ b/tests/fixtures/loader/graphloader-sidecar.test.ts
@@ -9,7 +9,7 @@
  *
  * The first fixture pins the regression for #56: a sidecar-declared
  * `domain.operationRequirements[opId].produces` must surface in
- * `bySemanticProducer` and `operations[opId].produces`, otherwise
+ * `producersByType` and `operations[opId].produces`, otherwise
  * semantic BFS cannot use it.
  */
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
@@ -48,7 +48,7 @@ function writeLayout(layout: SidecarLayout): void {
 // Fixture #56 — sidecar `produces` must surface in BFS-visible maps.
 // ---------------------------------------------------------------------------
 describe('graphLoader: sidecar-declared produces (#56)', () => {
-  it('registers sidecar produces in bySemanticProducer so semantic BFS can find them', async () => {
+  it('registers sidecar produces in producersByType so semantic BFS can find them', async () => {
     writeLayout({
       graph: {
         operations: [
@@ -73,10 +73,9 @@ describe('graphLoader: sidecar-declared produces (#56)', () => {
       },
     });
     const g = await loadGraph(baseDir);
-    expect(
-      g.bySemanticProducer.Foo,
-      'sidecar producer must be registered for semantic BFS',
-    ).toEqual(['producerOp']);
+    expect(g.producersByType.Foo, 'sidecar producer must be registered for semantic BFS').toEqual([
+      'producerOp',
+    ]);
   });
 
   it("registers sidecar produces on the operation's own produces list", async () => {
@@ -120,7 +119,7 @@ describe('graphLoader: sidecar-declared produces (#56)', () => {
       },
     });
     const g = await loadGraph(baseDir);
-    expect(g.bySemanticProducer.Foo).toEqual(
+    expect(g.producersByType.Foo).toEqual(
       expect.arrayContaining(['extractorProducer', 'sidecarProducer']),
     );
   });
@@ -148,7 +147,7 @@ describe('graphLoader: sidecar-declared produces (#56)', () => {
       },
     });
     const g = await loadGraph(baseDir);
-    expect(g.bySemanticProducer.Foo).toEqual(['opOne']);
+    expect(g.producersByType.Foo).toEqual(['opOne']);
     expect(g.operations.opOne?.produces.filter((s) => s === 'Foo').length).toBe(1);
   });
 });

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -46,22 +46,22 @@ function makeOp(operationId: string, opts: NodeOpts = {}): OperationNode {
 
 function makeGraph(nodes: OperationNode[]): OperationGraph {
   const operations: Record<string, OperationNode> = {};
-  const bySemanticProducer: Record<string, string[]> = {};
-  const domainProducers: Record<string, string[]> = {};
+  const producersByType: Record<string, string[]> = {};
+  const producersByState: Record<string, string[]> = {};
   for (const node of nodes) {
     operations[node.operationId] = node;
     for (const sem of node.produces) {
-      const list = bySemanticProducer[sem] ?? [];
+      const list = producersByType[sem] ?? [];
       list.push(node.operationId);
-      bySemanticProducer[sem] = list;
+      producersByType[sem] = list;
     }
     for (const ds of node.domainProduces ?? []) {
-      const list = domainProducers[ds] ?? [];
+      const list = producersByState[ds] ?? [];
       list.push(node.operationId);
-      domainProducers[ds] = list;
+      producersByState[ds] = list;
     }
   }
-  return { operations, bySemanticProducer, domainProducers };
+  return { operations, producersByType, producersByState };
 }
 
 function plan(graph: OperationGraph, endpointOpId: string): EndpointScenarioCollection {

--- a/tests/regression/semantic-types-witnesses.test.ts
+++ b/tests/regression/semantic-types-witnesses.test.ts
@@ -95,20 +95,20 @@ describe('domain-semantics.json — semanticTypes.witnesses relation (#70)', () 
     ).toEqual([]);
   });
 
-  // Class-scoped guard: no domainProducers[state] entry should contain duplicate
+  // Class-scoped guard: no producersByState[state] entry should contain duplicate
   // opIds. The witness implication (semanticTypes[T].witnesses) re-adds every
   // producer of T as a producer of the witnessed state, which previously
   // double-counted any opId that already produced the witnessed state via
   // runtimeStates.producedBy / capabilities.producedBy /
   // operationRequirements.produces. addProducer() now dedups at the writer so
   // every current AND future callsite is covered.
-  it('domainProducers contains no duplicate opIds per state (witness merge dedup)', async () => {
+  it('producersByState contains no duplicate opIds per state (witness merge dedup)', async () => {
     const { loadGraph } = await import('../../path-analyser/src/graphLoader.ts');
     const baseDir = path.resolve(import.meta.dirname, '../../path-analyser');
     const graph = await loadGraph(baseDir);
 
     const dupes: { state: string; opId: string; count: number }[] = [];
-    for (const [state, opIds] of Object.entries(graph.domainProducers ?? {})) {
+    for (const [state, opIds] of Object.entries(graph.producersByState ?? {})) {
       const counts = new Map<string, number>();
       for (const opId of opIds) counts.set(opId, (counts.get(opId) ?? 0) + 1);
       for (const [opId, count] of counts) {
@@ -118,7 +118,7 @@ describe('domain-semantics.json — semanticTypes.witnesses relation (#70)', () 
 
     expect(
       dupes,
-      `domainProducers must not contain duplicate opIds per state: ${JSON.stringify(dupes, null, 2)}`,
+      `producersByState must not contain duplicate opIds per state: ${JSON.stringify(dupes, null, 2)}`,
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Vocabulary alignment for the two inverse-index maps on `OperationGraph`. Pure rename — no behavioural change.

| Before | After |
|---|---|
| `OperationGraph.domainProducers` | `OperationGraph.producersByState` |
| `OperationGraph.bySemanticProducer` | `OperationGraph.producersByType` |

## Why

The two maps had inconsistent prefixes (one `domain`, one `by`) despite being structurally identical (`Record<state-or-type, opId[]>` reverse lookups). The new names:

- Make the inverse-index nature explicit (avoids confusion with the forward-direction `artifactKinds.*.producesStates` and `OperationNode.domainProduces` fields, which are *declarations* of what an operation produces).
- Pair the two as a matched set: `producersByState` / `producersByType`.

## What changed

- `path-analyser/src/types.ts` — field renames on `OperationGraph`.
- `path-analyser/src/graphLoader.ts` — local variable renames + comment updates.
- `path-analyser/src/scenarioGenerator.ts`, `path-analyser/src/index.ts` — call sites.
- `tests/fixtures/planner/planner-contracts.test.ts`, `tests/fixtures/loader/graphloader-sidecar.test.ts` — fixture local variables and assertion targets.

## Verification

- `npm run lint` clean
- 3× `tsc --noEmit` clean
- `testsuite:generate` + `generate:request-validation` clean
- 105/105 tests pass
- No snapshot drift

## Stacked on

This PR is stacked on #73 (Zod validator). Merge order: #71 → #72 → #73 → this.

Refs #66
