### PR TITLE
refactor: collapse universal-seed prologue to nullish-coalesce form (#86)

### DIFF
--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -234,10 +234,11 @@ function renderScenarioTest(
   //   - no bindings-loop assignment at all (fresh `ctx`) — `??` falls through to seedBinding(...)
   // This replaces the pre-#86 unconditional `if (ctx[...] === undefined) { ... }`
   // form, which was dead code in the third case. `??` (not `=== undefined`) is
-  // intentional: null bindings are not produced by the planner today, and a
-  // null tenant would be semantically equivalent to "no tenant" anyway.
-  // Revisit before tightening to `=== undefined` if the planner ever starts
-  // emitting null literals in `s.bindings`.
+  // intentional: any nullish binding value (`null` or `undefined`) is treated
+  // as missing and triggers seeding. The planner does not currently emit `null`
+  // literals in `s.bindings` for any global seed; revisit before tightening to
+  // `=== undefined` if a future seed ever needs `null` to remain distinct from
+  // "missing".
   //
   // Entries that declare a defaultSentinel + stripFromMultipartWhenDefault
   // also emit a `__<fieldName>IsDefault` local that drives the multipart

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -227,24 +227,33 @@ function renderScenarioTest(
     }
   }
   // Universal-seed prologue derived from domain-semantics.json#globalContextSeeds.
-  // Each entry emits an idempotent `=== undefined` guard so the bindings loop
-  // above (which may already have populated the binding from a literal value
-  // or from seedBinding for __PENDING__) is never overwritten. Entries that
-  // declare a defaultSentinel + stripFromMultipartWhenDefault also emit a
-  // `__<fieldName>IsDefault` local that drives the multipart skip branch
-  // below — this is the only place the emitter knows about the sentinel.
+  // Each entry emits a single nullish-coalesced assignment that is idempotent
+  // over all three bindings-loop outcomes above:
+  //   - literal binding (`ctx['<k>'] = "value";`) — `??` short-circuits, value preserved
+  //   - `__PENDING__` already seeded by the in-loop `=== undefined` guard — `??` short-circuits
+  //   - no bindings-loop assignment at all (fresh `ctx`) — `??` falls through to seedBinding(...)
+  // This replaces the pre-#86 unconditional `if (ctx[...] === undefined) { ... }`
+  // form, which was dead code in the third case. `??` (not `=== undefined`) is
+  // intentional: null bindings are not produced by the planner today, and a
+  // null tenant would be semantically equivalent to "no tenant" anyway.
+  // Revisit before tightening to `=== undefined` if the planner ever starts
+  // emitting null literals in `s.bindings`.
+  //
+  // Entries that declare a defaultSentinel + stripFromMultipartWhenDefault
+  // also emit a `__<fieldName>IsDefault` local that drives the multipart
+  // skip branch below — this is the only place the emitter knows about the
+  // sentinel.
   //
   // Safety: `binding`, `fieldName`, `seedRule` are all required by the
   // domain-semantics validator (#87) to match `/^[A-Za-z_$][A-Za-z0-9_$]*$/`,
   // and `defaultSentinel` is required to contain no single quotes,
   // backslashes, or line terminators. That lets us interpolate them
   // directly into emitted single-quoted TS string literals without an
-  // escape pass and preserves byte identity with the pre-#87 hand-written
-  // strings.
+  // escape pass.
   const sentinelLocals = new Map<string, string>(); // fieldName -> local var name
   for (const seed of globalContextSeeds) {
     body.push(
-      `  if (ctx['${seed.binding}'] === undefined) { ctx['${seed.binding}'] = seedBinding('${seed.seedRule}'); }`,
+      `  ctx['${seed.binding}'] = ctx['${seed.binding}'] ?? seedBinding('${seed.seedRule}');`,
     );
     if (seed.stripFromMultipartWhenDefault && seed.defaultSentinel !== undefined) {
       const local = `__${seed.fieldName}IsDefault`;

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -123,6 +123,19 @@ describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? 
   // The pre-#86 form. Must not reappear in the universal-seed prologue.
   const PRE_86_TENANT_GUARD = `ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`;
 
+  // Count occurrences of `needle` in `haystack` without regex escaping.
+  function countOccurrences(haystack: string, needle: string): number {
+    if (needle.length === 0) return 0;
+    let count = 0;
+    let from = 0;
+    while (true) {
+      const i = haystack.indexOf(needle, from);
+      if (i === -1) return count;
+      count += 1;
+      from = i + needle.length;
+    }
+  }
+
   function buildCollectionWithBindings(
     bindings: Record<string, unknown>,
     extras: { templateRefsTenant?: boolean; extractsTenant?: boolean } = {},
@@ -168,16 +181,16 @@ describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? 
     return file.content;
   }
 
-  test('literal tenantIdVar binding seeds the value and emits the ?? fallback', async () => {
+  test('literal tenantIdVar binding seeds the value and emits the ?? fallback exactly once', async () => {
     const content = await renderFirst(buildCollectionWithBindings({ tenantIdVar: 'acme' }));
     expect(content).toContain(`ctx['tenantIdVar'] = "acme";`);
-    expect(content).toContain(TENANT_FALLBACK);
+    expect(countOccurrences(content, TENANT_FALLBACK)).toBe(1);
     // The universal-seed prologue must not reintroduce the pre-#86 `=== undefined` guard.
     expect(content).not.toContain(PRE_86_TENANT_GUARD);
     expect(content).not.toMatch(/__seededTenant/);
   });
 
-  test('__PENDING__ tenantIdVar referenced by a template emits a guarded auto-seed and the ?? fallback', async () => {
+  test('__PENDING__ tenantIdVar referenced by a template emits a guarded auto-seed and the ?? fallback exactly once', async () => {
     const content = await renderFirst(
       buildCollectionWithBindings({ tenantIdVar: '__PENDING__' }, { templateRefsTenant: true }),
     );
@@ -187,11 +200,11 @@ describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? 
     expect(content).toContain(
       `if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`,
     );
-    expect(content).toContain(TENANT_FALLBACK);
+    expect(countOccurrences(content, TENANT_FALLBACK)).toBe(1);
     expect(content).not.toMatch(/__seededTenant/);
   });
 
-  test('extractionVars tenantIdVar skips eager seeding but still emits the ?? fallback', async () => {
+  test('extractionVars tenantIdVar skips eager seeding but still emits the ?? fallback exactly once', async () => {
     const content = await renderFirst(
       buildCollectionWithBindings(
         { tenantIdVar: 'ignored-because-extracted' },
@@ -199,14 +212,14 @@ describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? 
       ),
     );
     expect(content).not.toContain(`ctx['tenantIdVar'] = "ignored-because-extracted";`);
-    expect(content).toContain(TENANT_FALLBACK);
+    expect(countOccurrences(content, TENANT_FALLBACK)).toBe(1);
     expect(content).not.toContain(PRE_86_TENANT_GUARD);
     expect(content).not.toMatch(/__seededTenant/);
   });
 
-  test('no tenantIdVar binding at all emits the ?? fallback (#86: was previously a dead `=== undefined` guard)', async () => {
+  test('no tenantIdVar binding at all emits the ?? fallback exactly once (#86: was previously a dead `=== undefined` guard)', async () => {
     const content = await renderFirst(buildCollectionWithBindings({}));
-    expect(content).toContain(TENANT_FALLBACK);
+    expect(countOccurrences(content, TENANT_FALLBACK)).toBe(1);
     // Pre-#86 dead-guard must not reappear when the bindings loop assigned nothing.
     expect(content).not.toContain(PRE_86_TENANT_GUARD);
     expect(content).not.toMatch(/__seededTenant/);

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -120,8 +120,12 @@ describe('PlaywrightEmitter (Emitter contract)', () => {
 // `__seededTenant` never appears anywhere in the output.
 describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? form, #86)', () => {
   const TENANT_FALLBACK = `ctx['tenantIdVar'] = ctx['tenantIdVar'] ?? seedBinding('tenantIdVar');`;
-  // The pre-#86 form. Must not reappear in the universal-seed prologue.
-  const PRE_86_TENANT_GUARD = `ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`;
+  // The pre-#86 universal-seed-prologue form. The bindings loop *also* emits
+  // exactly this string for a `__PENDING__` binding referenced by a template,
+  // so absence is asserted by counting occurrences (0 for every shape *except*
+  // __PENDING__-referenced-by-template, where the count is exactly 1 — proving
+  // the prologue did not also emit it).
+  const FULL_TENANT_GUARD = `if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`;
 
   // Count occurrences of `needle` in `haystack` without regex escaping.
   function countOccurrences(haystack: string, needle: string): number {
@@ -186,7 +190,8 @@ describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? 
     expect(content).toContain(`ctx['tenantIdVar'] = "acme";`);
     expect(countOccurrences(content, TENANT_FALLBACK)).toBe(1);
     // The universal-seed prologue must not reintroduce the pre-#86 `=== undefined` guard.
-    expect(content).not.toContain(PRE_86_TENANT_GUARD);
+    // Bindings loop emits a literal here, not a guard, so the full guard count is 0.
+    expect(countOccurrences(content, FULL_TENANT_GUARD)).toBe(0);
     expect(content).not.toMatch(/__seededTenant/);
   });
 
@@ -197,9 +202,11 @@ describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? 
     // The in-bindings-loop `=== undefined` guard for __PENDING__ is intentional —
     // it runs *before* the universal-seed prologue, and a duplicate seedBinding
     // call there would be wasted. The ?? line then short-circuits over it.
-    expect(content).toContain(
-      `if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`,
-    );
+    //
+    // Asserting exactly-one occurrence is a class-scoped guard against the
+    // emitter regressing and re-emitting the pre-#86 guard form in the
+    // universal-seed prologue as well (which would push the count to 2).
+    expect(countOccurrences(content, FULL_TENANT_GUARD)).toBe(1);
     expect(countOccurrences(content, TENANT_FALLBACK)).toBe(1);
     expect(content).not.toMatch(/__seededTenant/);
   });
@@ -213,7 +220,9 @@ describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? 
     );
     expect(content).not.toContain(`ctx['tenantIdVar'] = "ignored-because-extracted";`);
     expect(countOccurrences(content, TENANT_FALLBACK)).toBe(1);
-    expect(content).not.toContain(PRE_86_TENANT_GUARD);
+    // Bindings loop skips this case (extraction wins); prologue must not
+    // re-emit the pre-#86 guard either.
+    expect(countOccurrences(content, FULL_TENANT_GUARD)).toBe(0);
     expect(content).not.toMatch(/__seededTenant/);
   });
 
@@ -221,7 +230,7 @@ describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? 
     const content = await renderFirst(buildCollectionWithBindings({}));
     expect(countOccurrences(content, TENANT_FALLBACK)).toBe(1);
     // Pre-#86 dead-guard must not reappear when the bindings loop assigned nothing.
-    expect(content).not.toContain(PRE_86_TENANT_GUARD);
+    expect(countOccurrences(content, FULL_TENANT_GUARD)).toBe(0);
     expect(content).not.toMatch(/__seededTenant/);
   });
 });

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -98,15 +98,30 @@ describe('PlaywrightEmitter (Emitter contract)', () => {
   });
 });
 
-// Regression guard for PR #79 / issue #80: the emitter no longer declares or
-// writes a `__seededTenant` flag. The `tenantIdVar` fallback is now a single
-// idempotent `=== undefined` guard. These tests exercise the three shapes the
-// bindings loop can produce for `tenantIdVar` (literal value, __PENDING__
-// auto-seed, and extracted-by-an-earlier-step) plus a control with no
-// `tenantIdVar` binding at all, asserting the simplified guard appears
-// exactly once and `__seededTenant` never appears anywhere in the output.
-describe('emitter: tenantIdVar seeding (no __seededTenant flag, #79/#80)', () => {
-  const TENANT_FALLBACK = `if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`;
+// Regression guard for PR #79 / issue #80 (no `__seededTenant` flag) and
+// issue #86 (universal-seed prologue collapsed to nullish-coalesce).
+//
+// The universal-seed prologue derived from globalContextSeeds emits one
+// idempotent line per seed:
+//   ctx['<binding>'] = ctx['<binding>'] ?? seedBinding('<seedRule>');
+// `??` short-circuits over both literal assignments from the bindings loop
+// and the `__PENDING__`-guarded auto-seed (which still uses `=== undefined`
+// in the bindings loop because it runs *before* the universal-seed prologue
+// and a duplicate seedBinding call there would be wasteful). When no
+// bindings-loop assignment exists for the seed, `??` falls through to
+// seedBinding(...). This replaces the pre-#86 unconditional `=== undefined`
+// guard, which was dead code in the no-assignment case.
+//
+// These tests exercise the three shapes the bindings loop can produce for
+// `tenantIdVar` (literal value, __PENDING__ auto-seed, extracted-by-an-
+// earlier-step) plus a control with no `tenantIdVar` binding at all,
+// asserting the `??` line appears exactly once, the universal-seed prologue
+// never re-emits the `=== undefined` form for that binding, and
+// `__seededTenant` never appears anywhere in the output.
+describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? form, #86)', () => {
+  const TENANT_FALLBACK = `ctx['tenantIdVar'] = ctx['tenantIdVar'] ?? seedBinding('tenantIdVar');`;
+  // The pre-#86 form. Must not reappear in the universal-seed prologue.
+  const PRE_86_TENANT_GUARD = `ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`;
 
   function buildCollectionWithBindings(
     bindings: Record<string, unknown>,
@@ -153,17 +168,22 @@ describe('emitter: tenantIdVar seeding (no __seededTenant flag, #79/#80)', () =>
     return file.content;
   }
 
-  test('literal tenantIdVar binding seeds the value and emits the simplified fallback', async () => {
+  test('literal tenantIdVar binding seeds the value and emits the ?? fallback', async () => {
     const content = await renderFirst(buildCollectionWithBindings({ tenantIdVar: 'acme' }));
     expect(content).toContain(`ctx['tenantIdVar'] = "acme";`);
     expect(content).toContain(TENANT_FALLBACK);
+    // The universal-seed prologue must not reintroduce the pre-#86 `=== undefined` guard.
+    expect(content).not.toContain(PRE_86_TENANT_GUARD);
     expect(content).not.toMatch(/__seededTenant/);
   });
 
-  test('__PENDING__ tenantIdVar referenced by a template emits a guarded auto-seed and the simplified fallback', async () => {
+  test('__PENDING__ tenantIdVar referenced by a template emits a guarded auto-seed and the ?? fallback', async () => {
     const content = await renderFirst(
       buildCollectionWithBindings({ tenantIdVar: '__PENDING__' }, { templateRefsTenant: true }),
     );
+    // The in-bindings-loop `=== undefined` guard for __PENDING__ is intentional —
+    // it runs *before* the universal-seed prologue, and a duplicate seedBinding
+    // call there would be wasted. The ?? line then short-circuits over it.
     expect(content).toContain(
       `if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`,
     );
@@ -171,7 +191,7 @@ describe('emitter: tenantIdVar seeding (no __seededTenant flag, #79/#80)', () =>
     expect(content).not.toMatch(/__seededTenant/);
   });
 
-  test('extractionVars tenantIdVar skips eager seeding but still emits the simplified fallback', async () => {
+  test('extractionVars tenantIdVar skips eager seeding but still emits the ?? fallback', async () => {
     const content = await renderFirst(
       buildCollectionWithBindings(
         { tenantIdVar: 'ignored-because-extracted' },
@@ -180,12 +200,15 @@ describe('emitter: tenantIdVar seeding (no __seededTenant flag, #79/#80)', () =>
     );
     expect(content).not.toContain(`ctx['tenantIdVar'] = "ignored-because-extracted";`);
     expect(content).toContain(TENANT_FALLBACK);
+    expect(content).not.toContain(PRE_86_TENANT_GUARD);
     expect(content).not.toMatch(/__seededTenant/);
   });
 
-  test('no tenantIdVar binding at all still emits the simplified fallback (control)', async () => {
+  test('no tenantIdVar binding at all emits the ?? fallback (#86: was previously a dead `=== undefined` guard)', async () => {
     const content = await renderFirst(buildCollectionWithBindings({}));
     expect(content).toContain(TENANT_FALLBACK);
+    // Pre-#86 dead-guard must not reappear when the bindings loop assigned nothing.
+    expect(content).not.toContain(PRE_86_TENANT_GUARD);
     expect(content).not.toMatch(/__seededTenant/);
   });
 });
@@ -375,13 +398,9 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
       globalContextSeeds: [TENANT_SEED, orgSeed],
     });
     const c = file.content;
-    // Both seeds emit an idempotent ?? guard.
-    expect(c).toContain(
-      `if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`,
-    );
-    expect(c).toContain(
-      `if (ctx['orgIdVar'] === undefined) { ctx['orgIdVar'] = seedBinding('orgIdVar'); }`,
-    );
+    // Both seeds emit an idempotent ?? assignment in the universal-seed prologue (#86).
+    expect(c).toContain(`ctx['tenantIdVar'] = ctx['tenantIdVar'] ?? seedBinding('tenantIdVar');`);
+    expect(c).toContain(`ctx['orgIdVar'] = ctx['orgIdVar'] ?? seedBinding('orgIdVar');`);
     // Both seeds declare a sentinel local named after the field.
     expect(c).toContain(`const __tenantIdIsDefault = ctx['tenantIdVar'] === '<default>';`);
     expect(c).toContain(`const __orgIdIsDefault = ctx['orgIdVar'] === '<root>';`);
@@ -416,9 +435,7 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
       globalContextSeeds: [seedOnly],
     });
     const c = file.content;
-    expect(c).toContain(
-      `if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`,
-    );
+    expect(c).toContain(`ctx['tenantIdVar'] = ctx['tenantIdVar'] ?? seedBinding('tenantIdVar');`);
     expect(c).not.toMatch(/__tenantIdIsDefault/);
     expect(c).not.toMatch(/&& __\w+IsDefault\) continue;/);
   });


### PR DESCRIPTION
Closes #86.

## Summary

Replace the per-seed `if (ctx['<binding>'] === undefined) { ... }` guard in `renderScenarioTest`'s universal-seed prologue (the data-driven prologue introduced in #87/#88) with a single uniform nullish-coalesce assignment:

```ts
ctx['<binding>'] = ctx['<binding>'] ?? seedBinding('<seedRule>');
```

Idempotent over all three bindings-loop outcomes — literal assignment, `__PENDING__`-guarded auto-seed, no assignment at all.

## Why this shape (vs. the branched alternative in #86)

The original #86 proposal would have tracked which keys the bindings loop assigned (`assignedBindings: Set<string>`) and emitted one of two shapes per seed. `??` collapses both shapes into one uniform line, removes the emit-time analysis entirely, and keeps zero per-binding-name knowledge in the emitter — fully consistent with the data-driven direction of #87/#88.

Design discussion: https://github.com/camunda/api-test-generator/issues/86#issuecomment-4347526143

## Behavioural change

Cosmetic-only at runtime. Emitted scenarios collapse a two-line dead guard to one `??` line in the no-assignment case; runtime behaviour for all three cases is unchanged.

## Tests

Existing class-scoped guards in `tests/codegen/playwright-emitter.test.ts` (the describe formerly titled *"emitter: tenantIdVar seeding (no __seededTenant flag, #79/#80)"*, now *"emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? form, #86)"*) updated to:

- Assert the `??` shape in all four scenario outcomes (literal, `__PENDING__`, extracted, no-binding control).
- Assert the absence of the pre-#86 `=== undefined` guard in the universal-seed prologue (class-scoped — no specific binding name baked in beyond the test fixture's `TENANT_SEED`).
- Keep the assertion that the in-bindings-loop `__PENDING__` guard (`=== undefined`) is still emitted, because that one runs *before* the universal-seed prologue and the `??` line short-circuits over it at runtime.
- Multipart-strip describe also updated for the two-seed and seed-only cases.

## Note on `??` vs `=== undefined`

`??` short-circuits on both `null` and `undefined`; `=== undefined` only on `undefined`. The planner does not produce `null` literals in `s.bindings` today, and a `null` tenant is semantically equivalent to "no tenant" anyway. The emit-site comment flags this so a future reader doesn't tighten it back to `=== undefined` and re-introduce the dead-code shape.

## Generated output drift

`path-analyser/dist/generated-tests/*` is gitignored and regenerated by CI. The drift (one line per scenario per global seed) is intentional and verified locally — every `if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }` collapses to `ctx['tenantIdVar'] = ctx['tenantIdVar'] ?? seedBinding('tenantIdVar');`. `__tenantIdIsDefault` follow-up line unchanged.

## Pre-push gate

- `npx tsc --noEmit -p path-analyser/tsconfig.json` — clean
- `npm run lint` — clean
- `npm run testsuite:generate && npm run generate:request-validation` — clean
- `npm test` — 145/145 passed across 21 files
