### PR TITLE
fix: gate witness implication on authoritative producers

### DIFF
--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -290,13 +290,29 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     // every operation that produces T as a producer of the witnessed
     // state. This unifies the typed-dataflow lens (producersByType)
     // with the runtime-state lens (producersByState).
+    //
+    // #95: gate the implication on `providerMap[T] === true`. Without
+    // this gate, an op that carries T only as incidental response
+    // metadata (e.g. createDocument's 201 carries
+    // metadata.processInstanceKey with provider:false) is added to
+    // producersByState[witnessed]. The semantic-producer expansion in
+    // scenarioGenerator.ts then treats that op's `domainProduces`
+    // entry as a real production claim, and rejects the candidate
+    // when the witnessed state's transitive `requires` chain is unmet
+    // — silently dropping otherwise-valid chains (the getDocument →
+    // createDocument symptom in #95). Authoritative producers
+    // (`provider: true`) are still surfaced; that is the relation #70
+    // intended to capture.
     if (domain?.semanticTypes) {
       for (const [semanticType, spec] of Object.entries(domain.semanticTypes)) {
         const witnessed = spec.witnesses;
         if (typeof witnessed !== 'string' || witnessed.length === 0) continue;
         const producers = producersByType[semanticType] ?? [];
         for (const opId of producers) {
-          if (operations[opId]) addProducer(witnessed, opId);
+          const op = operations[opId];
+          if (!op) continue;
+          if (op.providerMap?.[semanticType] !== true) continue;
+          addProducer(witnessed, opId);
         }
       }
     }

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -203,6 +203,82 @@ describe('bundled-spec invariants: planner output', () => {
     expect(offenders).toEqual([]);
   });
 
