### PR TITLE
chore: align domain-semantics.schema.json with current sidecar shape

### DIFF
--- a/path-analyser/domain-semantics.json
+++ b/path-analyser/domain-semantics.json
@@ -120,9 +120,7 @@
   },
   "artifactFileKinds": {
     ".bpmn": ["bpmnProcess"],
-    ".bpmn20.xml": ["bpmnProcess"],
     ".dmn": ["dmnDecision", "dmnDrd"],
-    ".dmn11.xml": ["dmnDecision", "dmnDrd"],
     ".form": ["form"],
     ".json": ["form"]
   },

--- a/path-analyser/domain-semantics.schema.json
+++ b/path-analyser/domain-semantics.schema.json
@@ -79,9 +79,9 @@
       }
     },
     "artifactFileKinds": {
-      "description": "Map of file extension (including leading dot, e.g. `.bpmn`) to the list of artifactKinds that file may contain.",
+      "description": "Map of single file extensions as returned by `path.extname()` (including leading dot, e.g. `.bpmn` or `.xml`) to the list of artifactKinds that file may contain. Multi-dot suffixes such as `.bpmn20.xml` are intentionally NOT allowed: runtime consumers in path-analyser/src/index.ts resolve only the final extension via `path.extname(...)`, so multi-dot keys never match at runtime and would be silently dead config.",
       "type": "object",
-      "propertyNames": {"pattern": "^\\.[A-Za-z0-9._]+$"},
+      "propertyNames": {"pattern": "^\\.[A-Za-z0-9_]+$"},
       "additionalProperties": {
         "type": "array",
         "items": {"type": "string"},
@@ -94,12 +94,11 @@
       "additionalProperties": {"type": "string"}
     },
     "operationArtifactRules": {
-      "description": "Per-operation rules describing how request fields map to deployable artifacts. Consumed by the planner to decompose composite deployment operations into per-artifact slices.",
+      "description": "Per-operation rules describing how request fields map to deployable artifacts. Consumed by the planner to decompose composite deployment operations into per-artifact slices. Field shape mirrors `ArtifactRule` and `OperationArtifactRuleSpec` in path-analyser/src/types.ts — keep them in sync.",
       "type": "object",
       "additionalProperties": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["rules"],
         "properties": {
           "composable": {"type": "boolean"},
           "rules": {
@@ -107,10 +106,19 @@
             "items": {
               "type": "object",
               "additionalProperties": false,
-              "required": ["id", "artifactKind"],
+              "required": ["artifactKind"],
               "properties": {
                 "id": {"type": "string", "minLength": 1},
-                "artifactKind": {"type": "string", "minLength": 1}
+                "artifactKind": {"type": "string", "minLength": 1},
+                "priority": {"type": "integer"},
+                "producesSemantics": {
+                  "type": "array",
+                  "items": {"type": "string"}
+                },
+                "producesStates": {
+                  "type": "array",
+                  "items": {"type": "string"}
+                }
               }
             }
           }

--- a/path-analyser/domain-semantics.schema.json
+++ b/path-analyser/domain-semantics.schema.json
@@ -2,15 +2,19 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "domain-semantics.schema.json",
   "title": "Domain Semantics Sidecar",
+  "description": "Hand-maintained sidecar consumed by path-analyser. Cross-section invariants (e.g. artifactKindStateDeclared, semanticTypeWitnessTargetResolves) are enforced at load time by path-analyser/src/domainSemanticsValidator.ts and intentionally NOT re-encoded here — Draft-07 cannot express them.",
   "type": "object",
+  "additionalProperties": false,
   "required": ["identifiers","runtimeStates","operationRequirements","version"],
   "properties": {
-    "version": {"type": "integer"},
+    "$schema": {"type": "string"},
+    "version": {"type": "integer", "minimum": 1},
     "identifiers": {
       "type": "object",
       "additionalProperties": {
         "type": "object",
-        "required": ["kind","validityState","boundBy"],
+        "additionalProperties": false,
+        "required": ["kind","boundBy"],
         "properties": {
           "kind": {"const": "identifier"},
           "validityState": {"type": "string"},
@@ -24,6 +28,7 @@
       "type": "object",
       "additionalProperties": {
         "type": "object",
+        "additionalProperties": false,
         "required": ["kind","parameter","producedBy"],
         "properties": {
           "kind": {"const": "capability"},
@@ -37,6 +42,7 @@
       "type": "object",
       "additionalProperties": {
         "type": "object",
+        "additionalProperties": false,
         "required": ["kind","producedBy"],
         "properties": {
           "kind": {"const": "state"},
@@ -47,16 +53,91 @@
         }
       }
     },
+    "semanticTypes": {
+      "description": "Declarations of semantic identifier types (e.g. ProcessDefinitionKey). Each entry's `witnesses` names the runtimeStates/capabilities entry whose presence proves the semantic value exists. Cross-section resolution of `witnesses` is enforced at load time by domainSemanticsValidator.ts.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "witnesses": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "artifactKinds": {
+      "description": "Declarations of deployable artifact kinds (e.g. bpmnProcess). `producesStates` and `producesSemantics` cross-references are enforced at load time by domainSemanticsValidator.ts.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "producesStates": {"type": "array", "items": {"type": "string"}},
+          "producesSemantics": {"type": "array", "items": {"type": "string"}},
+          "identifierType": {"type": "string"},
+          "deploymentSlices": {"type": "array", "items": {"type": "string"}}
+        }
+      }
+    },
+    "artifactFileKinds": {
+      "description": "Map of file extension (including leading dot, e.g. `.bpmn`) to the list of artifactKinds that file may contain.",
+      "type": "object",
+      "propertyNames": {"pattern": "^\\.[A-Za-z0-9._]+$"},
+      "additionalProperties": {
+        "type": "array",
+        "items": {"type": "string"},
+        "minItems": 1
+      }
+    },
+    "semanticTypeToArtifactKind": {
+      "description": "Map of semantic type name (e.g. ProcessDefinitionKey) to the artifactKind that produces it. Used by the planner to resolve which fixture kind satisfies a semantic prerequisite.",
+      "type": "object",
+      "additionalProperties": {"type": "string"}
+    },
+    "operationArtifactRules": {
+      "description": "Per-operation rules describing how request fields map to deployable artifacts. Consumed by the planner to decompose composite deployment operations into per-artifact slices.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["rules"],
+        "properties": {
+          "composable": {"type": "boolean"},
+          "rules": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["id", "artifactKind"],
+              "properties": {
+                "id": {"type": "string", "minLength": 1},
+                "artifactKind": {"type": "string", "minLength": 1}
+              }
+            }
+          }
+        }
+      }
+    },
     "operationRequirements": {
       "type": "object",
       "additionalProperties": {
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "requires": {"type": "array", "items": {"type": "string"}},
           "disjunctions": {"type": "array", "items": {"type": "array", "items": {"type": "string"}}},
           "implicitAdds": {"type": "array", "items": {"type": "string"}},
           "produces": {"type": "array", "items": {"type": "string"}},
-          "valueBindings": {"type": "object", "additionalProperties": {"type": "string"}}
+          "valueBindings": {
+            "type": "object",
+            "description": "Field-name -> source binding. Each value is one of two grammars: `semantic:<TypeName>` (resolves a semanticTypes entry) or `<StateName>.<parameterName>` (resolves a runtimeStates/capabilities parameter). Cross-section resolution is enforced at load time by domainSemanticsValidator.ts.",
+            "additionalProperties": {
+              "type": "string",
+              "oneOf": [
+                {"pattern": "^semantic:[A-Za-z_][A-Za-z0-9_]*$"},
+                {"pattern": "^[A-Za-z_][A-Za-z0-9_]*\\.[A-Za-z_][A-Za-z0-9_]*$"}
+              ]
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
Closes #74

The JSON Schema referenced by `domain-semantics.json` via `$schema` was significantly behind the canonical shape. It pre-dated #71's `semanticTypes`/`witnesses` additions and never declared `artifactKinds`, `artifactFileKinds`, `semanticTypeToArtifactKind`, or `operationArtifactRules`, so `$schema`-aware editors silently accepted typos like `witness:` for `witnesses:`.

Cross-section invariants (`artifactKindStateDeclared`, `semanticTypeWitnessTargetResolves`, etc.) remain enforced at load time by [`path-analyser/src/domainSemanticsValidator.ts`](path-analyser/src/domainSemanticsValidator.ts) (#73). Draft-07 cannot express them and they are intentionally not duplicated in the schema.

### Changes

- Add `semanticTypes`, `artifactKinds`, `artifactFileKinds`, `semanticTypeToArtifactKind`, `operationArtifactRules` declarations with their current field shapes.
- Tighten `valueBindings`: each value must now match `semantic:<TypeName>` or `<StateName>.<param>` via `oneOf` patterns.
- Set `additionalProperties: false` on the top level and every sub-shape so typos like `requirses:` fail editor validation instead of being silently dropped.
- Constrain `artifactFileKinds` property names to single-extname-style extensions (`^\.[A-Za-z0-9_]+$`) — multi-dot suffixes like `.bpmn20.xml` are intentionally rejected because runtime consumers resolve only the final extension via `path.extname(...)`.
- Drop `validityState` from the `identifiers` required list — the current sidecar already has `JobTypeValue` without one, so the previous required list was already lying.
- Document at the schema root that cross-section invariants live in the runtime validator, not the schema.

Follow-ups from review (commit a39419f):

- Tightened `artifactFileKinds` pattern (above) and pruned the dead `.bpmn20.xml` / `.dmn11.xml` entries from `domain-semantics.json` so the sidecar validates against the tightened schema.
- Relaxed `operationArtifactRules.rules[]` to match the `ArtifactRule` TypeScript type: `id` is optional, `priority` / `producesSemantics` / `producesStates` are allowed.

### Verification

- AJV-validated the current sidecar against the new schema → **accepted**.
- Mutated the sidecar with each typo class the issue calls out → **all rejected**:
  - unknown top-level section (`bootstrapSequences`)
  - unknown sub-key in `artifactKinds`
  - `witness:` instead of `witnesses:` in `semanticTypes`
  - `requirses:` instead of `requires:` in `operationRequirements`
  - raw-string `valueBindings` value (not matching either grammar)
  - missing leading dot or multi-dot suffix in `artifactFileKinds` key
  - unknown extra field on an `operationArtifactRules.rules[]` entry
- `npm run lint` clean, `npm test` 145/145 green.