### PR TITLE
fix: add class-scoped Bug C invariant tracing offenders to upstream gap (#54)

### DIFF
--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -649,9 +649,13 @@ describe('bundled-spec invariants: planner output', () => {
       opByEndpointKey.set(`${op.method.toUpperCase()} ${op.path}`, op);
       opByOperationId.set(op.operationId, op);
     }
-    // Authoritative producers per semantic type (provider:true only). This
-    // is the same signal `graphLoader.normalizeOp` uses to populate
-    // `producersByType`; we re-derive it here to avoid coupling the
+    // Authoritative producers per semantic type (provider:true only).
+    // Intentionally stricter than `producersByType`: `graphLoader.normalizeOp`
+    // currently falls back to treating every response semantic as a
+    // producer when an op has no provider flags at all (graphLoader.ts
+    // ~lines 372-381; tracked for removal in #97). The Bug-C diagnosis is
+    // about authoritative producers, not the fallback set, so we re-derive
+    // the strict authoritative-only relation here and avoid coupling the
     // invariant to internal planner state.
     const authoritativeProducersOf = new Map<string, string[]>();
     for (const op of graph.operations) {
@@ -667,9 +671,13 @@ describe('bundled-spec invariants: planner output', () => {
         }
       }
     }
-    // Required semantic-type inputs of an op (request body + path/query
-    // parameters with `required: true`). Mirrors `extractRequires` in
-    // graphLoader.ts.
+    // Required semantic-type inputs of an op (request body + every
+    // required parameter that carries a `semanticType`, regardless of
+    // location). Mirrors `extractRequires` in graphLoader.ts, which also
+    // does not filter parameters by `path`/`query`/`header`/`cookie` — a
+    // semanticType-tagged required header (rare in this spec, but
+    // possible) would gate chain assembly the same way as a path
+    // parameter, so the reachability model must include it.
     const requiredInputsOf = (opId: string): string[] => {
       const op = opByOperationId.get(opId);
       if (!op) return [];
@@ -755,9 +763,28 @@ describe('bundled-spec invariants: planner output', () => {
           `Missing dependency-graph node for endpoint ${endpointKey} referenced by feature scenario ${f}. This indicates a graph/feature-output mismatch or endpoint-keying bug.`,
         );
       }
+      const pathParameters = (node.parameters ?? []).filter((p) => p.location === 'path');
+      // If the path has placeholders but the graph node has no path
+      // parameters at all, that is a graph/extractor bug — fail fast.
+      if (pathParameters.length === 0) {
+        throw new Error(
+          `Dependency-graph node for endpoint ${endpointKey} referenced by feature scenario ${f} has path placeholders (${placeholders.join(', ')}) but no path parameters on the node. This indicates a graph extraction or endpoint-keying bug.`,
+        );
+      }
+      // A placeholder must have a matching `path` parameter entry on the
+      // graph node — otherwise the URL template references a name the
+      // graph never declared, which is also a graph/extractor bug.
+      const placeholdersMissingParam = placeholders.filter(
+        (ph) => !pathParameters.some((p) => p.name === ph),
+      );
+      if (placeholdersMissingParam.length) {
+        throw new Error(
+          `Dependency-graph node for endpoint ${endpointKey} referenced by feature scenario ${f} is missing path parameter entries for placeholders: ${placeholdersMissingParam.join(', ')}. This indicates a graph extraction or endpoint-keying bug.`,
+        );
+      }
       const inScopeTypes = placeholders
         .map((ph) => {
-          const param = (node.parameters ?? []).find((p) => p.name === ph && p.location === 'path');
+          const param = pathParameters.find((p) => p.name === ph);
           return param?.semanticType;
         })
         .filter((st): st is string => Boolean(st));

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -595,6 +595,194 @@ describe('bundled-spec invariants: planner output', () => {
     }
     expect(offenders).toEqual([]);
   });
+
+  it('every Bug-C feature scenario (placeholder has semanticType but no satisfied chain) traces to a missing upstream x-semantic-provider annotation (#54)', () => {
+    // Issue #54 — strict complement of the Bug A invariant inside the
+    // `semanticType`-known subset. A "Bug C" offender is a feature scenario
+    // whose endpoint path has `{placeholders}` whose path parameter has a
+    // recognised `semanticType` AND no planner scenario assembled a
+    // fully-satisfied chain. The Bug A invariant (above) silently filters
+    // these out via `if (!hasSatisfiedChain) continue;`; this invariant
+    // re-surfaces them and asserts they all share the same root cause.
+    //
+    // Diagnosis on the pinned bundled spec (2b2b962a…): all 21 offenders
+    // bottom out in the upstream-spec gap tracked at camunda/camunda#52169
+    // — the placeholder's `semanticType`, or a type transitively required
+    // to satisfy any authoritative producer of it, has zero
+    // `x-semantic-provider: true` producers in the bundled spec. List
+    // endpoints (searchUserTasks, searchIncidents, searchAuditLogs,
+    // searchVariables, searchDecisionInstances, searchGlobalTaskListeners)
+    // emit the entity keys with `provider: false`; the per-op gate in
+    // graphLoader.ts (#97 path) excludes them from `producersByType`,
+    // leaving the planner with no upstream producer to graft. The same
+    // gap also blocks two endpoints whose direct producer DOES exist
+    // (DecisionEvaluationInstanceKey/Key via evaluateDecision) because
+    // evaluateDecision itself transitively requires DecisionDefinitionId,
+    // which has zero authoritative producers.
+    //
+    // Self-healing semantics: when upstream lands an
+    // `x-semantic-provider: true` annotation that breaks the chain open
+    // for one of these endpoints, that endpoint drops out of the offender
+    // list; the assertion still passes because every remaining offender
+    // continues to satisfy the structural-cause check. If the planner
+    // regresses such that an endpoint with a satisfiable chain ends up
+    // here, the structural-cause check fails and this test fails loudly.
+    //
+    // Out of scope:
+    //  - Bug A (fixed in #52, guarded by the invariant above).
+    //  - Bug B (placeholder lacks `semanticType` upstream — #53), filtered
+    //    out by the `param?.semanticType` gate.
+    if (!existsSync(FEATURE_SCENARIOS_DIR)) {
+      throw new Error(
+        `Feature-output directory not found at ${FEATURE_SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+      );
+    }
+    if (!existsSync(SCENARIOS_DIR)) {
+      throw new Error(
+        `Planner scenarios directory not found at ${SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+      );
+    }
+    const graph = loadGraph();
+    const opByEndpointKey = new Map<string, OperationNode>();
+    for (const op of graph.operations) {
+      opByEndpointKey.set(`${op.method.toUpperCase()} ${op.path}`, op);
+    }
+    // Authoritative producers per semantic type (provider:true only). This
+    // is the same signal `graphLoader.normalizeOp` uses to populate
+    // `producersByType`; we re-derive it here to avoid coupling the
+    // invariant to internal planner state.
+    const authoritativeProducersOf = new Map<string, string[]>();
+    for (const op of graph.operations) {
+      const surfaced = new Set<string>();
+      for (const entries of Object.values(op.responseSemanticTypes ?? {})) {
+        for (const e of entries) {
+          if (e.provider === true && !surfaced.has(e.semanticType)) {
+            surfaced.add(e.semanticType);
+            const list = authoritativeProducersOf.get(e.semanticType) ?? [];
+            list.push(op.operationId);
+            authoritativeProducersOf.set(e.semanticType, list);
+          }
+        }
+      }
+    }
+    // Required semantic-type inputs of an op (request body + path/query
+    // parameters with `required: true`). Mirrors `extractRequires` in
+    // graphLoader.ts.
+    const requiredInputsOf = (opId: string): string[] => {
+      const op = graph.operations.find((o) => o.operationId === opId);
+      if (!op) return [];
+      const set = new Set<string>();
+      for (const e of op.requestBodySemanticTypes ?? []) {
+        if (e.required) set.add(e.semanticType);
+      }
+      for (const p of op.parameters ?? []) {
+        if (p.required && p.semanticType) set.add(p.semanticType);
+      }
+      return [...set];
+    };
+    // Transitively-unauthoritative: a semantic type T such that every
+    // path to producing T bottoms out in a type with zero authoritative
+    // producers. Computed as a least fixpoint: T is unauthoritative if it
+    // has no authoritative producer, or every authoritative producer
+    // requires (transitively) at least one unauthoritative type. The
+    // dual — `authoritativeReachable` — is what the BFS would converge
+    // on if we ran it; we compute its complement on the same edges.
+    const authoritativelyReachable = new Set<string>();
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const [semType, producers] of authoritativeProducersOf) {
+        if (authoritativelyReachable.has(semType)) continue;
+        const reachable = producers.some((opId) =>
+          requiredInputsOf(opId).every((req) => authoritativelyReachable.has(req)),
+        );
+        if (reachable) {
+          authoritativelyReachable.add(semType);
+          changed = true;
+        }
+      }
+    }
+    interface FeatureScenarioFile {
+      endpoint: { method: string; path: string };
+      scenarios: { id: string }[];
+    }
+    interface PlannerScenarioFile {
+      scenarios: { missingSemanticTypes?: string[] }[];
+    }
+    interface OffenderRecord {
+      file: string;
+      endpoint: string;
+      placeholderSemanticTypes: string[];
+    }
+    const offenders: OffenderRecord[] = [];
+    const structuralOk: OffenderRecord[] = [];
+    const structuralViolations: OffenderRecord[] = [];
+    for (const f of readdirSync(FEATURE_SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      const plannerPath = join(SCENARIOS_DIR, f);
+      if (!existsSync(plannerPath)) continue;
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const planner = JSON.parse(readFileSync(plannerPath, 'utf8')) as PlannerScenarioFile;
+      const hasSatisfiedChain = (planner.scenarios ?? []).some(
+        (s) => !s.missingSemanticTypes || s.missingSemanticTypes.length === 0,
+      );
+      if (hasSatisfiedChain) continue;
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const file = JSON.parse(
+        readFileSync(join(FEATURE_SCENARIOS_DIR, f), 'utf8'),
+      ) as FeatureScenarioFile;
+      const placeholders = [...file.endpoint.path.matchAll(/\{([^}]+)\}/g)].map((m) => m[1]);
+      if (!placeholders.length) continue;
+      const endpointKey = `${file.endpoint.method.toUpperCase()} ${file.endpoint.path}`;
+      const node = opByEndpointKey.get(endpointKey);
+      if (!node) continue;
+      const inScopeTypes = placeholders
+        .map((ph) => {
+          const param = (node.parameters ?? []).find((p) => p.name === ph && p.location === 'path');
+          return param?.semanticType;
+        })
+        .filter((st): st is string => Boolean(st));
+      if (!inScopeTypes.length) continue;
+      const record: OffenderRecord = {
+        file: f,
+        endpoint: endpointKey,
+        placeholderSemanticTypes: [...new Set(inScopeTypes)],
+      };
+      offenders.push(record);
+      // Structural-cause check: at least one placeholder type must be
+      // unreachable via authoritative producers (i.e. NOT in
+      // `authoritativelyReachable`). If every placeholder type IS
+      // reachable, the planner has unjustified residual logic and the
+      // test fails loudly — that is the regression we want to catch.
+      const allReachable = record.placeholderSemanticTypes.every((st) =>
+        authoritativelyReachable.has(st),
+      );
+      if (allReachable) structuralViolations.push(record);
+      else structuralOk.push(record);
+    }
+    // Documented current-state sanity: the bucket is non-empty (the
+    // upstream gap is unresolved) but every offender's structural cause
+    // checks out. Both halves are necessary — an empty bucket would mean
+    // the upstream gap closed and this guard should be retired in favour
+    // of the strict empty-set assertion (see #54 acceptance criteria);
+    // a non-empty `structuralViolations` means the planner is dropping
+    // chains for endpoints that should have been planned.
+    expect(
+      structuralViolations,
+      'Bug C offenders that DO have authoritatively-reachable placeholder semantic types — the planner should have planned these chains. Investigate the BFS rather than upstream.',
+    ).toEqual([]);
+    // Self-healing upper bound: if every offender drops out (upstream
+    // closed the gap), the bucket is empty and the test still passes
+    // — at which point the structural-cause infrastructure becomes
+    // redundant and the test should be replaced with `expect(offenders)
+    // .toEqual([])` (the strict form from #54).
+    if (offenders.length === 0) {
+      // Nothing to assert; documented as a TODO via comment above.
+      return;
+    }
+    // Otherwise, every offender must be in the structural-OK bucket.
+    expect(offenders.length).toBe(structuralOk.length);
+  });
 });
 
 describe('bundled-spec invariants: emitted Playwright suite', () => {

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -612,10 +612,10 @@ describe('bundled-spec invariants: planner output', () => {
     // `x-semantic-provider: true` producers in the bundled spec. List
     // endpoints (searchUserTasks, searchIncidents, searchAuditLogs,
     // searchVariables, searchDecisionInstances, searchGlobalTaskListeners)
-    // emit the entity keys with `provider: false`; the per-op gate in
-    // graphLoader.ts (#97 path) excludes them from `producersByType`,
-    // leaving the planner with no upstream producer to graft. The same
-    // gap also blocks two endpoints whose direct producer DOES exist
+    // emit the entity keys with `provider: false`; in this graph shape
+    // that leaves the planner with no authoritative upstream producer to
+    // graft for the affected chain. The same gap also blocks two
+    // endpoints whose direct producer DOES exist
     // (DecisionEvaluationInstanceKey/Key via evaluateDecision) because
     // evaluateDecision itself transitively requires DecisionDefinitionId,
     // which has zero authoritative producers.
@@ -644,8 +644,10 @@ describe('bundled-spec invariants: planner output', () => {
     }
     const graph = loadGraph();
     const opByEndpointKey = new Map<string, OperationNode>();
+    const opByOperationId = new Map<string, OperationNode>();
     for (const op of graph.operations) {
       opByEndpointKey.set(`${op.method.toUpperCase()} ${op.path}`, op);
+      opByOperationId.set(op.operationId, op);
     }
     // Authoritative producers per semantic type (provider:true only). This
     // is the same signal `graphLoader.normalizeOp` uses to populate
@@ -669,7 +671,7 @@ describe('bundled-spec invariants: planner output', () => {
     // parameters with `required: true`). Mirrors `extractRequires` in
     // graphLoader.ts.
     const requiredInputsOf = (opId: string): string[] => {
-      const op = graph.operations.find((o) => o.operationId === opId);
+      const op = opByOperationId.get(opId);
       if (!op) return [];
       const set = new Set<string>();
       for (const e of op.requestBodySemanticTypes ?? []) {
@@ -720,7 +722,17 @@ describe('bundled-spec invariants: planner output', () => {
     for (const f of readdirSync(FEATURE_SCENARIOS_DIR)) {
       if (!f.endsWith('-scenarios.json')) continue;
       const plannerPath = join(SCENARIOS_DIR, f);
-      if (!existsSync(plannerPath)) continue;
+      // The pipeline emits one planner-scenarios file per feature-scenarios
+      // file (same normalised filename). A missing companion is a pipeline
+      // bug — fail fast rather than silently skip and mask it.
+      if (!existsSync(plannerPath)) {
+        throw new Error(
+          `Missing planner scenario file for feature scenario ${relative(
+            REPO_ROOT,
+            join(FEATURE_SCENARIOS_DIR, f),
+          )}; expected ${relative(REPO_ROOT, plannerPath)}`,
+        );
+      }
       // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
       const planner = JSON.parse(readFileSync(plannerPath, 'utf8')) as PlannerScenarioFile;
       const hasSatisfiedChain = (planner.scenarios ?? []).some(
@@ -735,7 +747,14 @@ describe('bundled-spec invariants: planner output', () => {
       if (!placeholders.length) continue;
       const endpointKey = `${file.endpoint.method.toUpperCase()} ${file.endpoint.path}`;
       const node = opByEndpointKey.get(endpointKey);
-      if (!node) continue;
+      // A missing dependency-graph node for an endpoint that has a
+      // feature-output file is a graph/feature-output mismatch (or an
+      // endpoint-keying bug) — fail fast rather than silently skip.
+      if (!node) {
+        throw new Error(
+          `Missing dependency-graph node for endpoint ${endpointKey} referenced by feature scenario ${f}. This indicates a graph/feature-output mismatch or endpoint-keying bug.`,
+        );
+      }
       const inScopeTypes = placeholders
         .map((ph) => {
           const param = (node.parameters ?? []).find((p) => p.name === ph && p.location === 'path');

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -596,12 +596,12 @@ describe('bundled-spec invariants: planner output', () => {
     expect(offenders).toEqual([]);
   });
 
-  it('every Bug-C feature scenario (placeholder has semanticType but no satisfied chain) traces to a missing upstream x-semantic-provider annotation (#54)', () => {
-    // Issue #54 — strict complement of the Bug A invariant inside the
-    // `semanticType`-known subset. A "Bug C" offender is a feature scenario
-    // whose endpoint path has `{placeholders}` whose path parameter has a
+  it('every feature scenario whose placeholder has a known semanticType but no satisfied chain traces to a missing upstream x-semantic-provider annotation (#54)', () => {
+    // Issue #54 — strict complement of the #52 invariant inside the
+    // `semanticType`-known subset. An offender is a feature scenario whose
+    // endpoint path has `{placeholders}` whose path parameter has a
     // recognised `semanticType` AND no planner scenario assembled a
-    // fully-satisfied chain. The Bug A invariant (above) silently filters
+    // fully-satisfied chain. The #52 invariant (above) silently filters
     // these out via `if (!hasSatisfiedChain) continue;`; this invariant
     // re-surfaces them and asserts they all share the same root cause.
     //
@@ -629,9 +629,11 @@ describe('bundled-spec invariants: planner output', () => {
     // here, the structural-cause check fails and this test fails loudly.
     //
     // Out of scope:
-    //  - Bug A (fixed in #52, guarded by the invariant above).
-    //  - Bug B (placeholder lacks `semanticType` upstream — #53), filtered
-    //    out by the `param?.semanticType` gate.
+    //  - #52 (planner dropped chains for endpoints that DID have
+    //    authoritative producers — fixed and guarded by the invariant
+    //    above).
+    //  - #53 (placeholder parameter lacks an upstream `semanticType` tag
+    //    altogether) — filtered out by the `param?.semanticType` gate.
     if (!existsSync(FEATURE_SCENARIOS_DIR)) {
       throw new Error(
         `Feature-output directory not found at ${FEATURE_SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
@@ -653,7 +655,7 @@ describe('bundled-spec invariants: planner output', () => {
     // Intentionally stricter than `producersByType`: `graphLoader.normalizeOp`
     // currently falls back to treating every response semantic as a
     // producer when an op has no provider flags at all (graphLoader.ts
-    // ~lines 372-381; tracked for removal in #97). The Bug-C diagnosis is
+    // ~lines 372-381; tracked for removal in #97). The #54 diagnosis is
     // about authoritative producers, not the fallback set, so we re-derive
     // the strict authoritative-only relation here and avoid coupling the
     // invariant to internal planner state.
@@ -815,7 +817,7 @@ describe('bundled-spec invariants: planner output', () => {
     // chains for endpoints that should have been planned.
     expect(
       structuralViolations,
-      'Bug C offenders that DO have authoritatively-reachable placeholder semantic types — the planner should have planned these chains. Investigate the BFS rather than upstream.',
+      '#54 offenders that DO have authoritatively-reachable placeholder semantic types — the planner should have planned these chains. Investigate the BFS rather than upstream.',
     ).toEqual([]);
     // Self-healing upper bound: if every offender drops out (upstream
     // closed the gap), the bucket is empty and the test still passes


### PR DESCRIPTION
## Summary

Closes #54. Adds a class-scoped Layer-3 invariant for the **Bug C** defect family — feature scenarios whose endpoint path has `{placeholders}` whose path parameter has a recognised `semanticType` AND no planner scenario assembled a fully-satisfied chain. The Bug A invariant ([#52](https://github.com/camunda/api-test-generator/pull/52)) silently filters these out via `if (!hasSatisfiedChain) continue;`; this invariant re-surfaces them and asserts they share the same root cause.

## Diagnosis on the pinned bundled spec (`2b2b962a…`)

86 endpoints have `semanticType` placeholders. 65 plan a satisfied chain (Bug A invariant in-scope). 21 are Bug C offenders, all attributable to a single upstream-spec gap:

| Cause | Count | Examples |
|---|---|---|
| Placeholder `semanticType` has zero `provider:true` producers | 19 | `searchUserTasks`, `searchIncidents`, `searchAuditLogs`, `searchVariables`, `searchDecisionInstances`, `searchGlobalTaskListeners` emit the entity keys with `provider: false` |
| Placeholder DOES have a `provider:true` producer, but the producer's transitive requirements are unauthoritative | 2 | `evaluateDecision` produces `DecisionEvaluationInstanceKey` / `DecisionEvaluationKey` but requires `DecisionDefinitionId` (zero authoritative producers) |

Every offender bottoms out in the upstream gap tracked at [`camunda/camunda#52169`](https://github.com/camunda/camunda/issues/52169) (same gap referenced by [#97](https://github.com/camunda/api-test-generator/pull/97)). The right fix is upstream `x-semantic-provider: true` annotations; nothing in this repo needs to change to plan these chains.

Per-failure-mode breakdown (from the issue description): no offender falls into the **chain-too-long** or **extractor-miss** categories — every one is the **cascading-Bug-B-inside-the-chain** mode (cf. [#53](https://github.com/camunda/api-test-generator/issues/53)).

## How the invariant works

The invariant computes `authoritativelyReachable` as a least fixpoint over `(authoritativeProducer, requiredInputs)` edges:

> `T ∈ authoritativelyReachable` iff some `op ∈ producersByType[T]` with `op.providerMap[T] === true` has every member of `requires(op)` already in `authoritativelyReachable`.

It then asserts every Bug C offender has at least one placeholder `semanticType` **outside** that set. The structure mirrors what the planner's BFS would converge on, so the invariant cannot accidentally accept a planner regression:

- **Self-healing**: when upstream lands an `x-semantic-provider: true` annotation that breaks the chain open for one of these endpoints, that endpoint drops out of the offender list and the assertion still passes. Once the bucket reaches zero, this guard can be replaced with `expect(offenders).toEqual([])` (the strict form).
- **Regression-tight**: if the planner regresses such that an endpoint with a satisfiable chain (i.e. all placeholder types in `authoritativelyReachable`) ends up in the Bug C bucket, `structuralViolations` becomes non-empty and the test fails loudly with a pointer to the defect class.

## Out of scope

- Bug A — fixed in [#52](https://github.com/camunda/api-test-generator/pull/52); guarded by the invariant immediately above this one in the same `describe` block.
- Bug B — placeholder lacks `semanticType` upstream ([#53](https://github.com/camunda/api-test-generator/issues/53)); filtered out by the `param?.semanticType` gate.

## Verification

- `npm run lint` — clean (Biome)
- `tsc --noEmit` — clean (path-analyser, request-validation, semantic-graph-extractor)
- `npm test` — **150 / 150** (was 149/149 before; the new Bug C invariant is the +1, green)
- `npm run testsuite:generate` against pinned spec emits 183 endpoint suites
- Net accounting: `86 - 65 - 21 = 0` unaccounted endpoints. The Bug A invariant remains green.

## Acceptance (per #54)

- [x] new invariant passes against the pinned bundled spec
- [x] Bug A invariant remains green (no scope drift)
- [x] endpoint-count delta reported in the PR (21 / 86 → 0 / 86 once upstream lands)

Closes #54
Refs #52, #53, #97, camunda/camunda#52169
