### PR TITLE
refactor(emitter): remove redundant __seededTenant flag

### DIFF
--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -105,7 +105,6 @@ function renderScenarioTest(s: EndpointScenario): string {
   const title = `${s.id} - ${escapeQuotes(s.name || 'scenario')}`;
   const body: string[] = [];
   body.push(`test('${title}', async ({ request }) => {`);
-  body.push(`  let __seededTenant = false;`);
   if (s.description) {
     const desc = String(s.description).trim();
     // Wrap long description lines at ~100 chars for readability
@@ -159,17 +158,17 @@ function renderScenarioTest(s: EndpointScenario): string {
         if (extractionVars.has(k)) continue; // Will be provided by extraction
         // Use centralized seeding util at runtime (generate inside test execution for deterministic mode support)
         body.push(`  if (ctx['${k}'] === undefined) { ctx['${k}'] = seedBinding('${k}'); }`);
-        if (k === 'tenantIdVar') body.push(`  __seededTenant = true;`);
         continue;
       }
       if (extractionVars.has(k)) continue;
       body.push(`  ctx['${k}'] = ${JSON.stringify(v)};`);
-      if (k === 'tenantIdVar') body.push(`  __seededTenant = true;`);
     }
   }
-  // Ensure tenantIdVar default sourced from seeding rules (configurable) only once
+  // Ensure tenantIdVar default sourced from seeding rules (configurable). Idempotent: the
+  // `=== undefined` guard means re-seeding never happens if the bindings loop above already
+  // populated tenantIdVar (whether from a literal value or from seedBinding for __PENDING__).
   body.push(
-    `  if (!__seededTenant && ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); __seededTenant = true; }`,
+    `  if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`,
   );
   body.push(`  const __tenantIdIsDefault = ctx['tenantIdVar'] === '<default>';`);
   if (!s.requestPlan) {

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -82,3 +82,94 @@ describe('PlaywrightEmitter (Emitter contract)', () => {
     expect(file.content).toBe(direct);
   });
 });
+
+// Regression guard for PR #79 / issue #80: the emitter no longer declares or
+// writes a `__seededTenant` flag. The `tenantIdVar` fallback is now a single
+// idempotent `=== undefined` guard. These tests exercise the three shapes the
+// bindings loop can produce for `tenantIdVar` (literal value, __PENDING__
+// auto-seed, and extracted-by-an-earlier-step) plus a control with no
+// `tenantIdVar` binding at all, asserting the simplified guard appears
+// exactly once and `__seededTenant` never appears anywhere in the output.
+describe('emitter: tenantIdVar seeding (no __seededTenant flag, #79/#80)', () => {
+  const TENANT_FALLBACK = `if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`;
+
+  function buildCollectionWithBindings(
+    bindings: Record<string, unknown>,
+    extras: { templateRefsTenant?: boolean; extractsTenant?: boolean } = {},
+  ): EndpointScenarioCollection {
+    return {
+      endpoint: { operationId: 'createWidget', method: 'POST', path: '/widgets' },
+      requiredSemanticTypes: [],
+      optionalSemanticTypes: [],
+      scenarios: [
+        {
+          id: 'sc1',
+          name: 'tenant case',
+          operations: [{ operationId: 'createWidget', method: 'POST', path: '/widgets' }],
+          producedSemanticTypes: [],
+          satisfiedSemanticTypes: [],
+          bindings,
+          requestPlan: [
+            {
+              operationId: 'createWidget',
+              method: 'POST',
+              pathTemplate: '/widgets',
+              expect: { status: 200 },
+              bodyTemplate: extras.templateRefsTenant
+                ? { tenantId: '${' + 'tenantIdVar}' }
+                : { name: 'static' },
+              extract: extras.extractsTenant
+                ? [{ fieldPath: 'tenantId', bind: 'tenantIdVar' }]
+                : undefined,
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  async function renderFirst(collection: EndpointScenarioCollection): Promise<string> {
+    const [file] = await PlaywrightEmitter.emit(collection, {
+      outDir: '/unused',
+      suiteName: 'createWidget',
+      mode: 'feature',
+    });
+    return file.content;
+  }
+
+  test('literal tenantIdVar binding seeds the value and emits the simplified fallback', async () => {
+    const content = await renderFirst(buildCollectionWithBindings({ tenantIdVar: 'acme' }));
+    expect(content).toContain(`ctx['tenantIdVar'] = "acme";`);
+    expect(content).toContain(TENANT_FALLBACK);
+    expect(content).not.toMatch(/__seededTenant/);
+  });
+
+  test('__PENDING__ tenantIdVar referenced by a template emits a guarded auto-seed and the simplified fallback', async () => {
+    const content = await renderFirst(
+      buildCollectionWithBindings({ tenantIdVar: '__PENDING__' }, { templateRefsTenant: true }),
+    );
+    expect(content).toContain(
+      `if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`,
+    );
+    expect(content).toContain(TENANT_FALLBACK);
+    expect(content).not.toMatch(/__seededTenant/);
+  });
+
+  test('extractionVars tenantIdVar skips eager seeding but still emits the simplified fallback', async () => {
+    const content = await renderFirst(
+      buildCollectionWithBindings(
+        { tenantIdVar: 'ignored-because-extracted' },
+        { extractsTenant: true },
+      ),
+    );
+    expect(content).not.toContain(`ctx['tenantIdVar'] = "ignored-because-extracted";`);
+    expect(content).toContain(TENANT_FALLBACK);
+    expect(content).not.toMatch(/__seededTenant/);
+  });
+
+  test('no tenantIdVar binding at all still emits the simplified fallback (control)', async () => {
+    const content = await renderFirst(buildCollectionWithBindings({}));
+    expect(content).toContain(TENANT_FALLBACK);
+    expect(content).not.toMatch(/__seededTenant/);
+  });
+});


### PR DESCRIPTION
## Why

The Playwright emitter declared `let __seededTenant = false;` at the top of every scenario body, set it to `true` in two places inside the bindings loop, then checked it in the fallback as `if (!__seededTenant && ctx['tenantIdVar'] === undefined)`. The flag is dead weight: it is set to `true` exactly when the bindings loop populates `ctx['tenantIdVar']`, so `!__seededTenant` and `ctx['tenantIdVar'] === undefined` are perfectly correlated.

## What

Truth table walk of the bindings loop branches:

| branch | sets ctx | sets flag | fallback fires? |
|---|---|---|---|
| literal value | yes | yes | no (ctx defined) |
| `__PENDING__`, used in template | yes | yes | no (ctx defined) |
| `__PENDING__`, in extractionVars | no | no | yes (intentional) |
| not in `s.bindings` | no | no | yes (intentional) |

## What this is NOT

The fallback firing in the `extractionVars` case is **load-bearing, not a defect** — I initially thought to skip it. The early `<default>` seed lets `__tenantIdIsDefault` evaluate to true, so the multipart loop omits the `tenantId` field. The server then returns the real tenant id which a later step extracts. So the only safe change is removing the dead flag, **not** changing when the fallback fires.

## Generated diff per scenario

```diff
-  let __seededTenant = false;
   ...
-  if (!__seededTenant && ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); __seededTenant = true; }
+  if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }
```

## Verification

- `npm run lint` clean
- `npx tsc --noEmit -p path-analyser/tsconfig.json` clean
- `npm test` 110/110
- Spot-checked regenerated `activateJobs.feature.spec.ts` — flag gone, fallback simplified, multipart skip-on-default still works.


Closes #80
