### PR TITLE
feat: emit Playwright variant suites for optional sub-shape scenarios (#105)

### DIFF
--- a/path-analyser/src/codegen/emitter.ts
+++ b/path-analyser/src/codegen/emitter.ts
@@ -12,8 +12,8 @@ export interface EmitContext {
   outDir: string;
   /** Suite name used for test naming (for example, `describe()` blocks) and optionally for file names, depending on the emitter. */
   suiteName: string;
-  /** Generation mode — `feature` is the default for path-analyser scenarios. */
-  mode: 'feature' | 'integration';
+  /** Generation mode — `feature` is the default for path-analyser scenarios. `variant` is used for optional sub-shape variant suites (#37 / #105). */
+  mode: 'feature' | 'integration' | 'variant';
   /**
    * Bindings that every emitted scenario must seed before its request plan
    * runs (e.g. the default-tenant identifier under single-tenant mode).

--- a/path-analyser/src/codegen/index.ts
+++ b/path-analyser/src/codegen/index.ts
@@ -82,6 +82,7 @@ async function run() {
     ? process.cwd()
     : path.resolve(process.cwd(), 'path-analyser');
   const featureDir = path.join(baseDir, 'dist/feature-output');
+  const variantDir = path.join(baseDir, 'dist/variant-output');
   const outDir = path.join(baseDir, 'dist/generated-tests');
 
   if (help || !positional) {
@@ -140,8 +141,42 @@ async function run() {
         console.warn('Skipping file (parse/emission failed):', f, msg);
       }
     }
+    // Issue #105: also materialise optional sub-shape variant scenarios
+    // (#37) into Playwright tests. The variant-output directory is
+    // populated by the planner only for endpoints with at least one
+    // optional sub-shape; emit nothing when the directory is absent so
+    // local runs that scope to feature scenarios still succeed.
+    let variantCount = 0;
+    let variantFiles: string[] = [];
+    try {
+      variantFiles = (await fs.readdir(variantDir)).filter((f) => f.endsWith('-scenarios.json'));
+    } catch (e) {
+      if (
+        !(typeof e === 'object' && e !== null && 'code' in e && Reflect.get(e, 'code') === 'ENOENT')
+      ) {
+        throw e;
+      }
+    }
+    for (const f of variantFiles) {
+      try {
+        const content = await fs.readFile(path.join(variantDir, f), 'utf8');
+        const parsed = parseScenarioCollection(content);
+        if (!parsed.endpoint?.operationId) continue;
+        if (!parsed.scenarios?.length) continue;
+        await writeEmitted(emitter, parsed, {
+          outDir,
+          suiteName: parsed.endpoint.operationId,
+          mode: 'variant',
+          globalContextSeeds,
+        });
+        variantCount++;
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        console.warn('Skipping variant file (parse/emission failed):', f, msg);
+      }
+    }
     console.log(
-      `Generated test suites for ${count} endpoints in ${outDir} (target: ${emitter.id})`,
+      `Generated test suites for ${count} endpoints (+${variantCount} variant suites) in ${outDir} (target: ${emitter.id})`,
     );
     return;
   }

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -13,7 +13,7 @@ import { materializeSupport } from './materialize-support.js';
 interface EmitOptions {
   outDir: string;
   suiteName?: string;
-  mode?: 'feature' | 'integration';
+  mode?: 'feature' | 'integration' | 'variant';
   /**
    * See {@link EmitContext.globalContextSeeds}. Forwarded verbatim from the
    * orchestrator so this entry point and {@link PlaywrightEmitter.emit}
@@ -28,7 +28,7 @@ interface EmitOptions {
  */
 export function playwrightSuiteFileName(
   collection: EndpointScenarioCollection,
-  mode: 'feature' | 'integration',
+  mode: 'feature' | 'integration' | 'variant',
 ): string {
   return `${collection.endpoint.operationId}.${mode}.spec.ts`;
 }
@@ -42,7 +42,7 @@ export function renderPlaywrightSuite(
   collection: EndpointScenarioCollection,
   opts: {
     suiteName?: string;
-    mode?: 'feature' | 'integration';
+    mode?: 'feature' | 'integration' | 'variant';
     globalContextSeeds?: readonly GlobalContextSeed[];
   },
 ): string {

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -594,9 +594,9 @@ function mergePopulatesSubShapeIntoFinalBody(
 function setLeafPlaceholder(root: Record<string, unknown>, path: string, value: string): void {
   // Tokenise: each segment is either `name` or `name[]`.
   const segments = path.split('.');
-  // current is the container we mutate; for array segments we descend
-  // into element [0]. Track parent + key so we can rewrite after type
-  // coercion when needed.
+  // `cursor` is the current container being mutated in place; for array
+  // segments, we ensure `cursor[key]` is an array and then descend into
+  // element [0].
   let cursor: unknown = root;
   for (let i = 0; i < segments.length; i++) {
     const seg = segments[i];

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -327,10 +327,16 @@ async function main() {
       const variantCollection = generateOptionalSubShapeVariants(graph, op.operationId, {
         maxScenarios: 20,
       });
-      // Augment with response shape so downstream codegen has the same
-      // metadata as base/feature scenarios.
-      if (resp) {
-        for (const s of variantCollection.scenarios) {
+      // Augment with response shape (when available) so downstream codegen
+      // has the same metadata as base/feature scenarios. The requestPlan
+      // call is intentionally unconditional — variant scenarios for
+      // 204/no-response endpoints (e.g. modifyProcessInstance) still need
+      // a plan so the emitter renders runnable test bodies. Without this,
+      // those tests would render an empty body that fails biome's
+      // unused-`request`-param lint after `dist/generated-tests` is
+      // formatted (#105).
+      for (const s of variantCollection.scenarios) {
+        if (resp) {
           s.responseShapeSemantics = resp.producedSemantics || undefined;
           s.responseShapeFields = resp.fields.map((f) => ({
             name: f.name,
@@ -341,15 +347,15 @@ async function main() {
           }));
           if (resp.nestedSlices) s.responseNestedSlices = resp.nestedSlices;
           if (resp.nestedItems) s.responseArrayItemFields = resp.nestedItems;
-          s.requestPlan = buildRequestPlan(
-            s,
-            resp,
-            graph,
-            canonical,
-            requestIndex.byOperation,
-            successStatusByOp,
-          );
         }
+        s.requestPlan = buildRequestPlan(
+          s,
+          resp,
+          graph,
+          canonical,
+          requestIndex.byOperation,
+          successStatusByOp,
+        );
       }
       if (variantCollection.scenarios.length) {
         await writeFile(
@@ -530,6 +536,15 @@ function buildRequestPlan(
       steps.push(dup);
     }
   }
+  // Issue #105 (Phase 3): for variant scenarios, deep-merge the populated
+  // sub-shape into the FINAL step's bodyTemplate. The planner stamps
+  // `populatesSubShape` on each variant scenario; the emitter expects the
+  // `${semanticVar}` placeholders to already be present in the body so it
+  // can substitute them via its standard `"${var}"` → `ctx["var"]` rewrite.
+  // Producer extracts for each leaf semantic are populated by the
+  // non-final-step block above (responseSemanticTypes), so the placeholders
+  // resolve at runtime to values pulled from the prerequisite chain.
+  mergePopulatesSubShapeIntoFinalBody(scenario, steps);
   // Issue #61: alias producer extracts under placeholder-derived var names.
   // The Playwright emitter substitutes `{placeholder}` with
   // `ctx.<camelCase(placeholder)>Var`, but producer steps bind under
@@ -543,6 +558,89 @@ function buildRequestPlan(
   // name. Keeps the emitter dumb and the alias visible in scenario JSON.
   aliasProducerExtractsToPlaceholders(scenario, steps, graph);
   return steps;
+}
+
+function mergePopulatesSubShapeIntoFinalBody(
+  scenario: EndpointScenario,
+  steps: RequestStep[],
+): void {
+  const sub = scenario.populatesSubShape;
+  if (!sub || !sub.leafPaths?.length) return;
+  if (!steps.length) return;
+  const finalStep = steps[steps.length - 1];
+  if (finalStep.bodyKind !== 'json') return;
+  const body: Record<string, unknown> = isPlainRecord(finalStep.bodyTemplate)
+    ? { ...finalStep.bodyTemplate }
+    : {};
+  const leafSemantics = sub.leafSemantics ?? [];
+  for (let i = 0; i < sub.leafPaths.length; i++) {
+    const leafPath = sub.leafPaths[i];
+    const semantic = leafSemantics[i];
+    if (!semantic) continue;
+    const bind = `${camelCase(semantic)}Var`;
+    setLeafPlaceholder(body, leafPath, `\${${bind}}`);
+    scenario.bindings ||= {};
+    if (!scenario.bindings[bind]) scenario.bindings[bind] = '__PENDING__';
+  }
+  finalStep.bodyTemplate = body;
+}
+
+/**
+ * Walks `path` (e.g. `startInstructions[].elementId`, or
+ * `filter.processInstanceKey`) and inserts `value` at the leaf, creating
+ * intermediate objects/arrays as needed. `[]` segments coerce the parent
+ * to a single-element array.
+ */
+function setLeafPlaceholder(root: Record<string, unknown>, path: string, value: string): void {
+  // Tokenise: each segment is either `name` or `name[]`.
+  const segments = path.split('.');
+  // current is the container we mutate; for array segments we descend
+  // into element [0]. Track parent + key so we can rewrite after type
+  // coercion when needed.
+  let cursor: unknown = root;
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    const isArray = seg.endsWith('[]');
+    const key = isArray ? seg.slice(0, -2) : seg;
+    const isLast = i === segments.length - 1;
+    if (!isPlainRecord(cursor)) return; // defensive: malformed input
+    if (isArray) {
+      // Ensure cursor[key] is an array with at least one element object.
+      const existing = cursor[key];
+      let arr: unknown[];
+      if (Array.isArray(existing)) {
+        arr = existing;
+      } else {
+        arr = [];
+        cursor[key] = arr;
+      }
+      if (arr.length === 0 || !isPlainRecord(arr[0])) {
+        arr[0] = {};
+      }
+      if (isLast) {
+        // Leaf is itself an array root with no further segment; treat as
+        // scalar slot at index 0. (The planner currently only emits
+        // sub-shapes whose leaf is a deeper field, so this branch is a
+        // safety net for future leaf-as-root variants.)
+        arr[0] = value;
+        return;
+      }
+      cursor = arr[0];
+      continue;
+    }
+    if (isLast) {
+      cursor[key] = value;
+      return;
+    }
+    const next = cursor[key];
+    if (isPlainRecord(next)) {
+      cursor = next;
+    } else {
+      const created: Record<string, unknown> = {};
+      cursor[key] = created;
+      cursor = created;
+    }
+  }
 }
 
 function aliasProducerExtractsToPlaceholders(

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -1373,3 +1373,78 @@ describe('bundled-spec invariants: emitted Playwright suite', () => {
     expect(totalActual).toBe(totalExpected);
   });
 });
+
+describe('bundled-spec invariants: emitted Playwright variant suite (#105)', () => {
+  it('every variant scenario file is materialised as a *.variant.spec.ts (#105)', () => {
+    // Class-scoped guard for Phase 3 of #105: the codegen pipeline must
+    // consume every JSON file under dist/variant-output/ and emit a
+    // matching `<operationId>.variant.spec.ts` under dist/generated-tests/.
+    // A regression that drops the variant-output scan would silently
+    // strip every populated-sub-shape test from CI; this invariant
+    // forces the failure to surface at the suite level rather than as
+    // missing coverage.
+    if (!existsSync(VARIANT_SCENARIOS_DIR) || !existsSync(GENERATED_TESTS_DIR)) {
+      throw new Error(`Generated artifacts not found. Run 'npm run testsuite:generate' first.`);
+    }
+    const missing: string[] = [];
+    let variantFilesSeen = 0;
+    for (const f of readdirSync(VARIANT_SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const coll = JSON.parse(
+        readFileSync(join(VARIANT_SCENARIOS_DIR, f), 'utf8'),
+      ) as VariantScenarioFile;
+      if (!coll.scenarios?.length) continue;
+      variantFilesSeen++;
+      const specName = `${coll.endpoint.operationId}.variant.spec.ts`;
+      if (!existsSync(join(GENERATED_TESTS_DIR, specName))) {
+        missing.push(specName);
+      }
+    }
+    expect(variantFilesSeen).toBeGreaterThan(0); // sanity: pipeline produced variants
+    expect(missing).toEqual([]);
+  });
+
+  it('every variant scenario populating startInstructions[] emits a body with startInstructions: [{...}] (#105)', () => {
+    // Class-scoped acceptance test for Phase 3 of #105: every variant
+    // whose `populatesSubShape.rootPath === "startInstructions[]"` must
+    // produce a generated test whose body literal contains
+    // `startInstructions:` and a nested `elementId:` reference. We
+    // grep the spec source rather than parse it because the literal is
+    // emitted with `ctx[...]` substitutions for placeholders.
+    if (!existsSync(VARIANT_SCENARIOS_DIR) || !existsSync(GENERATED_TESTS_DIR)) {
+      throw new Error(`Generated artifacts not found. Run 'npm run testsuite:generate' first.`);
+    }
+    const offenders: { spec: string; reason: string }[] = [];
+    let assertionsRun = 0;
+    for (const f of readdirSync(VARIANT_SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const coll = JSON.parse(
+        readFileSync(join(VARIANT_SCENARIOS_DIR, f), 'utf8'),
+      ) as VariantScenarioFile;
+      const startInstrVariants = coll.scenarios.filter(
+        (s) => s.populatesSubShape?.rootPath === 'startInstructions[]',
+      );
+      if (startInstrVariants.length === 0) continue;
+      const specName = `${coll.endpoint.operationId}.variant.spec.ts`;
+      const specPath = join(GENERATED_TESTS_DIR, specName);
+      if (!existsSync(specPath)) {
+        offenders.push({ spec: specName, reason: 'spec file missing' });
+        continue;
+      }
+      const src = readFileSync(specPath, 'utf8');
+      if (!src.includes('startInstructions:')) {
+        offenders.push({ spec: specName, reason: 'no startInstructions: literal in body' });
+        continue;
+      }
+      if (!src.includes('elementId:')) {
+        offenders.push({ spec: specName, reason: 'no elementId: literal in startInstructions' });
+        continue;
+      }
+      assertionsRun++;
+    }
+    expect(assertionsRun).toBeGreaterThan(0); // sanity: at least one variant exercises the path
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #105.

Wires the variant-output JSON files produced by the planner (#37 / #51) through to runnable Playwright tests under `path-analyser/dist/generated-tests/<operationId>.variant.spec.ts`.

## What lands

**Phase 3 — codegen for variant scenarios**
- `EmitContext.mode` accepts `'variant'`; emitter writes `<opId>.variant.spec.ts` so variant suites do not collide with `<opId>.feature.spec.ts`.
- `path-analyser/src/codegen/index.ts` scans `dist/variant-output/` alongside `dist/feature-output/` and emits one suite per variant collection. Missing directory is non-fatal.
- `buildRequestPlan` deep-merges `scenario.populatesSubShape` into the FINAL step's `bodyTemplate`, walking `rootPath`/`leafPaths` and binding each leaf to `${camelCase(semantic)}Var`. The non-final-producer extract block already binds the same var name from the upstream `searchElementInstances` response, so the placeholder resolves at runtime.
- `buildRequestPlan` is now called unconditionally for variants so 204-response endpoints (e.g. `modifyProcessInstance`) get a runnable plan instead of an empty test body that fails biome's unused-`request`-param lint after formatting.

**Phase 4 — eventually-consistent finalisation**
Already covered by the existing emitter wrapping mechanism (#106) — every read-shape EC step gets `awaitEventually(...)`. Variant scenarios carry the same `s.operations[].eventuallyConsistent` flag, so no further emitter work was needed. Verified on `createProcessInstance.variant.spec.ts`: the `searchElementInstances` step is wrapped and its extracted `elementIdVar` flows into `startInstructions[0].elementId`.

**Phase 5 — Layer-3 invariants**
Added two named invariants in `tests/regression/bundled-spec-invariants.test.ts`:
- every variant scenario file is materialised as a `*.variant.spec.ts`
- every variant with `populatesSubShape.rootPath === "startInstructions[]"` emits a body containing `startInstructions:` and `elementId:`

Both were demonstrated red against the pre-fix tree before the implementation landed (red/green discipline).

## Sample emitted body

`path-analyser/dist/generated-tests/createProcessInstance.variant.spec.ts` (final step):

```ts
const body4 = {
  processDefinitionKey: ctx.processDefinitionKeyVar,
  startInstructions: [
    {
      elementId: ctx.elementIdVar,
    },
  ],
};
```

`elementIdVar` is bound from the prior `searchElementInstances` step (wrapped in `awaitEventually` because that op is `x-eventually-consistent: true`).

## Out of scope (per #105)

- Negative variants (deselecting populated values)
- Nested optional sub-shapes
- Full Awaitility-style retry harness for EC steps (the vendored `awaitEventually` helper is sufficient)
- Extractor-level sub-shape metadata

## Verification

```
npm run lint                                  # 0 errors, 1 pre-existing warning
npx tsc --noEmit -p {extractor,planner,validation}/tsconfig.json   # all clean
TEST_SEED=snapshot-baseline npm run testsuite:generate   # 183 endpoints + 58 variant suites
npm run generate:request-validation
npm test                                      # 178/178 passing (was 174)
```

`tests/regression/generated-suites-typecheck.test.ts` confirms every emitted variant suite passes `tsc --noEmit`.
