### PR TITLE
refactor(emitter): extract @@FILE fixture-resolution helper from Playwright emitter

### DIFF
--- a/path-analyser/scripts/copy-support-templates.js
+++ b/path-analyser/scripts/copy-support-templates.js
@@ -18,7 +18,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-const SUPPORT_FILES = ['env.ts', 'recorder.ts', 'seeding.ts', 'seed-rules.json'];
+const SUPPORT_FILES = ['env.ts', 'recorder.ts', 'seeding.ts', 'fixtures.ts', 'seed-rules.json'];
 
 async function main() {
   const root = process.cwd();

--- a/path-analyser/scripts/copy-support-templates.js
+++ b/path-analyser/scripts/copy-support-templates.js
@@ -13,6 +13,7 @@
 //     env.ts
 //     recorder.ts
 //     seeding.ts
+//     fixtures.ts
 //     seed-rules.json
 // ---------------------------------------------------------------------------
 import { promises as fs } from 'node:fs';

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -138,6 +138,7 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   lines.push("import { buildBaseUrl, authHeaders } from './support/env';");
   lines.push("import { recordResponse, sanitizeBody } from './support/recorder';");
   lines.push("import { extractInto, seedBinding } from './support/seeding';");
+  lines.push("import { resolveFixture } from './support/fixtures';");
   lines.push('');
   if (needsValidation) {
     // Resolve responses.json relative to this spec file so the suite is
@@ -325,26 +326,8 @@ function renderScenarioTest(
       body.push(`    }`);
       body.push(`    for (const [k,v] of Object.entries(${bodyVar}.files||{})) {
         if (typeof v === 'string' && v.startsWith('@@FILE:')) {
-          let p = v.slice('@@FILE:'.length);
-          // Resolve relative paths against likely fixture locations
-          const fsMod = await import('fs');
-          const pathMod = await import('path');
-          const candidates = [
-            p,
-            pathMod.resolve(process.cwd(), p),
-    // When running from path-analyser dir
-    pathMod.resolve(process.cwd(), 'fixtures', p),
-    // When running from repo root
-    pathMod.resolve(process.cwd(), 'path-analyser/fixtures', p),
-            // when running compiled tests from dist/generated-tests
-            typeof __dirname !== 'undefined' ? pathMod.resolve(__dirname, '../../fixtures', p) : undefined,
-            typeof __dirname !== 'undefined' ? pathMod.resolve(__dirname, '../fixtures', p) : undefined
-          ].filter(Boolean) as string[];
-          let buf: Buffer | undefined;
-          for (const cand of candidates) {
-            try { buf = await fsMod.promises.readFile(cand); break; } catch {}
-          }
-          if (!buf) { throw new Error('Fixture not found: ' + p); }
+          const p = v.slice('@@FILE:'.length);
+          const buf = await resolveFixture(p);
           const name = p.split('/').pop() || 'file';
           multipart[k] = { name, mimeType: 'application/octet-stream', buffer: buf };
         } else {

--- a/path-analyser/src/codegen/playwright/materialize-support.ts
+++ b/path-analyser/src/codegen/playwright/materialize-support.ts
@@ -8,8 +8,9 @@
 //
 // Two template sets are copied:
 //   * support/ — runtime helpers (env.ts, recorder.ts, seeding.ts,
-//                seed-rules.json). Sources: path-analyser/src/codegen/support/,
-//                staged into dist/src/codegen/playwright/support-templates/ at
+//                fixtures.ts, seed-rules.json). Sources:
+//                path-analyser/src/codegen/support/, staged into
+//                dist/src/codegen/playwright/support-templates/ at
 //                build time.
 //   * project root — package.json, playwright.config.ts, tsconfig.json,
 //                    .env.example, README.md.
@@ -27,6 +28,7 @@ export const SUPPORT_TEMPLATE_FILES = [
   'env.ts',
   'recorder.ts',
   'seeding.ts',
+  'fixtures.ts',
   'seed-rules.json',
 ] as const;
 

--- a/path-analyser/src/codegen/support/fixtures.ts
+++ b/path-analyser/src/codegen/support/fixtures.ts
@@ -1,12 +1,18 @@
 // Centralized fixture resolution for generated Playwright tests.
 //
-// `@@FILE:<rel-path>` markers in scenario bodies are replaced with the bytes
-// of a real fixture file at materialization time. Suites can run from the
-// repo root, from path-analyser/, or from a vendored standalone copy, so we
-// try a handful of likely locations rather than pin a single layout.
+// `@@FILE:<rel-path>` markers in scenario bodies are resolved to the bytes
+// of a real fixture file when the generated tests run. Suites can run from
+// the repo root, from path-analyser/, or from a vendored standalone copy,
+// so we try a handful of likely locations rather than pin a single layout.
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+function errnoCode(err: unknown): string | undefined {
+  if (!err || typeof err !== 'object') return undefined;
+  const code = Reflect.get(err, 'code');
+  return typeof code === 'string' ? code : undefined;
+}
 
 /**
  * Read a fixture identified by a `@@FILE:`-relative path. Throws if no
@@ -18,6 +24,11 @@ import { fileURLToPath } from 'node:url';
  * own `import.meta.url` (it lives under `<suite>/support/`) and also walks
  * up an extra level so it finds `path-analyser/fixtures/` regardless of
  * how the suite was vendored or invoked.
+ *
+ * Only `ENOENT` / `ENOTDIR` are treated as "try the next candidate".
+ * Any other error (e.g. `EACCES` — file exists but is unreadable) is
+ * remembered and surfaced in the final thrown message so debugging
+ * fixture issues isn't reduced to a generic "not found".
  */
 export async function resolveFixture(p: string): Promise<Buffer> {
   const here = path.dirname(fileURLToPath(import.meta.url));
@@ -35,12 +46,18 @@ export async function resolveFixture(p: string): Promise<Buffer> {
     path.resolve(here, '..', '..', 'fixtures', p),
     path.resolve(here, '..', '..', '..', 'fixtures', p),
   ];
+  let lastError: Error | undefined;
   for (const cand of candidates) {
     try {
       return await fs.readFile(cand);
-    } catch {
-      // try next candidate
+    } catch (err) {
+      const code = errnoCode(err);
+      if (code === 'ENOENT' || code === 'ENOTDIR') continue;
+      lastError = err instanceof Error ? err : new Error(String(err));
     }
+  }
+  if (lastError) {
+    throw new Error(`Fixture not found: ${p}. Last error: ${lastError.message}`);
   }
   throw new Error(`Fixture not found: ${p}`);
 }

--- a/path-analyser/src/codegen/support/fixtures.ts
+++ b/path-analyser/src/codegen/support/fixtures.ts
@@ -31,6 +31,9 @@ function errnoCode(err: unknown): string | undefined {
  * fixture issues isn't reduced to a generic "not found".
  */
 export async function resolveFixture(p: string): Promise<Buffer> {
+  if (typeof p !== 'string' || p.trim() === '') {
+    throw new Error('Fixture path missing after @@FILE:');
+  }
   const here = path.dirname(fileURLToPath(import.meta.url));
   const candidates: string[] = [
     p,

--- a/path-analyser/src/codegen/support/fixtures.ts
+++ b/path-analyser/src/codegen/support/fixtures.ts
@@ -1,0 +1,38 @@
+// Centralized fixture resolution for generated Playwright tests.
+//
+// `@@FILE:<rel-path>` markers in scenario bodies are replaced with the bytes
+// of a real fixture file at materialization time. Suites can run from the
+// repo root, from path-analyser/, or from a vendored standalone copy, so we
+// try a handful of likely locations rather than pin a single layout.
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Read a fixture identified by a `@@FILE:`-relative path. Throws if no
+ * candidate location resolves.
+ */
+export async function resolveFixture(p: string): Promise<Buffer> {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates: string[] = [
+    p,
+    path.resolve(process.cwd(), p),
+    // When running from path-analyser/
+    path.resolve(process.cwd(), 'fixtures', p),
+    // When running from repo root
+    path.resolve(process.cwd(), 'path-analyser/fixtures', p),
+    // Walk up from this helper (lives in <suite>/support/) looking for a
+    // sibling fixtures/ directory.
+    path.resolve(here, '..', 'fixtures', p),
+    path.resolve(here, '..', '..', 'fixtures', p),
+    path.resolve(here, '..', '..', '..', 'fixtures', p),
+  ];
+  for (const cand of candidates) {
+    try {
+      return await fs.readFile(cand);
+    } catch {
+      // try next candidate
+    }
+  }
+  throw new Error(`Fixture not found: ${p}`);
+}

--- a/path-analyser/src/codegen/support/fixtures.ts
+++ b/path-analyser/src/codegen/support/fixtures.ts
@@ -11,6 +11,13 @@ import { fileURLToPath } from 'node:url';
 /**
  * Read a fixture identified by a `@@FILE:`-relative path. Throws if no
  * candidate location resolves.
+ *
+ * Candidate order is intentionally a superset of the previous inline
+ * resolver in the emitter. The previous code resolved relative to
+ * `__dirname` of each emitted spec; this helper resolves relative to its
+ * own `import.meta.url` (it lives under `<suite>/support/`) and also walks
+ * up an extra level so it finds `path-analyser/fixtures/` regardless of
+ * how the suite was vendored or invoked.
  */
 export async function resolveFixture(p: string): Promise<Buffer> {
   const here = path.dirname(fileURLToPath(import.meta.url));
@@ -22,7 +29,8 @@ export async function resolveFixture(p: string): Promise<Buffer> {
     // When running from repo root
     path.resolve(process.cwd(), 'path-analyser/fixtures', p),
     // Walk up from this helper (lives in <suite>/support/) looking for a
-    // sibling fixtures/ directory.
+    // sibling fixtures/ directory. Three levels covers the standalone
+    // vendored layout, dist/generated-tests/, and the repo-root layout.
     path.resolve(here, '..', 'fixtures', p),
     path.resolve(here, '..', '..', 'fixtures', p),
     path.resolve(here, '..', '..', '..', 'fixtures', p),


### PR DESCRIPTION
Closes #91.

## What

The Playwright emitter inlined a ~25-line candidate-search block into every multipart step that referenced a `@@FILE:<rel-path>` fixture. Each emitted suite duplicated this verbatim per step, used `as string[]`, and mixed path-discovery policy with scenario logic.

Extracted the resolution into a single `resolveFixture(p)` helper vendored alongside the other support modules (`env`, `recorder`, `seeding`). The emitter now produces:

```ts
const buf = await resolveFixture(p);
```

## Changes

- New `path-analyser/src/codegen/support/fixtures.ts` exporting `resolveFixture(p): Promise<Buffer>`.
- Added `'fixtures.ts'` to `SUPPORT_TEMPLATE_FILES` (`materialize-support.ts`) and to `SUPPORT_FILES` (`scripts/copy-support-templates.js`) so it ships with every emitted suite.
- Emitter imports `resolveFixture` and replaces the inline block with the single call.

## Candidate-set change (intentional)

The candidate set is a **superset** of the previous inline resolver — not a 1:1 preservation. The previous code was emitted into each spec and resolved relative to the spec's own `__dirname`. The helper lives in `<suite>/support/fixtures.ts`, one directory deeper, so it resolves relative to `import.meta.url` and walks one extra level up to keep finding `path-analyser/fixtures/` regardless of how the suite is vendored:

| Source                                  | Previous (per-spec)                     | Helper (sibling support/)                  |
| --------------------------------------- | --------------------------------------- | ------------------------------------------ |
| literal path `p`                        | ✓                                       | ✓                                          |
| `cwd/p`                                 | ✓                                       | ✓                                          |
| `cwd/fixtures/p`                        | ✓                                       | ✓                                          |
| `cwd/path-analyser/fixtures/p`          | ✓                                       | ✓                                          |
| up from running file looking for `fixtures/p` | `__dirname/../fixtures` and `__dirname/../../fixtures` | `here/../fixtures`, `here/../../fixtures`, `here/../../../fixtures` |

The extra `here/../../../fixtures` candidate compensates for the support file being one directory deeper than the specs. Net effect: every fixture path that resolved under the old emitter still resolves; a few additional standalone-vendored layouts now also resolve.

## Verification

Pre-push checklist run, all green:

- `npm run lint`
- `npx tsc --noEmit -p path-analyser/tsconfig.json`
- `SPEC_REF=<pinned> npm run fetch-spec:ref`
- `TEST_SEED=snapshot-baseline npm run testsuite:generate`
- `npm run generate:request-validation`
- `npm test` — **145/145 passing**, including `generated-suites-typecheck` (runs `tsc --noEmit` over the regenerated suite).
