### PR TITLE
fix(planner): alias producer extracts under URL placeholder var names

### DIFF
--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -35,6 +35,8 @@ interface RawOp {
   requires?: unknown;
   requiresSemanticTypes?: unknown;
   parameters?: Array<{
+    name?: string;
+    location?: string;
     schema?: { semanticType?: string };
     semanticType?: string;
     required?: boolean;
@@ -408,7 +410,24 @@ function normalizeOp(opId: string, op: RawOp): OperationNode {
     responseSemanticTypes: Object.keys(normalizedResponseSemanticTypes).length
       ? normalizedResponseSemanticTypes
       : undefined,
+    pathParameters: extractPathParameters(op),
   };
+}
+
+function extractPathParameters(op: RawOp): { name: string; semanticType?: string }[] | undefined {
+  if (!Array.isArray(op.parameters)) return undefined;
+  const out: { name: string; semanticType?: string }[] = [];
+  for (const p of op.parameters) {
+    if (!p || p.location !== 'path' || typeof p.name !== 'string') continue;
+    const semanticType =
+      typeof p.semanticType === 'string'
+        ? p.semanticType
+        : typeof p.schema?.semanticType === 'string'
+          ? p.schema.semanticType
+          : undefined;
+    out.push({ name: p.name, semanticType });
+  }
+  return out.length ? out : undefined;
 }
 
 function extractRequires(op: RawOp): { required: string[]; optional: string[] } {

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -428,7 +428,59 @@ function buildRequestPlan(
       steps.push(dup);
     }
   }
+  // Issue #61: alias producer extracts under placeholder-derived var names.
+  // The Playwright emitter substitutes `{placeholder}` with
+  // `ctx.<camelCase(placeholder)>Var`, but producer steps bind under
+  // `<camelCase(semanticType)>Var`. When the OpenAPI path-param's name
+  // differs from its `x-semantic-type` (e.g. `{adHocSubProcessInstanceKey}`
+  // with semantic type `ElementInstanceKey`), the names never meet and the
+  // literal `${...}` leaks into the URL at runtime. For each path
+  // placeholder on the final step whose semantic type was already extracted
+  // by an earlier step under a differently-named bind, push an additional
+  // alias extract on that producer step bound to the placeholder-derived
+  // name. Keeps the emitter dumb and the alias visible in scenario JSON.
+  aliasProducerExtractsToPlaceholders(scenario, steps, graph);
   return steps;
+}
+
+function aliasProducerExtractsToPlaceholders(
+  scenario: EndpointScenario,
+  steps: RequestStep[],
+  graph: OperationGraph,
+): void {
+  if (steps.length < 2) return;
+  const finalStep = steps[steps.length - 1];
+  const placeholders = [...finalStep.pathTemplate.matchAll(/\{([^}]+)\}/g)].map((m) => m[1]);
+  if (placeholders.length === 0) return;
+  const finalNode = graph.operations[finalStep.operationId];
+  const pathParams = finalNode?.pathParameters ?? [];
+  for (const ph of placeholders) {
+    const param = pathParams.find((p) => p.name === ph);
+    const semanticType = param?.semanticType;
+    if (!semanticType) continue;
+    const placeholderVar = `${camelCase(ph)}Var`;
+    const semanticVar = `${camelCase(semanticType)}Var`;
+    if (placeholderVar === semanticVar) continue;
+    // Walk earlier steps to find an extract bound under the semanticType-
+    // derived var. Prefer the most recent such extract so the alias points
+    // at the freshest production in the chain.
+    for (let i = steps.length - 2; i >= 0; i--) {
+      const earlier = steps[i];
+      const sourceExtract = (earlier.extract ?? []).find((e) => e.bind === semanticVar);
+      if (!sourceExtract) continue;
+      const existingBinds = new Set((earlier.extract ?? []).map((e) => e.bind));
+      if (existingBinds.has(placeholderVar)) break;
+      earlier.extract = (earlier.extract ?? []).concat({
+        fieldPath: sourceExtract.fieldPath,
+        bind: placeholderVar,
+        semantic: sourceExtract.semantic,
+        note: 'placeholderAlias',
+      });
+      scenario.bindings ||= {};
+      if (!scenario.bindings[placeholderVar]) scenario.bindings[placeholderVar] = '__PENDING__';
+      break;
+    }
+  }
 }
 
 function determineExpectedStatus(

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -41,6 +41,12 @@ export interface OperationNode extends OperationRef {
     string,
     { semanticType: string; fieldPath: string; required?: boolean }[]
   >;
+  // Path parameters with their declared `x-semantic-type`. Used by
+  // `buildRequestPlan` to alias producer extracts under the
+  // placeholder-derived var name when an OpenAPI path-param's name differs
+  // from its semanticType (issue #61). Populated in graphLoader from the
+  // raw operation node.
+  pathParameters?: { name: string; semanticType?: string }[];
 }
 
 export interface OperationGraph {
@@ -222,7 +228,7 @@ export interface RequestStep {
   bodyKind?: 'json' | 'multipart';
   multipartTemplate?: unknown; // object suitable for Playwright multipart option
   expect: { status: number };
-  extract?: { fieldPath: string; bind: string; semantic?: string }[];
+  extract?: { fieldPath: string; bind: string; semantic?: string; note?: string }[];
   notes?: string;
   // Optional: expected slices in deployments[] for createDeployment responses, derived from domain sidecar
   expectedDeploymentSlices?: string[];

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -450,19 +450,6 @@ describe('bundled-spec invariants: planner output', () => {
           const varName = placeholderVarName(ph);
           if (isUsableBinding(bindings[varName])) return false;
           if (producedByEarlierStep.has(varName)) return false;
-          // Temporary workaround for placeholder-name vs. semantic-type alias
-          // mismatch (issue #61). When a producer extracts under
-          // `<camelCase(semantic)>Var` but the URL template substitutes
-          // `<placeholderName>Var`, the names never meet, so we also check
-          // the semantic-type-derived alias here. Tracked separately as a
-          // follow-up to #58 (BFS deferral); remove this alias fallback once
-          // #61 fixes placeholder/semanticType binding.
-          const param = parameters.find((p) => p.name === ph && p.location === 'path');
-          if (param?.semanticType) {
-            const aliasVar = `${param.semanticType.charAt(0).toLowerCase()}${param.semanticType.slice(1)}Var`;
-            if (isUsableBinding(bindings[aliasVar])) return false;
-            if (producedByEarlierStep.has(aliasVar)) return false;
-          }
           return true;
         });
         if (unsatisfied.length) {


### PR DESCRIPTION
## Summary

Fixes #61. When an OpenAPI path parameter's name differs from its declared `x-semantic-type`, the producer step in a multi-step scenario extracted under `<camelCase(semanticType)>Var` while the Playwright emitter substituted the placeholder with `ctx.<camelCase(placeholderName)>Var`. The names never met, so the literal `${placeholderName}` leaked into emitted URLs at runtime.

Concrete instance:

```
POST /element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation
- placeholder:    adHocSubProcessInstanceKey
- semanticType:   ElementInstanceKey
- producer:       activateJobs binds elementInstanceKeyVar
- emitted URL:    `${ctx.adHocSubProcessInstanceKeyVar || '${adHocSubProcessInstanceKey}'}`
                                                          ^^^^ literal leak
```

## Approach

Producer-side aliasing (option 1 from the issue):

- After building all request steps in `buildRequestPlan`, walk the final step's path placeholders.
- For each placeholder whose semantic type matches an extract on an earlier producer step (under the semantic-derived bind), push an additional alias extract on that producer step bound to the placeholder-derived var name.
- Emitter stays dumb; the alias is visible in scenario JSON (`note: 'placeholderAlias'`).

To support the lookup, propagated path-parameter `name` and `semanticType` from the operation-dependency-graph through `graphLoader.normalizeOp` onto a new `OperationNode.pathParameters` field.

## Red / green / class-scoped

Two commits:

1. `test(planner): remove invariant alias-fallback workaround for #61` — removes the workaround in `tests/regression/bundled-spec-invariants.test.ts` that was masking the defect by accepting the semanticType-derived alias as a binding substitute. Class-scoped: invariant iterates **every** feature-output scenario, not just `activateAdHocSubProcessActivities`. Confirmed it fails on the current planner output.
2. `fix(planner): alias producer extracts under URL placeholder var names` — minimal producer-side alias logic. The strict invariant now passes.

## Verification

- All 110 vitest tests pass (was 109/110 after the red commit, with the expected failure naming `adHocSubProcessInstanceKey`).
- Spot-checked the regenerated emitter output: producer step now sets `ctx['adHocSubProcessInstanceKeyVar']` immediately before the URL is built.
- Pre-push checklist: lint clean, tsc clean across all 3 workspaces, pipeline regenerated under `TEST_SEED=snapshot-baseline`, full test suite green.

Closes #61