+  it('every endpoint whose only required semantic has a self-sufficient authoritative producer plans at least one chain (#95)', () => {
+    // Class-scoped guard against the #95 defect family: the witness
+    // implication in graphLoader must not turn an authoritative producer
+    // candidate into a dead end by laundering an incidental response
+    // semantic into a phantom domain-state production claim. The
+    // observable symptom of #95 was `getDocument` (single required
+    // semantic `DocumentId`, two authoritative producers `createDocument`
+    // / `createDocuments` with no further required inputs) emitting
+    // `scenarios: []` — every BFS candidate dropped at the prereq gate.
+    //
+    // Scope: endpoints with exactly one required semantic type T, where
+    // at least one authoritative producer of T has no required inputs
+    // of its own (i.e. is self-sufficient). Endpoints whose authoritative
+    // producers have unmet upstream requirements are out of scope here
+    // — those are separate planner gaps tracked elsewhere.
+    if (!existsSync(SCENARIOS_DIR)) {
+      throw new Error(
+        `Scenarios directory not found at ${SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+      );
+    }
+    loadGraph();
+    // Build authoritative producers and their required-input counts.
+    const authoritativeProducers = new Map<string, OperationNode[]>();
+    const requiredInputCount = new Map<string, number>();
+    for (const op of cachedGraph?.operations ?? []) {
+      let required = 0;
+      for (const e of op.requestBodySemanticTypes ?? []) {
+        if (e.required) required++;
+      }
+      for (const p of op.parameters ?? []) {
+        if (p.required && p.semanticType) required++;
+      }
+      requiredInputCount.set(op.operationId, required);
+      for (const entries of Object.values(op.responseSemanticTypes ?? {})) {
+        for (const e of entries) {
+          if (!e.provider) continue;
+          const list = authoritativeProducers.get(e.semanticType) ?? [];
+          list.push(op);
+          authoritativeProducers.set(e.semanticType, list);
+        }
+      }
+    }
+    const offenders: { file: string; endpoint: string; required: string[] }[] = [];
+    for (const f of readdirSync(SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const file = JSON.parse(readFileSync(join(SCENARIOS_DIR, f), 'utf8')) as ScenarioFile;
+      const required = file.requiredSemanticTypes ?? [];
+      if (required.length !== 1) continue;
+      const t = required[0];
+      const producers = authoritativeProducers.get(t) ?? [];
+      const endpointId = file.endpoint?.operationId;
+      const externalSelfSufficient = producers.filter(
+        (p) => p.operationId !== endpointId && (requiredInputCount.get(p.operationId) ?? 0) === 0,
+      );
+      if (externalSelfSufficient.length === 0) continue;
+      if (file.scenarios.length === 0) {
+        offenders.push({ file: f, endpoint: endpointId, required });
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('getDocument emits at least one non-trivial integration-path scenario (#95 reproducer)', () => {
+    // Concrete instance the class-scoped invariant above subsumes. Kept
+    // as a focused reproducer so a regression points at the exact symptom
+    // (getDocument planning an empty scenario set because createDocument
+    // was laundered into producersByState[ProcessInstanceExists]) rather
+    // than at the abstract invariant.
+    const scen = loadScenarioFile('get--documents--{documentId}-scenarios.json');
+    expect(scen.scenarios.length).toBeGreaterThan(0);
+    const firstChain = scen.scenarios[0].operations.map((o) => o.operationId);
+    expect(firstChain).toContain('createDocument');
+    expect(firstChain[firstChain.length - 1]).toBe('getDocument');
+  });
+
   it('every step in every scenario has its required semantic inputs produced by an earlier step (#35)', () => {
     // Class-scoped guard against the #35 defect family: BFS must not
     // insert any operation whose `requires.required` is not satisfied

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -236,7 +236,13 @@ describe('bundled-spec invariants: planner output', () => {
         if (p.required && p.semanticType) required++;
       }
       requiredInputCount.set(op.operationId, required);
-      for (const entries of Object.values(op.responseSemanticTypes ?? {})) {
+      // Restrict to 2xx/3xx success responses: an authoritative provider
+      // annotation on a 4xx/5xx error response does not represent a
+      // producer the planner can rely on, and treating it as one would
+      // make this invariant overstrict.
+      for (const [statusCode, entries] of Object.entries(op.responseSemanticTypes ?? {})) {
+        const code = Number.parseInt(statusCode, 10);
+        if (!Number.isFinite(code) || code < 200 || code >= 400) continue;
         for (const e of entries) {
           if (!e.provider) continue;
           const list = authoritativeProducers.get(e.semanticType) ?? [];

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -58,7 +58,12 @@ interface DependencyGraph {
 interface ScenarioFile {
   endpoint: { operationId: string };
   requiredSemanticTypes: string[];
-  scenarios: { id: string; operations: { operationId: string }[] }[];
+  unsatisfied?: boolean;
+  scenarios: {
+    id: string;
+    operations: { operationId: string }[];
+    missingSemanticTypes?: string[];
+  }[];
 }
 
 let cachedGraph: DependencyGraph | undefined;
@@ -265,7 +270,17 @@ describe('bundled-spec invariants: planner output', () => {
         (p) => p.operationId !== endpointId && (requiredInputCount.get(p.operationId) ?? 0) === 0,
       );
       if (externalSelfSufficient.length === 0) continue;
-      if (file.scenarios.length === 0) {
+      // A planned chain means at least one scenario that is neither the
+      // sentinel "unsatisfied" entry nor flagged with missingSemanticTypes.
+      // `scenarios.length > 0` alone is insufficient: the planner emits a
+      // single sentinel scenario when nothing satisfies the requirements,
+      // which would otherwise mask the regression this invariant guards.
+      const realScenarios = (file.scenarios ?? []).filter(
+        (s) =>
+          s.id !== 'unsatisfied' &&
+          (!s.missingSemanticTypes || s.missingSemanticTypes.length === 0),
+      );
+      if (file.unsatisfied === true || realScenarios.length === 0) {
         offenders.push({ file: f, endpoint: endpointId, required });
       }
     }

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -274,9 +274,16 @@ describe('bundled-spec invariants: planner output', () => {
     // than at the abstract invariant.
     const scen = loadScenarioFile('get--documents--{documentId}-scenarios.json');
     expect(scen.scenarios.length).toBeGreaterThan(0);
-    const firstChain = scen.scenarios[0].operations.map((o) => o.operationId);
-    expect(firstChain).toContain('createDocument');
-    expect(firstChain[firstChain.length - 1]).toBe('getDocument');
+    // Order-independent: any scenario that ends with getDocument and
+    // contains createDocument upstream proves the witness gate worked.
+    // We don't pin scenarios[0] because plausible future planner
+    // changes (e.g. createDocuments planned first) would shift order
+    // without invalidating the property we care about.
+    const matchingScenario = scen.scenarios.find((scenario) => {
+      const chain = scenario.operations.map((o) => o.operationId);
+      return chain.includes('createDocument') && chain[chain.length - 1] === 'getDocument';
+    });
+    expect(matchingScenario).toBeDefined();
   });
 
   it('every step in every scenario has its required semantic inputs produced by an earlier step (#35)', () => {

--- a/tests/regression/graph-loader-witness-implication.test.ts
+++ b/tests/regression/graph-loader-witness-implication.test.ts
@@ -1,0 +1,94 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { loadGraph } from '../../path-analyser/src/graphLoader.ts';
+
+/**
+ * Witness-implication gating — class-scoped regression for #95.
+ *
+ * `domain-semantics.json` declares `semanticTypes[T].witnesses = W` for
+ * key-shaped semantic types: producing a value of `T` is taken as
+ * evidence that runtime state `W` holds. `graphLoader.ts` lifts this
+ * relation by adding every op in `producersByType[T]` to
+ * `producersByState[W]` and to that op's `domainProduces`.
+ *
+ * The defect this test guards against: when the lift runs against
+ * *every* producer in `producersByType[T]` — including incidental
+ * producers (`provider: false`) whose response merely carries a field
+ * of semantic type `T` as metadata — the planner inherits a phantom
+ * `domainProduces[W]` claim. BFS then evaluates the candidate, finds
+ * `W`'s `runtimeStates.requires` unmet, and silently drops the
+ * candidate, blocking otherwise-valid chains (the `getDocument` →
+ * `createDocument` symptom in #95).
+ *
+ * Class-scoped invariant: the witness implication may only flow from
+ * **authoritative** producers (`providerMap[T] === true`). An op that
+ * carries `T` only as incidental response metadata must NOT be added
+ * to `producersByState[W]` or to its own `domainProduces` via the
+ * witness path.
+ */
+
+describe('graphLoader: witness implication gating (#95)', () => {
+  it('an op that produces a witnessed semantic type only incidentally is not added to producersByState[witnessed]', async () => {
+    const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
+    const baseDir = path.join(REPO_ROOT, 'path-analyser');
+    const graph = await loadGraph(baseDir);
+
+    const semanticTypes = graph.domain?.semanticTypes ?? {};
+    const offenders: { opId: string; semanticType: string; witnessed: string }[] = [];
+
+    for (const [semanticType, spec] of Object.entries(semanticTypes)) {
+      const witnessed = spec.witnesses;
+      if (typeof witnessed !== 'string' || witnessed.length === 0) continue;
+
+      const producers = graph.producersByType[semanticType] ?? [];
+      const witnessProducers = new Set(graph.producersByState?.[witnessed] ?? []);
+
+      for (const opId of producers) {
+        const op = graph.operations[opId];
+        if (!op) continue;
+        const isAuthoritative = op.providerMap?.[semanticType] === true;
+        if (isAuthoritative) continue;
+        if (witnessProducers.has(opId)) {
+          // Allow the case where the op also produces the witnessed state
+          // through a non-witness channel (e.g. operationRequirements.produces
+          // explicitly lists the state). Only flag ops whose ONLY route to
+          // producersByState[W] is the witness implication.
+          const declaredViaRequirements =
+            (graph.domain?.operationRequirements?.[opId]?.produces ?? []).includes(witnessed) ||
+            (graph.domain?.operationRequirements?.[opId]?.implicitAdds ?? []).includes(witnessed);
+          const declaredViaRuntimeStates = (
+            graph.domain?.runtimeStates?.[witnessed]?.producedBy ?? []
+          ).includes(opId);
+          const declaredViaCapabilities = (
+            graph.domain?.capabilities?.[witnessed]?.producedBy ?? []
+          ).includes(opId);
+          if (!declaredViaRequirements && !declaredViaRuntimeStates && !declaredViaCapabilities) {
+            offenders.push({ opId, semanticType, witnessed });
+          }
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      `incidental producers laundered via witness implication into producersByState (#95): ${JSON.stringify(offenders, null, 2)}`,
+    ).toEqual([]);
+  });
+
+  it('createDocument is not registered as a producer of ProcessInstanceExists (concrete #95 reproducer)', async () => {
+    // Concrete instance the class-scoped invariant above subsumes. Kept
+    // as a focused reproducer so a regression points at the exact symptom
+    // (getDocument planning an empty scenario set) rather than at the
+    // abstract invariant.
+    const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
+    const baseDir = path.join(REPO_ROOT, 'path-analyser');
+    const graph = await loadGraph(baseDir);
+
+    const witnessProducers = graph.producersByState?.ProcessInstanceExists ?? [];
+    expect(witnessProducers).not.toContain('createDocument');
+    expect(witnessProducers).not.toContain('createDocuments');
+
+    const createDocument = graph.operations.createDocument;
+    expect(createDocument?.domainProduces ?? []).not.toContain('ProcessInstanceExists');
+  });
+});

