### PR TITLE
chore: collapse extract guard into extractInto helper

### DIFF
--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -311,14 +311,16 @@ function renderScenarioTest(s: EndpointScenario): string {
         `    await validateResponse(${routeSpec}, ${varName}, { responsesFilePath: __responsesFile });`,
       );
     }
-    // Extraction
+    // Extraction. `extractInto` is the vendored helper from
+    // support/seeding.ts; it skips the assignment when the value is
+    // `undefined` so seeded bindings (e.g. tenantIdVar) and earlier
+    // extracts in the same scenario aren't clobbered by a later step
+    // whose response shape omits the field. See its JSDoc for the full
+    // preserve-on-undefined rationale.
     if (step.extract?.length) {
       body.push(`    const json = await ${varName}.json();`);
       for (const ex of step.extract) {
         const optAcc = toOptionalAccessor(ex.fieldPath);
-        // extractInto preserves the existing ctx binding when the response
-        // field is undefined — matters for seeded values (e.g. tenantIdVar)
-        // and for earlier extracts that later steps must not clobber.
         body.push(`    extractInto(ctx, '${ex.bind}', json${optAcc});`);
       }
     }

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -103,7 +103,7 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   // the generated suite has no dependency on this generator project.
   lines.push("import { buildBaseUrl, authHeaders } from './support/env';");
   lines.push("import { recordResponse, sanitizeBody } from './support/recorder';");
-  lines.push("import { seedBinding } from './support/seeding';");
+  lines.push("import { extractInto, seedBinding } from './support/seeding';");
   lines.push('');
   if (needsValidation) {
     // Resolve responses.json relative to this spec file so the suite is
@@ -314,12 +314,12 @@ function renderScenarioTest(s: EndpointScenario): string {
     // Extraction
     if (step.extract?.length) {
       body.push(`    const json = await ${varName}.json();`);
-      let exIdx = 0;
       for (const ex of step.extract) {
         const optAcc = toOptionalAccessor(ex.fieldPath);
-        const vname = `val_${idx + 1}_${++exIdx}`;
-        body.push(`    const ${vname} = json${optAcc};`);
-        body.push(`    if (${vname} !== undefined) { ctx['${ex.bind}'] = ${vname}; }`);
+        // extractInto preserves the existing ctx binding when the response
+        // field is undefined — matters for seeded values (e.g. tenantIdVar)
+        // and for earlier extracts that later steps must not clobber.
+        body.push(`    extractInto(ctx, '${ex.bind}', json${optAcc});`);
       }
     }
     body.push('  }');

--- a/path-analyser/src/codegen/support/seeding.ts
+++ b/path-analyser/src/codegen/support/seeding.ts
@@ -216,3 +216,18 @@ export function seedBinding(varName: string, _opts?: SeedOptions): string {
 export function debugSeed(varName: string): string {
   return seedBinding(varName);
 }
+
+/**
+ * Conditionally bind an extracted response value into the scenario context.
+ *
+ * Preserves the existing binding when `value` is `undefined` so that:
+ *   - seeded values (from `seedBinding`) survive a missing response field
+ *   - earlier extracts in the same scenario aren't clobbered by later steps
+ *     whose response shape doesn't include the same field
+ *
+ * Note: `null` is treated as a real overwrite (matches the prior emitter
+ * semantics, which only guarded against `undefined`).
+ */
+export function extractInto(ctx: Record<string, unknown>, key: string, value: unknown): void {
+  if (value !== undefined) ctx[key] = value;
+}

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -173,3 +173,101 @@ describe('emitter: tenantIdVar seeding (no __seededTenant flag, #79/#80)', () =>
     expect(content).not.toMatch(/__seededTenant/);
   });
 });
