### PR TITLE
fix: drop permissive produces fallback in graphLoader

### DIFF
--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -369,16 +369,21 @@ function normalizeOp(opId: string, op: RawOp): OperationNode {
       }
     }
   }
-  // If any provider flags exist, restrict produced semantics to only provider:true; else, include all response-derived
-  if (Object.keys(providerMap).length) {
-    responseDerived.forEach((st) => {
-      if (providerMap[st]) produces.push(st);
-    });
-  } else {
-    responseDerived.forEach((st) => {
-      produces.push(st);
-    });
-  }
+  // Only `provider: true` response semantics flow into `produces`. The
+  // canonical signal for "this op authoritatively produces a value of
+  // semantic type T in its response" is `x-semantic-provider: true` on
+  // the response field schema. Earlier, when no field on a response
+  // carried `provider: true`, every response semantic was promoted into
+  // `produces` as a fallback — which laundered incidental response
+  // metadata (e.g. `createDocument`'s `metadata.processInstanceKey`)
+  // into `producersByType[T]` and downstream into BFS candidate sets.
+  // That fallback was the upstream cause of #95 and is removed in #97.
+  // Operations whose specs are not yet annotated with
+  // `x-semantic-provider` will stop appearing in `producersByType` for
+  // their response fields; tracked upstream as camunda/camunda#52169.
+  responseDerived.forEach((st) => {
+    if (providerMap[st]) produces.push(st);
+  });
 
   const { required, optional } = extractRequires(op);
 

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -293,13 +293,73 @@ describe('bundled-spec invariants: planner output', () => {
     // (getDocument planning an empty scenario set because createDocument
     // was laundered into producersByState[ProcessInstanceExists]) rather
     // than at the abstract invariant.
+    //
+    // #97 update: dropping the permissive `produces` fallback in
+    // graphLoader means `createDocument` no longer appears in
+    // `producersByType[DocumentId]` until the upstream OpenAPI spec
+    // annotates `createDocument`'s `documentId` response field with
+    // `x-semantic-provider: true` (tracked in camunda/camunda#52169).
+    // Until that lands and the spec pin is bumped, this assertion is
+    // self-healing: it accepts either the original positive state
+    // (chain is planned) OR the documented current state (createDocument
+    // is not yet a canonical producer of DocumentId). When upstream
+    // lands, the second branch becomes false, the first branch must
+    // hold, and any future regression to "no chain planned" still
+    // fails the test loudly.
+    const REPO_ROOT = join(import.meta.dirname, '..', '..');
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const rawGraph = JSON.parse(
+      readFileSync(
+        join(
+          REPO_ROOT,
+          'semantic-graph-extractor',
+          'dist',
+          'output',
+          'operation-dependency-graph.json',
+        ),
+        'utf8',
+      ),
+    ) as {
+      operations: Array<{
+        operationId: string;
+        responseSemanticTypes?: Record<
+          string,
+          Array<{ semanticType?: unknown; provider?: unknown }>
+        >;
+      }>;
+    };
+    const createDocument = rawGraph.operations.find((o) => o.operationId === 'createDocument');
+    expect(createDocument, 'createDocument operation must exist in raw graph').toBeDefined();
+    const createDocumentProvidesDocumentId = Object.values(
+      createDocument?.responseSemanticTypes ?? {},
+    ).some(
+      (arr) =>
+        Array.isArray(arr) &&
+        arr.some((e) => e?.semanticType === 'DocumentId' && e?.provider === true),
+    );
+
     const scen = loadScenarioFile('get--documents--{documentId}-scenarios.json');
+
+    if (!createDocumentProvidesDocumentId) {
+      // Documented current-state branch: while upstream is missing the
+      // annotation, getDocument's only producer chain is structurally
+      // unreachable and the planner emits the sentinel `unsatisfied`
+      // scenario. Assert that exact shape so a regression away from it
+      // (e.g. silent re-introduction of the fallback) trips this guard.
+      expect(scen.scenarios.length).toBeGreaterThan(0);
+      const onlySentinel = scen.scenarios.every(
+        (s) =>
+          s.id === 'unsatisfied' || (s.missingSemanticTypes && s.missingSemanticTypes.length > 0),
+      );
+      expect(
+        onlySentinel,
+        'expected only an unsatisfied/missing-semantics scenario while createDocument lacks provider:true on documentId (camunda/camunda#52169)',
+      ).toBe(true);
+      return;
+    }
+
+    // Upstream-annotated branch: original positive assertion.
     expect(scen.scenarios.length).toBeGreaterThan(0);
-    // Order-independent: any scenario that ends with getDocument and
-    // contains createDocument upstream proves the witness gate worked.
-    // We don't pin scenarios[0] because plausible future planner
-    // changes (e.g. createDocuments planned first) would shift order
-    // without invalidating the property we care about.
     const matchingScenario = scen.scenarios.find((scenario) => {
       const chain = scenario.operations.map((o) => o.operationId);
       return chain.includes('createDocument') && chain[chain.length - 1] === 'getDocument';

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -367,6 +367,111 @@ describe('bundled-spec invariants: planner output', () => {
     expect(matchingScenario).toBeDefined();
   });
 
+  it('evaluateDecision is reachable via [createDeployment, evaluateDecision] once DecisionDefinitionId is annotated (camunda/camunda#52271)', () => {
+    // Self-healing guard for the array + allOf + nullable + provider-array
+    // inheritance combination — the most structurally complex shape any
+    // `x-semantic-provider` annotation in the upstream spec exercises.
+    //
+    // `createDeployment`'s 200 response is:
+    //   DeploymentResponse
+    //     .deployments[]                                  (array)
+    //       .decisionDefinition                           (nullable: true)
+    //         allOf:
+    //           - $ref: DeploymentDecisionResult
+    //             x-semantic-provider:
+    //               - decisionDefinitionId  <-- promoted by camunda/camunda#52271
+    //               - decisionRequirementsId
+    //               - decisionDefinitionKey  (already present pre-#52271)
+    //               - decisionRequirementsKey
+    //               - name
+    //               - version
+    //
+    // For the planner to discover `[createDeployment, evaluateDecision]`,
+    // the extractor's response walker must descend through (a) array
+    // `items`, (b) `allOf` wrappers, (c) propagate the parent object's
+    // `x-semantic-provider: [...]` array down to each named child via
+    // `inheritedProvider` — and emit `provider: true` on the resulting
+    // leaf. None of those branches are exercised by the simpler
+    // `getDocument` reproducer above (`DocumentReference` is a flat
+    // object directly under the response).
+    //
+    // Self-healing pattern (mirrors the #95 reproducer): assert the
+    // upstream-annotated branch only when the canonical signal is
+    // present on `createDeployment`'s response. While upstream is
+    // unannotated, assert the documented current state instead so a
+    // regression away from it (e.g. the dropped fallback re-introduced)
+    // still trips this guard. When camunda/camunda#52271 lands and the
+    // spec pin is bumped, the second branch becomes false, the first
+    // branch must hold, and any future regression to "no chain planned"
+    // fails the test loudly.
+    const REPO_ROOT = join(import.meta.dirname, '..', '..');
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const rawGraph = JSON.parse(
+      readFileSync(
+        join(
+          REPO_ROOT,
+          'semantic-graph-extractor',
+          'dist',
+          'output',
+          'operation-dependency-graph.json',
+        ),
+        'utf8',
+      ),
+    ) as {
+      operations: Array<{
+        operationId: string;
+        responseSemanticTypes?: Record<
+          string,
+          Array<{ semanticType?: unknown; provider?: unknown; fieldPath?: unknown }>
+        >;
+      }>;
+    };
+    const createDeployment = rawGraph.operations.find((o) => o.operationId === 'createDeployment');
+    expect(createDeployment, 'createDeployment operation must exist in raw graph').toBeDefined();
+    const createDeploymentProvidesDecisionDefinitionId = Object.values(
+      createDeployment?.responseSemanticTypes ?? {},
+    ).some(
+      (arr) =>
+        Array.isArray(arr) &&
+        arr.some((e) => e?.semanticType === 'DecisionDefinitionId' && e?.provider === true),
+    );
+
+    const scen = loadScenarioFile('post--decision-definitions--evaluation-scenarios.json');
+
+    if (!createDeploymentProvidesDecisionDefinitionId) {
+      // Documented current-state branch: while upstream is missing the
+      // annotation, evaluateDecision's only producer chain is structurally
+      // unreachable and the planner emits the sentinel `unsatisfied`
+      // scenario. Assert that exact shape so a regression away from it
+      // (e.g. silent re-introduction of the fallback, or accidental
+      // demotion of the response walker) trips this guard.
+      expect(scen.scenarios.length).toBeGreaterThan(0);
+      const onlySentinel = scen.scenarios.every(
+        (s) =>
+          s.id === 'unsatisfied' || (s.missingSemanticTypes && s.missingSemanticTypes.length > 0),
+      );
+      expect(
+        onlySentinel,
+        'expected only an unsatisfied/missing-semantics scenario while createDeployment lacks provider:true on decisionDefinitionId (camunda/camunda#52271)',
+      ).toBe(true);
+      return;
+    }
+
+    // Upstream-annotated branch: positive assertion. Once #52271 lands
+    // and the spec pin is bumped, this is the durable regression guard
+    // against the array + allOf + nullable + inheritance combination
+    // breaking in the response walker.
+    expect(scen.scenarios.length).toBeGreaterThan(0);
+    const matchingScenario = scen.scenarios.find((scenario) => {
+      const chain = scenario.operations.map((o) => o.operationId);
+      return chain.includes('createDeployment') && chain[chain.length - 1] === 'evaluateDecision';
+    });
+    expect(
+      matchingScenario,
+      'expected a chain ending in evaluateDecision that includes createDeployment as a producer of DecisionDefinitionId',
+    ).toBeDefined();
+  });
+
   it('every step in every scenario has its required semantic inputs produced by an earlier step (#35)', () => {
     // Class-scoped guard against the #35 defect family: BFS must not
     // insert any operation whose `requires.required` is not satisfied

--- a/tests/regression/graph-loader-produces-fallback.test.ts
+++ b/tests/regression/graph-loader-produces-fallback.test.ts
@@ -1,0 +1,165 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { loadGraph } from '../../path-analyser/src/graphLoader.ts';
+
+/**
+ * `produces` fallback tightening — class-scoped regression for #97.
+ *
+ * Follow-up to #95 / #96. The witness-implication gate landed in #96
+ * prevents incidental response semantics from being laundered into
+ * `producersByState[witnessed]`, but the upstream cause — the
+ * `produces` fallback in `graphLoader.ts` — was left in place because
+ * tightening it ripples through more chains than the targeted #95 fix
+ * warranted.
+ *
+ * The defect this test guards against: when an op's response carries
+ * semantic types but **no** field is flagged `provider: true`, the
+ * fallback used to add every response semantic to `op.produces` (and
+ * thus to `producersByType[T]`). That is what put `createDocument`
+ * into `producersByType["ProcessInstanceKey"]` in the first place —
+ * its 201 response carries `metadata.processInstanceKey` purely as
+ * bookkeeping (`provider: false`), but because the response declared
+ * no authoritative provider at all, the fallback claimed the whole
+ * response surface as produced output.
+ *
+ * Class-scoped invariant (canonical signal only): for every op `O`
+ * and every semantic type `T`, if `O ∈ producersByType[T]`, then there
+ * must be canonical evidence — either
+ *   (a) at least one response field of type `T` carries `provider: true`, or
+ *   (b) the op declares `T` via an explicit
+ *       `produces` / `producesSemanticTypes` / `producesSemanticType` /
+ *       `outputsSemanticTypes` field on its raw graph entry, or
+ *   (c) `domain.operationRequirements[O]` lists `T` in its `produces`
+ *       or `implicitAdds` (sidecar-declared, surfaced into
+ *       `producersByType` per #56).
+ *
+ * Empirically the upstream OpenAPI spec is under-annotated (see
+ * camunda/camunda#52169). Until those annotations land, dropping the
+ * fallback shrinks `producersByType` for several ops; that regression
+ * is honest — those entries were built on phantom inferences.
+ */
+
+describe('graphLoader: produces fallback tightening (#97)', () => {
+  it('every op in producersByType[T] has canonical evidence (provider:true or explicit produces)', async () => {
+    const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
+    const baseDir = path.join(REPO_ROOT, 'path-analyser');
+    const graph = await loadGraph(baseDir);
+
+    // Guard against vacuous pass.
+    expect(graph.producersByType, 'producersByType must be built').toBeDefined();
+    const totalProducers = Object.values(graph.producersByType).reduce(
+      (acc, ids) => acc + (ids?.length ?? 0),
+      0,
+    );
+    expect(
+      totalProducers,
+      'producersByType must contain at least some entries for this invariant to be meaningful',
+    ).toBeGreaterThan(0);
+
+    // We need to consult the *raw* op JSON to see explicit `produces` /
+    // `producesSemanticTypes` declarations, since `normalizeOp` collapses
+    // them into the same `produces` array as the response-derived ones.
+    const fs = await import('node:fs');
+    const rawGraphPath = path.join(
+      REPO_ROOT,
+      'semantic-graph-extractor',
+      'dist',
+      'output',
+      'operation-dependency-graph.json',
+    );
+    const rawGraph = JSON.parse(fs.readFileSync(rawGraphPath, 'utf8')) as {
+      operations: Array<{
+        operationId: string;
+        produces?: unknown;
+        producesSemanticType?: unknown;
+        producesSemanticTypes?: unknown;
+        outputsSemanticTypes?: unknown;
+        responseSemanticTypes?: Record<
+          string,
+          Array<{ semanticType?: unknown; provider?: unknown }>
+        >;
+      }>;
+    };
+    const rawByOpId = new Map<string, (typeof rawGraph.operations)[number]>();
+    for (const op of rawGraph.operations) rawByOpId.set(op.operationId, op);
+
+    const collectStrings = (v: unknown): string[] => {
+      if (typeof v === 'string') return [v];
+      if (Array.isArray(v)) return v.filter((x): x is string => typeof x === 'string');
+      return [];
+    };
+
+    const offenders: { opId: string; semanticType: string }[] = [];
+
+    for (const [semanticType, opIds] of Object.entries(graph.producersByType)) {
+      for (const opId of opIds ?? []) {
+        const raw = rawByOpId.get(opId);
+        if (!raw) {
+          // Op missing from raw graph — flag rather than silently allow.
+          offenders.push({ opId, semanticType });
+          continue;
+        }
+        // Canonical evidence (a): at least one response field of this
+        // semantic type carries provider:true.
+        let hasProviderFlag = false;
+        for (const arr of Object.values(raw.responseSemanticTypes ?? {})) {
+          if (!Array.isArray(arr)) continue;
+          for (const entry of arr) {
+            if (entry?.semanticType === semanticType && entry?.provider === true) {
+              hasProviderFlag = true;
+              break;
+            }
+          }
+          if (hasProviderFlag) break;
+        }
+        if (hasProviderFlag) continue;
+
+        // Canonical evidence (b): explicit produces declaration.
+        const explicit = new Set([
+          ...collectStrings(raw.produces),
+          ...collectStrings(raw.producesSemanticType),
+          ...collectStrings(raw.producesSemanticTypes),
+          ...collectStrings(raw.outputsSemanticTypes),
+        ]);
+        if (explicit.has(semanticType)) continue;
+
+        // Canonical evidence (c): domain-semantics sidecar declares
+        // produces / implicitAdds (surfaced into producersByType per #56).
+        const opReqs = graph.domain?.operationRequirements?.[opId];
+        const sidecarProduces = new Set([
+          ...(opReqs?.produces ?? []),
+          ...(opReqs?.implicitAdds ?? []),
+        ]);
+        if (sidecarProduces.has(semanticType)) continue;
+
+        offenders.push({ opId, semanticType });
+      }
+    }
+
+    expect(
+      offenders,
+      `ops appearing in producersByType[T] without canonical evidence (#97): ${JSON.stringify(offenders, null, 2)}`,
+    ).toEqual([]);
+  });
+
+  it('createDocument does not produce ProcessInstanceKey or ProcessDefinitionId (concrete #97 reproducer)', async () => {
+    // Concrete instance the class-scoped invariant above subsumes.
+    // `createDocument`'s 201 response carries
+    //   metadata.processInstanceKey  (semanticType: ProcessInstanceKey, provider:false)
+    //   metadata.processDefinitionId (semanticType: ProcessDefinitionId, provider:false)
+    // purely as bookkeeping. Neither is an authoritative production of
+    // createDocument; the fallback laundered them into
+    // producersByType[ProcessInstanceKey] / [ProcessDefinitionId].
+    const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
+    const baseDir = path.join(REPO_ROOT, 'path-analyser');
+    const graph = await loadGraph(baseDir);
+
+    expect(graph.producersByType, 'producersByType must be built').toBeDefined();
+    const procInstKeyProducers = graph.producersByType.ProcessInstanceKey ?? [];
+    const procDefIdProducers = graph.producersByType.ProcessDefinitionId ?? [];
+    expect(procInstKeyProducers).not.toContain('createDocument');
+    expect(procInstKeyProducers).not.toContain('createDocuments');
+    expect(procDefIdProducers).not.toContain('createDocument');
+    expect(procDefIdProducers).not.toContain('createDocuments');
+  });
+});

--- a/tests/regression/graph-loader-produces-fallback.test.ts
+++ b/tests/regression/graph-loader-produces-fallback.test.ts
@@ -67,6 +67,7 @@ describe('graphLoader: produces fallback tightening (#97)', () => {
       'output',
       'operation-dependency-graph.json',
     );
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
     const rawGraph = JSON.parse(fs.readFileSync(rawGraphPath, 'utf8')) as {
       operations: Array<{
         operationId: string;


### PR DESCRIPTION
Closes #97
Refs #95, #96
Refs camunda/camunda#52169

## Defect

`graphLoader.ts` previously promoted every response semantic into `op.produces` whenever no field on the response carried `provider: true`. That fallback laundered incidental response metadata (most visibly `createDocument`'s `metadata.processInstanceKey`) into `producersByType[T]` and was the upstream cause of the witness-implication defect fixed in #96.

## Fix

Drop the fallback. `provider: true` (sourced from `x-semantic-provider: true` in the upstream OpenAPI spec) is now the only signal that a response semantic counts as authoritative production.

```diff
- if (Object.keys(providerMap).length) {
-   responseDerived.forEach((st) => {
-     if (providerMap[st]) produces.push(st);
-   });
- } else {
-   responseDerived.forEach((st) => {
-     produces.push(st);
-   });
- }
+ responseDerived.forEach((st) => {
+   if (providerMap[st]) produces.push(st);
+ });
```

## Honest regression: chains that need upstream annotation

Per the discussion on #97, the upstream OpenAPI spec is currently under-annotated — 18 mutating operations carry response fields that are clearly authoritative producers but lack `x-semantic-provider: true`. Tracked upstream as **camunda/camunda#52169** with a full table of (op, status, field, semantic type) tuples.

Until those annotations land and the spec pin is bumped, several chains regress:

- `getDocument` no longer plans `[createDocument, getDocument]` — `createDocument.documentId` lacks the annotation upstream, so `createDocument` is not in `producersByType[DocumentId]`.
- Equivalent regressions affect endpoints whose only producer was via the fallback (e.g. resolving a `BatchOperationKey` after a batch operation).

The regression is honest: those chains were built on phantom inferences. They will return automatically once the upstream annotations land and the spec pin is bumped.

## Red / green discipline

Per AGENTS.md, the failing test landed in a separate commit before the production change:

1. **Red** — `fd87521` `test: add failing class-scoped guard for produces fallback laundering (#97)`
2. **Green** — `9efd8a8` `fix: drop permissive produces fallback in graphLoader (#97)`

Verify the red step locally:

```bash
git checkout fd87521 -- tests/regression/graph-loader-produces-fallback.test.ts
git checkout main -- path-analyser/src/graphLoader.ts
npm test
```

Both new tests fail.

## Tests

Both class-scoped and concrete (per the standing rule):

- `tests/regression/graph-loader-produces-fallback.test.ts`
  - **Class-scoped:** for every `(opId, T)` where `opId in producersByType[T]`, there must be canonical evidence — either (a) at least one response field of type `T` carries `provider: true`, (b) the op declares `T` via an explicit `produces` / `producesSemanticTypes` / `producesSemanticType` / `outputsSemanticTypes` field, or (c) `domain.operationRequirements[opId]` lists `T` in `produces` or `implicitAdds` (sidecar-declared, surfaced into `producersByType` per #56).
  - **Concrete reproducer:** `createDocument` and `createDocuments` are not in `producersByType[ProcessInstanceKey]` or `producersByType[ProcessDefinitionId]`.

- `tests/regression/bundled-spec-invariants.test.ts` (`getDocument emits at least one non-trivial integration-path scenario (#95 reproducer)`) updated to a **self-healing** form:
  - While upstream is unannotated (current state): asserts that `getDocument` emits only the sentinel `unsatisfied` / missing-semantics scenario. A regression that silently re-introduces the fallback would re-create real-looking scenarios and fail this branch.
  - Once upstream lands and the spec is bumped: the original positive assertion (chain ending in `getDocument` containing `createDocument`) takes effect automatically.

## Verification

- `npm test` — 151/151 passing
- `npm run lint` — clean
- `npx tsc --noEmit` — clean across all three workspace tsconfigs
- `TEST_SEED=snapshot-baseline npm run testsuite:generate` + `npm run generate:request-validation` regenerated; L3 invariants ran against the regenerated tree

## Out of scope

- The 20 GET ops that currently appear in `producersByType` purely via the fallback (e.g. `getDecisionInstance`, `getElementInstance`) are also dropped by this change. They were never authoritative producers — a `GET` reflects state, it doesn't produce it. Downstream chain planning should reach those values via the corresponding `create*` op once upstream is annotated.
- Annotating the upstream spec is **not** in scope for this PR. Tracked separately at camunda/camunda#52169.
