### PR TITLE
fix: wipe pipeline output dirs before regenerating

### DIFF
--- a/path-analyser/src/codegen/index.ts
+++ b/path-analyser/src/codegen/index.ts
@@ -55,6 +55,11 @@ async function run() {
     process.exit(1);
   }
 
+  // Wipe before write so emitted spec files left over from a previous spec
+  // version cannot survive into the current run. Without this, local
+  // pre-push validation can diverge from CI (which always sees a fresh tree).
+  // The support/ tree, README.md, and responses.json are re-materialised below.
+  await fs.rm(outDir, { recursive: true, force: true });
   await fs.mkdir(outDir, { recursive: true });
   // Vendor the runtime support helpers into <outDir>/support/ so the
   // emitted suite is self-contained (no imports back into this generator).

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1,5 +1,5 @@
 import fsSync from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildCanonicalShapes } from './canonicalSchemas.js';
@@ -32,6 +32,13 @@ async function main() {
   const baseDir = cwd.endsWith(suffix) ? cwd : path.resolve(cwd, suffix);
   const outputDir = path.resolve(baseDir, 'dist/output');
   const featureDir = path.resolve(baseDir, 'dist/feature-output');
+  // Wipe before write so files left over from a previous spec version (e.g.
+  // an operationId that no longer exists upstream) cannot survive into the
+  // current run and silently break Layer-3 invariants. Without this, local
+  // pre-push validation can diverge from CI — CI checks out a fresh tree
+  // and never sees the stale files.
+  await rm(outputDir, { recursive: true, force: true });
+  await rm(featureDir, { recursive: true, force: true });
   await mkdir(outputDir, { recursive: true });
   await mkdir(featureDir, { recursive: true });
 

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -151,6 +151,34 @@ describe('bundled-spec invariants: extractor classification', () => {
 });
 
 describe('bundled-spec invariants: planner output', () => {
+  it('no scenario file references an operationId that is not in the dependency graph (stale-output guard)', () => {
+    // Class-scoped guard against a stale `path-analyser/dist/output/`:
+    // if a previous pipeline run left behind a `<verb>--<path>-scenarios.json`
+    // for an operationId that the current spec no longer defines, downstream
+    // invariants (notably the prereq guard above) silently break locally
+    // while CI stays green (CI checks out a fresh tree). Asserting that
+    // every emitted scenario file's `endpoint.operationId` exists in the
+    // current graph forces `npm run testsuite:generate` to keep its output
+    // directory in sync with the current spec.
+    if (!existsSync(SCENARIOS_DIR)) {
+      throw new Error(
+        `Scenarios directory not found at ${SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+      );
+    }
+    loadGraph();
+    const orphans: { file: string; operationId: string }[] = [];
+    for (const f of readdirSync(SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const file = JSON.parse(readFileSync(join(SCENARIOS_DIR, f), 'utf8')) as ScenarioFile;
+      const opId = file.endpoint?.operationId;
+      if (opId && !cachedOperationById?.has(opId)) {
+        orphans.push({ file: f, operationId: opId });
+      }
+    }
+    expect(orphans).toEqual([]);
+  });
+
   it('every createProcessInstance scenario starts with createDeployment as the first prerequisite (#32, #35)', () => {
     // Locks in #32 (PDK/PDI sourced from createDeployment) and #35
     // (no spurious intermediate steps): with prereq-checking and the


### PR DESCRIPTION
Both `path-analyser/src/index.ts` (writes `dist/output/` and
`dist/feature-output/`) and `path-analyser/src/codegen/index.ts`
(writes `dist/generated-tests/`) used `mkdir -p` only — no cleanup
before write. Stale per-endpoint files from a previous spec version
therefore survived `npm run testsuite:generate` indefinitely, even
when the planner stopped emitting them.

This made local pre-push validation diverge silently from CI:
- CI checks out a fresh tree; `dist/` starts empty; only the files the
  current pipeline emits exist; Layer-3 invariants pass.
- A long-lived local checkout accumulates orphan `<verb>--<path>-scenarios.json`
  files referencing operationIds the current spec no longer defines.
  The "every step has its required prereqs (#35)" invariant then fails
  locally with `Operation X not found in dependency graph` against a
  ghost file.

Fix: `fs.rm(dir, { recursive: true, force: true })` immediately before
each `mkdir`. Re-materialised content (per-endpoint scenarios, support
templates, README.md, responses.json, generated specs) is unchanged.

Layer-3 regression guard: add a class-scoped invariant
`no scenario file references an operationId that is not in the
dependency graph (stale-output guard)` to bundled-spec-invariants.test.ts.
Verified red→green:
- Plant `post--ghost-scenarios.json` with `endpoint.operationId =
  ghostOperation` → invariant fails with the orphan listed.
- Apply the production fix → testsuite:generate wipes the orphan
  before writing, invariant passes, full suite 118/118.