### PR TITLE
feat(planner): annotate scenarios with unbindable path placeholders

### DIFF
--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -272,6 +272,8 @@ async function main() {
       unsatisfied: !!collection.unsatisfied,
       missingSemanticTypes: collection.scenarios.find((s) => s.id === 'unsatisfied')
         ?.missingSemanticTypes,
+      missingPathPlaceholders: collection.scenarios.find((s) => s.id === 'unsatisfied')
+        ?.missingPathPlaceholders,
     });
     processed++;
   }

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -272,7 +272,12 @@ async function main() {
       unsatisfied: !!collection.unsatisfied,
       missingSemanticTypes: collection.scenarios.find((s) => s.id === 'unsatisfied')
         ?.missingSemanticTypes,
-      missingPathPlaceholders: collection.scenarios.find((s) => s.id === 'unsatisfied')
+      // `missingPathPlaceholders` is stamped on every scenario by the planner
+      // (it is a per-endpoint fact, not a per-scenario one), so read it from
+      // any scenario rather than only the `unsatisfied` one — the offenders
+      // we want to surface here are precisely those whose scenarios are
+      // satisfied but whose URL still leaks a literal `${placeholder}`.
+      missingPathPlaceholders: collection.scenarios.find((s) => s.missingPathPlaceholders?.length)
         ?.missingPathPlaceholders,
     });
     processed++;
@@ -297,6 +302,29 @@ async function main() {
   }
 
   console.log(`Generated scenario files for ${processed} endpoints.`);
