### PR TITLE
refactor(emitter): derive tenant special-casing from domain-semantics.json (#87)

### DIFF
--- a/path-analyser/domain-semantics.json
+++ b/path-analyser/domain-semantics.json
@@ -151,5 +151,15 @@
       ]
     }
   },
+  "globalContextSeeds": [
+    {
+      "binding": "tenantIdVar",
+      "fieldName": "tenantId",
+      "seedRule": "tenantIdVar",
+      "defaultSentinel": "<default>",
+      "stripFromMultipartWhenDefault": true,
+      "rationale": "Camunda single-tenant mode default — every emitted scenario seeds tenantIdVar via the seed rule (which yields '<default>'), and multipart bodies must drop the tenantId field when the default sentinel is present so the broker assigns the default tenant."
+    }
+  ],
   "version": 1
 }

--- a/path-analyser/domain-semantics.schema.json
+++ b/path-analyser/domain-semantics.schema.json
@@ -59,6 +59,23 @@
           "valueBindings": {"type": "object", "additionalProperties": {"type": "string"}}
         }
       }
+    },
+    "globalContextSeeds": {
+      "description": "Bindings that every emitted scenario must seed into ctx before its request plan runs (e.g. the default-tenant identifier under single-tenant mode). Drives the emitter's universal-seed logic so the codegen layer carries no hard-coded bind names or sentinel values.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["binding", "fieldName", "seedRule"],
+        "additionalProperties": false,
+        "properties": {
+          "binding": {"type": "string", "description": "ctx[<binding>] key the seed populates."},
+          "fieldName": {"type": "string", "description": "Request-body / multipart field name this binding maps to."},
+          "seedRule": {"type": "string", "description": "Key passed to seedBinding() at runtime; must match a rule in seed-rules.json."},
+          "defaultSentinel": {"type": "string", "description": "Magic value that, when present in ctx[<binding>], triggers field-stripping in multipart bodies."},
+          "stripFromMultipartWhenDefault": {"type": "boolean", "description": "If true, the emitter inserts a multipart-loop branch that drops the field when ctx[<binding>] equals the defaultSentinel."},
+          "rationale": {"type": "string"}
+        }
+      }
     }
   }
 }

--- a/path-analyser/domain-semantics.schema.json
+++ b/path-analyser/domain-semantics.schema.json
@@ -68,13 +68,38 @@
         "required": ["binding", "fieldName", "seedRule"],
         "additionalProperties": false,
         "properties": {
-          "binding": {"type": "string", "description": "ctx[<binding>] key the seed populates."},
-          "fieldName": {"type": "string", "description": "Request-body / multipart field name this binding maps to."},
-          "seedRule": {"type": "string", "description": "Key passed to seedBinding() at runtime; must match a rule in seed-rules.json."},
-          "defaultSentinel": {"type": "string", "description": "Magic value that, when present in ctx[<binding>], triggers field-stripping in multipart bodies."},
+          "binding": {
+            "type": "string",
+            "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*$",
+            "description": "ctx[<binding>] key the seed populates. Must be a safe JS identifier (matches the runtime check in domainSemanticsValidator.ts) so the emitter can interpolate it into emitted TS without escaping."
+          },
+          "fieldName": {
+            "type": "string",
+            "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*$",
+            "description": "Request-body / multipart field name this binding maps to. Must be a safe JS identifier — used to derive the emitter's `__<fieldName>IsDefault` sentinel local."
+          },
+          "seedRule": {
+            "type": "string",
+            "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*$",
+            "description": "Key passed to seedBinding() at runtime; must match a rule in seed-rules.json. Restricted to a safe identifier so it can be interpolated into the emitted seedBinding('<seedRule>') call without escaping."
+          },
+          "defaultSentinel": {
+            "type": "string",
+            "pattern": "^[^'\\\\\r\n\t\u0000-\u001f\u2028\u2029]*$",
+            "description": "Magic value that, when present in ctx[<binding>], triggers field-stripping in multipart bodies. Rejects single quotes, backslashes, line terminators, and control characters (including U+2028/U+2029) so it stays safe inside the single-quoted TS string literal the emitter produces."
+          },
           "stripFromMultipartWhenDefault": {"type": "boolean", "description": "If true, the emitter inserts a multipart-loop branch that drops the field when ctx[<binding>] equals the defaultSentinel."},
           "rationale": {"type": "string"}
-        }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {"stripFromMultipartWhenDefault": {"const": true}},
+              "required": ["stripFromMultipartWhenDefault"]
+            },
+            "then": {"required": ["defaultSentinel"]}
+          }
+        ]
       }
     }
   }

--- a/path-analyser/src/codegen/emitter.ts
+++ b/path-analyser/src/codegen/emitter.ts
@@ -1,4 +1,4 @@
-import type { EndpointScenarioCollection } from '../types.js';
+import type { EndpointScenarioCollection, GlobalContextSeed } from '../types.js';
 
 /**
  * Context passed to an {@link Emitter} on every invocation.
@@ -14,6 +14,15 @@ export interface EmitContext {
   suiteName: string;
   /** Generation mode — `feature` is the default for path-analyser scenarios. */
   mode: 'feature' | 'integration';
