### PR TITLE
fix(test): align graph-loader regression test with producersByState rename

### DIFF
--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -249,7 +249,7 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
         const state = spec.validityState;
         // Skip identifiers whose validityState is not declared in the sidecar.
         // Empty strings are invalid data and would surface as a malformed
-        // domainProducers key — the regression test in
+        // producersByState key — the regression test in
         // tests/regression/graph-loader-undefined-state-key.test.ts asserts
         // no such key is ever written. We use `state == null` per #65 review:
         // an empty string is not the same as "absent" and should not be

--- a/tests/regression/graph-loader-undefined-state-key.test.ts
+++ b/tests/regression/graph-loader-undefined-state-key.test.ts
@@ -2,21 +2,22 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { loadGraph } from '../../path-analyser/src/graphLoader.ts';
 
-describe('graphLoader: domainProducers validation', () => {
-  it('does not write invalid keys to domainProducers', async () => {
+describe('graphLoader: producersByState validation', () => {
+  it('does not write invalid keys to producersByState', async () => {
     // Anchor paths off this test file so the test does not depend on process.cwd().
     const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
     const baseDir = path.join(REPO_ROOT, 'path-analyser');
     const graph = await loadGraph(baseDir);
 
-    expect(graph.domainProducers, 'domainProducers sidecar should be loaded').toBeDefined();
+    expect(graph.producersByState, 'producersByState sidecar should be loaded').toBeDefined();
 
-    const producers = graph.domainProducers;
+    const producers = graph.producersByState;
     const keys = Object.keys(producers ?? {});
 
-    expect(keys, 'domainProducers should not contain the literal string "undefined"').not.toContain(
-      'undefined',
-    );
+    expect(
+      keys,
+      'producersByState should not contain the literal string "undefined"',
+    ).not.toContain('undefined');
 
     for (const key of keys) {
       expect(typeof key, 'key should be a string').toBe('string');


### PR DESCRIPTION
End-to-end sanity check after the #66 stack merged surfaced a real regression on `main`:

- PR #75 renamed `domainProducers` → `producersByState` everywhere.
- PR #65 added `tests/regression/graph-loader-undefined-state-key.test.ts` referencing `domainProducers`.
- Because #65 merged after #75 in GitHub's merge order, the rename never reached the new test.

Result: `expect(graph.domainProducers).toBeDefined()` failed because the field is now `undefined` (replaced by `producersByState`).

This is exactly the failure mode #65 review comment 4 was designed to catch — the new `toBeDefined()` assertion correctly refused to let the test pass vacuously.

**Fix:** rename the test's references to `producersByState`. Also sweep one stale `domainProducers` mention in a `graphLoader.ts` comment.

No production behaviour changes.