+  // Surface endpoints whose URL contains a path placeholder no chain step or
+  // global seed can bind. The planner still emits these scenarios, but the
+  // rendered URL leaks a literal `${placeholder}` at runtime. The cure is
+  // upstream `x-semantic-type` tags (#53). Logging here gives a one-glance
+  // signal rather than requiring reviewers to grep summary JSON.
+  const blocked: { endpoint: string; placeholders: string[] }[] = [];
+  for (const e of summaryEntries) {
+    const collection = e;
+    if (collection.missingPathPlaceholders?.length) {
+      blocked.push({
+        endpoint: `${collection.method.toUpperCase()} ${collection.path}`,
+        placeholders: collection.missingPathPlaceholders,
+      });
+    }
+  }
+  if (blocked.length) {
+    console.log(
+      `\n${blocked.length} endpoint(s) have unbindable path placeholders (blocked on #53):`,
+    );
+    for (const b of blocked) {
+      console.log(`  ${b.endpoint}  →  {${b.placeholders.join(', ')}}`);
+    }
+  }
 }
 
 main().catch((err) => {

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -52,6 +52,27 @@ export function generateScenariosForEndpoint(
   const required = [...endpoint.requires.required];
   const optional = [...endpoint.requires.optional];
 
+  // Detect path placeholders that no chain step and no global context seed
+  // can bind. These are typically admin-entity IDs whose path parameter has
+  // no upstream `x-semantic-type` tag (issue #53). The BFS still plans
+  // chains for any *typed* requirements (so e.g. `tenantId` in
+  // `/tenants/{tenantId}/roles/{roleId}` is still chained from
+  // `createTenant`), but every emitted scenario is annotated with
+  // `missingPathPlaceholders` so downstream consumers — and the
+  // planner-correctness invariant in
+  // tests/regression/bundled-spec-invariants.test.ts — know the rendered
+  // URL will leak a literal `${placeholder}` at runtime.
+  const seededPlaceholderNames = new Set(
+    (graph.domain?.globalContextSeeds ?? []).map((s) => s.fieldName),
+  );
+  const unbindablePlaceholders = [...endpoint.path.matchAll(/\{([^}]+)\}/g)]
+    .map((m) => m[1])
+    .filter((ph) => {
+      if (seededPlaceholderNames.has(ph)) return false;
+      const param = (endpoint.pathParameters ?? []).find((p) => p.name === ph);
+      return !param?.semanticType;
+    });
+
   // Domain requirements flattening (for initial endpoint) - treat all domainRequiresAll as required states for ranking only (not gating existing logic yet)
   const domainRequiredStates = endpoint.domainRequiresAll ? [...endpoint.domainRequiresAll] : [];
   const domainDisjunctions = endpoint.domainDisjunctions ? [...endpoint.domainDisjunctions] : [];
@@ -73,6 +94,9 @@ export function generateScenariosForEndpoint(
       hasEventuallyConsistent: endpoint.eventuallyConsistent || undefined,
       eventuallyConsistentCount: endpoint.eventuallyConsistent ? 1 : undefined,
       domainStatesRequired: domainRequiredStates.length ? domainRequiredStates : undefined,
+      missingPathPlaceholders: unbindablePlaceholders.length
+        ? [...unbindablePlaceholders]
+        : undefined,
     };
     return {
       endpoint: toRef(endpoint),
@@ -101,6 +125,9 @@ export function generateScenariosForEndpoint(
       producedSemanticTypes: [...endpoint.produces],
       satisfiedSemanticTypes: endpoint.produces.filter((s) => initialNeeded.has(s)),
       missingSemanticTypes: missing,
+      missingPathPlaceholders: unbindablePlaceholders.length
+        ? [...unbindablePlaceholders]
+        : undefined,
       hasEventuallyConsistent: endpoint.eventuallyConsistent || undefined,
       eventuallyConsistentCount: endpoint.eventuallyConsistent ? 1 : undefined,
       domainStatesRequired: domainRequiredStates.length ? domainRequiredStates : undefined,
@@ -651,6 +678,16 @@ export function generateScenariosForEndpoint(
     if (aBoot !== bBoot) return bBoot - aBoot; // any bootstrap before none
     return a.operations.length - b.operations.length;
   });
+
+  // Annotate every emitted scenario with the unbindable-placeholder list so
+  // downstream consumers (codegen, the planner-correctness invariant) can
+  // see at scenario granularity that the URL will leak `${placeholder}` at
+  // runtime even though the typed semantic chain is satisfied.
+  if (unbindablePlaceholders.length) {
+    for (const s of scenarios) {
+      s.missingPathPlaceholders = [...unbindablePlaceholders];
+    }
+  }
 
   return {
     endpoint: toRef(endpoint),

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -72,6 +72,12 @@ export interface EndpointScenario {
   producedSemanticTypes: string[];
   satisfiedSemanticTypes: string[]; // semantic types endpoint needs
   missingSemanticTypes?: string[]; // only for unsatisfied scenario
+  // Path placeholders that could not be bound by any chain step or global
+  // context seed (e.g. an admin-entity ID whose parameter lacks an upstream
+  // `x-semantic-type` tag — issue #53). Set on the unsatisfied scenario
+  // emitted by `generateScenariosForEndpoint` when the placeholder would
+  // otherwise leak as a literal `${name}` into the rendered URL.
+  missingPathPlaceholders?: string[];
   cycleInvolved?: boolean;
   productionMap?: Record<string, string>; // semanticType -> operationId
   providerList?: Record<string, string[]>; // semanticType -> all producing opIds encountered
@@ -141,6 +147,7 @@ export interface GenerationSummaryEntry {
   scenarioCount: number;
   unsatisfied: boolean;
   missingSemanticTypes?: string[];
+  missingPathPlaceholders?: string[];
 }
 
 // Feature coverage variant spec (internal planning structure)

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -831,6 +831,112 @@ describe('bundled-spec invariants: planner output', () => {
     // Otherwise, every offender must be in the structural-OK bucket.
     expect(offenders.length).toBe(structuralOk.length);
   });
+
+  it('no planner scenario is marked satisfied while leaving a path placeholder unbindable', () => {
+    // Planner-correctness guard. The BFS only considers `requiredSemanticTypes`
+    // when deciding whether a scenario is satisfied. If a path placeholder's
+    // parameter has no `semanticType` upstream, the planner silently drops it
+    // from the requirement set and reports `unsatisfied: false`, even though
+    // the emitted URL will contain a literal `${placeholder}` at runtime
+    // (because no chain step extracts it and no global seed binds it).
+    //
+    // Concrete example (current bundled spec):
+    //   PUT /tenants/{tenantId}/roles/{roleId}
+    //   - tenantId: semanticType=TenantId (chained via createTenant)
+    //   - roleId:   no semanticType (issue #53 — admin-entity untyped)
+    //   Planner output: unsatisfied=false, satisfiedSemanticTypes=[TenantId]
+    //   Generated URL: /tenants/${ctx.tenantIdVar}/roles/${ctx.roleIdVar || '${roleId}'}
+    //   → ctx.roleIdVar is never set; URL leaks `${roleId}` literal at runtime.
+    //
+    // This is more dangerous than #53's single-placeholder case because the
+    // scenario *looks* satisfied to a reviewer scanning the planner output.
+    //
+    // Invariant: for every planner scenario marked satisfied (no
+    // `missingSemanticTypes`), every `{placeholder}` in the endpoint path
+    // must be bindable from at least one of:
+    //   (a) the placeholder's path parameter has a `semanticType` (the
+    //       existing chain machinery is responsible for binding it);
+    //   (b) the placeholder name matches a `globalContextSeeds[].fieldName`
+    //       in `path-analyser/domain-semantics.json` (e.g. `tenantId`).
+    if (!existsSync(SCENARIOS_DIR)) {
+      throw new Error(
+        `Planner scenarios directory not found at ${SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+      );
+    }
+    const graph = loadGraph();
+    const opByEndpointKey = new Map<string, OperationNode>();
+    for (const op of graph.operations) {
+      opByEndpointKey.set(`${op.method.toUpperCase()} ${op.path}`, op);
+    }
+    interface DomainSemanticsFile {
+      globalContextSeeds?: { fieldName: string }[];
+    }
+    const domainPath = join(REPO_ROOT, 'path-analyser', 'domain-semantics.json');
+    if (!existsSync(domainPath)) {
+      throw new Error(`domain-semantics.json not found at ${domainPath}`);
+    }
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const domain = JSON.parse(readFileSync(domainPath, 'utf8')) as DomainSemanticsFile;
+    const seededPlaceholders = new Set((domain.globalContextSeeds ?? []).map((s) => s.fieldName));
+    interface PlannerScenarioFile {
+      endpoint: { method: string; path: string };
+      unsatisfied?: boolean;
+      scenarios: {
+        id: string;
+        missingSemanticTypes?: string[];
+        missingPathPlaceholders?: string[];
+      }[];
+    }
+    const offenders: { file: string; endpoint: string; unbindable: string[] }[] = [];
+    for (const f of readdirSync(SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const planner = JSON.parse(
+        readFileSync(join(SCENARIOS_DIR, f), 'utf8'),
+      ) as PlannerScenarioFile;
+      if (planner.unsatisfied === true) continue;
+      const placeholders = [...planner.endpoint.path.matchAll(/\{([^}]+)\}/g)].map((m) => m[1]);
+      if (!placeholders.length) continue;
+      const endpointKey = `${planner.endpoint.method.toUpperCase()} ${planner.endpoint.path}`;
+      const node = opByEndpointKey.get(endpointKey);
+      if (!node) {
+        throw new Error(
+          `Missing dependency-graph node for endpoint ${endpointKey} referenced by planner file ${f}.`,
+        );
+      }
+      const pathParams = (node.parameters ?? []).filter((p) => p.location === 'path');
+      // A placeholder is independently bindable iff its path parameter has a
+      // semanticType (the chain machinery is responsible for binding it) OR
+      // its name matches a global context seed. This check does not consult
+      // the planner's `missingPathPlaceholders` annotation — that is what
+      // we are validating — so the invariant catches a regression where the
+      // planner stops annotating these scenarios.
+      const unbindable = placeholders.filter((ph) => {
+        if (seededPlaceholders.has(ph)) return false;
+        const param = pathParams.find((p) => p.name === ph);
+        return !param?.semanticType;
+      });
+      if (!unbindable.length) continue;
+      // A scenario is "fully claimed satisfied" iff both `missingSemanticTypes`
+      // and `missingPathPlaceholders` are empty. The presence of
+      // `missingPathPlaceholders` (set by `generateScenariosForEndpoint`) is
+      // the planner's signal that the URL will leak a literal placeholder.
+      // If any scenario claims full satisfaction while the endpoint has an
+      // unbindable placeholder, the planner is silently lying.
+      const hasFullySatisfied = (planner.scenarios ?? []).some(
+        (s) =>
+          (!s.missingSemanticTypes || s.missingSemanticTypes.length === 0) &&
+          (!s.missingPathPlaceholders || s.missingPathPlaceholders.length === 0),
+      );
+      if (hasFullySatisfied) {
+        offenders.push({ file: f, endpoint: endpointKey, unbindable });
+      }
+    }
+    expect(
+      offenders,
+      'Planner reported satisfied scenarios for endpoints whose URL has unbindable path placeholders. Either upstream must add an x-semantic-type tag (issue #53), or the planner must annotate the scenario with `missingPathPlaceholders` so the broken URL is not silently emitted.',
+    ).toEqual([]);
+  });
 });
 
 describe('bundled-spec invariants: emitted Playwright suite', () => {


### PR DESCRIPTION
## What this PR does (and does not) do

**Visibility only.** This PR does **not** fix the runtime breakage. The 45 affected endpoints will still 404 against a real broker after this lands. It (a) annotates each scenario with the unbindable placeholders so the broken URL stops hiding behind a seemingly-satisfied chain, and (b) prints the affected endpoints at the end of every pipeline run so reviewers don't have to grep summary JSON.

The actual remediation is upstream `x-semantic-type` tags, tracked at #53 (and `camunda/camunda#52169`). Once those land, `missingPathPlaceholders` becomes empty and the affected endpoints rejoin the working suite without a code change here.

## Problem

When an endpoint path contains a `{placeholder}` whose path parameter has no upstream `x-semantic-type` and no matching `globalContextSeeds` entry, no chain step or seed prologue populates it. The emitter falls back to the literal `${placeholder}` in the rendered URL.

Until now the planner silently ignored these untyped placeholders when deciding whether a scenario was satisfied:

```
PUT /tenants/{tenantId}/roles/{roleId}
  unsatisfied: false
  chain: createTenant → assignRoleToTenant
  rendered URL: /tenants/${ctx.tenantIdVar}/roles/${ctx.roleIdVar || "${roleId}"}
                                                ^^^ never set
```

This is more dangerous than the single-untyped-placeholder shape covered by #53 because the chain *looks* correct to a reviewer scanning planner output.

## Fix

In `generateScenariosForEndpoint`, after computing the satisfied chain, annotate every emitted scenario with `missingPathPlaceholders` listing every URL placeholder whose parameter lacks a `semanticType` and is not covered by `globalContextSeeds[].fieldName`. The chain is preserved (so the existing #95 / #52 invariants continue to see the typed-portion chain), but downstream consumers and reviewers get an explicit signal that the URL will leak.

## Pipeline log

At the end of `npm run testsuite:generate` the orchestrator now prints e.g.

```
Generated scenario files for 183 endpoints.

45 endpoint(s) have unbindable path placeholders (blocked on #53):
  GET /groups/{groupId}  →  {groupId}
  PUT /tenants/{tenantId}/roles/{roleId}  →  {roleId}
  ...
```

This is the consumer of the new annotation. Without it, the JSON field is just structural overhead.

## Tests

Layer-3 consistency invariant added in `tests/regression/bundled-spec-invariants.test.ts`:

> "no planner scenario is marked satisfied while leaving a path placeholder unbindable"

- **Red**: fails on `main` with 45 offenders covering the admin-entity surface (groups, roles, mapping-rules, clients, global cluster variables, and co-placeholder cases like `/tenants/{tenantId}/roles/{roleId}`). The bindability check uses the dependency graph + `globalContextSeeds` directly, so it does not depend on the planner annotation it validates.
- **Green**: passes after this commit; every offender carries a populated `missingPathPlaceholders`.

This is a *consistency* guard (planner annotation matches independent bindability check), not a *don't-let-new-ones-in* guard. A future spec bump that introduces a new untagged admin-entity endpoint would still pass — it would just appear in the pipeline log next to the existing 45.

## Why annotate rather than skip / refuse

Considered alternatives:

- **Refuse to plan** (mark whole scenario `unsatisfied`) — broke #95 and #52, which expect typed-requirement chains to be planned. Broadens blast radius.
- **Skip emission** — cleaner runtime story, but hides 45 endpoints from the suite without an obvious signal.
- **Emitter throw** — better runtime DX than today, still ships failing tests.

The annotation + log is the smallest correct visibility step. It's forward-compatible: when upstream tags land per-endpoint, those endpoints drop out of the log and silently rejoin the working suite without a code change here.

## Local gates

- `npm run lint` — clean
- `npx tsc --noEmit -p {semantic-graph-extractor,path-analyser,request-validation}/tsconfig.json` — clean
- `npm test` — 151/151 (was 150/150)