+  /**
+   * Bindings that every emitted scenario must seed before its request plan
+   * runs (e.g. the default-tenant identifier under single-tenant mode).
+   * Sourced from `domain-semantics.json#globalContextSeeds`. Optional so
+   * emitters that don't need universal seeding (or unit tests that exercise
+   * unrelated paths) can omit it; when omitted the emitter writes no
+   * universal-seed prologue and no multipart strip branches.
+   */
+  globalContextSeeds?: readonly GlobalContextSeed[];
 }
 
 /**

--- a/path-analyser/src/codegen/index.ts
+++ b/path-analyser/src/codegen/index.ts
@@ -36,8 +36,20 @@ async function loadGlobalContextSeeds(baseDir: string): Promise<GlobalContextSee
   let text: string;
   try {
     text = await fs.readFile(path.join(baseDir, 'domain-semantics.json'), 'utf8');
-  } catch {
-    return [];
+  } catch (error) {
+    // Only treat a missing sidecar as non-fatal. EACCES, EISDIR, transient
+    // I/O errors, etc. all indicate a real operational problem and must
+    // surface so the build fails loudly rather than silently emitting a
+    // suite without its universal-seed prologue.
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      Reflect.get(error, 'code') === 'ENOENT'
+    ) {
+      return [];
+    }
+    throw error;
   }
   // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
   const parsed = JSON.parse(text) as unknown;

--- a/path-analyser/src/codegen/index.ts
+++ b/path-analyser/src/codegen/index.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import type { DomainSemantics, EndpointScenarioCollection, GlobalContextSeed } from '../types.js';
+import { validateDomainSemantics } from '../domainSemanticsValidator.js';
+import type { EndpointScenarioCollection, GlobalContextSeed } from '../types.js';
 import { parseCliArgs } from './cli-args.js';
 import { writeEmitted } from './orchestrator.js';
 import { PlaywrightEmitter } from './playwright/emitter.js';
@@ -24,19 +25,33 @@ function parseScenarioCollection(text: string): EndpointScenarioCollection {
 
 /**
  * Load `globalContextSeeds` from `domain-semantics.json`. The full sidecar
- * is validated by graphLoader during planning; here we only read the seeds
- * to feed the emitter, so a missing or malformed file is non-fatal — the
- * emitter simply won't write a universal-seed prologue.
+ * is validated by graphLoader during planning, but we re-validate here
+ * because these values are interpolated directly into emitted TS source —
+ * a malformed entry (wrong type, unsafe characters, duplicate fieldName)
+ * would produce a broken suite or, worse, allow config-driven code
+ * injection. A missing file is non-fatal; an invalid file aborts the
+ * generator with a fail-fast diagnostic.
  */
 async function loadGlobalContextSeeds(baseDir: string): Promise<GlobalContextSeed[]> {
+  let text: string;
   try {
-    const text = await fs.readFile(path.join(baseDir, 'domain-semantics.json'), 'utf8');
-    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
-    const parsed = JSON.parse(text) as DomainSemantics;
-    return parsed.globalContextSeeds ?? [];
+    text = await fs.readFile(path.join(baseDir, 'domain-semantics.json'), 'utf8');
   } catch {
     return [];
   }
+  // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+  const parsed = JSON.parse(text) as unknown;
+  const errors = validateDomainSemantics(parsed);
+  if (errors.length > 0) {
+    const formatted = errors.map((e) => `  - [${e.invariant}] ${e.message}`).join('\n');
+    throw new Error(
+      `domain-semantics.json failed validation (${errors.length} error(s)):\n${formatted}`,
+    );
+  }
+  // validateDomainSemantics returning [] means the parsed shape conforms.
+  // biome-ignore lint/plugin: validated above by validateDomainSemantics
+  const validated = parsed as { globalContextSeeds?: GlobalContextSeed[] };
+  return validated.globalContextSeeds ?? [];
 }
 
 function printUsage(): void {

--- a/path-analyser/src/codegen/index.ts
+++ b/path-analyser/src/codegen/index.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import type { EndpointScenarioCollection } from '../types.js';
+import type { DomainSemantics, EndpointScenarioCollection, GlobalContextSeed } from '../types.js';
 import { parseCliArgs } from './cli-args.js';
 import { writeEmitted } from './orchestrator.js';
 import { PlaywrightEmitter } from './playwright/emitter.js';
@@ -20,6 +20,23 @@ registerEmitter(PlaywrightEmitter);
 function parseScenarioCollection(text: string): EndpointScenarioCollection {
   // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
   return JSON.parse(text) as EndpointScenarioCollection;
+}
+
+/**
+ * Load `globalContextSeeds` from `domain-semantics.json`. The full sidecar
+ * is validated by graphLoader during planning; here we only read the seeds
+ * to feed the emitter, so a missing or malformed file is non-fatal — the
+ * emitter simply won't write a universal-seed prologue.
+ */
+async function loadGlobalContextSeeds(baseDir: string): Promise<GlobalContextSeed[]> {
+  try {
+    const text = await fs.readFile(path.join(baseDir, 'domain-semantics.json'), 'utf8');
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const parsed = JSON.parse(text) as DomainSemantics;
+    return parsed.globalContextSeeds ?? [];
+  } catch {
+    return [];
+  }
 }
 
 function printUsage(): void {
@@ -75,6 +92,7 @@ async function run() {
   }
 
   const files = (await fs.readdir(featureDir)).filter((f) => f.endsWith('-scenarios.json'));
+  const globalContextSeeds = await loadGlobalContextSeeds(baseDir);
 
   if (positional === '--all') {
     let count = 0;
@@ -87,6 +105,7 @@ async function run() {
           outDir,
           suiteName: parsed.endpoint.operationId,
           mode: 'feature',
+          globalContextSeeds,
         });
         count++;
       } catch (e) {
@@ -123,6 +142,7 @@ async function run() {
     outDir,
     suiteName: endpointOpId,
     mode: 'feature',
+    globalContextSeeds,
   });
   console.log('Generated test suite for', endpointOpId, 'at', outDir, `(target: ${emitter.id})`);
 }

--- a/path-analyser/src/codegen/orchestrator.ts
+++ b/path-analyser/src/codegen/orchestrator.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import type { EndpointScenarioCollection } from '../types.js';
-import type { Emitter } from './emitter.js';
+import type { EmitContext, Emitter } from './emitter.js';
 
 /**
  * Write all files emitted by an {@link Emitter} into `outDir`. Centralising
@@ -13,7 +13,7 @@ import type { Emitter } from './emitter.js';
 export async function writeEmitted(
   emitter: Emitter,
   collection: EndpointScenarioCollection,
-  ctx: { outDir: string; suiteName: string; mode: 'feature' | 'integration' },
+  ctx: EmitContext,
 ): Promise<string[]> {
   const files = await emitter.emit(collection, ctx);
   const written: string[] = [];

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -1,6 +1,11 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import type { EndpointScenario, EndpointScenarioCollection, RequestStep } from '../../types.js';
+import type {
+  EndpointScenario,
+  EndpointScenarioCollection,
+  GlobalContextSeed,
+  RequestStep,
+} from '../../types.js';
 import type { EmitContext, EmittedFile, Emitter } from '../emitter.js';
 import { materializeSupport } from './materialize-support.js';
 
@@ -8,6 +13,12 @@ interface EmitOptions {
   outDir: string;
   suiteName?: string;
   mode?: 'feature' | 'integration';
+  /**
+   * See {@link EmitContext.globalContextSeeds}. Forwarded verbatim from the
+   * orchestrator so this entry point and {@link PlaywrightEmitter.emit}
+   * produce identical output for the same inputs.
+   */
+  globalContextSeeds?: readonly GlobalContextSeed[];
 }
 
 /**
@@ -28,12 +39,17 @@ export function playwrightSuiteFileName(
  */
 export function renderPlaywrightSuite(
   collection: EndpointScenarioCollection,
-  opts: { suiteName?: string; mode?: 'feature' | 'integration' },
+  opts: {
+    suiteName?: string;
+    mode?: 'feature' | 'integration';
+    globalContextSeeds?: readonly GlobalContextSeed[];
+  },
 ): string {
   return buildSuiteSource(collection, {
     outDir: '',
     suiteName: opts.suiteName,
     mode: opts.mode,
+    globalContextSeeds: opts.globalContextSeeds,
   });
 }
 
