### PR TITLE
fix: prefer authoritative producers when grafting feature-output chains

### DIFF
--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -162,13 +162,27 @@ async function main() {
     // graph (an upstream-spec gap) are not regressed.
     const integrationCandidates = collection.scenarios.filter((sc) => sc.id !== 'unsatisfied');
     const requiredTypes = collection.requiredSemanticTypes ?? [];
+    // Restrict the authoritative-producer check to required types that
+    // actually have an authoritative producer somewhere in the graph.
+    // If an endpoint requires types `[A, B]` and only `A` has an
+    // authoritative producer anywhere, requiring chains to authoritatively
+    // produce both would reject every candidate and force the fallback to
+    // length-only selection — at which point the chain might also miss
+    // the authoritative producer for `A`. Filtering first means we still
+    // gate on `A` while exempting `B` (an upstream-spec gap), matching
+    // the L3 invariant's exemption rule.
+    const requiredTypesWithAuthoritativeProducer = requiredTypes.filter((t) =>
+      (graph.producersByType[t] ?? []).some(
+        (opId) => graph.operations[opId]?.providerMap?.[t] === true,
+      ),
+    );
     const isAuthoritativeChain = (sc: EndpointScenario): boolean => {
-      if (!requiredTypes.length) return true;
+      if (!requiredTypesWithAuthoritativeProducer.length) return true;
       // Endpoint-self does not count: an op cannot bind its own URL
       // placeholder from its own response.
       const prereqOpIds = sc.operations.slice(0, -1).map((o) => o.operationId);
       if (!prereqOpIds.length) return false;
-      return requiredTypes.every((t) =>
+      return requiredTypesWithAuthoritativeProducer.every((t) =>
         prereqOpIds.some((opId) => graph.operations[opId]?.providerMap?.[t] === true),
       );
     };

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -140,12 +140,46 @@ async function main() {
     if (featureCollection.scenarios.length > MAX_FEATURE_SCENARIOS) {
       featureCollection.scenarios = featureCollection.scenarios.slice(0, MAX_FEATURE_SCENARIOS);
     }
-    // Choose a representative integration scenario to supply dependency chain (shortest non-unsatisfied with >1 ops; fallback scenario-1)
+    // Choose a representative integration scenario to supply the
+    // dependency chain. Shortest non-`unsatisfied` chain with >1 ops,
+    // *gated on producer authority for the endpoint's required types*.
+    //
+    // The planner's `producersByType` index is intentionally permissive
+    // (it includes echo-only response fields so domain-progression and
+    // witness lenses stay connected — see graphLoader.ts #95). That
+    // means a chain like `createDocument -> cancelProcessInstance` can
+    // satisfy the BFS for ProcessInstanceKey even though createDocument
+    // merely echoes `metadata.processInstanceKey` (provider:false) from
+    // the request. If the selector picked that chain, the extracted
+    // value would be empty at runtime and the URL placeholder would
+    // leak.
+    //
+    // Resolution: among multi-op chains, prefer those whose prerequisite
+    // operations include at least one *authoritative* (provider:true)
+    // producer for every required semantic type. Fall back to the
+    // length-only sort when no such chain exists, so endpoints whose
+    // required types have no authoritative producer anywhere in the
+    // graph (an upstream-spec gap) are not regressed.
     const integrationCandidates = collection.scenarios.filter((sc) => sc.id !== 'unsatisfied');
+    const requiredTypes = collection.requiredSemanticTypes ?? [];
+    const isAuthoritativeChain = (sc: EndpointScenario): boolean => {
+      if (!requiredTypes.length) return true;
+      // Endpoint-self does not count: an op cannot bind its own URL
+      // placeholder from its own response.
+      const prereqOpIds = sc.operations.slice(0, -1).map((o) => o.operationId);
+      if (!prereqOpIds.length) return false;
+      return requiredTypes.every((t) =>
+        prereqOpIds.some((opId) => graph.operations[opId]?.providerMap?.[t] === true),
+      );
+    };
+    const multiOpCandidates = integrationCandidates.filter((sc) => sc.operations.length > 1);
+    const byLength = (a: EndpointScenario, b: EndpointScenario) =>
+      a.operations.length - b.operations.length;
+    const authoritativeMultiOp = multiOpCandidates.filter(isAuthoritativeChain);
     const chainSource =
-      integrationCandidates
-        .filter((sc) => sc.operations.length > 1)
-        .sort((a, b) => a.operations.length - b.operations.length)[0] || integrationCandidates[0];
+      [...authoritativeMultiOp].sort(byLength)[0] ||
+      [...multiOpCandidates].sort(byLength)[0] ||
+      integrationCandidates[0];
     // The chain-graft + requestPlan synthesis must run for every endpoint,
     // not just those with a response shape. Operations with a
     // 204 No-Content response (cancelProcessInstance, completeJob,

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -893,6 +893,116 @@ describe('bundled-spec invariants: planner output', () => {
       'Planner returned an empty scenarios array while reporting unsatisfied=false. The BFS exhausted its queue without completing any chain (typically because every producer for the required semantic type self-cycles or has unreachable prereqs). The planner must mark these as unsatisfied — silent zero-scenario results break every downstream consumer that trusts unsatisfied=false.',
     ).toEqual([]);
   });
+
+  it('every feature scenario chain contains an authoritative producer for each requiredSemanticType', () => {
+    // Chain-selector correctness guard. The feature-output stage in
+    // `path-analyser/src/index.ts` chooses one integration scenario from
+    // the planner output to graft as the dependency chain in front of
+    // every feature scenario. The current selector picks the
+    // shortest non-`unsatisfied` chain with >1 operations and falls back
+    // to `scenarios[0]` — with no check that the producers in that chain
+    // are *authoritative* for the endpoint's required semantic types.
+    //
+    // Concrete example (current bundled spec):
+    //   POST /process-instances/{processInstanceKey}/cancellation
+    //     requiredSemanticTypes: [ProcessInstanceKey]
+    //   planner offers:
+    //     scenario-1: createDocument -> cancelProcessInstance      (length 2)
+    //     scenario-4: createDeployment -> createProcessInstance
+    //                 -> cancelProcessInstance                     (length 3)
+    //   selector picks scenario-1 because it is shorter.
+    //   But createDocument is NOT an authoritative producer for
+    //   ProcessInstanceKey: its 201 response carries
+    //   `metadata.processInstanceKey` with `provider: false` — it merely
+    //   echoes whatever metadata the request supplied. The "extracted"
+    //   key is empty at runtime and the URL renders with a literal
+    //   `${processInstanceKey}` placeholder.
+    //
+    // The planner's `producersByType` index is intentionally permissive
+    // (it includes echo fields so domain-progression and witness lenses
+    // stay connected — see graphLoader.ts #95). The chain selector is
+    // the right place to prefer authoritative providers, because it
+    // chooses which single chain becomes the test prefix.
+    //
+    // Invariant: for every feature scenario whose endpoint has a
+    // non-empty `requiredSemanticTypes`, every chain operation set must
+    // contain at least one operation whose response declares that
+    // semantic type with `provider: true`. If no authoritative producer
+    // for a required type exists *anywhere* in the graph, the type is
+    // exempt — that is an upstream-spec gap, not a selector bug.
+    if (!existsSync(FEATURE_SCENARIOS_DIR)) {
+      throw new Error(
+        `Feature-output directory not found at ${FEATURE_SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+      );
+    }
+    const graph = loadGraph();
+    const authoritativeProducers = new Map<string, Set<string>>();
+    for (const op of graph.operations) {
+      for (const [status, arr] of Object.entries(op.responseSemanticTypes ?? {})) {
+        if (!/^2\d\d$/.test(status)) continue;
+        for (const entry of arr) {
+          if (entry.provider !== true) continue;
+          let bucket = authoritativeProducers.get(entry.semanticType);
+          if (!bucket) {
+            bucket = new Set();
+            authoritativeProducers.set(entry.semanticType, bucket);
+          }
+          bucket.add(op.operationId);
+        }
+      }
+    }
+
+    interface FeatureScenarioFile {
+      endpoint: { method: string; path: string; operationId: string };
+      requiredSemanticTypes?: string[];
+      unsatisfied?: boolean;
+      scenarios: { id: string; operations: { operationId: string }[] }[];
+    }
+    const offenders: {
+      op: string;
+      scenarioId: string;
+      chain: string[];
+      missingAuthoritative: { type: string; authoritativeProducers: string[] }[];
+    }[] = [];
+    for (const f of readdirSync(FEATURE_SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const feat = JSON.parse(
+        readFileSync(join(FEATURE_SCENARIOS_DIR, f), 'utf8'),
+      ) as FeatureScenarioFile;
+      if (feat.unsatisfied === true) continue;
+      const required = feat.requiredSemanticTypes ?? [];
+      if (!required.length) continue;
+      for (const sc of feat.scenarios ?? []) {
+        const chainOps = (sc.operations ?? []).map((o) => o.operationId);
+        // Endpoint-self does not count: an op cannot bind its own URL
+        // placeholder from its own response. Restrict the search to
+        // prerequisite steps (everything except the final endpoint op).
+        const prereqOps = chainOps.slice(0, -1);
+        if (prereqOps.length === 0) continue;
+        const missing: { type: string; authoritativeProducers: string[] }[] = [];
+        for (const t of required) {
+          const auth = authoritativeProducers.get(t);
+          if (!auth || auth.size === 0) continue; // upstream-spec gap, exempt
+          if (!prereqOps.some((opId) => auth.has(opId))) {
+            missing.push({ type: t, authoritativeProducers: [...auth].sort() });
+          }
+        }
+        if (missing.length) {
+          offenders.push({
+            op: feat.endpoint.operationId,
+            scenarioId: sc.id,
+            chain: chainOps,
+            missingAuthoritative: missing,
+          });
+        }
+      }
+    }
+    expect(
+      offenders,
+      'Feature-output chain selector grafted a prerequisite chain whose producers are not authoritative for the endpoint\'s required semantic type. The selected chain extracts the type from an "echo" response field (e.g. createDocument\'s `metadata.processInstanceKey` with provider:false) instead of from a real producer (createProcessInstance with provider:true). At runtime the extracted variable is empty and the URL placeholder leaks. Prefer chains containing at least one `provider:true` producer per required type before falling back to the shortest chain.',
+    ).toEqual([]);
+  });
 });
 
 describe('bundled-spec invariants: emitted Playwright suite', () => {


### PR DESCRIPTION
## Problem

The feature-output stage in `path-analyser/src/index.ts` chooses one integration scenario from the planner's output to graft as the dependency chain in front of every feature scenario. The selector picked the **shortest non-`unsatisfied` chain with >1 operations**, with no check that the producers in that chain were *authoritative* (`provider:true`) for the endpoint's required semantic types.

The planner's `producersByType` index is intentionally permissive — it includes echo-only response fields so domain-progression and witness lenses stay connected (see graphLoader.ts #95). That means a chain like `createDocument -> cancelProcessInstance` satisfies the BFS for `ProcessInstanceKey` even though `createDocument` merely echoes `metadata.processInstanceKey` (`provider:false`) from the request body. At runtime the extracted variable is empty and the URL renders with a literal `${processInstanceKey}` placeholder.

### Concrete example (current bundled spec)

`POST /process-instances/{processInstanceKey}/cancellation` requires `ProcessInstanceKey`. The planner offered both:

- `scenario-1`: `createDocument -> cancelProcessInstance` (length 2)
- `scenario-4`: `createDeployment -> createProcessInstance -> cancelProcessInstance` (length 3)

The selector picked `scenario-1` because it was shorter.

### Affected endpoints (12)

`cancelProcessInstance`, `deleteProcessInstance`, `getProcessInstance`, `getProcessInstanceCallHierarchy`, `getProcessInstanceSequenceFlows`, `getProcessInstanceStatistics`, `migrateProcessInstance`, `modifyProcessInstance`, `resolveProcessInstanceIncidents`, `searchProcessInstanceIncidents`, `assignUserToTenant`, `unassignUserFromTenant`.

## Fix

Among multi-op chains, prefer those whose prerequisite operations include at least one `provider:true` producer for every required semantic type. Fall back to the length-only sort when no such chain exists, so endpoints whose required types have no authoritative producer anywhere in the graph (an upstream-spec gap) are not regressed.

Verified after fix:
- `cancelProcessInstance` -> `createDeployment -> createProcessInstance -> cancelProcessInstance`
- `assignUserToTenant` -> `createTenant -> createAdminUser -> assignUserToTenant`

## Test (red/green/class-scoped)

New L3 invariant in `tests/regression/bundled-spec-invariants.test.ts`:

> *every feature scenario chain contains an authoritative producer for each requiredSemanticType*

Class-scoped — every endpoint, every feature scenario, every required type. Fails on `main` with 12 distinct offenders; passes after the fix. Endpoints whose required types have no authoritative producer anywhere in the graph are exempt (upstream-spec gap, not a selector bug).

## Pre-push gate

- Biome lint: clean
- `tsc --noEmit` for all three workspaces: clean
- `npm test`: 152/152 pass

## Relation to prior PRs

- #102 (merged): planner BFS no longer reports `unsatisfied:false` when it gives up. This PR addresses a separate failure mode: BFS *does* complete chains, but the chain selector picks the wrong one.
- #53 (upstream): 45 endpoints remain blocked on missing `x-semantic-type` annotations — out of scope here.
