### PR TITLE
fix(planner): mark BFS-give-up scenarios as unsatisfied

### DIFF
--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -652,6 +652,44 @@ export function generateScenariosForEndpoint(
     return a.operations.length - b.operations.length;
   });
 
+  // BFS-give-up guard: if the search loop exhausted its queue without
+  // completing any scenario (typically because every producer for a
+  // required semantic type self-cycles or its own prerequisites are
+  // unreachable), surface that as `unsatisfied: true` rather than a
+  // silent `{ scenarios: [], unsatisfied: false }` — the latter would
+  // mislead every downstream consumer that trusts `unsatisfied: false`
+  // (orchestrator logs, codegen, Layer-3 invariants). The early return
+  // above only catches the simpler case where `producersByType` is
+  // empty for a required type; this branch covers "producers exist but
+  // BFS cannot reach a terminal state from them". Mirror the early
+  // return's shape so downstream code paths handle both uniformly.
+  if (scenarios.length === 0) {
+    scenarios.push({
+      id: 'unsatisfied',
+      operations: [toRef(endpoint)],
+      producedSemanticTypes: [...endpoint.produces],
+      satisfiedSemanticTypes: [],
+      // Report every required semantic type as missing — including any
+      // the endpoint self-produces. The early-return branch above filters
+      // out endpoint-self-produced types because they will exist after
+      // the call for downstream consumers; here we are signalling the
+      // BFS could not build a *prerequisite* chain, and an endpoint
+      // cannot be its own prerequisite (it cannot bind its own URL
+      // placeholder from its own response).
+      missingSemanticTypes: [...initialNeeded],
+      hasEventuallyConsistent: endpoint.eventuallyConsistent || undefined,
+      eventuallyConsistentCount: endpoint.eventuallyConsistent ? 1 : undefined,
+      domainStatesRequired: domainRequiredStates.length ? domainRequiredStates : undefined,
+    });
+    return {
+      endpoint: toRef(endpoint),
+      requiredSemanticTypes: required,
+      optionalSemanticTypes: optional,
+      scenarios,
+      unsatisfied: true,
+    };
+  }
+
   return {
     endpoint: toRef(endpoint),
     requiredSemanticTypes: required,

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -831,6 +831,68 @@ describe('bundled-spec invariants: planner output', () => {
     // Otherwise, every offender must be in the structural-OK bucket.
     expect(offenders.length).toBe(structuralOk.length);
   });
+
+  it('no planner result has zero scenarios while reporting unsatisfied=false', () => {
+    // Planner-correctness guard. The BFS in `generateScenariosForEndpoint`
+    // exits the search loop after exhausting its queue and unconditionally
+    // returns `unsatisfied: false` regardless of whether any scenario was
+    // actually completed. When an endpoint's required semantic type has
+    // producers, but every producer either self-cycles (e.g. `getUserTask`
+    // requires UserTaskKey to produce UserTaskKey) or its own prerequisites
+    // are unreachable, the BFS exhausts the queue with zero completed
+    // chains and the result is `{ scenarios: [], unsatisfied: false }`.
+    //
+    // Concrete example (current bundled spec):
+    //   POST /user-tasks/{userTaskKey}/assignment  requires UserTaskKey
+    //   producersByType[UserTaskKey] = [getUserTask, getAuditLog]
+    //   - getUserTask requires UserTaskKey itself (self-cycle)
+    //   - getAuditLog requires AuditLogKey, whose only producer also
+    //     self-cycles
+    //   Planner output: { scenarios: [], unsatisfied: false }
+    //   Generated test: POST `${baseUrl}/user-tasks/${ctx.userTaskKeyVar
+    //                          || '${userTaskKey}'}/assignment`
+    //   → URL leaks `${userTaskKey}` literal at runtime.
+    //
+    // This is structurally the same broken-URL shape covered by the
+    // unbindable-placeholder cases (45 endpoints blocked on upstream #53),
+    // but the cause is internal to the planner: a producer exists, the BFS
+    // just cannot use it. The result is silent — `unsatisfied: false` is
+    // the strongest possible "this endpoint is fine" signal in the planner
+    // output, and downstream code (orchestrator logs, the codegen, every
+    // Layer-3 invariant) trusts it.
+    //
+    // Invariant: for every planner result, if `scenarios.length === 0` then
+    // `unsatisfied` must be `true`. The planner is allowed to give up; it
+    // is not allowed to give up silently.
+    if (!existsSync(SCENARIOS_DIR)) {
+      throw new Error(
+        `Planner scenarios directory not found at ${SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+      );
+    }
+    interface PlannerResultFile {
+      endpoint: { method: string; path: string; operationId: string };
+      requiredSemanticTypes?: string[];
+      scenarios: unknown[];
+      unsatisfied?: boolean;
+    }
+    const offenders: { op: string; endpoint: string; required: string[] }[] = [];
+    for (const f of readdirSync(SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const planner = JSON.parse(readFileSync(join(SCENARIOS_DIR, f), 'utf8')) as PlannerResultFile;
+      if (!Array.isArray(planner.scenarios) || planner.scenarios.length > 0) continue;
+      if (planner.unsatisfied === true) continue;
+      offenders.push({
+        op: planner.endpoint.operationId,
+        endpoint: `${planner.endpoint.method.toUpperCase()} ${planner.endpoint.path}`,
+        required: planner.requiredSemanticTypes ?? [],
+      });
+    }
+    expect(
+      offenders,
+      'Planner returned an empty scenarios array while reporting unsatisfied=false. The BFS exhausted its queue without completing any chain (typically because every producer for the required semantic type self-cycles or has unreachable prereqs). The planner must mark these as unsatisfied — silent zero-scenario results break every downstream consumer that trusts unsatisfied=false.',
+    ).toEqual([]);
+  });
 });
 
 describe('bundled-spec invariants: emitted Playwright suite', () => {


### PR DESCRIPTION
## Problem

When `generateScenariosForEndpoint`'s BFS exhausted its queue without completing any chain — typically because every producer for a required semantic type self-cycles or its prerequisites are unreachable — the result was:

```json
{ "scenarios": [], "unsatisfied": false }
```

Downstream code treats `unsatisfied: false` as "this endpoint is fine". The codegen then emits a 1-step spec whose URL leaks a literal `${placeholder}` at runtime. Structurally the same broken-URL shape as the endpoints blocked on upstream #53 — but with a cause internal to the planner: a producer **does** exist, the BFS just cannot use it.

Concrete trace on the bundled spec:

```
POST /user-tasks/{userTaskKey}/assignment   requires UserTaskKey
  producersByType[UserTaskKey] = [getUserTask, getAuditLog]
  - getUserTask requires UserTaskKey itself  → self-cycle, skipped
  - getAuditLog requires AuditLogKey, whose only producer (getAuditLog
    itself, the second in producersByType) also self-cycles → dead end
  Queue exhausts → unsatisfied: false (silent)
  Generated test URL: `${baseUrl}/user-tasks/${ctx.userTaskKeyVar
                       || '${userTaskKey}'}/assignment`
                                            ^^^ never set, leaks at runtime
```

20 endpoints affected: `getAuditLog`, `evaluateDecision`, `getDecisionInstance`, `deleteDecisionInstance`, `createGlobalTaskListener`, `getGlobalTaskListener`, `updateGlobalTaskListener`, `deleteGlobalTaskListener`, `getIncident`, `resolveIncident`, `getUserTask`, `updateUserTask`, `unassignUserTask`, `assignUserTask`, `searchUserTaskAuditLogs`, `completeUserTask`, `searchUserTaskEffectiveVariables`, `getUserTaskForm`, `searchUserTaskVariables`, `getVariable`.

## Fix

In `path-analyser/src/scenarioGenerator.ts`, after the BFS loop:

```ts
if (scenarios.length === 0) {
  scenarios.push({
    id: 'unsatisfied',
    operations: [toRef(endpoint)],
    producedSemanticTypes: [...endpoint.produces],
    satisfiedSemanticTypes: [],
    missingSemanticTypes: [...initialNeeded],
    ...
  });
  return { ..., scenarios, unsatisfied: true };
}
```

Mirrors the existing early-return branch's shape so downstream code paths handle both uniformly. Critically, `missingSemanticTypes` is the **entire** `initialNeeded` set — unlike the early-return path we do NOT filter out endpoint-self-produced types, because an endpoint cannot be its own prerequisite (it cannot bind its own URL placeholder from its own response). Without this filter difference, `getUserTask` would still claim `missingSemanticTypes: []` (because it self-produces `UserTaskKey`) and the existing #52 invariant would still see it as "satisfied".

## Tests

Layer-3 invariant added in `tests/regression/bundled-spec-invariants.test.ts`:

> "no planner result has zero scenarios while reporting unsatisfied=false"

- **Red**: 20 offenders on `main`.
- **Green**: 0 offenders after this commit.
- Independent of the fix — reads `scenarios.length` and `unsatisfied` directly from planner output.

## Side effects

20 endpoints flip from `unsatisfied: false` to `unsatisfied: true`, joining the 3 already-unsatisfied (now 23 total). Their broken-URL specs are still emitted (codegen does not gate on `unsatisfied`), but downstream consumers that filter on the flag now see them.

## Local gates

- `npm run lint` — clean
- `npx tsc --noEmit -p {semantic-graph-extractor,path-analyser,request-validation}/tsconfig.json` — clean
- `npm test` — 151/151 (was 150/150)