+
+// Regression guard for PR #84: the emitter collapses the per-extracted-field
+// `const val_N_M = json...; if (val_N_M !== undefined) { ctx[...] = val_N_M; }`
+// triple into a single `extractInto(ctx, '<bind>', json...)` call. The class-
+// scoped assertions here lock that shape in: any reintroduction of the old
+// `val_N_M` temporary or `!== undefined` ctx-assignment guard fails the test.
+describe('emitter: extractInto helper for response extraction (#84)', () => {
+  function buildCollectionWithExtracts(
+    extracts: { fieldPath: string; bind: string }[],
+  ): EndpointScenarioCollection {
+    return {
+      endpoint: { operationId: 'createWidget', method: 'POST', path: '/widgets' },
+      requiredSemanticTypes: [],
+      optionalSemanticTypes: [],
+      scenarios: [
+        {
+          id: 'sc1',
+          name: 'extract case',
+          operations: [{ operationId: 'createWidget', method: 'POST', path: '/widgets' }],
+          producedSemanticTypes: [],
+          satisfiedSemanticTypes: [],
+          requestPlan: [
+            {
+              operationId: 'createWidget',
+              method: 'POST',
+              pathTemplate: '/widgets',
+              expect: { status: 200 },
+              extract: extracts,
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  async function renderFirst(collection: EndpointScenarioCollection): Promise<string> {
+    const [file] = await PlaywrightEmitter.emit(collection, {
+      outDir: '/unused',
+      suiteName: 'createWidget',
+      mode: 'feature',
+    });
+    return file.content;
+  }
+
+  test('imports extractInto alongside seedBinding from the vendored support module', async () => {
+    const content = await renderFirst(
+      buildCollectionWithExtracts([{ fieldPath: 'widgetKey', bind: 'widgetKeyVar' }]),
+    );
+    expect(content).toContain("import { extractInto, seedBinding } from './support/seeding';");
+  });
+
+  test('emits exactly one extractInto(ctx, ...) call per extract entry', async () => {
+    const content = await renderFirst(
+      buildCollectionWithExtracts([
+        { fieldPath: 'widgetKey', bind: 'widgetKeyVar' },
+        { fieldPath: 'tenantId', bind: 'tenantIdVar' },
+        { fieldPath: 'meta.createdBy', bind: 'createdByVar' },
+      ]),
+    );
+    expect(content).toContain(`extractInto(ctx, 'widgetKeyVar', json?.widgetKey);`);
+    expect(content).toContain(`extractInto(ctx, 'tenantIdVar', json?.tenantId);`);
+    expect(content).toContain(`extractInto(ctx, 'createdByVar', json?.meta?.createdBy);`);
+    const matches = content.match(/extractInto\(ctx, '/g) ?? [];
+    expect(matches).toHaveLength(3);
+  });
+
+  test('reads the response body once per step (single `const json = await ...json()`)', async () => {
+    const content = await renderFirst(
+      buildCollectionWithExtracts([
+        { fieldPath: 'a', bind: 'aVar' },
+        { fieldPath: 'b', bind: 'bVar' },
+      ]),
+    );
+    const jsonReads = content.match(/const json = await \w+\.json\(\);/g) ?? [];
+    expect(jsonReads).toHaveLength(1);
+  });
+
+  test('does not reintroduce the legacy val_N_M temporary or !== undefined ctx guard', async () => {
+    // Class-scoped guard: any reintroduction of the old shape — a
+    // `const val_N_M` temporary or an `if (val_N_M !== undefined) { ctx[...] = ... }`
+    // assignment guard — fails this test, regardless of which extract triggered it.
+    const content = await renderFirst(
+      buildCollectionWithExtracts([
+        { fieldPath: 'widgetKey', bind: 'widgetKeyVar' },
+        { fieldPath: 'tenantId', bind: 'tenantIdVar' },
+      ]),
+    );
+    expect(content).not.toMatch(/const val_\d+_\d+\s*=/);
+    expect(content).not.toMatch(/if\s*\(\s*val_\d+_\d+\s*!==\s*undefined\s*\)/);
+    expect(content).not.toMatch(/if\s*\([^)]+!==\s*undefined\s*\)\s*\{\s*ctx\[/);
+  });
+
+  test('omits the extract block entirely when step.extract is missing or empty', async () => {
+    const noExtracts = await renderFirst(buildCollectionWithExtracts([]));
+    expect(noExtracts).not.toContain('extractInto(');
+    expect(noExtracts).not.toContain('const json = await');
+  });
+});


### PR DESCRIPTION
The Playwright emitter previously emitted a 3-line block per extracted
field — a `val_N_M` temporary, an `if (val_N_M !== undefined)` guard,
and the assignment to `ctx[...]`. For high-fan-out responses (e.g.
`createDeployment` extracts 6 bindings), this produced ~18 lines of
near-identical noise per step that obscured what each scenario was
actually doing.

Collapse the per-field block into a single call to a new `extractInto`
helper that lives in `support/seeding.ts` (already vendored into every
generated suite by `copy-support-templates.js`).

Behaviour is preserved exactly: `extractInto` still skips the
assignment when `value === undefined`, so seeded values and earlier
extracts in the same scenario are not clobbered by a later step whose
response shape happens to omit the same field. `null` is treated as a
real overwrite, matching the prior emitter semantics.

## Before

```ts
const json = await resp1.json();
const val_1_1 = json?.deployments?.[0]?.processDefinition?.processDefinitionId;
if (val_1_1 !== undefined) { ctx['processDefinitionIdVar'] = val_1_1; }
const val_1_2 = json?.deployments?.[0]?.processDefinition?.processDefinitionKey;
if (val_1_2 !== undefined) { ctx['processDefinitionKeyVar'] = val_1_2; }
const val_1_3 = json?.deployments?.[0]?.form?.formKey;
if (val_1_3 !== undefined) { ctx['formKeyVar'] = val_1_3; }
const val_1_4 = json?.deploymentKey;
if (val_1_4 !== undefined) { ctx['deploymentKeyVar'] = val_1_4; }
const val_1_5 = json?.tenantId;
if (val_1_5 !== undefined) { ctx['tenantIdVar'] = val_1_5; }
const val_1_6 = json?.deployments?.[0]?.decisionDefinition?.decisionDefinitionId;
if (val_1_6 !== undefined) { ctx['decisionDefinitionIdVar'] = val_1_6; }
```

## After

```ts
const json = await resp1.json();
extractInto(ctx, 'processDefinitionIdVar',  json?.deployments?.[0]?.processDefinition?.processDefinitionId);
extractInto(ctx, 'processDefinitionKeyVar', json?.deployments?.[0]?.processDefinition?.processDefinitionKey);
extractInto(ctx, 'formKeyVar',              json?.deployments?.[0]?.form?.formKey);
extractInto(ctx, 'deploymentKeyVar',        json?.deploymentKey);
extractInto(ctx, 'tenantIdVar',             json?.tenantId);
extractInto(ctx, 'decisionDefinitionIdVar', json?.deployments?.[0]?.decisionDefinition?.decisionDefinitionId);
```

## Verification

No production tests change. Regenerated artifact shape (per
`activateJobs` scenario): 30 `extractInto(ctx, ...)` calls, 0
occurrences of the old `val_N_M` pattern.