--- a/tests/regression/graph-loader-witness-implication.test.ts
+++ b/tests/regression/graph-loader-witness-implication.test.ts
@@ -33,7 +33,19 @@ describe('graphLoader: witness implication gating (#95)', () => {
     const baseDir = path.join(REPO_ROOT, 'path-analyser');
     const graph = await loadGraph(baseDir);
 
+    // Guard against vacuous pass: if the domain sidecar fails to load,
+    // semanticTypes is empty and the loop below is a no-op. Assert the
+    // prerequisite shape so a missing sidecar fails the test loudly.
+    expect(graph.domain?.semanticTypes, 'domain.semanticTypes must load').toBeDefined();
+    expect(graph.producersByState, 'producersByState must be built').toBeDefined();
     const semanticTypes = graph.domain?.semanticTypes ?? {};
+    const witnessedSemantics = Object.values(semanticTypes).filter(
+      (s) => typeof s.witnesses === 'string' && s.witnesses.length > 0,
+    );
+    expect(
+      witnessedSemantics.length,
+      'at least one semanticType must declare a witness for this invariant to be meaningful',
+    ).toBeGreaterThan(0);
     const offenders: { opId: string; semanticType: string; witnessed: string }[] = [];
 
     for (const [semanticType, spec] of Object.entries(semanticTypes)) {
@@ -84,11 +96,16 @@ describe('graphLoader: witness implication gating (#95)', () => {
     const baseDir = path.join(REPO_ROOT, 'path-analyser');
     const graph = await loadGraph(baseDir);
 
-    const witnessProducers = graph.producersByState?.ProcessInstanceExists ?? [];
+    // Guard against vacuous pass: optional chaining + ?? [] would hide
+    // a missing producersByState or createDocument and still satisfy
+    // the not.toContain checks.
+    expect(graph.producersByState, 'producersByState must be built').toBeDefined();
+    const witnessProducers = graph.producersByState.ProcessInstanceExists ?? [];
     expect(witnessProducers).not.toContain('createDocument');
     expect(witnessProducers).not.toContain('createDocuments');
 
     const createDocument = graph.operations.createDocument;
-    expect(createDocument?.domainProduces ?? []).not.toContain('ProcessInstanceExists');
+    expect(createDocument, 'createDocument operation must exist').toBeDefined();
+    expect(createDocument.domainProduces ?? []).not.toContain('ProcessInstanceExists');
   });
 });


### PR DESCRIPTION
Closes #95

## Defect

`graphLoader.ts` lifts `semanticTypes[T].witnesses = W` (introduced in #70) by adding **every** op in `producersByType[T]` to `producersByState[W]` and to that op's `domainProduces`. The lift runs over all producers, including incidental ones (`provider: false`) whose response carries a field of semantic type T only as metadata.

`createDocument`'s 201 response includes `metadata.processInstanceKey` with `provider: false`. The lift adds `createDocument` to `producersByState["ProcessInstanceExists"]` and pushes `ProcessInstanceExists` onto `createDocument.domainProduces`. BFS for `getDocument` then evaluates `createDocument` as a candidate, sees the phantom `ProcessInstanceExists` whose `runtimeStates.requires = ["ProcessDefinitionDeployed"]` is unmet, and silently drops the candidate. `getDocument` ends up with `scenarios: []` and the emitted Playwright spec calls `GET /documents/${documentId}` with an unresolved placeholder.

## Fix

Gate the witness implication on `op.providerMap[T] === true`. Authoritative producers (e.g. `createProcessInstance` for `ProcessInstanceKey → ProcessInstanceExists`) still surface the witness; incidental producers do not.

```diff
 if (domain?.semanticTypes) {
   for (const [semanticType, spec] of Object.entries(domain.semanticTypes)) {
     const witnessed = spec.witnesses;
     if (typeof witnessed !== 'string' || witnessed.length === 0) continue;
     const producers = producersByType[semanticType] ?? [];
     for (const opId of producers) {
-      if (operations[opId]) addProducer(witnessed, opId);
+      const op = operations[opId];
+      if (!op) continue;
+      if (op.providerMap?.[semanticType] !== true) continue;
+      addProducer(witnessed, opId);
     }
   }
 }
```

## Red / green discipline

Per AGENTS.md, the failing tests landed in a separate commit before the production change:

1. **Red** — `542f4e7` `test: add failing class-scoped guard for witness implication laundering (#95)`
2. **Green** — `d91e935` `fix: gate witness implication on authoritative producers (#95)`

You can verify the red step locally:

```bash
git checkout 542f4e7 -- tests/regression/graph-loader-witness-implication.test.ts tests/regression/bundled-spec-invariants.test.ts
git checkout main -- path-analyser/src/graphLoader.ts
npm test
```

This shows 4 failures (class-scoped + concrete in both test files).

## Tests

Both class-scoped and concrete (per the standing rule):

- `tests/regression/graph-loader-witness-implication.test.ts`
  - **Class-scoped:** for every `(opId, semanticType)` where `opId ∈ producersByType[T]` and `T` has a declared `witnesses: W`, the op must NOT appear in `producersByState[W]` purely via the witness implication unless `op.providerMap[T] === true`. Tolerates ops that legitimately reach `producersByState[W]` via `runtimeStates.producedBy`, `capabilities.producedBy`, or `operationRequirements.produces`/`implicitAdds`.
  - **Concrete reproducer:** `createDocument` and `createDocuments` are not in `producersByState["ProcessInstanceExists"]`, and `createDocument.domainProduces` does not include `"ProcessInstanceExists"`.

- `tests/regression/bundled-spec-invariants.test.ts`
  - **Class-scoped (Layer 3):** every endpoint with exactly one required semantic type T, where at least one external authoritative producer of T has zero required inputs, plans at least one chain. Scope is intentionally tight to the defect class — endpoints whose authoritative producers have unmet upstream requirements (e.g. `getDecisionInstance`, `deleteDecisionInstance`) are pre-existing planner gaps and remain out of scope.
  - **Concrete reproducer:** `getDocument` emits at least one non-trivial scenario whose first step is `createDocument`.

## Verification

- `npm test` — 149/149 passing
- `npm run lint` — clean
- `npm run testsuite:generate` + `npm run generate:request-validation` regenerated; `getDocument` now plans `[createDocument, getDocument]` instead of `scenarios: []`.

## Out of scope

The companion `produces` lift in `graphLoader.ts` (around line 357) also promotes incidental response semantics into `op.produces` when no provider flags are present. That fallback is the upstream cause of `createDocument` ending up in `producersByType["ProcessInstanceKey"]` in the first place. Tightening it would be a larger change that ripples through more chains; this PR keeps the fix targeted to the witness-implication gate, which is sufficient to unblock #95. A follow-up issue should track the broader cleanup if desired.