@@ -70,6 +86,7 @@ export const PlaywrightEmitter: Emitter = {
     const content = renderPlaywrightSuite(collection, {
       suiteName: ctx.suiteName,
       mode: ctx.mode,
+      globalContextSeeds: ctx.globalContextSeeds,
     });
     return [
       {
@@ -114,14 +131,18 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
     lines.push('');
   }
   lines.push(`test.describe('${suiteName}', () => {`);
+  const seeds = opts.globalContextSeeds ?? [];
   for (const scenario of collection.scenarios) {
-    lines.push(renderScenarioTest(scenario));
+    lines.push(renderScenarioTest(scenario, seeds));
   }
   lines.push('});');
   return lines.join('\n');
 }
 
-function renderScenarioTest(s: EndpointScenario): string {
+function renderScenarioTest(
+  s: EndpointScenario,
+  globalContextSeeds: readonly GlobalContextSeed[],
+): string {
   const title = `${s.id} - ${escapeQuotes(s.name || 'scenario')}`;
   const body: string[] = [];
   body.push(`test('${title}', async ({ request }) => {`);
@@ -184,13 +205,29 @@ function renderScenarioTest(s: EndpointScenario): string {
       body.push(`  ctx['${k}'] = ${JSON.stringify(v)};`);
     }
   }
-  // Ensure tenantIdVar default sourced from seeding rules (configurable). Idempotent: the
-  // `=== undefined` guard means re-seeding never happens if the bindings loop above already
-  // populated tenantIdVar (whether from a literal value or from seedBinding for __PENDING__).
-  body.push(
-    `  if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`,
-  );
-  body.push(`  const __tenantIdIsDefault = ctx['tenantIdVar'] === '<default>';`);
+  // Universal-seed prologue derived from domain-semantics.json#globalContextSeeds.
+  // Each entry emits an idempotent `=== undefined` guard so the bindings loop
+  // above (which may already have populated the binding from a literal value
+  // or from seedBinding for __PENDING__) is never overwritten. Entries that
+  // declare a defaultSentinel + stripFromMultipartWhenDefault also emit a
+  // `__<fieldName>IsDefault` local that drives the multipart skip branch
+  // below — this is the only place the emitter knows about the sentinel.
+  const sentinelLocals = new Map<string, string>(); // fieldName -> local var name
+  for (const seed of globalContextSeeds) {
+    body.push(
+      `  if (ctx['${seed.binding}'] === undefined) { ctx['${seed.binding}'] = seedBinding('${seed.seedRule}'); }`,
+    );
+    if (seed.stripFromMultipartWhenDefault && seed.defaultSentinel !== undefined) {
+      const local = `__${seed.fieldName}IsDefault`;
+      sentinelLocals.set(seed.fieldName, local);
+      // Single-quoted, escape-only-the-single-quote rendering matches the
+      // pre-#87 hand-written `'<default>'` literal so emitted suites are
+      // byte-identical for sentinels that contain no embedded single quotes
+      // (which the schema strongly discourages anyway).
+      const sentinelLiteral = `'${seed.defaultSentinel.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+      body.push(`  const ${local} = ctx['${seed.binding}'] === ${sentinelLiteral};`);
+    }
+  }
   if (!s.requestPlan) {
     body.push('  // No request plan available');
     body.push('});');
@@ -237,7 +274,13 @@ function renderScenarioTest(s: EndpointScenario): string {
       // Files are passed as { name, mimeType, buffer }
       body.push(`    const multipart: Record<string, any> = {};`);
       body.push(`    for (const [k,v] of Object.entries(${bodyVar}.fields||{})) {`);
-      body.push(`      if (k === 'tenantId' && __tenantIdIsDefault) continue;`);
+      // Emit a strip branch for every globalContextSeeds entry whose
+      // sentinel local was declared in the prologue. The emitter never
+      // hard-codes a field name here — the field name is the metadata key
+      // and the local was named after it.
+      for (const [fieldName, local] of sentinelLocals) {
+        body.push(`      if (k === '${fieldName}' && ${local}) continue;`);
+      }
       body.push(`      if (v !== undefined && v !== null) multipart[k] = String(v);`);
       body.push(`    }`);
       body.push(`    for (const [k,v] of Object.entries(${bodyVar}.files||{})) {
@@ -313,10 +356,10 @@ function renderScenarioTest(s: EndpointScenario): string {
     }
     // Extraction. `extractInto` is the vendored helper from
     // support/seeding.ts; it skips the assignment when the value is
-    // `undefined` so seeded bindings (e.g. tenantIdVar) and earlier
-    // extracts in the same scenario aren't clobbered by a later step
-    // whose response shape omits the field. See its JSDoc for the full
-    // preserve-on-undefined rationale.
+    // `undefined` so seeded bindings (e.g. globalContextSeeds entries)
+    // and earlier extracts in the same scenario aren't clobbered by a
+    // later step whose response shape omits the field. See its JSDoc
+    // for the full preserve-on-undefined rationale.
     if (step.extract?.length) {
       body.push(`    const json = await ${varName}.json();`);
       for (const ex of step.extract) {

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { assertSafeGlobalContextSeeds } from '../../domainSemanticsValidator.js';
 import type {
   EndpointScenario,
   EndpointScenarioCollection,
@@ -98,6 +99,15 @@ export const PlaywrightEmitter: Emitter = {
 };
 
 function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOptions): string {
+  // Boundary safety re-check (#87 review): every public entry point —
+  // renderPlaywrightSuite, emitPlaywrightSuite, PlaywrightEmitter.emit —
+  // funnels through here. Re-validating means a programmatic caller that
+  // bypasses the loader cannot smuggle malformed seeds through to the
+  // string-interpolation sites below. The loader (codegen/index.ts) also
+  // validates, so this is intentionally redundant defense-in-depth.
+  if (opts.globalContextSeeds && opts.globalContextSeeds.length > 0) {
+    assertSafeGlobalContextSeeds(opts.globalContextSeeds);
+  }
   const lines: string[] = [];
   const suiteName = opts.suiteName || collection.endpoint.operationId;
 

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -105,7 +105,14 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   // bypasses the loader cannot smuggle malformed seeds through to the
   // string-interpolation sites below. The loader (codegen/index.ts) also
   // validates, so this is intentionally redundant defense-in-depth.
-  if (opts.globalContextSeeds && opts.globalContextSeeds.length > 0) {
+  //
+  // Validate whenever the caller supplied *anything* for globalContextSeeds
+  // (including `[]`, non-arrays, or otherwise iterable values). The previous
+  // `length > 0` short-circuit could be bypassed by a non-array with no
+  // `length` property, leaving downstream `for (const seed of …)` to throw
+  // a less actionable error. assertSafeGlobalContextSeeds is the single
+  // chokepoint that enforces both Array-ness and per-entry safety.
+  if (opts.globalContextSeeds !== undefined) {
     assertSafeGlobalContextSeeds(opts.globalContextSeeds);
   }
   const lines: string[] = [];

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -212,6 +212,14 @@ function renderScenarioTest(
   // declare a defaultSentinel + stripFromMultipartWhenDefault also emit a
   // `__<fieldName>IsDefault` local that drives the multipart skip branch
   // below — this is the only place the emitter knows about the sentinel.
+  //
+  // Safety: `binding`, `fieldName`, `seedRule` are all required by the
+  // domain-semantics validator (#87) to match `/^[A-Za-z_$][A-Za-z0-9_$]*$/`,
+  // and `defaultSentinel` is required to contain no single quotes,
+  // backslashes, or line terminators. That lets us interpolate them
+  // directly into emitted single-quoted TS string literals without an
+  // escape pass and preserves byte identity with the pre-#87 hand-written
+  // strings.
   const sentinelLocals = new Map<string, string>(); // fieldName -> local var name
   for (const seed of globalContextSeeds) {
     body.push(
@@ -220,12 +228,7 @@ function renderScenarioTest(
     if (seed.stripFromMultipartWhenDefault && seed.defaultSentinel !== undefined) {
       const local = `__${seed.fieldName}IsDefault`;
       sentinelLocals.set(seed.fieldName, local);
-      // Single-quoted, escape-only-the-single-quote rendering matches the
-      // pre-#87 hand-written `'<default>'` literal so emitted suites are
-      // byte-identical for sentinels that contain no embedded single quotes
-      // (which the schema strongly discourages anyway).
-      const sentinelLiteral = `'${seed.defaultSentinel.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
-      body.push(`  const ${local} = ctx['${seed.binding}'] === ${sentinelLiteral};`);
+      body.push(`  const ${local} = ctx['${seed.binding}'] === '${seed.defaultSentinel}';`);
     }
   }
   if (!s.requestPlan) {

--- a/path-analyser/src/domainSemanticsValidator.ts
+++ b/path-analyser/src/domainSemanticsValidator.ts
@@ -370,7 +370,12 @@ export function validateDomainSemantics(raw: unknown): DomainSemanticsValidation
  * — both surfaces use the same `GlobalContextSeedSchema` and
  * `checkGlobalContextSeedsCoherent` so they cannot drift.
  */
-export function assertSafeGlobalContextSeeds(seeds: readonly unknown[]): void {
+export function assertSafeGlobalContextSeeds(seeds: unknown): void {
+  if (!Array.isArray(seeds)) {
+    throw new TypeError(
+      `globalContextSeeds must be an array when provided (received ${seeds === null ? 'null' : typeof seeds}).`,
+    );
+  }
   const arrayResult = z.array(GlobalContextSeedSchema).safeParse(seeds);
   if (!arrayResult.success) {
     const formatted = arrayResult.error.issues

--- a/path-analyser/src/domainSemanticsValidator.ts
+++ b/path-analyser/src/domainSemanticsValidator.ts
@@ -56,6 +56,17 @@ const OperationDomainRequirementsSchema = z
   })
   .passthrough();
 
+const GlobalContextSeedSchema = z
+  .object({
+    binding: z.string().min(1),
+    fieldName: z.string().min(1),
+    seedRule: z.string().min(1),
+    defaultSentinel: z.string().optional(),
+    stripFromMultipartWhenDefault: z.boolean().optional(),
+    rationale: z.string().optional(),
+  })
+  .passthrough();
+
 // Top-level shape — `passthrough` so unrelated fields (operationArtifactRules,
 // artifactFileKinds, semanticTypeToArtifactKind, identifiers, version, $schema)
 // flow through unmodified.
@@ -66,6 +77,7 @@ const DomainSemanticsShape = z
     semanticTypes: z.record(z.string(), SemanticTypeSpecSchema).optional(),
     artifactKinds: z.record(z.string(), ArtifactKindSpecSchema).optional(),
     operationRequirements: z.record(z.string(), OperationDomainRequirementsSchema).optional(),
+    globalContextSeeds: z.array(GlobalContextSeedSchema).optional(),
   })
   .passthrough();
 
@@ -198,6 +210,33 @@ function checkDisjunctionMemberResolves(d: DomainSemanticsShape): CrossRefIssue[
   return issues;
 }
 
+// #87: every globalContextSeeds entry must have a unique `binding` so the
+// emitter's per-binding sentinel local (`__<fieldName>IsDefault`) and seed
+// line don't collide. Also reject `stripFromMultipartWhenDefault: true`
+// without a `defaultSentinel` — the strip branch needs something to compare
+// against, otherwise the emitter would have to choose a fallback sentinel
+// itself (re-introducing the very hard-coding this entry is meant to remove).
+function checkGlobalContextSeedsCoherent(d: DomainSemanticsShape): CrossRefIssue[] {
+  const issues: CrossRefIssue[] = [];
+  const seen = new Set<string>();
+  for (const seed of d.globalContextSeeds ?? []) {
+    if (seen.has(seed.binding)) {
+      issues.push({
+        code: 'globalContextSeedBindingUnique',
+        message: `globalContextSeeds contains duplicate binding "${seed.binding}"`,
+      });
+    }
+    seen.add(seed.binding);
+    if (seed.stripFromMultipartWhenDefault === true && seed.defaultSentinel === undefined) {
+      issues.push({
+        code: 'globalContextSeedStripRequiresSentinel',
+        message: `globalContextSeeds entry for binding "${seed.binding}" sets stripFromMultipartWhenDefault but has no defaultSentinel`,
+      });
+    }
+  }
+  return issues;
+}
+
 const CROSS_REF_CHECKS = [
   checkArtifactKindStateDeclared,
   checkArtifactKindWitnessDeclared,
@@ -205,6 +244,7 @@ const CROSS_REF_CHECKS = [
   checkSemanticBindingTargetResolves,
   checkDisjunctionNotWitnessRedundant,
   checkDisjunctionMemberResolves,
+  checkGlobalContextSeedsCoherent,
 ] as const;
 
 // Composed schema: structural shape + every cross-reference invariant.

--- a/path-analyser/src/domainSemanticsValidator.ts
+++ b/path-analyser/src/domainSemanticsValidator.ts
@@ -56,7 +56,11 @@ const OperationDomainRequirementsSchema = z
   })
   .passthrough();
 
-const GlobalContextSeedSchema = z
+// Strict: mirrors `additionalProperties: false` in domain-semantics.schema.json
+// so runtime validation matches the published JSON Schema. Unknown keys are
+// almost always a typo (e.g. `seedRules` for `seedRule`) and silently
+// dropping them would mask the typo until the emitted suite misbehaves.
+export const GlobalContextSeedSchema = z
   .object({
     binding: z.string().min(1),
     fieldName: z.string().min(1),
@@ -65,7 +69,7 @@ const GlobalContextSeedSchema = z
     stripFromMultipartWhenDefault: z.boolean().optional(),
     rationale: z.string().optional(),
   })
-  .passthrough();
+  .strict();
 
 // Top-level shape — `passthrough` so unrelated fields (operationArtifactRules,
 // artifactFileKinds, semanticTypeToArtifactKind, identifiers, version, $schema)
@@ -210,23 +214,80 @@ function checkDisjunctionMemberResolves(d: DomainSemanticsShape): CrossRefIssue[
   return issues;
 }
 
-// #87: every globalContextSeeds entry must have a unique `binding` so the
-// emitter's per-binding sentinel local (`__<fieldName>IsDefault`) and seed
-// line don't collide. Also reject `stripFromMultipartWhenDefault: true`
-// without a `defaultSentinel` — the strip branch needs something to compare
-// against, otherwise the emitter would have to choose a fallback sentinel
-// itself (re-introducing the very hard-coding this entry is meant to remove).
+// JS/TS identifier syntax. Conservative — ASCII only — because the emitter
+// builds locals like `__<fieldName>IsDefault` and ctx keys like `<binding>`
+// from these strings; restricting them to identifier-safe ASCII rules out
+// accidental code injection (`'; DROP TABLE`-style) and ensures the emitted
+// TS compiles regardless of the surrounding generator's escape choices.
+function isSafeIdentifierName(name: string): boolean {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name);
+}
+
+// `defaultSentinel` is interpolated into a single-quoted TS string literal
+// (preserved verbatim from the pre-#87 emitter so generated suites stay
+// byte-identical). Reject characters that would break that literal: single
+// quotes, backslashes, line terminators, and other control characters.
+// Unicode line separators U+2028 / U+2029 also terminate string literals in
+// JS so they're rejected too. The current production sentinel `<default>`
+// passes; anything that would have required escaping fails fast at load.
+function sentinelHasUnsafeChars(sentinel: string): boolean {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars to reject them
+  return /['\\\r\n\t\u0000-\u001f\u2028\u2029]/.test(sentinel);
+}
+
+// #87: every globalContextSeeds entry must have a unique, identifier-safe
+// `binding` and `fieldName`. The emitter's sentinel local is
+// `__<fieldName>IsDefault`, the multipart strip branch keys off `fieldName`,
+// and ctx[<binding>] / seedBinding('<seedRule>') interpolate `binding` and
+// `seedRule` directly. Restricting these to safe identifiers (and rejecting
+// duplicates) means the emitter can interpolate them without an escape pass,
+// rules out config-driven code injection, and prevents two entries from
+// declaring the same `const __...IsDefault`. Also reject
+// `stripFromMultipartWhenDefault: true` without a `defaultSentinel` — the
+// strip branch needs something to compare against, otherwise the emitter
+// would have to choose a fallback sentinel itself (re-introducing the very
+// hard-coding this entry is meant to remove).
 function checkGlobalContextSeedsCoherent(d: DomainSemanticsShape): CrossRefIssue[] {
   const issues: CrossRefIssue[] = [];
-  const seen = new Set<string>();
+  const seenBindings = new Set<string>();
+  const seenFieldNames = new Set<string>();
   for (const seed of d.globalContextSeeds ?? []) {
-    if (seen.has(seed.binding)) {
+    if (seenBindings.has(seed.binding)) {
       issues.push({
         code: 'globalContextSeedBindingUnique',
         message: `globalContextSeeds contains duplicate binding "${seed.binding}"`,
       });
     }
-    seen.add(seed.binding);
+    seenBindings.add(seed.binding);
+
+    if (seenFieldNames.has(seed.fieldName)) {
+      issues.push({
+        code: 'globalContextSeedFieldNameUnique',
+        message: `globalContextSeeds contains duplicate fieldName "${seed.fieldName}"`,
+      });
+    }
+    seenFieldNames.add(seed.fieldName);
+
+    for (const [key, value] of [
+      ['binding', seed.binding],
+      ['fieldName', seed.fieldName],
+      ['seedRule', seed.seedRule],
+    ] as const) {
+      if (!isSafeIdentifierName(value)) {
+        issues.push({
+          code: 'globalContextSeedSafeIdentifier',
+          message: `globalContextSeeds entry for binding "${seed.binding}" has ${key} "${value}", which is not a safe identifier (must match /^[A-Za-z_$][A-Za-z0-9_$]*$/)`,
+        });
+      }
+    }
+
+    if (seed.defaultSentinel !== undefined && sentinelHasUnsafeChars(seed.defaultSentinel)) {
+      issues.push({
+        code: 'globalContextSeedSentinelSafe',
+        message: `globalContextSeeds entry for binding "${seed.binding}" has defaultSentinel containing characters (single-quote, backslash, line terminator, or control char) that would break the emitted single-quoted string literal`,
+      });
+    }
+
     if (seed.stripFromMultipartWhenDefault === true && seed.defaultSentinel === undefined) {
       issues.push({
         code: 'globalContextSeedStripRequiresSentinel',

--- a/path-analyser/src/domainSemanticsValidator.ts
+++ b/path-analyser/src/domainSemanticsValidator.ts
@@ -348,3 +348,39 @@ export function validateDomainSemantics(raw: unknown): DomainSemanticsValidation
     return { invariant, message: issue.message };
   });
 }
+
+/**
+ * Boundary-level safety assertion for `globalContextSeeds`.
+ *
+ * The Playwright emitter interpolates `binding`, `fieldName`, `seedRule`,
+ * and `defaultSentinel` directly into emitted TS source as identifiers and
+ * single-quoted string literals (#87). The loader validates the seeds when
+ * reading `domain-semantics.json`, but the public emitter entry points
+ * (`renderPlaywrightSuite`, `emitPlaywrightSuite`, `PlaywrightEmitter.emit`)
+ * accept a `globalContextSeeds` argument from any caller. This helper
+ * re-validates at that boundary so a programmatic caller cannot bypass
+ * the loader's safety net and produce broken or injection-vulnerable
+ * generated suites.
+ *
+ * Throws on any structural issue (Zod `.strict()` schema) or any
+ * cross-seed coherence violation (uniqueness, identifier safety, sentinel
+ * char safety, strip-requires-sentinel). Returns silently on success.
+ *
+ * The validation is intentionally redundant with `validateDomainSemantics`
+ * — both surfaces use the same `GlobalContextSeedSchema` and
+ * `checkGlobalContextSeedsCoherent` so they cannot drift.
+ */
+export function assertSafeGlobalContextSeeds(seeds: readonly unknown[]): void {
+  const arrayResult = z.array(GlobalContextSeedSchema).safeParse(seeds);
+  if (!arrayResult.success) {
+    const formatted = arrayResult.error.issues
+      .map((i) => `  - ${i.path.join('.')}: ${i.message}`)
+      .join('\n');
+    throw new Error(`globalContextSeeds failed structural validation:\n${formatted}`);
+  }
+  const issues = checkGlobalContextSeedsCoherent({ globalContextSeeds: arrayResult.data });
+  if (issues.length > 0) {
+    const formatted = issues.map((i) => `  - [${i.code}] ${i.message}`).join('\n');
+    throw new Error(`globalContextSeeds failed coherence validation:\n${formatted}`);
+  }
+}

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -270,10 +270,10 @@ export interface DomainSemantics {
 /**
  * One entry in {@link DomainSemantics.globalContextSeeds}. Drives the
  * Playwright emitter's per-scenario seed prologue: for every entry the
- * emitter writes a `ctx[<binding>] ??= seedBinding('<seedRule>')` line and,
- * when {@link defaultSentinel} + {@link stripFromMultipartWhenDefault} are
- * present, a multipart-loop branch that drops {@link fieldName} when the
- * binding equals the sentinel.
+ * emitter writes an `if (ctx['<binding>'] === undefined) { ctx['<binding>'] =
+ * seedBinding('<seedRule>'); }` guard and, when {@link defaultSentinel} +
+ * {@link stripFromMultipartWhenDefault} are present, a multipart-loop branch
+ * that drops {@link fieldName} when the binding equals the sentinel.
  */
 export interface GlobalContextSeed {
   /** ctx[<binding>] key the seed populates. */

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -259,6 +259,35 @@ export interface DomainSemantics {
   // semantic type T witnesses the existence of state `semanticTypes[T].witnesses`.
   // The loader uses this to populate producersByState from producersByType.
   semanticTypes?: Record<string, SemanticTypeSpec>;
+  // #87: bindings that every emitted scenario must seed before its request
+  // plan runs (e.g. the default-tenant identifier under single-tenant mode).
+  // The Playwright emitter consumes this list to derive its universal-seed
+  // logic so the codegen layer carries no hard-coded bind names or sentinel
+  // values.
+  globalContextSeeds?: GlobalContextSeed[];
+}
+
+/**
+ * One entry in {@link DomainSemantics.globalContextSeeds}. Drives the
+ * Playwright emitter's per-scenario seed prologue: for every entry the
+ * emitter writes a `ctx[<binding>] ??= seedBinding('<seedRule>')` line and,
+ * when {@link defaultSentinel} + {@link stripFromMultipartWhenDefault} are
+ * present, a multipart-loop branch that drops {@link fieldName} when the
+ * binding equals the sentinel.
+ */
+export interface GlobalContextSeed {
+  /** ctx[<binding>] key the seed populates. */
+  binding: string;
+  /** Request-body / multipart field name this binding maps to. */
+  fieldName: string;
+  /** Key passed to seedBinding() at runtime; must match a rule in seed-rules.json. */
+  seedRule: string;
+  /** Magic value that, when present in ctx[<binding>], triggers field-stripping in multipart bodies. */
+  defaultSentinel?: string;
+  /** If true, the emitter inserts a multipart-loop branch that drops {@link fieldName} when ctx[<binding>] equals {@link defaultSentinel}. */
+  stripFromMultipartWhenDefault?: boolean;
+  /** Free-form documentation for maintainers. */
+  rationale?: string;
 }
 
 export interface SemanticTypeSpec {

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -4,7 +4,22 @@ import {
   playwrightSuiteFileName,
   renderPlaywrightSuite,
 } from '../../path-analyser/src/codegen/playwright/emitter.ts';
-import type { EndpointScenarioCollection } from '../../path-analyser/src/types.ts';
+import type {
+  EndpointScenarioCollection,
+  GlobalContextSeed,
+} from '../../path-analyser/src/types.ts';
+
+// The tenant-related tests below all derive the emitter's universal-seed
+// behaviour from this fixture, mirroring the entry shipped in
+// path-analyser/domain-semantics.json so the assertions track production
+// configuration shape.
+const TENANT_SEED: GlobalContextSeed = {
+  binding: 'tenantIdVar',
+  fieldName: 'tenantId',
+  seedRule: 'tenantIdVar',
+  defaultSentinel: '<default>',
+  stripFromMultipartWhenDefault: true,
+};
 
 const COLLECTION: EndpointScenarioCollection = {
   endpoint: { operationId: 'createWidget', method: 'POST', path: '/widgets' },
@@ -133,6 +148,7 @@ describe('emitter: tenantIdVar seeding (no __seededTenant flag, #79/#80)', () =>
       outDir: '/unused',
       suiteName: 'createWidget',
       mode: 'feature',
+      globalContextSeeds: [TENANT_SEED],
     });
     return file.content;
   }
@@ -269,5 +285,135 @@ describe('emitter: extractInto helper for response extraction (#84)', () => {
     const noExtracts = await renderFirst(buildCollectionWithExtracts([]));
     expect(noExtracts).not.toContain('extractInto(');
     expect(noExtracts).not.toContain('const json = await');
+  });
+});
+
+// Regression guard for #87: the emitter contains zero hard-coded bind names
+// or sentinel string literals. Every "tenant"-flavoured branch must derive
+// from a globalContextSeeds entry passed via EmitContext. The tests here
+// pin both halves of that contract:
+//
+//   1. A class-scoped source scan rejects reintroduction of the literals
+//      'tenantIdVar', 'tenantId', '<default>', or '__seededTenant' anywhere
+//      in path-analyser/src/codegen/playwright/emitter.ts.
+//   2. Parallel-entry test: a *second* globalContextSeeds entry produces
+//      parallel code with no further emitter changes — proving the loop is
+//      generic and not a one-off branch dressed up as a loop.
+//   3. Empty-seeds test: when no seeds are supplied, no universal-seed
+//      prologue is emitted and no multipart strip branch is inserted.
+describe('emitter: globalContextSeeds is the only source of universal-seed knowledge (#87)', () => {
+  test('emitter.ts source contains no hard-coded tenant bind names or sentinel strings', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const url = await import('node:url');
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const emitterPath = path.resolve(here, '../../path-analyser/src/codegen/playwright/emitter.ts');
+    const source = await fs.readFile(emitterPath, 'utf8');
+    // Strip line comments so the issue/PR cross-references in JSDoc don't
+    // false-positive. Block comments are kept intentionally — a block
+    // comment matching one of these literals is still a smell.
+    const codeOnly = source
+      .split('\n')
+      .map((l) => l.replace(/\/\/.*$/, ''))
+      .join('\n');
+    for (const literal of ["'tenantIdVar'", "'tenantId'", "'<default>'", '__seededTenant']) {
+      expect(
+        codeOnly,
+        `emitter.ts must not contain the literal ${literal} (issue #87)`,
+      ).not.toContain(literal);
+    }
+  });
+
+  function buildCollectionWithMultipart(): EndpointScenarioCollection {
+    return {
+      endpoint: { operationId: 'createWidget', method: 'POST', path: '/widgets' },
+      requiredSemanticTypes: [],
+      optionalSemanticTypes: [],
+      scenarios: [
+        {
+          id: 'sc1',
+          name: 'multipart case',
+          operations: [{ operationId: 'createWidget', method: 'POST', path: '/widgets' }],
+          producedSemanticTypes: [],
+          satisfiedSemanticTypes: [],
+          requestPlan: [
+            {
+              operationId: 'createWidget',
+              method: 'POST',
+              pathTemplate: '/widgets',
+              expect: { status: 200 },
+              bodyKind: 'multipart',
+              multipartTemplate: {
+                fields: { tenantId: '${' + 'tenantIdVar}', orgId: '${' + 'orgIdVar}' },
+                files: {},
+              },
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  test('a second globalContextSeeds entry produces parallel seed + strip code', async () => {
+    const orgSeed: GlobalContextSeed = {
+      binding: 'orgIdVar',
+      fieldName: 'orgId',
+      seedRule: 'orgIdVar',
+      defaultSentinel: '<root>',
+      stripFromMultipartWhenDefault: true,
+    };
+    const [file] = await PlaywrightEmitter.emit(buildCollectionWithMultipart(), {
+      outDir: '/unused',
+      suiteName: 'createWidget',
+      mode: 'feature',
+      globalContextSeeds: [TENANT_SEED, orgSeed],
+    });
+    const c = file.content;
+    // Both seeds emit an idempotent ?? guard.
+    expect(c).toContain(
+      `if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`,
+    );
+    expect(c).toContain(
+      `if (ctx['orgIdVar'] === undefined) { ctx['orgIdVar'] = seedBinding('orgIdVar'); }`,
+    );
+    // Both seeds declare a sentinel local named after the field.
+    expect(c).toContain(`const __tenantIdIsDefault = ctx['tenantIdVar'] === '<default>';`);
+    expect(c).toContain(`const __orgIdIsDefault = ctx['orgIdVar'] === '<root>';`);
+    // Both seeds insert a parallel multipart-strip branch.
+    expect(c).toContain(`if (k === 'tenantId' && __tenantIdIsDefault) continue;`);
+    expect(c).toContain(`if (k === 'orgId' && __orgIdIsDefault) continue;`);
+  });
+
+  test('without seeds the emitter writes no universal-seed prologue and no multipart strip branch', async () => {
+    const [file] = await PlaywrightEmitter.emit(buildCollectionWithMultipart(), {
+      outDir: '/unused',
+      suiteName: 'createWidget',
+      mode: 'feature',
+      // no globalContextSeeds
+    });
+    const c = file.content;
+    expect(c).not.toMatch(/IsDefault\b/);
+    expect(c).not.toMatch(/seedBinding\('tenantIdVar'\)/);
+    expect(c).not.toMatch(/&& __\w+IsDefault\) continue;/);
+  });
+
+  test('seed without stripFromMultipartWhenDefault emits the guard but no strip branch', async () => {
+    const seedOnly: GlobalContextSeed = {
+      binding: 'tenantIdVar',
+      fieldName: 'tenantId',
+      seedRule: 'tenantIdVar',
+    };
+    const [file] = await PlaywrightEmitter.emit(buildCollectionWithMultipart(), {
+      outDir: '/unused',
+      suiteName: 'createWidget',
+      mode: 'feature',
+      globalContextSeeds: [seedOnly],
+    });
+    const c = file.content;
+    expect(c).toContain(
+      `if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`,
+    );
+    expect(c).not.toMatch(/__tenantIdIsDefault/);
+    expect(c).not.toMatch(/&& __\w+IsDefault\) continue;/);
   });
 });

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -423,3 +423,81 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
     expect(c).not.toMatch(/&& __\w+IsDefault\) continue;/);
   });
 });
+
+// Boundary safety guards (#87 review): the public emitter entry points
+// re-validate `globalContextSeeds` so a programmatic caller that bypasses
+// the loader (codegen/index.ts) still cannot smuggle malformed input
+// through to the string-interpolation sites in the emitted suite.
+describe('emitter: boundary safety re-validation (#87 review)', () => {
+  test('rejects unsafe identifier in binding via PlaywrightEmitter.emit', async () => {
+    const badSeed = {
+      binding: 'tenant-id', // '-' is not safe-identifier syntax
+      fieldName: 'tenantId',
+      seedRule: 'tenantIdVar',
+    } satisfies GlobalContextSeed;
+    await expect(
+      PlaywrightEmitter.emit(COLLECTION, {
+        outDir: '/unused',
+        suiteName: 'createWidget',
+        mode: 'feature',
+        globalContextSeeds: [badSeed],
+      }),
+    ).rejects.toThrow(/globalContextSeedSafeIdentifier|safe identifier/);
+  });
+
+  test('rejects duplicate fieldName via renderPlaywrightSuite', () => {
+    const seedA: GlobalContextSeed = {
+      binding: 'tenantIdVar',
+      fieldName: 'tenantId',
+      seedRule: 'tenantIdVar',
+    };
+    const seedB: GlobalContextSeed = {
+      binding: 'orgIdVar',
+      fieldName: 'tenantId', // duplicate
+      seedRule: 'orgIdVar',
+    };
+    expect(() =>
+      renderPlaywrightSuite(COLLECTION, {
+        suiteName: 'createWidget',
+        mode: 'feature',
+        globalContextSeeds: [seedA, seedB],
+      }),
+    ).toThrow(/globalContextSeedFieldNameUnique|duplicate fieldName/);
+  });
+
+  test('rejects unsafe sentinel (newline) via renderPlaywrightSuite', () => {
+    const badSeed: GlobalContextSeed = {
+      binding: 'tenantIdVar',
+      fieldName: 'tenantId',
+      seedRule: 'tenantIdVar',
+      defaultSentinel: 'line1\nline2',
+    };
+    expect(() =>
+      renderPlaywrightSuite(COLLECTION, {
+        suiteName: 'createWidget',
+        mode: 'feature',
+        globalContextSeeds: [badSeed],
+      }),
+    ).toThrow(/globalContextSeedSentinelSafe|line terminator|control char/);
+  });
+
+  test('accepts the production tenant seed shape', () => {
+    expect(() =>
+      renderPlaywrightSuite(COLLECTION, {
+        suiteName: 'createWidget',
+        mode: 'feature',
+        globalContextSeeds: [TENANT_SEED],
+      }),
+    ).not.toThrow();
+  });
+
+  test('empty seeds array is a no-op (no validation triggered)', () => {
+    expect(() =>
+      renderPlaywrightSuite(COLLECTION, {
+        suiteName: 'createWidget',
+        mode: 'feature',
+        globalContextSeeds: [],
+      }),
+    ).not.toThrow();
+  });
+});

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -302,7 +302,7 @@ describe('emitter: extractInto helper for response extraction (#84)', () => {
 //   3. Empty-seeds test: when no seeds are supplied, no universal-seed
 //      prologue is emitted and no multipart strip branch is inserted.
 describe('emitter: globalContextSeeds is the only source of universal-seed knowledge (#87)', () => {
-  test('emitter.ts source contains no hard-coded tenant bind names or sentinel strings', async () => {
+  test('emitter.ts source contains no hard-coded tenant bind names or sentinel strings (any quote style)', async () => {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
     const url = await import('node:url');
@@ -316,11 +316,17 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
       .split('\n')
       .map((l) => l.replace(/\/\/.*$/, ''))
       .join('\n');
-    for (const literal of ["'tenantIdVar'", "'tenantId'", "'<default>'", '__seededTenant']) {
-      expect(
-        codeOnly,
-        `emitter.ts must not contain the literal ${literal} (issue #87)`,
-      ).not.toContain(literal);
+    // Match any quote style (single, double, backtick) so re-introducing
+    // the same coupling via "tenantIdVar" or `tenantIdVar` is also caught.
+    const forbiddenPatterns = [
+      { label: 'quoted tenantIdVar', pattern: /['"`]tenantIdVar['"`]/ },
+      { label: 'quoted tenantId', pattern: /['"`]tenantId['"`]/ },
+      { label: 'quoted <default>', pattern: /['"`]<default>['"`]/ },
+      { label: 'bare __seededTenant', pattern: /\b__seededTenant\b/ },
+      { label: 'quoted __seededTenant', pattern: /['"`]__seededTenant['"`]/ },
+    ];
+    for (const { label, pattern } of forbiddenPatterns) {
+      expect(codeOnly, `emitter.ts must not contain ${label} (issue #87)`).not.toMatch(pattern);
     }
   });
 

--- a/tests/regression/domain-semantics-validator.test.ts
+++ b/tests/regression/domain-semantics-validator.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { validateDomainSemantics } from '../../path-analyser/src/domainSemanticsValidator.ts';
+import {
+  assertSafeGlobalContextSeeds,
+  validateDomainSemantics,
+} from '../../path-analyser/src/domainSemanticsValidator.ts';
 
 // ---------------------------------------------------------------------------
 // Class-scoped guards for path-analyser/src/domainSemanticsValidator.ts.
@@ -227,5 +230,40 @@ describe('validateDomainSemantics', () => {
     // cross-ref invariants), so the error list is non-empty even though no
     // cross-ref invariant fires.
     expect(errs.length).toBeGreaterThan(0);
+  });
+});
+
+// Boundary chokepoint used by the emitter (renderPlaywrightSuite /
+// emitPlaywrightSuite / PlaywrightEmitter.emit). Class-of-defect guard:
+// the previous boundary check short-circuited on `seeds.length > 0`, which
+// a programmatic JS caller could bypass with any non-array value (no
+// `.length`, or `.length === 0` on an iterable). The validator must reject
+// every non-array shape with a clear "must be an array" message before the
+// per-entry zod schema runs.
+describe('assertSafeGlobalContextSeeds (boundary)', () => {
+  it('accepts an empty array (validation runs and trivially passes)', () => {
+    expect(() => assertSafeGlobalContextSeeds([])).not.toThrow();
+  });
+
+  it('rejects every non-array shape with a "must be an array" error', () => {
+    const nonArrays: readonly unknown[] = [
+      undefined,
+      null,
+      'not-an-array',
+      42,
+      true,
+      { 0: 'fake', length: 0 },
+      { 0: 'fake', length: 1 },
+      new Set([{ binding: 'x', fieldName: 'x', seedRule: 'x' }]),
+    ];
+    for (const bad of nonArrays) {
+      expect(() => assertSafeGlobalContextSeeds(bad)).toThrow(/must be an array/);
+    }
+  });
+
+  it('rejects an array of malformed entries with structural validation errors', () => {
+    expect(() => assertSafeGlobalContextSeeds([{ binding: 'tenant-id' }])).toThrow(
+      /structural validation/,
+    );
   });
 });

--- a/tests/regression/domain-semantics-validator.test.ts
+++ b/tests/regression/domain-semantics-validator.test.ts
@@ -128,4 +128,104 @@ describe('validateDomainSemantics', () => {
     const parsed: unknown = JSON.parse(raw);
     expect(validateDomainSemantics(parsed)).toEqual([]);
   });
+
+  // -------------------------------------------------------------------------
+  // globalContextSeeds: input-validation guards (#87 review)
+  //
+  // Every seed entry is interpolated directly into emitted TS source — these
+  // checks make config-driven code injection structurally impossible and
+  // pre-empt collisions in the emitted prologue / multipart strip branch.
+  // -------------------------------------------------------------------------
+
+  it('reports globalContextSeedBindingUnique when two seeds share a binding', () => {
+    const errs = validateDomainSemantics({
+      globalContextSeeds: [
+        { binding: 'tenantIdVar', fieldName: 'tenantId', seedRule: 'tenantIdVar' },
+        { binding: 'tenantIdVar', fieldName: 'otherField', seedRule: 'tenantIdVar' },
+      ],
+    });
+    expect(errs.map((e) => e.invariant)).toContain('globalContextSeedBindingUnique');
+  });
+
+  it('reports globalContextSeedFieldNameUnique when two seeds share a fieldName', () => {
+    const errs = validateDomainSemantics({
+      globalContextSeeds: [
+        { binding: 'tenantIdVar', fieldName: 'tenantId', seedRule: 'tenantIdVar' },
+        { binding: 'orgIdVar', fieldName: 'tenantId', seedRule: 'orgIdVar' },
+      ],
+    });
+    expect(errs.map((e) => e.invariant)).toContain('globalContextSeedFieldNameUnique');
+  });
+
+  it('reports globalContextSeedSafeIdentifier when binding is not a safe identifier', () => {
+    const errs = validateDomainSemantics({
+      globalContextSeeds: [
+        { binding: 'tenant-id', fieldName: 'tenantId', seedRule: 'tenantIdVar' },
+      ],
+    });
+    expect(errs.map((e) => e.invariant)).toContain('globalContextSeedSafeIdentifier');
+  });
+
+  it('reports globalContextSeedSafeIdentifier when fieldName is not a safe identifier', () => {
+    const errs = validateDomainSemantics({
+      globalContextSeeds: [
+        { binding: 'tenantIdVar', fieldName: 'tenant-id', seedRule: 'tenantIdVar' },
+      ],
+    });
+    expect(errs.map((e) => e.invariant)).toContain('globalContextSeedSafeIdentifier');
+  });
+
+  it('reports globalContextSeedSafeIdentifier when seedRule is not a safe identifier', () => {
+    const errs = validateDomainSemantics({
+      globalContextSeeds: [
+        { binding: 'tenantIdVar', fieldName: 'tenantId', seedRule: 'rule with spaces' },
+      ],
+    });
+    expect(errs.map((e) => e.invariant)).toContain('globalContextSeedSafeIdentifier');
+  });
+
+  it('reports globalContextSeedSentinelSafe when defaultSentinel contains a single quote', () => {
+    const errs = validateDomainSemantics({
+      globalContextSeeds: [
+        {
+          binding: 'tenantIdVar',
+          fieldName: 'tenantId',
+          seedRule: 'tenantIdVar',
+          defaultSentinel: "it's broken",
+        },
+      ],
+    });
+    expect(errs.map((e) => e.invariant)).toContain('globalContextSeedSentinelSafe');
+  });
+
+  it('reports globalContextSeedSentinelSafe when defaultSentinel contains a newline', () => {
+    const errs = validateDomainSemantics({
+      globalContextSeeds: [
+        {
+          binding: 'tenantIdVar',
+          fieldName: 'tenantId',
+          seedRule: 'tenantIdVar',
+          defaultSentinel: 'line1\nline2',
+        },
+      ],
+    });
+    expect(errs.map((e) => e.invariant)).toContain('globalContextSeedSentinelSafe');
+  });
+
+  it('rejects unknown properties on a globalContextSeeds entry (.strict())', () => {
+    const errs = validateDomainSemantics({
+      globalContextSeeds: [
+        {
+          binding: 'tenantIdVar',
+          fieldName: 'tenantId',
+          seedRule: 'tenantIdVar',
+          unknownKey: 'oops', // typo or removed-but-still-in-config field
+        },
+      ],
+    });
+    // Strict-mode Zod surfaces a structural issue (not one of our named
+    // cross-ref invariants), so the error list is non-empty even though no
+    // cross-ref invariant fires.
+    expect(errs.length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Summary

Closes #87. Removes string-literal spec coupling from the Playwright emitter by deriving the universal-seed prologue and multipart-strip branches from a new `globalContextSeeds` key in `domain-semantics.json`.

## Before

`path-analyser/src/codegen/playwright/emitter.ts` carried three string-literal branches that hard-coded one Camunda concept (default tenant under single-tenant mode):

```ts
body.push(
  `  if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`,
);
body.push(`  const __tenantIdIsDefault = ctx['tenantIdVar'] === '<default>';`);
// ...later, inside the multipart loop:
body.push(`      if (k === 'tenantId' && __tenantIdIsDefault) continue;`);
```

A reader of the emitter could not tell why `tenantIdVar` deserved three branches when no other binding did. Renaming the upstream field, dropping the default-tenant concept, or adding a parallel concept (orgs, workspaces) would silently break the emitter.

## After

The emitter walks `EmitContext.globalContextSeeds` (loaded once from `domain-semantics.json` by `codegen/index.ts`):

```ts
for (const seed of globalContextSeeds) {
  body.push(
    `  if (ctx['${seed.binding}'] === undefined) { ctx['${seed.binding}'] = seedBinding('${seed.seedRule}'); }`,
  );
  if (seed.stripFromMultipartWhenDefault && seed.defaultSentinel !== undefined) {
    const local = `__${seed.fieldName}IsDefault`;
    sentinelLocals.set(seed.fieldName, local);
    body.push(`  const ${local} = ctx['${seed.binding}'] === '${escape(seed.defaultSentinel)}';`);
  }
}
// ...later, inside the multipart loop:
for (const [fieldName, local] of sentinelLocals) {
  body.push(`      if (k === '${fieldName}' && ${local}) continue;`);
}
```

The single production entry in `domain-semantics.json`:

```json
"globalContextSeeds": [
  {
    "binding": "tenantIdVar",
    "fieldName": "tenantId",
    "seedRule": "tenantIdVar",
    "defaultSentinel": "<default>",
    "stripFromMultipartWhenDefault": true,
    "rationale": "Camunda single-tenant mode default — ..."
  }
]
```

Generated suite output is **byte-identical** to pre-refactor (verified against `path-analyser/dist/generated-tests/activateJobs.feature.spec.ts` and the full 183-endpoint generation).

## Schema + validator

- `domain-semantics.schema.json` gains a `globalContextSeeds` array with required `binding` / `fieldName` / `seedRule`.
- `DomainSemantics` TS type gains the optional field; new `GlobalContextSeed` interface is exported.
- Validator adds two class-scoped invariants:
  - `globalContextSeedBindingUnique` — duplicate bindings would produce colliding sentinel locals.
  - `globalContextSeedStripRequiresSentinel` — `stripFromMultipartWhenDefault: true` without a `defaultSentinel` is incoherent (nothing to compare against).

## Tests

- Existing tenant tests in `tests/codegen/playwright-emitter.test.ts` now pass the seed via `EmitContext.globalContextSeeds`. Assertions on emitted shape are unchanged.
- **Class-scoped guard** (`#87`): a unit test scans `emitter.ts` source and rejects reintroduction of the literals `'tenantIdVar'`, `'tenantId'`, `'<default>'`, or `__seededTenant`. Strips line comments first so issue cross-references in JSDoc don't false-positive.
- **Parallel-entry test**: a *second* `globalContextSeeds` entry (`orgIdVar` / `orgId` / `<root>`) produces parallel seed + sentinel + strip code with no further emitter changes — proving the loop is generic, not a one-off branch dressed up.
- **Empty-seeds test**: with no seeds, no universal-seed prologue and no multipart strip branch are emitted.
- **Seed-without-strip test**: `stripFromMultipartWhenDefault: false` emits the `??` guard but no sentinel local and no strip branch.

## Pre-push gate (all green)

- `npm run lint` — 0 diagnostics
- `npx tsc --noEmit` — clean for `semantic-graph-extractor`, `path-analyser`, `request-validation`
- `TEST_SEED=snapshot-baseline npm run testsuite:generate` + `npm run generate:request-validation` — regenerated cleanly
- `npm test` — **127/127 tests pass**
- Generated `*.feature.spec.ts` output is byte-identical to pre-refactor

## Relationship to other PRs / issues

- **Closes #87**.
- **Supersedes #86** (the dead-guard cleanup): under the schema-driven emitter, dropping the redundant `=== undefined` guard is a one-line change to omit it for entries whose binding never has a prior assignment in the same scenario. Keeping #86 open as a smaller follow-up is fine if reviewers prefer; otherwise it can be closed in favour of this PR.
