### PR TITLE
fix: walker treats allOf-wrapped primitives as transparent

### DIFF
--- a/request-validation/src/schema/walker.ts
+++ b/request-validation/src/schema/walker.ts
@@ -73,7 +73,17 @@ export function buildWalk(op: OperationModel): SchemaWalkResult | undefined {
         }
       }
     }
-    if (!hasObject) return schema; // fallback
+    if (!hasObject) {
+      // Leaf-primitive allOf case: when every typed branch resolves to the
+      // same primitive type (e.g. `allOf: [{$ref: TenantId}, {description}]`
+      // dereferences to `allOf: [{type: 'string', minLength: 22, ...}, {description}]`),
+      // flatten into a synthetic schema so per-field mutation analysers
+      // (`bodyTypeMismatch`, `constraintViolations`, `enumViolations`) can
+      // see the resolved type and constraints. Without this, the wrapped
+      // field looks typeless and silently drops out of negative coverage —
+      // see camunda/api-test-generator#110.
+      return mergePrimitiveAllOf(schema);
+    }
     // Merge host schema's own direct properties/required (outside allOf) so we don't lose them
     if (schema.properties) {
       for (const [k, v] of Object.entries(schema.properties)) {
@@ -139,4 +149,59 @@ function extractConstraints(schema: SchemaFragment): Record<string, unknown> {
     if (schema[k] !== undefined) out[k] = schema[k];
   }
   return out;
+}
+
+const PRIMITIVE_TYPES = new Set(['string', 'integer', 'number', 'boolean']);
+const PRIMITIVE_CONSTRAINT_KEYS = [
+  'format',
+  'minLength',
+  'maxLength',
+  'pattern',
+  'minimum',
+  'maximum',
+  'exclusiveMinimum',
+  'exclusiveMaximum',
+  'multipleOf',
+];
+
+/**
+ * Flatten an `allOf` whose branches resolve to a single primitive type into
+ * a synthetic schema fragment carrying the resolved `type`, format, enum,
+ * and primitive constraints. Branches without a `type` (e.g. description-only
+ * partials) are tolerated and merged in for their constraint keys. Mixed
+ * primitive types (e.g. `[{type: 'string'}, {type: 'integer'}]`) are not
+ * flattened — they fall back to the original schema so downstream consumers
+ * are not misled.
+ *
+ * The host schema's own primitive constraints (declared alongside `allOf`)
+ * win on conflict so authors can override at the use site.
+ */
+function mergePrimitiveAllOf(schema: SchemaFragment): SchemaFragment {
+  if (!Array.isArray(schema.allOf)) return schema;
+  let resolvedType: string | undefined;
+  for (const part of schema.allOf) {
+    if (!part || typeof part !== 'object') continue;
+    const t = Array.isArray(part.type) ? part.type[0] : part.type;
+    if (typeof t !== 'string') continue;
+    if (!PRIMITIVE_TYPES.has(t)) return schema; // not a primitive-leaf allOf
+    if (resolvedType && resolvedType !== t) return schema; // mixed primitives — bail
+    resolvedType = t;
+  }
+  if (!resolvedType) return schema;
+  const merged: SchemaFragment = { type: resolvedType };
+  // Branch contributions first, then host overrides.
+  for (const part of schema.allOf) {
+    if (!part || typeof part !== 'object') continue;
+    for (const k of PRIMITIVE_CONSTRAINT_KEYS) {
+      if (part[k] !== undefined && merged[k] === undefined) merged[k] = part[k];
+    }
+    if (Array.isArray(part.enum) && !Array.isArray(merged.enum)) {
+      merged.enum = part.enum.slice();
+    }
+  }
+  for (const k of PRIMITIVE_CONSTRAINT_KEYS) {
+    if (schema[k] !== undefined) merged[k] = schema[k];
+  }
+  if (Array.isArray(schema.enum)) merged.enum = schema.enum.slice();
+  return merged;
 }

--- a/tests/request-validation/allof-typed-primitive-walker.test.ts
+++ b/tests/request-validation/allof-typed-primitive-walker.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { generateBodyTypeMismatch } from '../../request-validation/src/analysis/bodyTypeMismatch.js';
+import { generateConstraintViolations } from '../../request-validation/src/analysis/constraintViolations.js';
+import type { OperationModel, SchemaFragment } from '../../request-validation/src/model/types.js';
+import { buildWalk } from '../../request-validation/src/schema/walker.js';
+
+/**
+ * Class-scoped regression guard for camunda/api-test-generator#110.
+ *
+ * Defect class: when a body property's schema is an `allOf` whose branches
+ * resolve to a single primitive type (e.g. `allOf: [{$ref: TenantId}, {description: '…'}]`
+ * dereferences to `allOf: [{type: 'string', minLength: 22}, {description: '…'}]`),
+ * the schema walker must treat the wrapper as transparent and surface:
+ *   - the resolved primitive `type`
+ *   - the merged primitive constraints (minLength/maxLength/pattern/format/enum/min/max/...)
+ *
+ * If the walker fails this, the per-field mutation analysers
+ * (`bodyTypeMismatch`, `constraintViolations`, `enumViolations`) silently
+ * stop emitting scenarios for the wrapped field, and every typed-identifier
+ * promotion in the upstream Camunda spec drops the absolute scenario count
+ * in `request-validation/generated/COVERAGE.md`.
+ *
+ * The test is class-scoped: any allOf-wrapped primitive field must be
+ * walked transparently, regardless of which operation or property carries it.
+ */
+describe('request-validation: walker treats allOf-wrapped primitives as transparent (#110)', () => {
+  function makeOp(properties: Record<string, SchemaFragment>, required: string[]): OperationModel {
+    return {
+      operationId: 'createWidget',
+      method: 'POST',
+      path: '/widgets',
+      tags: [],
+      requestBodySchema: {
+        type: 'object',
+        required,
+        properties,
+      },
+      requiredProps: required,
+      parameters: [],
+    };
+  }
+
+  it('walker surfaces type for allOf-wrapped string field', () => {
+    const op = makeOp(
+      {
+        tenantId: {
+          allOf: [
+            { type: 'string', minLength: 1, maxLength: 32 },
+            { description: 'The tenant identifier.' },
+          ],
+        },
+      },
+      ['tenantId'],
+    );
+    const walk = buildWalk(op);
+    const node = walk?.root?.properties?.tenantId;
+    expect(node).toBeDefined();
+    expect(node?.type).toBe('string');
+  });
+
+  it('walker surfaces merged primitive constraints for allOf-wrapped string field', () => {
+    const op = makeOp(
+      {
+        tenantId: {
+          allOf: [
+            { type: 'string', minLength: 1, maxLength: 32, pattern: '^[a-z]+$' },
+            { description: 'The tenant identifier.' },
+          ],
+        },
+      },
+      ['tenantId'],
+    );
+    const walk = buildWalk(op);
+    const node = walk?.root?.properties?.tenantId;
+    expect(node?.constraints).toMatchObject({
+      minLength: 1,
+      maxLength: 32,
+      pattern: '^[a-z]+$',
+    });
+  });
+
+  it('walker merges constraints scattered across allOf branches', () => {
+    const op = makeOp(
+      {
+        amount: {
+          allOf: [
+            { type: 'integer', minimum: 0 },
+            { maximum: 1000, description: 'capped' },
+          ],
+        },
+      },
+      ['amount'],
+    );
+    const walk = buildWalk(op);
+    const node = walk?.root?.properties?.amount;
+    expect(node?.type).toBe('integer');
+    expect(node?.constraints).toMatchObject({ minimum: 0, maximum: 1000 });
+  });
+
+  it('bodyTypeMismatch emits scenarios for allOf-wrapped primitive fields', () => {
+    const op = makeOp(
+      {
+        tenantId: {
+          allOf: [
+            { type: 'string', minLength: 1, maxLength: 32 },
+            { description: 'The tenant identifier.' },
+          ],
+        },
+      },
+      ['tenantId'],
+    );
+    const scenarios = generateBodyTypeMismatch([op], { maxPerField: 4 });
+    const tenantIdScenarios = scenarios.filter((s) => s.target === 'tenantId');
+    expect(tenantIdScenarios.length).toBeGreaterThan(0);
+  });
+
+  it('constraintViolations emits scenarios for allOf-wrapped primitive fields', () => {
+    const op = makeOp(
+      {
+        tenantId: {
+          allOf: [
+            { type: 'string', minLength: 1, maxLength: 32 },
+            { description: 'The tenant identifier.' },
+          ],
+        },
+      },
+      ['tenantId'],
+    );
+    const scenarios = generateConstraintViolations([op], {});
+    const tenantIdScenarios = scenarios.filter((s) => s.target === 'tenantId');
+    expect(tenantIdScenarios.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #110.

## Defect

When a body property's schema is an `allOf` whose dereferenced branches resolve to a single primitive type (e.g. `allOf: [{$ref: TenantId}, {description: '…'}]` becomes `allOf: [{type: 'string', minLength: 22, ...}, {description: '…'}]` after `SwaggerParser.dereference()`), `buildWalk()` previously fell back to the host schema and emitted a `WalkNode` with `type: undefined` and empty `constraints`. The per-field mutation analysers (`bodyTypeMismatch`, `constraintViolations`, `enumViolations`) then silently stopped emitting scenarios for the wrapped field.

Upstream effect: every typed-identifier promotion in `camunda/camunda` (e.g. inline `type: string` → `allOf: [{$ref: TenantId}, ...]`) dropped the absolute scenario count in `request-validation/generated/COVERAGE.md` without flagging a coverage gap.

## Fix

Extend `mergeAllOf` in `request-validation/src/schema/walker.ts` to handle the leaf-primitive case via a new `mergePrimitiveAllOf` helper. When every typed branch resolves to the same primitive, it returns a synthetic `SchemaFragment` carrying the resolved `type`, `format`, `enum`, and primitive constraints (`minLength`, `maxLength`, `pattern`, `minimum`, `maximum`, `exclusiveMinimum/Maximum`, `multipleOf`). Host-level declarations win on conflict so authors can override at the use site. Mixed primitive types (e.g. `[{type: 'string'}, {type: 'integer'}]`) fall through unchanged so downstream consumers are not misled.

Verified against `camunda/camunda#52321` head (`bbd7740`) where the regression first surfaced:

| | totalScenarios |
|---|---|
| `main` baseline (`7a8f25e`) | 1016 |
| PR #52321 head, pre-fix | 1003 |
| PR #52321 head, post-fix | **1037** |

The post-fix count is *above* the main baseline because the typed-identifier promotion now exposes more constraint mutations (`format-invalid`, `belowMinLength`, etc.) than the inline-string shape did. `createUser` and `createAdminUser` each gain 4 scenarios.

## Tests (red/green/class-scoped)

`tests/request-validation/allof-typed-primitive-walker.test.ts` adds five class-scoped assertions:

1. `walker surfaces type for allOf-wrapped string field`
2. `walker surfaces merged primitive constraints for allOf-wrapped string field`
3. `walker merges constraints scattered across allOf branches`
4. `bodyTypeMismatch emits scenarios for allOf-wrapped primitive fields`
5. `constraintViolations emits scenarios for allOf-wrapped primitive fields`

All five fail on `main` (`type` is `undefined`, scenario emission count is 0); all five pass after the walker fix. The assertions are scoped to the defect class — any allOf-wrapped primitive on any operation is exercised, not just the specific field that surfaced the bug.

## Pre-push checklist

- `npm run lint` — clean (1 pre-existing warning unrelated to this change)
- `npx tsc --noEmit` for all three workspace tsconfigs — clean
- `TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation` — clean
- `npm test` — 25 files / 183 tests pass
