### PR TITLE
feat: consume x-semantic-establishes for entity-existence chain planning

### DIFF
--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -575,9 +575,19 @@ function normalizeEstablishes(raw: unknown): OperationNode['establishes'] {
     if (typeof e.semanticType !== 'string' || e.semanticType.length === 0) return undefined;
     identifiedBy.push({ in: e.in, name: e.name, semanticType: e.semanticType });
   }
+  // Same `shape` restriction as the extractor: an unknown string would
+  // silently degrade to non-edge behaviour and `normalizeOp` would push
+  // the components into `produces` and strip them from `requires` —
+  // the exact opposite of the intended edge semantics. Reject unknown
+  // shapes wholesale.
+  const rawShape = r.shape;
+  const KNOWN_SHAPES = new Set<string>(['edge']);
+  const shapeValid =
+    rawShape === undefined || (typeof rawShape === 'string' && KNOWN_SHAPES.has(rawShape));
+  if (!shapeValid) return undefined;
   return {
     kind: r.kind,
-    shape: typeof r.shape === 'string' ? r.shape : undefined,
+    shape: typeof rawShape === 'string' ? rawShape : undefined,
     identifiedBy,
   };
 }

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -554,21 +554,27 @@ function normalizeEstablishes(raw: unknown): OperationNode['establishes'] {
   if (!raw || typeof raw !== 'object') return undefined;
   // biome-ignore lint/plugin: extractor JSON contract — fields validated below.
   const r = raw as { kind?: unknown; shape?: unknown; identifiedBy?: unknown };
-  if (typeof r.kind !== 'string' || !Array.isArray(r.identifiedBy)) return undefined;
+  if (typeof r.kind !== 'string' || r.kind.length === 0) return undefined;
+  if (!Array.isArray(r.identifiedBy) || r.identifiedBy.length === 0) return undefined;
+  // Strict validation mirrors the extractor (semantic-graph-extractor/
+  // schema-analyzer.ts): any invalid `identifiedBy` member rejects the
+  // *whole* annotation. Silently dropping individual entries would
+  // reintroduce the partial-state hazard #112 is meant to close —
+  // e.g. a composite (path+body) identifier with one malformed `in`
+  // value would degrade to a single-identifier establisher and start
+  // producing wrong chains. This path runs against
+  // OPERATION_GRAPH_PATH overrides too, so a hand-edited or
+  // upstream-malformed graph JSON gets the same treatment as the spec.
   const identifiedBy: NonNullable<OperationNode['establishes']>['identifiedBy'] = [];
   for (const id of r.identifiedBy) {
-    if (!id || typeof id !== 'object') continue;
+    if (!id || typeof id !== 'object') return undefined;
     // biome-ignore lint/plugin: extractor JSON contract — fields validated below.
     const e = id as { in?: unknown; name?: unknown; semanticType?: unknown };
-    if (
-      (e.in === 'body' || e.in === 'path') &&
-      typeof e.name === 'string' &&
-      typeof e.semanticType === 'string'
-    ) {
-      identifiedBy.push({ in: e.in, name: e.name, semanticType: e.semanticType });
-    }
+    if (e.in !== 'body' && e.in !== 'path') return undefined;
+    if (typeof e.name !== 'string' || e.name.length === 0) return undefined;
+    if (typeof e.semanticType !== 'string' || e.semanticType.length === 0) return undefined;
+    identifiedBy.push({ in: e.in, name: e.name, semanticType: e.semanticType });
   }
-  if (!identifiedBy.length) return undefined;
   return {
     kind: r.kind,
     shape: typeof r.shape === 'string' ? r.shape : undefined,

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -156,7 +156,28 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
   const responseProducersByType: Record<string, string[]> = {};
   const establishersByType: Record<string, string[]> = {};
   for (const op of Object.values(operations)) {
+    // `producersByType` is the authoritative-producer index after #98:
+    // membership means "this op returns or witnesses an authoritative
+    // value for semantic T in its response (or via a sidecar produces
+    // declaration)". Establishers do NOT meet that contract — they
+    // register a *client-minted* value at request time, not a
+    // server-authoritative one. Keep the two indexes semantically
+    // distinct so variant planning, provider preference, and
+    // missing-producer signals continue to mean what they say.
+    //
+    // The synthesised entry stays on `op.produces` so the BFS produced-
+    // set propagation (many sites in scenarioGenerator) still marks
+    // the establisher's identifier semantics as satisfied after the
+    // op is scheduled. Skipping it only here keeps the *global* index
+    // clean while preserving per-op satisfaction tracking.
+    const synthesisedFromEstablishes = new Set<string>();
+    if (op.establishes && op.establishes.shape !== 'edge') {
+      for (const id of op.establishes.identifiedBy) {
+        synthesisedFromEstablishes.add(id.semanticType);
+      }
+    }
     for (const st of op.produces) {
+      if (synthesisedFromEstablishes.has(st)) continue;
       const list = producersByType[st] ?? [];
       list.push(op.operationId);
       producersByType[st] = list;

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -54,6 +54,7 @@ interface RawOp {
   eventuallyConsistent?: boolean;
   operationMetadata?: OperationNode['operationMetadata'];
   conditionalIdempotency?: OperationNode['conditionalIdempotency'];
+  establishes?: OperationNode['establishes'];
   'x-eventually-consistent'?: boolean;
 }
 
@@ -153,11 +154,19 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
 
   const producersByType: Record<string, string[]> = {};
   const responseProducersByType: Record<string, string[]> = {};
+  const establishersByType: Record<string, string[]> = {};
   for (const op of Object.values(operations)) {
     for (const st of op.produces) {
       const list = producersByType[st] ?? [];
       list.push(op.operationId);
       producersByType[st] = list;
+    }
+    if (op.establishes && op.establishes.shape !== 'edge') {
+      for (const id of op.establishes.identifiedBy) {
+        const list = establishersByType[id.semanticType] ?? [];
+        if (!list.includes(op.operationId)) list.push(op.operationId);
+        establishersByType[id.semanticType] = list;
+      }
     }
     // Issue #37: inclusive index — every response semantic leaf, even
     // provider:false ones, becomes a discoverable producer for variant
@@ -359,6 +368,7 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     bootstrapSequences,
     domain,
     producersByState,
+    establishersByType: Object.keys(establishersByType).length ? establishersByType : undefined,
   };
 }
 
@@ -464,12 +474,45 @@ function normalizeOp(opId: string, op: RawOp): OperationNode {
     }
   }
 
+  // Issue #104: x-semantic-establishes contributes synthetic produced
+  // semantic types so BFS can schedule the establisher as a satisfier
+  // for any consumer that needs the same identifier. Establishers are
+  // intentionally NOT added to providerMap — they don't return an
+  // authoritative server value, they register a client-minted one — so
+  // the provider-preference filter in scenarioGenerator still reaches
+  // for true producers first when both kinds exist.
+  //
+  // Edge establishers (`shape: 'edge'`) are the membership operations
+  // — their `identifiedBy` entries enumerate the *components* of the
+  // composite identifier (e.g. {GroupId, Username}), which are
+  // *consumed* prerequisites, not values established by this op. The
+  // edge itself has no semantic type the planner can chain on, so we
+  // don't touch `produces` for edges.
+  const establishes = normalizeEstablishes(op.establishes);
+  const establishedSemantics = new Set<string>();
+  if (establishes && establishes.shape !== 'edge') {
+    for (const id of establishes.identifiedBy) {
+      produces.push(id.semanticType);
+      establishedSemantics.add(id.semanticType);
+    }
+  }
+
   return {
     operationId: op.operationId ?? op.id ?? op.name ?? opId,
     method: (op.method ?? op.httpMethod ?? op.verb ?? 'GET').toUpperCase(),
     path: op.path ?? op.route ?? op.url ?? '',
     produces: unique(produces),
-    requires: { required, optional },
+    // Issue #104: a non-edge establisher self-satisfies the identifier
+    // it mints, so drop the established semantic types from `requires`
+    // — otherwise BFS would chase a producer for a value the endpoint
+    // itself is going to mint and write into its own request body.
+    // Edge establishers don't enter this branch (no entries in
+    // `establishedSemantics`) because their `identifiedBy` components
+    // are pre-existing inputs that legitimately need a chain.
+    requires: {
+      required: required.filter((s) => !establishedSemantics.has(s)),
+      optional: optional.filter((s) => !establishedSemantics.has(s)),
+    },
     edges: op.edges ?? op.outgoingEdges ?? op.dependencies ?? op.deps ?? [],
     providerMap: Object.keys(providerMap).length ? providerMap : undefined,
     eventuallyConsistent:
@@ -482,6 +525,33 @@ function normalizeOp(opId: string, op: RawOp): OperationNode {
     pathParameters: extractPathParameters(op),
     optionalSubShapes: optionalSubShapes.length ? optionalSubShapes : undefined,
     responseSemanticLeaves: responseLeaves.length ? responseLeaves : undefined,
+    establishes,
+  };
+}
+
+function normalizeEstablishes(raw: unknown): OperationNode['establishes'] {
+  if (!raw || typeof raw !== 'object') return undefined;
+  // biome-ignore lint/plugin: extractor JSON contract — fields validated below.
+  const r = raw as { kind?: unknown; shape?: unknown; identifiedBy?: unknown };
+  if (typeof r.kind !== 'string' || !Array.isArray(r.identifiedBy)) return undefined;
+  const identifiedBy: NonNullable<OperationNode['establishes']>['identifiedBy'] = [];
+  for (const id of r.identifiedBy) {
+    if (!id || typeof id !== 'object') continue;
+    // biome-ignore lint/plugin: extractor JSON contract — fields validated below.
+    const e = id as { in?: unknown; name?: unknown; semanticType?: unknown };
+    if (
+      (e.in === 'body' || e.in === 'path') &&
+      typeof e.name === 'string' &&
+      typeof e.semanticType === 'string'
+    ) {
+      identifiedBy.push({ in: e.in, name: e.name, semanticType: e.semanticType });
+    }
+  }
+  if (!identifiedBy.length) return undefined;
+  return {
+    kind: r.kind,
+    shape: typeof r.shape === 'string' ? r.shape : undefined,
+    identifiedBy,
   };
 }
 

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -581,13 +581,11 @@ function normalizeEstablishes(raw: unknown): OperationNode['establishes'] {
   // the exact opposite of the intended edge semantics. Reject unknown
   // shapes wholesale.
   const rawShape = r.shape;
-  const KNOWN_SHAPES = new Set<string>(['edge']);
-  const shapeValid =
-    rawShape === undefined || (typeof rawShape === 'string' && KNOWN_SHAPES.has(rawShape));
+  const shapeValid = rawShape === undefined || rawShape === 'edge';
   if (!shapeValid) return undefined;
   return {
     kind: r.kind,
-    shape: typeof rawShape === 'string' ? rawShape : undefined,
+    shape: rawShape === 'edge' ? 'edge' : undefined,
     identifiedBy,
   };
 }

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -99,6 +99,24 @@ async function main() {
       });
       op.requires.optional = [...optReq];
     }
+    // Issue #104: re-apply the establisher self-satisfaction drop here.
+    // graphLoader's `normalizeOp` already strips established semantics
+    // from `requires`, but `loadOpenApiSemanticHints` walks the raw
+    // OpenAPI request schema independently and re-adds the same
+    // semantics back via the `x-semantic-type` annotations on the
+    // identifier fields the establisher mints. Without this second
+    // drop, self-establishing endpoints like `createUser` are
+    // regenerated as needing their own `Username`, BFS skips them as
+    // their own producer (`producerOpId === endpointOpId`), and the
+    // endpoint plans an unsatisfied scenario instead of the trivial
+    // "establisher alone" chain. Edge establishers (`shape: 'edge'`)
+    // are skipped — their `identifiedBy` components are pre-existing
+    // inputs and the hint-derived `requires` for them is correct.
+    if (op.establishes && op.establishes.shape !== 'edge') {
+      const established = new Set(op.establishes.identifiedBy.map((i) => i.semanticType));
+      op.requires.required = op.requires.required.filter((s) => !established.has(s));
+      op.requires.optional = op.requires.optional.filter((s) => !established.has(s));
+    }
   }
 
   const summaryEntries: GenerationSummaryEntry[] = [];

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -710,20 +710,45 @@ export function generateScenariosForEndpoint(
       // from the chain, not values minted here.
       let establisherBindingSemantics = workingState.establisherBindingSemantics;
       if (producerNode.establishes && producerNode.establishes.shape !== 'edge') {
+        // Pre-flight: for each *body* identifier, the request-body
+        // builder (`buildRequestBodyFromCanonical` in path-analyser/
+        // src/index.ts) emits `${${camelCase(name)}Var}` from the raw
+        // field name with no per-step override. If a previously
+        // chained establisher already minted a different semantic at
+        // that exact var name, the second establisher's request body
+        // would render with the FIRST establisher's value — silently
+        // wrong. Numeric-suffix disambiguation (below) only saves the
+        // URL path because aliasing covers placeholder lookup; the
+        // body builder has no equivalent hook. Skip the candidate
+        // wholesale rather than emit a broken test. Path-only
+        // identifiers don't share this hazard because the placeholder-
+        // alias loop below threads the value under every placeholder
+        // name the URL emitter uses.
+        let bodyBindingClash = false;
+        for (const id of producerNode.establishes.identifiedBy) {
+          if (id.in !== 'body') continue;
+          const bodyVar = `${camelLower(id.name)}Var`;
+          const existingSemantic = establisherBindingSemantics?.[bodyVar];
+          if (existingSemantic && existingSemantic !== id.semanticType) {
+            bodyBindingClash = true;
+            break;
+          }
+        }
+        if (bodyBindingClash) continue;
         for (const id of producerNode.establishes.identifiedBy) {
           const baseVar = `${camelLower(id.name)}Var`;
-          // Find a key whose minted semanticType matches (reuse) or is
-          // free (mint). Always tracks via establisherBindingSemantics
-          // — bindingsDraft alone can't distinguish a value minted by
-          // an establisher from one minted by a producer extract.
+          // For BODY identifiers we never suffix — see clash check
+          // above. For PATH identifiers the URL emitter goes through
+          // the alias loop, so a numeric suffix is safe.
           let primaryVar = baseVar;
-          let suffix = 2;
-          while (
-            establisherBindingSemantics &&
-            establisherBindingSemantics[primaryVar] &&
-            establisherBindingSemantics[primaryVar] !== id.semanticType
-          ) {
-            primaryVar = `${baseVar}${suffix++}`;
+          if (id.in === 'path') {
+            let suffix = 2;
+            while (
+              establisherBindingSemantics?.[primaryVar] &&
+              establisherBindingSemantics[primaryVar] !== id.semanticType
+            ) {
+              primaryVar = `${baseVar}${suffix++}`;
+            }
           }
           const value =
             bindingsDraft[primaryVar] ??

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -100,10 +100,18 @@ export function generateScenariosForEndpoint(
     };
   }
 
-  // Determine impossible semantic types (no producer anywhere, excluding endpoint self-production)
+  // Determine impossible semantic types (no producer anywhere, excluding endpoint self-production).
+  // A semantic counts as reachable if EITHER a producersByType entry exists (authoritative
+  // server-returned values) OR an establishersByType entry exists (client-minted values guaranteed
+  // by an x-semantic-establishes annotation). Without the establishersByType branch this early
+  // gate would short-circuit endpoints whose required semantic is only mintable via an establisher
+  // (e.g. getUser/getTenant after the spec is annotated), and the BFS augmentation downstream
+  // would never run.
   const missing: string[] = [];
   for (const st of initialNeeded) {
-    if (!graph.producersByType[st] || graph.producersByType[st].length === 0) {
+    const hasProducer = graph.producersByType[st]?.length;
+    const hasEstablisher = graph.establishersByType?.[st]?.length;
+    if (!hasProducer && !hasEstablisher) {
       if (!endpoint.produces.includes(st)) missing.push(st);
     }
   }

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -673,15 +673,36 @@ export function generateScenariosForEndpoint(
       // sufficient because the body builder only writes a placeholder
       // when the binding key is absent.
       //
+      // Establishers don't produce a response extract, so the alias
+      // mechanism in `aliasProducerExtractsToPlaceholders` (issue #61)
+      // can't help when the consumer's path placeholder name differs
+      // from the establisher's identifier `name` (e.g. establisher
+      // mints `username` but consumer uses `/users/{userKey}` with
+      // semanticType `Username`). Pre-populate the same value under
+      // every distinct placeholder name found in the graph for the
+      // same semanticType so the URL emitter resolves it directly.
+      //
       // Edge establishers (`shape: 'edge'`) are skipped — their
       // `identifiedBy` entries are pre-existing components consumed
       // from the chain, not values minted here.
       if (producerNode.establishes && producerNode.establishes.shape !== 'edge') {
         for (const id of producerNode.establishes.identifiedBy) {
-          const varName = `${camelLower(id.name)}Var`;
-          if (!bindingsDraft[varName]) {
-            bindingsDraft[varName] =
-              `${camelLower(producerNode.establishes.kind)}_${deterministicSuffix(`establish:${producerNode.operationId}:${id.semanticType}:${varName}`)}`;
+          const primaryVar = `${camelLower(id.name)}Var`;
+          const value =
+            bindingsDraft[primaryVar] ??
+            `${camelLower(producerNode.establishes.kind)}_${deterministicSuffix(`establish:${producerNode.operationId}:${id.semanticType}:${primaryVar}`)}`;
+          if (!bindingsDraft[primaryVar]) bindingsDraft[primaryVar] = value;
+          // Mirror the binding under every other placeholder-derived
+          // var name used by any operation in the graph for this same
+          // semanticType. Cheap one-time scan per identifier; harmless
+          // if the consumer ends up not being chained.
+          for (const consumer of Object.values(graph.operations)) {
+            for (const param of consumer.pathParameters ?? []) {
+              if (param.semanticType !== id.semanticType) continue;
+              const aliasVar = `${camelLower(param.name)}Var`;
+              if (aliasVar === primaryVar) continue;
+              if (!bindingsDraft[aliasVar]) bindingsDraft[aliasVar] = value;
+            }
           }
         }
       }

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -446,6 +446,26 @@ export function generateScenariosForEndpoint(
     const targetSemantic = remaining[0];
     let producers: string[] = targetSemantic ? graph.producersByType[targetSemantic] || [] : [];
 
+    // #104: establishers are kept out of `producersByType` to preserve
+    // the "authoritative-producer only" contract that the rest of the
+    // analyser (variant planning, provider preference, missing-producer
+    // diagnostics) reads from that map. Augment the BFS candidate set
+    // here, where the planner explicitly needs a satisfier — the
+    // produced-set propagation downstream still works because the
+    // establisher's `op.produces` carries the synthesised semantic.
+    if (targetSemantic) {
+      const establishers = graph.establishersByType?.[targetSemantic];
+      if (establishers?.length) {
+        const seenIds = new Set(producers);
+        for (const e of establishers) {
+          if (!seenIds.has(e)) {
+            producers.push(e);
+            seenIds.add(e);
+          }
+        }
+      }
+    }
+
     // Provider preference & incidental suppression
     if (targetSemantic) {
       const providerSet = new Set<string>();

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -633,6 +633,30 @@ export function generateScenariosForEndpoint(
               `${camelLower(s)}_${deterministicSuffix(`sg:key:${s}:${varName}`)}`;
         }
       }
+      // Issue #104: when the producer is an establisher, mint a fresh
+      // client-minted binding for each `identifiedBy` entry. The varName
+      // matches what the request-body builder computes for a body field
+      // of the same `name` (`${camelCase(name)}Var`) AND what the
+      // emitter computes for a path placeholder of the same `name`
+      // (`buildUrlExpression`: `{name}` → `ctx.${camelCase(name)}Var`).
+      // That single shared key threads the same value into the
+      // establisher's request and into any downstream consumer's URL
+      // without any extract step. Pre-populating bindingsDraft is
+      // sufficient because the body builder only writes a placeholder
+      // when the binding key is absent.
+      //
+      // Edge establishers (`shape: 'edge'`) are skipped — their
+      // `identifiedBy` entries are pre-existing components consumed
+      // from the chain, not values minted here.
+      if (producerNode.establishes && producerNode.establishes.shape !== 'edge') {
+        for (const id of producerNode.establishes.identifiedBy) {
+          const varName = `${camelLower(id.name)}Var`;
+          if (!bindingsDraft[varName]) {
+            bindingsDraft[varName] =
+              `${camelLower(producerNode.establishes.kind)}_${deterministicSuffix(`establish:${producerNode.operationId}:${id.semanticType}:${varName}`)}`;
+          }
+        }
+      }
 
       const sig = signature(newOps, newProduced, newNeeded, nextCycle);
       if (seen.has(sig)) continue;

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -41,6 +41,13 @@ interface State {
   bootstrapFull?: boolean; // this state derives from a single bootstrap that covers all required
   modelsDraft?: GeneratedModelSpec[]; // synthesized models (mutable during BFS)
   bindingsDraft?: Record<string, string>; // variable bindings
+  // Issue #104: side index recording which semanticType each
+  // establisher-minted binding key was issued for. Lets the BFS
+  // detect collisions when two establishers in the same chain share
+  // a generic identifier `name` (e.g. `name`, `id`) but mint values
+  // for *different* semantic types — without it the second
+  // establisher would silently reuse the first establisher's value.
+  establisherBindingSemantics?: Record<string, string>;
   providerList?: Record<string, string[]>; // semantic -> all providers
   artifactsApplied?: string[]; // artifact rule ids used so far
 }
@@ -662,16 +669,32 @@ export function generateScenariosForEndpoint(
         }
       }
       // Issue #104: when the producer is an establisher, mint a fresh
-      // client-minted binding for each `identifiedBy` entry. The varName
-      // matches what the request-body builder computes for a body field
-      // of the same `name` (`${camelCase(name)}Var`) AND what the
-      // emitter computes for a path placeholder of the same `name`
-      // (`buildUrlExpression`: `{name}` → `ctx.${camelCase(name)}Var`).
+      // client-minted binding for each `identifiedBy` entry. The primary
+      // varName matches what the request-body builder computes for a
+      // body field of the same `name` (`${camelCase(name)}Var`) AND
+      // what the emitter computes for a path placeholder of the same
+      // `name` (`buildUrlExpression`: `{name}` → `ctx.${camelCase(name)}Var`).
       // That single shared key threads the same value into the
       // establisher's request and into any downstream consumer's URL
       // without any extract step. Pre-populating bindingsDraft is
       // sufficient because the body builder only writes a placeholder
       // when the binding key is absent.
+      //
+      // Disambiguation: when two establishers in the same chain share
+      // a generic identifier `name` (e.g. `name`, `id`) but mint
+      // values for *different* semantic types, blindly reusing the
+      // existing binding would silently hand the second resource the
+      // first resource's identifier. Track the semanticType minted
+      // under each varName in `establisherBindingSemantics`; on
+      // collision with a different semantic, mint under a numerically
+      // suffixed name (`nameVar2`, `nameVar3`, …). The suffixed key
+      // ensures the *value* is unique and is correctly threaded
+      // through the URL alias loop below for any consumer placeholder
+      // that resolves by `semanticType` rather than by `name`. (The
+      // request-body builder still resolves placeholders by raw field
+      // name and may reuse the primary key for the second establisher
+      // — that's a separate body-builder limitation tracked
+      // independently and out of scope for #104.)
       //
       // Establishers don't produce a response extract, so the alias
       // mechanism in `aliasProducerExtractsToPlaceholders` (issue #61)
@@ -685,13 +708,31 @@ export function generateScenariosForEndpoint(
       // Edge establishers (`shape: 'edge'`) are skipped — their
       // `identifiedBy` entries are pre-existing components consumed
       // from the chain, not values minted here.
+      let establisherBindingSemantics = workingState.establisherBindingSemantics;
       if (producerNode.establishes && producerNode.establishes.shape !== 'edge') {
         for (const id of producerNode.establishes.identifiedBy) {
-          const primaryVar = `${camelLower(id.name)}Var`;
+          const baseVar = `${camelLower(id.name)}Var`;
+          // Find a key whose minted semanticType matches (reuse) or is
+          // free (mint). Always tracks via establisherBindingSemantics
+          // — bindingsDraft alone can't distinguish a value minted by
+          // an establisher from one minted by a producer extract.
+          let primaryVar = baseVar;
+          let suffix = 2;
+          while (
+            establisherBindingSemantics &&
+            establisherBindingSemantics[primaryVar] &&
+            establisherBindingSemantics[primaryVar] !== id.semanticType
+          ) {
+            primaryVar = `${baseVar}${suffix++}`;
+          }
           const value =
             bindingsDraft[primaryVar] ??
             `${camelLower(producerNode.establishes.kind)}_${deterministicSuffix(`establish:${producerNode.operationId}:${id.semanticType}:${primaryVar}`)}`;
           if (!bindingsDraft[primaryVar]) bindingsDraft[primaryVar] = value;
+          establisherBindingSemantics = {
+            ...(establisherBindingSemantics ?? {}),
+            [primaryVar]: id.semanticType,
+          };
           // Mirror the binding under every other placeholder-derived
           // var name used by any operation in the graph for this same
           // semanticType. Cheap one-time scan per identifier; harmless
@@ -701,7 +742,17 @@ export function generateScenariosForEndpoint(
               if (param.semanticType !== id.semanticType) continue;
               const aliasVar = `${camelLower(param.name)}Var`;
               if (aliasVar === primaryVar) continue;
-              if (!bindingsDraft[aliasVar]) bindingsDraft[aliasVar] = value;
+              // Only alias when the slot is free OR was previously
+              // minted by an establisher for this same semanticType.
+              const existingSemantic = establisherBindingSemantics?.[aliasVar];
+              if (existingSemantic && existingSemantic !== id.semanticType) continue;
+              if (!bindingsDraft[aliasVar]) {
+                bindingsDraft[aliasVar] = value;
+                establisherBindingSemantics = {
+                  ...establisherBindingSemantics,
+                  [aliasVar]: id.semanticType,
+                };
+              }
             }
           }
         }
@@ -722,6 +773,7 @@ export function generateScenariosForEndpoint(
         bootstrapFull: state.bootstrapFull,
         modelsDraft,
         bindingsDraft,
+        establisherBindingSemantics,
         providerList: updateProviderList(
           state.providerList || {},
           producerNode,

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -42,12 +42,32 @@ interface State {
   modelsDraft?: GeneratedModelSpec[]; // synthesized models (mutable during BFS)
   bindingsDraft?: Record<string, string>; // variable bindings
   // Issue #104: side index recording which semanticType each
-  // establisher-minted binding key was issued for. Lets the BFS
-  // detect collisions when two establishers in the same chain share
-  // a generic identifier `name` (e.g. `name`, `id`) but mint values
-  // for *different* semantic types — without it the second
+  // establisher-minted PRIMARY binding key was issued for. Lets the
+  // BFS detect collisions when two establishers in the same chain
+  // share a generic identifier `name` (e.g. `name`, `id`) but mint
+  // values for *different* semantic types — without it the second
   // establisher would silently reuse the first establisher's value.
+  //
+  // Strictly tracks **primary** mints (the slot the establisher
+  // itself writes to). Cross-endpoint placeholder aliases live in
+  // `establisherAliasSemantics` below — they must not pollute this
+  // map because the body-collision guard reads only this map and an
+  // unrelated endpoint's alias would otherwise abort a legitimate
+  // body-id establisher whose primary slot collides with the alias
+  // name (PR #112 reviewer thread on scenarioGenerator.ts:769).
   establisherBindingSemantics?: Record<string, string>;
+  // Issue #104 / PR #112: side index of placeholder-name aliases
+  // mirrored from establisher primaries onto every other path
+  // placeholder name in the graph that carries the same
+  // semanticType. Kept SEPARATE from `establisherBindingSemantics`
+  // so the body-collision guard at the top of the establisher
+  // bookkeeping block (which reserves only primaries against
+  // future body-id establishers) does not see alias slots reserved
+  // for endpoints the current chain may never visit. Consulted
+  // (alongside primaries) only by the alias-overwrite check inside
+  // the alias loop, to avoid stomping a slot already aliased for a
+  // different semantic.
+  establisherAliasSemantics?: Record<string, string>;
   providerList?: Record<string, string[]>; // semantic -> all providers
   artifactsApplied?: string[]; // artifact rule ids used so far
 }
@@ -709,6 +729,7 @@ export function generateScenariosForEndpoint(
       // `identifiedBy` entries are pre-existing components consumed
       // from the chain, not values minted here.
       let establisherBindingSemantics = workingState.establisherBindingSemantics;
+      let establisherAliasSemantics = workingState.establisherAliasSemantics;
       if (producerNode.establishes && producerNode.establishes.shape !== 'edge') {
         // Pre-flight: for each *body* identifier, the request-body
         // builder (`buildRequestBodyFromCanonical` in path-analyser/
@@ -753,7 +774,26 @@ export function generateScenariosForEndpoint(
           const value =
             bindingsDraft[primaryVar] ??
             `${camelLower(producerNode.establishes.kind)}_${deterministicSuffix(`establish:${producerNode.operationId}:${id.semanticType}:${primaryVar}`)}`;
-          if (!bindingsDraft[primaryVar]) bindingsDraft[primaryVar] = value;
+          // A primary mint always wins over a stale alias that an
+          // earlier establisher in the same chain reserved for a
+          // *different* semanticType. Without this overwrite the
+          // alias value (e.g. a Username minted under `nameVar` for
+          // some unrelated endpoint) would silently bleed into the
+          // primary slot of a later body-id establisher whose own
+          // raw field is also `name` but for a different semantic
+          // (e.g. RoleName) — exactly the defect class guarded by
+          // the cross-endpoint alias-pollution fixture.
+          const aliasSemanticAtPrimary = establisherAliasSemantics?.[primaryVar];
+          const staleAlias =
+            aliasSemanticAtPrimary !== undefined && aliasSemanticAtPrimary !== id.semanticType;
+          if (staleAlias) {
+            const fresh = `${camelLower(producerNode.establishes.kind)}_${deterministicSuffix(`establish:${producerNode.operationId}:${id.semanticType}:${primaryVar}`)}`;
+            bindingsDraft[primaryVar] = fresh;
+            const { [primaryVar]: _drop, ...rest } = establisherAliasSemantics ?? {};
+            establisherAliasSemantics = rest;
+          } else if (!bindingsDraft[primaryVar]) {
+            bindingsDraft[primaryVar] = value;
+          }
           establisherBindingSemantics = {
             ...(establisherBindingSemantics ?? {}),
             [primaryVar]: id.semanticType,
@@ -762,19 +802,31 @@ export function generateScenariosForEndpoint(
           // var name used by any operation in the graph for this same
           // semanticType. Cheap one-time scan per identifier; harmless
           // if the consumer ends up not being chained.
+          //
+          // Aliases write to `establisherAliasSemantics` rather than
+          // `establisherBindingSemantics`. The body-collision guard
+          // (above) consults only the latter, so an alias reserved
+          // here for an unrelated endpoint cannot abort a future
+          // body-id establisher in the same chain whose primary slot
+          // collides with the alias name — see PR #112 reviewer
+          // thread on this file. The overwrite check below still
+          // consults BOTH maps so we don't stomp a slot already
+          // aliased for a different semanticType.
           for (const consumer of Object.values(graph.operations)) {
             for (const param of consumer.pathParameters ?? []) {
               if (param.semanticType !== id.semanticType) continue;
               const aliasVar = `${camelLower(param.name)}Var`;
               if (aliasVar === primaryVar) continue;
               // Only alias when the slot is free OR was previously
-              // minted by an establisher for this same semanticType.
-              const existingSemantic = establisherBindingSemantics?.[aliasVar];
+              // recorded (primary or alias) for this same
+              // semanticType.
+              const existingSemantic =
+                establisherBindingSemantics?.[aliasVar] ?? establisherAliasSemantics?.[aliasVar];
               if (existingSemantic && existingSemantic !== id.semanticType) continue;
               if (!bindingsDraft[aliasVar]) {
                 bindingsDraft[aliasVar] = value;
-                establisherBindingSemantics = {
-                  ...establisherBindingSemantics,
+                establisherAliasSemantics = {
+                  ...(establisherAliasSemantics ?? {}),
                   [aliasVar]: id.semanticType,
                 };
               }
@@ -799,6 +851,7 @@ export function generateScenariosForEndpoint(
         modelsDraft,
         bindingsDraft,
         establisherBindingSemantics,
+        establisherAliasSemantics,
         providerList: updateProviderList(
           state.providerList || {},
           producerNode,

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -479,7 +479,17 @@ export function generateScenariosForEndpoint(
 
     // Choose a semantic type to target next
     const targetSemantic = remaining[0];
-    let producers: string[] = targetSemantic ? graph.producersByType[targetSemantic] || [] : [];
+    // Shallow-copy the producer list before any local augmentation —
+    // `graph.producersByType[targetSemantic]` is the shared
+    // authoritative-producer index and must remain immutable across
+    // BFS candidate evaluation and across `generateScenariosForEndpoint`
+    // calls. Direct-reference + push() pollutes the index with
+    // establishers (#104) or any future locally-added candidates and
+    // leaks across endpoints, breaking the "producersByType is
+    // authoritative only" contract.
+    let producers: string[] = targetSemantic
+      ? [...(graph.producersByType[targetSemantic] ?? [])]
+      : [];
 
     // #104: establishers are kept out of `producersByType` to preserve
     // the "authoritative-producer only" contract that the rest of the

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -794,6 +794,15 @@ export function generateScenariosForEndpoint(
           } else if (!bindingsDraft[primaryVar]) {
             bindingsDraft[primaryVar] = value;
           }
+          // Re-read the primary value AFTER the stale-alias overwrite
+          // so the alias-mirroring loop below propagates the freshly-
+          // minted value rather than the stale alias value captured
+          // pre-overwrite. Otherwise an unrelated endpoint elsewhere
+          // in the graph that aliased `primaryVar` for a different
+          // semanticType would bleed its value into the new
+          // semantic's other placeholder aliases — see PR #112
+          // reviewer thread on the stale-alias overwrite branch.
+          const aliasValue = bindingsDraft[primaryVar];
           establisherBindingSemantics = {
             ...(establisherBindingSemantics ?? {}),
             [primaryVar]: id.semanticType,
@@ -824,7 +833,7 @@ export function generateScenariosForEndpoint(
                 establisherBindingSemantics?.[aliasVar] ?? establisherAliasSemantics?.[aliasVar];
               if (existingSemantic && existingSemantic !== id.semanticType) continue;
               if (!bindingsDraft[aliasVar]) {
-                bindingsDraft[aliasVar] = value;
+                bindingsDraft[aliasVar] = aliasValue;
                 establisherAliasSemantics = {
                   ...(establisherAliasSemantics ?? {}),
                   [aliasVar]: id.semanticType,

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -103,9 +103,15 @@ export interface OperationGraph {
   // Issue #104: parallel index of operations that *establish* a semantic
   // type via x-semantic-establishes (i.e. the value is client-minted
   // and written into the request rather than returned in the response).
-  // Establishers are also included in `producersByType` so existing BFS
-  // candidate selection finds them, but this index lets consumers
-  // distinguish establish-style satisfiers from producer-style ones.
+  // Establishers are intentionally KEPT OUT of `producersByType` so that
+  // index continues to mean "authoritative producer only" (the contract
+  // variant planning, provider preference, and missing-producer
+  // diagnostics rely on after #98). Planner code that needs to schedule
+  // an establisher as a satisfier consults `establishersByType` directly
+  // — see `scenarioGenerator.generateScenariosForEndpoint`. Per-op
+  // satisfaction tracking still works because the synthesised semantic
+  // remains on `OperationNode.produces`, which BFS reads to mark the
+  // identifier semantic satisfied once the establisher is scheduled.
   establishersByType?: Record<string, string[]>;
 }
 

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -71,6 +71,20 @@ export interface OperationNode extends OperationRef {
     status: string;
     provider: boolean;
   }>;
+  // Issue #104: x-semantic-establishes annotation passthrough. When
+  // present, the operation establishes an entity whose identifiers are
+  // client-minted via the listed request inputs. The planner schedules
+  // this op as a satisfier for each `identifiedBy[].semanticType` with
+  // a fresh shared binding written into both this step's request body /
+  // path param and any downstream consumer that reads the same
+  // semantic. Distinct from `producersByType` semantics: an establisher
+  // does not authoritatively *return* a value, it merely registers an
+  // identifier the client supplied.
+  establishes?: {
+    kind: string;
+    shape?: string;
+    identifiedBy: Array<{ in: 'body' | 'path'; name: string; semanticType: string }>;
+  };
 }
 
 export interface OperationGraph {
@@ -86,6 +100,13 @@ export interface OperationGraph {
   bootstrapSequences?: BootstrapSequence[];
   domain?: DomainSemantics; // loaded sidecar
   producersByState?: Record<string, string[]>; // domain state -> operations
+  // Issue #104: parallel index of operations that *establish* a semantic
+  // type via x-semantic-establishes (i.e. the value is client-minted
+  // and written into the request rather than returned in the response).
+  // Establishers are also included in `producersByType` so existing BFS
+  // candidate selection finds them, but this index lets consumers
+  // distinguish establish-style satisfiers from producer-style ones.
+  establishersByType?: Record<string, string[]>;
 }
 
 export interface BootstrapSequence {

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -82,7 +82,12 @@ export interface OperationNode extends OperationRef {
   // identifier the client supplied.
   establishes?: {
     kind: string;
-    shape?: string;
+    // Narrowed to the literal `'edge'` to match the extractor's
+    // strict shape gate and `graphLoader.normalizeEstablishes`
+    // (which drops any other shape wholesale). Downstream code
+    // (`scenarioGenerator`, the L3 invariants) compares `shape ===
+    // 'edge'` directly and can rely on this contract.
+    shape?: 'edge';
     identifiedBy: Array<{ in: 'body' | 'path'; name: string; semanticType: string }>;
   };
 }

--- a/semantic-graph-extractor/schema-analyzer.ts
+++ b/semantic-graph-extractor/schema-analyzer.ts
@@ -253,11 +253,25 @@ export class SchemaAnalyzer {
         }
       }
       if (allValid && identifiedBy.length === rawEstablishes.identifiedBy.length) {
-        establishes = {
-          kind: rawEstablishes.kind,
-          shape: typeof rawEstablishes.shape === 'string' ? rawEstablishes.shape : undefined,
-          identifiedBy,
-        };
+        // `shape` changes the meaning of `identifiedBy`: edges treat
+        // entries as PRE-EXISTING components consumed from the chain;
+        // non-edges treat them as VALUES MINTED by the establisher.
+        // Accepting any string `shape` would silently treat a typo
+        // (e.g. `'edeg'`) as a non-edge establisher and the planner
+        // would mint client-side values for what should be component
+        // inputs. Reject unknown shapes by dropping the whole
+        // annotation rather than falling back to the non-edge path.
+        const rawShape = rawEstablishes.shape;
+        const KNOWN_SHAPES = new Set<string>(['edge']);
+        const shapeValid =
+          rawShape === undefined || (typeof rawShape === 'string' && KNOWN_SHAPES.has(rawShape));
+        if (shapeValid) {
+          establishes = {
+            kind: rawEstablishes.kind,
+            shape: typeof rawShape === 'string' ? rawShape : undefined,
+            identifiedBy,
+          };
+        }
       }
     }
 

--- a/semantic-graph-extractor/schema-analyzer.ts
+++ b/semantic-graph-extractor/schema-analyzer.ts
@@ -1,5 +1,7 @@
 import {
   type ConditionalIdempotencySpec,
+  type EstablishesIdentifier,
+  type EstablishesSpec,
   type FieldSchema,
   type MediaTypeObject,
   type OpenAPISpec,
@@ -210,6 +212,42 @@ export class SchemaAnalyzer {
       }
     }
 
+    // Extract x-semantic-establishes (camunda/api-test-generator#104).
+    // The annotation is on the operation object and declares the entity
+    // kind plus the request inputs that carry the client-minted
+    // identifier(s). Each `identifiedBy` entry pairs an OpenAPI
+    // parameter (path or body) with the semantic type the planner can
+    // satisfy from a fresh binding shared between the establisher and
+    // any downstream consumer.
+    const rawEstablishes = operation['x-semantic-establishes'];
+    let establishes: EstablishesSpec | undefined;
+    if (
+      rawEstablishes &&
+      typeof rawEstablishes === 'object' &&
+      typeof rawEstablishes.kind === 'string' &&
+      Array.isArray(rawEstablishes.identifiedBy)
+    ) {
+      const identifiedBy: EstablishesIdentifier[] = [];
+      for (const id of rawEstablishes.identifiedBy) {
+        if (
+          id &&
+          typeof id === 'object' &&
+          (id.in === 'body' || id.in === 'path') &&
+          typeof id.name === 'string' &&
+          typeof id.semanticType === 'string'
+        ) {
+          identifiedBy.push({ in: id.in, name: id.name, semanticType: id.semanticType });
+        }
+      }
+      if (identifiedBy.length) {
+        establishes = {
+          kind: rawEstablishes.kind,
+          shape: typeof rawEstablishes.shape === 'string' ? rawEstablishes.shape : undefined,
+          identifiedBy,
+        };
+      }
+    }
+
     return {
       operationId: operation.operationId,
       method: method.toUpperCase(),
@@ -226,6 +264,7 @@ export class SchemaAnalyzer {
       cacheable: this.isCacheable(method, operation),
       operationMetadata,
       conditionalIdempotency,
+      establishes,
     };
   }
 

--- a/semantic-graph-extractor/schema-analyzer.ts
+++ b/semantic-graph-extractor/schema-analyzer.ts
@@ -225,9 +225,16 @@ export class SchemaAnalyzer {
       rawEstablishes &&
       typeof rawEstablishes === 'object' &&
       typeof rawEstablishes.kind === 'string' &&
-      Array.isArray(rawEstablishes.identifiedBy)
+      Array.isArray(rawEstablishes.identifiedBy) &&
+      rawEstablishes.identifiedBy.length > 0
     ) {
+      // Strict validation: any invalid member rejects the *whole*
+      // annotation. Surfacing a partial subset would silently mislead
+      // the planner — e.g. a composite (path+body) identifier with one
+      // malformed `in` value would degrade to a single-identifier
+      // establisher and start producing wrong chains.
       const identifiedBy: EstablishesIdentifier[] = [];
+      let allValid = true;
       for (const id of rawEstablishes.identifiedBy) {
         if (
           id &&
@@ -237,9 +244,12 @@ export class SchemaAnalyzer {
           typeof id.semanticType === 'string'
         ) {
           identifiedBy.push({ in: id.in, name: id.name, semanticType: id.semanticType });
+        } else {
+          allValid = false;
+          break;
         }
       }
-      if (identifiedBy.length) {
+      if (allValid && identifiedBy.length === rawEstablishes.identifiedBy.length) {
         establishes = {
           kind: rawEstablishes.kind,
           shape: typeof rawEstablishes.shape === 'string' ? rawEstablishes.shape : undefined,

--- a/semantic-graph-extractor/schema-analyzer.ts
+++ b/semantic-graph-extractor/schema-analyzer.ts
@@ -225,6 +225,7 @@ export class SchemaAnalyzer {
       rawEstablishes &&
       typeof rawEstablishes === 'object' &&
       typeof rawEstablishes.kind === 'string' &&
+      rawEstablishes.kind.length > 0 &&
       Array.isArray(rawEstablishes.identifiedBy) &&
       rawEstablishes.identifiedBy.length > 0
     ) {
@@ -241,7 +242,9 @@ export class SchemaAnalyzer {
           typeof id === 'object' &&
           (id.in === 'body' || id.in === 'path') &&
           typeof id.name === 'string' &&
-          typeof id.semanticType === 'string'
+          id.name.length > 0 &&
+          typeof id.semanticType === 'string' &&
+          id.semanticType.length > 0
         ) {
           identifiedBy.push({ in: id.in, name: id.name, semanticType: id.semanticType });
         } else {

--- a/semantic-graph-extractor/schema-analyzer.ts
+++ b/semantic-graph-extractor/schema-analyzer.ts
@@ -262,13 +262,11 @@ export class SchemaAnalyzer {
         // inputs. Reject unknown shapes by dropping the whole
         // annotation rather than falling back to the non-edge path.
         const rawShape = rawEstablishes.shape;
-        const KNOWN_SHAPES = new Set<string>(['edge']);
-        const shapeValid =
-          rawShape === undefined || (typeof rawShape === 'string' && KNOWN_SHAPES.has(rawShape));
+        const shapeValid = rawShape === undefined || rawShape === 'edge';
         if (shapeValid) {
           establishes = {
             kind: rawEstablishes.kind,
-            shape: typeof rawShape === 'string' ? rawShape : undefined,
+            shape: rawShape === 'edge' ? 'edge' : undefined,
             identifiedBy,
           };
         }

--- a/semantic-graph-extractor/types.ts
+++ b/semantic-graph-extractor/types.ts
@@ -64,6 +64,32 @@ export interface OperationObject {
   'x-eventually-consistent'?: boolean;
   'x-operation-kind'?: OperationMetadata | OperationMetadata[];
   'x-conditional-idempotency'?: ConditionalIdempotencySpec;
+  'x-semantic-establishes'?: EstablishesSpec;
+}
+
+// `x-semantic-establishes` declares that running this operation establishes a
+// (typically configuration-entity) instance whose identifier(s) are minted by
+// the client and supplied as request inputs. After the operation returns,
+// downstream `getX(id)` / `searchX` / `updateX(id)` operations on the same
+// entity become satisfiable using the same client-minted value(s). This is
+// the planning primitive that closes the gap left by `x-semantic-provider`,
+// which only applies when the response carries an authoritative value (see
+// camunda/api-test-generator#104, camunda/camunda#52272).
+export interface EstablishesSpec {
+  kind: string;
+  // Optional shape hint — `'edge'` for membership operations whose
+  // identifier is the composite of two existing entities (e.g.
+  // RoleUserMembership). The planner currently treats edges identically
+  // to regular establishers; the field is preserved for downstream
+  // consumers that may distinguish them.
+  shape?: string;
+  identifiedBy: EstablishesIdentifier[];
+}
+
+export interface EstablishesIdentifier {
+  in: 'body' | 'path';
+  name: string;
+  semanticType: string;
 }
 
 export interface Schema {
@@ -252,6 +278,12 @@ export interface Operation {
   operationMetadata?: OperationMetadata;
   // Conditional idempotency extension (x-conditional-idempotency)
   conditionalIdempotency?: ConditionalIdempotencySpec;
+  // Establisher annotation passthrough (x-semantic-establishes). When
+  // present, the operation establishes an entity whose identifier(s) are
+  // client-minted via the listed request inputs. The planner uses this to
+  // schedule the operation as a satisfier for the named `semanticType`s
+  // with a fresh shared binding (camunda/api-test-generator#104).
+  establishes?: EstablishesSpec;
 }
 
 export enum OperationType {

--- a/semantic-graph-extractor/types.ts
+++ b/semantic-graph-extractor/types.ts
@@ -79,9 +79,15 @@ export interface EstablishesSpec {
   kind: string;
   // Optional shape hint — `'edge'` for membership operations whose
   // identifier is the composite of two existing entities (e.g.
-  // RoleUserMembership). The planner currently treats edges identically
-  // to regular establishers; the field is preserved for downstream
-  // consumers that may distinguish them.
+  // RoleUserMembership). The planner treats edges DIFFERENTLY from
+  // regular establishers: `graphLoader` skips them when populating
+  // `producersByType` / `establishersByType` and does not drop their
+  // `identifiedBy` semantics from `requires` (the components are
+  // pre-existing inputs that must be satisfied by their own
+  // non-edge establishers), and `scenarioGenerator` skips them when
+  // pre-populating client-minted bindings. Non-edge establishers
+  // self-satisfy the identifier they mint and contribute it to
+  // `establishersByType`.
   shape?: string;
   identifiedBy: EstablishesIdentifier[];
 }

--- a/semantic-graph-extractor/types.ts
+++ b/semantic-graph-extractor/types.ts
@@ -88,7 +88,13 @@ export interface EstablishesSpec {
   // pre-populating client-minted bindings. Non-edge establishers
   // self-satisfy the identifier they mint and contribute it to
   // `establishersByType`.
-  shape?: string;
+  //
+  // Narrowed to the literal `'edge'`: the extractor's strict shape
+  // gate (`semantic-graph-extractor/schema-analyzer.ts`) drops any
+  // annotation whose `shape` is not `undefined` or exactly `'edge'`,
+  // so callers downstream of the extractor can rely on this contract
+  // without re-checking arbitrary string values.
+  shape?: 'edge';
   identifiedBy: EstablishesIdentifier[];
 }
 

--- a/tests/fixtures/extractor/extractor-establishes.test.ts
+++ b/tests/fixtures/extractor/extractor-establishes.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Construct fixtures for the semantic-graph extractor — x-semantic-establishes
+ * (camunda/api-test-generator#104, upstream camunda/camunda#52272).
+ *
+ * Each fixture isolates ONE shape of the annotation so a failure points at
+ * one parser branch, not at the bundled-spec aggregate. The class-scoped
+ * regression: any operation whose object satisfies the annotation contract
+ * (kind + non-empty identifiedBy) must surface it on `Operation.establishes`,
+ * regardless of whether body or path inputs carry the identifier.
+ */
+import { describe, expect, it } from 'vitest';
+import { SchemaAnalyzer } from '../../../semantic-graph-extractor/schema-analyzer.ts';
+import type { OpenAPISpec } from '../../../semantic-graph-extractor/types.ts';
+
+function extractOp(spec: OpenAPISpec, opId: string) {
+  const ops = new SchemaAnalyzer().extractOperations(spec);
+  const op = ops.find((o) => o.operationId === opId);
+  if (!op) throw new Error(`fixture: operation ${opId} not present in extracted spec`);
+  return op;
+}
+
+// Body-identifier establisher (createUser-shaped).
+const fixtureBodyIdentifier: OpenAPISpec = {
+  openapi: '3.0.3',
+  info: { title: 'fixture-establishes-body', version: '0.0.0' },
+  paths: {
+    '/users': {
+      post: {
+        operationId: 'createUserLike',
+        'x-semantic-establishes': {
+          kind: 'User',
+          identifiedBy: [{ in: 'body', name: 'username', semanticType: 'Username' }],
+        },
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['username'],
+                properties: {
+                  username: { type: 'string', 'x-semantic-type': 'Username' },
+                },
+              },
+            },
+          },
+        },
+        responses: { '201': { description: 'created' } },
+      },
+    },
+  },
+};
+
+// Edge establisher with shape:'edge' and two path identifiers
+// (assignUserToGroup-shaped).
+const fixtureEdgeMembership: OpenAPISpec = {
+  openapi: '3.0.3',
+  info: { title: 'fixture-establishes-edge', version: '0.0.0' },
+  paths: {
+    '/groups/{groupId}/users/{username}': {
+      put: {
+        operationId: 'assignUserToGroupLike',
+        'x-semantic-establishes': {
+          kind: 'GroupUserMembership',
+          shape: 'edge',
+          identifiedBy: [
+            { in: 'path', name: 'groupId', semanticType: 'GroupId' },
+            { in: 'path', name: 'username', semanticType: 'Username' },
+          ],
+        },
+        parameters: [
+          {
+            name: 'groupId',
+            in: 'path',
+            required: true,
+            schema: { type: 'string', 'x-semantic-type': 'GroupId' },
+          },
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string', 'x-semantic-type': 'Username' },
+          },
+        ],
+        responses: { '204': { description: 'no-content' } },
+      },
+    },
+  },
+};
+
+// Composite identifier (path + body) — createTenantClusterVariable-shaped.
+const fixtureCompositeIdentifier: OpenAPISpec = {
+  openapi: '3.0.3',
+  info: { title: 'fixture-establishes-composite', version: '0.0.0' },
+  paths: {
+    '/tenants/{tenantId}/cluster-variables': {
+      post: {
+        operationId: 'createTenantClusterVariableLike',
+        'x-semantic-establishes': {
+          kind: 'TenantClusterVariable',
+          identifiedBy: [
+            { in: 'path', name: 'tenantId', semanticType: 'TenantId' },
+            { in: 'body', name: 'name', semanticType: 'ClusterVariableName' },
+          ],
+        },
+        parameters: [
+          {
+            name: 'tenantId',
+            in: 'path',
+            required: true,
+            schema: { type: 'string', 'x-semantic-type': 'TenantId' },
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['name'],
+                properties: {
+                  name: { type: 'string', 'x-semantic-type': 'ClusterVariableName' },
+                },
+              },
+            },
+          },
+        },
+        responses: { '201': { description: 'created' } },
+      },
+    },
+  },
+};
+
+// Malformed annotation: missing identifiedBy. Must NOT surface establishes.
+const fixtureMalformedNoIdentifiers: OpenAPISpec = {
+  openapi: '3.0.3',
+  info: { title: 'fixture-establishes-malformed', version: '0.0.0' },
+  paths: {
+    '/things': {
+      post: {
+        operationId: 'createThingMalformed',
+        'x-semantic-establishes': { kind: 'Thing' },
+        responses: { '201': { description: 'created' } },
+      },
+    },
+  },
+};
+
+// Operation without the annotation — must remain `establishes: undefined`.
+const fixtureNoAnnotation: OpenAPISpec = {
+  openapi: '3.0.3',
+  info: { title: 'fixture-establishes-absent', version: '0.0.0' },
+  paths: {
+    '/things': {
+      post: {
+        operationId: 'createThingNoAnnotation',
+        responses: { '201': { description: 'created' } },
+      },
+    },
+  },
+};
+
+describe('extractor x-semantic-establishes (#104)', () => {
+  it('surfaces a body-identifier establisher with kind, in, name, and semanticType', () => {
+    const op = extractOp(fixtureBodyIdentifier, 'createUserLike');
+    expect(op.establishes).toEqual({
+      kind: 'User',
+      shape: undefined,
+      identifiedBy: [{ in: 'body', name: 'username', semanticType: 'Username' }],
+    });
+  });
+
+  it('preserves shape:edge and the full identifiedBy list for membership ops', () => {
+    const op = extractOp(fixtureEdgeMembership, 'assignUserToGroupLike');
+    expect(op.establishes?.shape).toBe('edge');
+    expect(op.establishes?.kind).toBe('GroupUserMembership');
+    expect(op.establishes?.identifiedBy).toEqual([
+      { in: 'path', name: 'groupId', semanticType: 'GroupId' },
+      { in: 'path', name: 'username', semanticType: 'Username' },
+    ]);
+  });
+
+  it('preserves a composite path+body identifier in declaration order', () => {
+    const op = extractOp(fixtureCompositeIdentifier, 'createTenantClusterVariableLike');
+    expect(op.establishes?.identifiedBy.map((i) => i.in)).toEqual(['path', 'body']);
+    expect(op.establishes?.identifiedBy.map((i) => i.semanticType)).toEqual([
+      'TenantId',
+      'ClusterVariableName',
+    ]);
+  });
+
+  it('rejects malformed annotations with no identifiedBy entries (no partial state)', () => {
+    const op = extractOp(fixtureMalformedNoIdentifiers, 'createThingMalformed');
+    expect(op.establishes).toBeUndefined();
+  });
+
+  it('leaves `establishes` undefined on operations without the annotation', () => {
+    const op = extractOp(fixtureNoAnnotation, 'createThingNoAnnotation');
+    expect(op.establishes).toBeUndefined();
+  });
+});

--- a/tests/fixtures/extractor/extractor-establishes.test.ts
+++ b/tests/fixtures/extractor/extractor-establishes.test.ts
@@ -237,4 +237,34 @@ describe('extractor x-semantic-establishes (#104)', () => {
     const op = extractOp(fixtureNoAnnotation, 'createThingNoAnnotation');
     expect(op.establishes).toBeUndefined();
   });
+
+  it('rejects the WHOLE annotation when `shape` is an unknown string', () => {
+    // Class-scoped strictness: any `shape` value other than the known
+    // set (`'edge'` or undefined) must reject the whole annotation.
+    // Without this, a typo (e.g. `'edeg'`) would degrade silently to
+    // non-edge behaviour, the planner would treat the entries as
+    // VALUES MINTED (instead of pre-existing components consumed from
+    // the chain), and the test suite would render with the wrong
+    // shape of test data.
+    // biome-ignore lint/plugin: intentional malformed annotation for negative-test fixture
+    const fixtureUnknownShape = {
+      openapi: '3.0.3',
+      info: { title: 'fixture-establishes-unknown-shape', version: '0.0.0' },
+      paths: {
+        '/things': {
+          post: {
+            operationId: 'createThingUnknownShape',
+            'x-semantic-establishes': {
+              kind: 'Thing',
+              shape: 'edeg', // typo of 'edge'
+              identifiedBy: [{ in: 'body', name: 'name', semanticType: 'ThingName' }],
+            },
+            responses: { '201': { description: 'created' } },
+          },
+        },
+      },
+    } as unknown as OpenAPISpec;
+    const op = extractOp(fixtureUnknownShape, 'createThingUnknownShape');
+    expect(op.establishes).toBeUndefined();
+  });
 });

--- a/tests/fixtures/extractor/extractor-establishes.test.ts
+++ b/tests/fixtures/extractor/extractor-establishes.test.ts
@@ -194,6 +194,38 @@ describe('extractor x-semantic-establishes (#104)', () => {
     expect(op.establishes).toBeUndefined();
   });
 
+  it('rejects the WHOLE annotation when any identifiedBy member is invalid', () => {
+    // Class-scoped strictness: a composite identifier with one valid
+    // entry and one invalid `in` value must NOT degrade to a
+    // single-identifier establisher. Surfacing the partial subset would
+    // silently mislead the planner into minting only one binding for
+    // what should be a composite identifier (e.g. tenant cluster
+    // variable losing its `name` half).
+    const fixturePartialMalformed: OpenAPISpec = {
+      openapi: '3.0.3',
+      info: { title: 'fixture-establishes-partial-malformed', version: '0.0.0' },
+      paths: {
+        '/tenants/{tenantId}/things': {
+          post: {
+            operationId: 'createPartialMalformed',
+            'x-semantic-establishes': {
+              kind: 'Thing',
+              identifiedBy: [
+                { in: 'path', name: 'tenantId', semanticType: 'TenantId' },
+                // Invalid `in` value — the whole annotation must be
+                // rejected, not silently dropped to the first entry.
+                { in: 'query', name: 'name', semanticType: 'ThingName' },
+              ],
+            },
+            responses: { '201': { description: 'created' } },
+          },
+        },
+      },
+    };
+    const op = extractOp(fixturePartialMalformed, 'createPartialMalformed');
+    expect(op.establishes).toBeUndefined();
+  });
+
   it('leaves `establishes` undefined on operations without the annotation', () => {
     const op = extractOp(fixtureNoAnnotation, 'createThingNoAnnotation');
     expect(op.establishes).toBeUndefined();

--- a/tests/fixtures/extractor/extractor-establishes.test.ts
+++ b/tests/fixtures/extractor/extractor-establishes.test.ts
@@ -132,7 +132,13 @@ const fixtureCompositeIdentifier: OpenAPISpec = {
 };
 
 // Malformed annotation: missing identifiedBy. Must NOT surface establishes.
-const fixtureMalformedNoIdentifiers: OpenAPISpec = {
+// The cast intentionally bypasses the OpenAPISpec contract — the whole
+// point of this fixture is to feed the extractor a malformed annotation
+// and assert it is rejected. The runtime extractor is the boundary under
+// test; the type cast simulates an upstream spec that violates the
+// contract.
+// biome-ignore lint/plugin: intentional malformed annotation for negative-test fixture
+const fixtureMalformedNoIdentifiers = {
   openapi: '3.0.3',
   info: { title: 'fixture-establishes-malformed', version: '0.0.0' },
   paths: {
@@ -144,7 +150,7 @@ const fixtureMalformedNoIdentifiers: OpenAPISpec = {
       },
     },
   },
-};
+} as unknown as OpenAPISpec;
 
 // Operation without the annotation — must remain `establishes: undefined`.
 const fixtureNoAnnotation: OpenAPISpec = {
@@ -201,7 +207,8 @@ describe('extractor x-semantic-establishes (#104)', () => {
     // silently mislead the planner into minting only one binding for
     // what should be a composite identifier (e.g. tenant cluster
     // variable losing its `name` half).
-    const fixturePartialMalformed: OpenAPISpec = {
+    // biome-ignore lint/plugin: intentional malformed annotation for negative-test fixture
+    const fixturePartialMalformed = {
       openapi: '3.0.3',
       info: { title: 'fixture-establishes-partial-malformed', version: '0.0.0' },
       paths: {
@@ -221,7 +228,7 @@ describe('extractor x-semantic-establishes (#104)', () => {
           },
         },
       },
-    };
+    } as unknown as OpenAPISpec;
     const op = extractOp(fixturePartialMalformed, 'createPartialMalformed');
     expect(op.establishes).toBeUndefined();
   });

--- a/tests/fixtures/integration/establishes-hint-merge.test.ts
+++ b/tests/fixtures/integration/establishes-hint-merge.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Integration fixture for the establisher self-satisfaction drop on the
+ * hint-merge path (camunda/api-test-generator#104, PR #112).
+ *
+ * The planner-only fixtures in `tests/fixtures/planner/` build their
+ * `OperationGraph` by hand and never exercise `loadOpenApiSemanticHints`.
+ * That helper walks the raw OpenAPI request schema independently of the
+ * graph and re-adds `Username`-style semanticTypes back to a self-
+ * establishing op's `requires` via the `x-semantic-type` annotation on
+ * the identifier field. Without the second-pass drop in
+ * `path-analyser/src/index.ts`, BFS skips the establisher as its own
+ * producer (`producerOpId === endpointOpId`) and the endpoint plans an
+ * unsatisfied chain.
+ *
+ * This fixture goes through `loadGraph` + `loadOpenApiSemanticHints`
+ * against a tiny on-disk spec so the hint-merge surface is actually
+ * exercised; it then replays the index.ts drop and asserts the merged
+ * `requires` no longer carries the established semantic.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { loadGraph, loadOpenApiSemanticHints } from '../../../path-analyser/src/graphLoader.ts';
+
+const SELF_ESTABLISHING_SPEC = `
+openapi: 3.0.3
+info:
+  title: fixture-establishes-hint-merge
+  version: 0.0.0
+paths:
+  /users:
+    post:
+      operationId: createUser
+      x-semantic-establishes:
+        kind: User
+        identifiedBy:
+          - in: body
+            name: username
+            semanticType: Username
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [username]
+              properties:
+                username:
+                  type: string
+                  x-semantic-type: Username
+      responses:
+        '201':
+          description: created
+`;
+
+let tmpDir: string;
+let specPath: string;
+let savedSpecPath: string | undefined;
+let savedGraphPath: string | undefined;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'establishes-hint-merge-'));
+  specPath = join(tmpDir, 'rest-api.bundle.yaml');
+  writeFileSync(specPath, SELF_ESTABLISHING_SPEC, 'utf8');
+  // Minimal graph with the self-establisher recorded as a producer for
+  // its own semantic — mirrors what the extractor would emit.
+  const graphPath = join(tmpDir, 'operation-dependency-graph.json');
+  writeFileSync(
+    graphPath,
+    JSON.stringify({
+      operations: {
+        createUser: {
+          operationId: 'createUser',
+          method: 'POST',
+          path: '/users',
+          requires: { required: [], optional: [] },
+          produces: ['Username'],
+          establishes: {
+            kind: 'User',
+            identifiedBy: [{ in: 'body', name: 'username', semanticType: 'Username' }],
+          },
+        },
+      },
+      producersByType: { Username: ['createUser'] },
+      establishersByType: { Username: ['createUser'] },
+    }),
+    'utf8',
+  );
+  savedSpecPath = process.env.OPENAPI_SPEC_PATH;
+  savedGraphPath = process.env.OPERATION_GRAPH_PATH;
+  process.env.OPENAPI_SPEC_PATH = specPath;
+  process.env.OPERATION_GRAPH_PATH = graphPath;
+});
+
+afterAll(() => {
+  if (savedSpecPath === undefined) delete process.env.OPENAPI_SPEC_PATH;
+  else process.env.OPENAPI_SPEC_PATH = savedSpecPath;
+  if (savedGraphPath === undefined) delete process.env.OPERATION_GRAPH_PATH;
+  else process.env.OPERATION_GRAPH_PATH = savedGraphPath;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('integration: x-semantic-establishes self-satisfaction drop on hint-merge path (#104)', () => {
+  it('drops established semantics from `requires` after hint-merge would re-add them', async () => {
+    const graph = await loadGraph(tmpDir);
+    const hints = await loadOpenApiSemanticHints(tmpDir);
+
+    // Sanity check: the hint-merger DID re-surface `Username` on
+    // `createUser` from the request body's `x-semantic-type`. If this
+    // assertion ever stops holding, the test no longer guards the
+    // drop and must be rewritten — it's not "just a flaky parser".
+    expect(hints.createUser?.required).toContain('Username');
+
+    // Replay the exact merge + drop sequence from
+    // `path-analyser/src/index.ts` (the loop body around L88-L120).
+    const op = graph.operations.createUser;
+    const reqReq = new Set(op.requires.required);
+    for (const s of hints.createUser?.required ?? []) reqReq.add(s);
+    op.requires.required = [...reqReq];
+    if (op.establishes && op.establishes.shape !== 'edge') {
+      const established = new Set(op.establishes.identifiedBy.map((i) => i.semanticType));
+      op.requires.required = op.requires.required.filter((s) => !established.has(s));
+      op.requires.optional = op.requires.optional.filter((s) => !established.has(s));
+    }
+
+    expect(op.requires.required).not.toContain('Username');
+  });
+});

--- a/tests/fixtures/planner/planner-establishes.test.ts
+++ b/tests/fixtures/planner/planner-establishes.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Planner contract fixtures — x-semantic-establishes
+ * (camunda/api-test-generator#104).
+ *
+ * Each fixture is a hand-built minimal `OperationGraph` that pairs an
+ * establisher with a consumer and asserts the chain shape
+ * `generateScenariosForEndpoint` must produce.
+ *
+ * Class-scoped invariant: any consumer whose required semantic type has
+ * an establisher must plan a satisfied chain ending in the establisher
+ * + consumer, with the consumer's path placeholder bound to the same
+ * client-minted value the establisher's request body carries.
+ */
+import { describe, expect, it } from 'vitest';
+import { generateScenariosForEndpoint } from '../../../path-analyser/src/scenarioGenerator.ts';
+import type { OperationGraph, OperationNode } from '../../../path-analyser/src/types.ts';
+
+interface NodeOpts {
+  required?: string[];
+  produces?: string[];
+  providerMap?: Record<string, boolean>;
+  establishes?: OperationNode['establishes'];
+  pathParameters?: OperationNode['pathParameters'];
+}
+
+function makeOp(
+  operationId: string,
+  method: string,
+  path: string,
+  opts: NodeOpts = {},
+): OperationNode {
+  return {
+    operationId,
+    method,
+    path,
+    requires: { required: opts.required ?? [], optional: [] },
+    produces: opts.produces ?? [],
+    providerMap: opts.providerMap,
+    establishes: opts.establishes,
+    pathParameters: opts.pathParameters,
+  };
+}
+
+function makeGraph(nodes: OperationNode[]): OperationGraph {
+  const operations: Record<string, OperationNode> = {};
+  const producersByType: Record<string, string[]> = {};
+  const establishersByType: Record<string, string[]> = {};
+  for (const node of nodes) {
+    operations[node.operationId] = node;
+    for (const sem of node.produces) {
+      const list = producersByType[sem] ?? [];
+      list.push(node.operationId);
+      producersByType[sem] = list;
+    }
+    if (node.establishes && node.establishes.shape !== 'edge') {
+      for (const id of node.establishes.identifiedBy) {
+        const list = establishersByType[id.semanticType] ?? [];
+        if (!list.includes(node.operationId)) list.push(node.operationId);
+        establishersByType[id.semanticType] = list;
+      }
+    }
+  }
+  return {
+    operations,
+    producersByType,
+    establishersByType: Object.keys(establishersByType).length ? establishersByType : undefined,
+  };
+}
+
+function opIdsOf(scenario: { operations: { operationId: string }[] }): string[] {
+  return scenario.operations.map((o) => o.operationId);
+}
+
+// Establisher (createUser) + consumer (getUser). The establisher mints
+// Username via its body; the consumer needs Username from its path.
+const fixtureSimpleEstablisherChain: OperationGraph = makeGraph([
+  makeOp('createUser', 'POST', '/users', {
+    // Mirrors graphLoader behaviour: the establisher self-satisfies its
+    // own body identifier, so `requires` is empty and Username is
+    // synthesised into `produces`.
+    produces: ['Username'],
+    establishes: {
+      kind: 'User',
+      identifiedBy: [{ in: 'body', name: 'username', semanticType: 'Username' }],
+    },
+  }),
+  makeOp('getUser', 'GET', '/users/{username}', {
+    required: ['Username'],
+    pathParameters: [{ name: 'username', semanticType: 'Username' }],
+  }),
+]);
+
+// Composite establisher (createTenantClusterVariable) + consumer
+// (getTenantClusterVariable). The establisher mints both identifiers
+// even though one is in the path: the BFS still treats the establisher
+// as the satisfier for both ClusterVariableName and TenantId, and the
+// scenario ends up satisfied without any other prereq op.
+const fixtureCompositeEstablisherChain: OperationGraph = makeGraph([
+  makeOp('createTenantClusterVariable', 'POST', '/tenants/{tenantId}/cluster-variables', {
+    produces: ['TenantId', 'ClusterVariableName'],
+    establishes: {
+      kind: 'TenantClusterVariable',
+      identifiedBy: [
+        { in: 'path', name: 'tenantId', semanticType: 'TenantId' },
+        { in: 'body', name: 'name', semanticType: 'ClusterVariableName' },
+      ],
+    },
+  }),
+  makeOp('getTenantClusterVariable', 'GET', '/cluster-variables/tenants/{tenantId}/{name}', {
+    required: ['TenantId', 'ClusterVariableName'],
+    pathParameters: [
+      { name: 'tenantId', semanticType: 'TenantId' },
+      { name: 'name', semanticType: 'ClusterVariableName' },
+    ],
+  }),
+]);
+
+// Edge establisher (assignUserToGroup, shape:'edge'). Components GroupId
+// and Username are pre-existing inputs, so the edge does NOT contribute
+// to producesByType / establishersByType for either component — they
+// must be satisfied by their respective non-edge establishers.
+const fixtureEdgeRequiresComponentChains: OperationGraph = makeGraph([
+  makeOp('createGroup', 'POST', '/groups', {
+    produces: ['GroupId'],
+    establishes: {
+      kind: 'Group',
+      identifiedBy: [{ in: 'body', name: 'groupId', semanticType: 'GroupId' }],
+    },
+  }),
+  makeOp('createUser', 'POST', '/users', {
+    produces: ['Username'],
+    establishes: {
+      kind: 'User',
+      identifiedBy: [{ in: 'body', name: 'username', semanticType: 'Username' }],
+    },
+  }),
+  makeOp('assignUserToGroup', 'PUT', '/groups/{groupId}/users/{username}', {
+    required: ['GroupId', 'Username'],
+    pathParameters: [
+      { name: 'groupId', semanticType: 'GroupId' },
+      { name: 'username', semanticType: 'Username' },
+    ],
+    establishes: {
+      kind: 'GroupUserMembership',
+      shape: 'edge',
+      identifiedBy: [
+        { in: 'path', name: 'groupId', semanticType: 'GroupId' },
+        { in: 'path', name: 'username', semanticType: 'Username' },
+      ],
+    },
+  }),
+]);
+
+describe('planner contracts: x-semantic-establishes (#104)', () => {
+  describe('simple establisher chain (createUser → getUser)', () => {
+    it('produces a satisfied chain whose first step is the establisher', () => {
+      const result = generateScenariosForEndpoint(fixtureSimpleEstablisherChain, 'getUser', {
+        maxScenarios: 10,
+      });
+      expect(result.unsatisfied).toBeFalsy();
+      expect(result.scenarios.length).toBeGreaterThan(0);
+      const ops = opIdsOf(result.scenarios[0]);
+      expect(ops).toEqual(['createUser', 'getUser']);
+    });
+
+    it('seeds a shared usernameVar binding consumed by both steps', () => {
+      const result = generateScenariosForEndpoint(fixtureSimpleEstablisherChain, 'getUser', {
+        maxScenarios: 10,
+      });
+      const scenario = result.scenarios[0];
+      expect(scenario.bindings).toBeDefined();
+      // Var name is derived from the identifiedBy `name` (the request-body
+      // / path-parameter name), not from the semantic type — that lets
+      // the body builder and the URL emitter find the same key without
+      // any extra alias step.
+      expect(scenario.bindings?.usernameVar).toBeDefined();
+      expect(typeof scenario.bindings?.usernameVar).toBe('string');
+      expect(scenario.bindings?.usernameVar).not.toBe('__PENDING__');
+    });
+  });
+
+  describe('establisher endpoint plans the trivial chain', () => {
+    it('createUser as endpoint plans without chasing a producer for its own Username', () => {
+      const result = generateScenariosForEndpoint(fixtureSimpleEstablisherChain, 'createUser', {
+        maxScenarios: 10,
+      });
+      expect(result.unsatisfied).toBeFalsy();
+      expect(result.scenarios.length).toBeGreaterThan(0);
+      // Establisher self-satisfies its own body identifier — no prereq
+      // chain, the scenario consists of the establisher alone.
+      expect(opIdsOf(result.scenarios[0])).toEqual(['createUser']);
+    });
+  });
+
+  describe('composite-identifier establisher (createTenantClusterVariable)', () => {
+    it('plans a satisfied chain to getTenantClusterVariable in one establisher step', () => {
+      const result = generateScenariosForEndpoint(
+        fixtureCompositeEstablisherChain,
+        'getTenantClusterVariable',
+        { maxScenarios: 10 },
+      );
+      expect(result.unsatisfied).toBeFalsy();
+      const ops = opIdsOf(result.scenarios[0]);
+      expect(ops).toEqual(['createTenantClusterVariable', 'getTenantClusterVariable']);
+    });
+
+    it('seeds bindings for both identifier names (tenantIdVar, nameVar)', () => {
+      const result = generateScenariosForEndpoint(
+        fixtureCompositeEstablisherChain,
+        'getTenantClusterVariable',
+        { maxScenarios: 10 },
+      );
+      const bindings = result.scenarios[0].bindings ?? {};
+      expect(bindings.tenantIdVar).toBeDefined();
+      expect(bindings.nameVar).toBeDefined();
+    });
+  });
+
+  describe('edge establisher (assignUserToGroup) requires component chains', () => {
+    it('plans a chain with both component establishers + the edge endpoint', () => {
+      const result = generateScenariosForEndpoint(
+        fixtureEdgeRequiresComponentChains,
+        'assignUserToGroup',
+        { maxScenarios: 10 },
+      );
+      expect(result.unsatisfied).toBeFalsy();
+      const ops = opIdsOf(result.scenarios[0]);
+      expect(ops).toContain('createGroup');
+      expect(ops).toContain('createUser');
+      expect(ops[ops.length - 1]).toBe('assignUserToGroup');
+    });
+
+    it('does NOT register the edge as an establisher of its component semantics', () => {
+      // Class-scoped: the edge's identifiedBy entries are PRE-EXISTING
+      // inputs, not values minted by the edge. Without this guard, an
+      // edge would compete with the real component establisher and the
+      // BFS could pick the edge as a producer for its own consumed
+      // component (a self-cycle that drops the chain).
+      expect(fixtureEdgeRequiresComponentChains.establishersByType?.GroupId).toEqual([
+        'createGroup',
+      ]);
+      expect(fixtureEdgeRequiresComponentChains.establishersByType?.Username).toEqual([
+        'createUser',
+      ]);
+    });
+  });
+});

--- a/tests/fixtures/planner/planner-establishes.test.ts
+++ b/tests/fixtures/planner/planner-establishes.test.ts
@@ -167,6 +167,87 @@ const fixtureEdgeRequiresComponentChains: OperationGraph = makeGraph([
   }),
 ]);
 
+// Placeholder-name mismatch: establisher mints `username` (body), but
+// the consumer's URL uses a *different* placeholder name (`{userKey}`)
+// that maps to the same semanticType `Username`. The planner must
+// alias the establisher's value under the consumer-derived var name
+// (`userKeyVar`) so the URL emitter resolves it directly.
+const fixturePlaceholderNameMismatch: OperationGraph = makeGraph([
+  makeOp('createUser', 'POST', '/users', {
+    produces: ['Username'],
+    establishes: {
+      kind: 'User',
+      identifiedBy: [{ in: 'body', name: 'username', semanticType: 'Username' }],
+    },
+  }),
+  makeOp('getUserByKey', 'GET', '/users/{userKey}', {
+    required: ['Username'],
+    pathParameters: [{ name: 'userKey', semanticType: 'Username' }],
+  }),
+]);
+
+// Same-name body collision across two different semanticTypes: both
+// establishers mint a body identifier called `name`, but one is
+// `ThingName` and the other is `WidgetName`. The body builder
+// (path-analyser/src/index.ts) emits `${nameVar}` from the raw field
+// name with no per-step override, so silently sharing one binding
+// would feed the second establisher the first's value. The planner
+// must skip the second candidate rather than emit a broken test.
+const fixtureBodyCollisionSameName: OperationGraph = makeGraph([
+  makeOp('createThing', 'POST', '/things', {
+    produces: ['ThingName'],
+    establishes: {
+      kind: 'Thing',
+      identifiedBy: [{ in: 'body', name: 'name', semanticType: 'ThingName' }],
+    },
+  }),
+  makeOp('createWidget', 'POST', '/widgets', {
+    produces: ['WidgetName'],
+    establishes: {
+      kind: 'Widget',
+      identifiedBy: [{ in: 'body', name: 'name', semanticType: 'WidgetName' }],
+    },
+  }),
+  // Consumer that needs both — planner has to chain both establishers,
+  // but their body-field collision must be detected and the second
+  // candidate skipped.
+  makeOp('linkThingToWidget', 'POST', '/links', {
+    required: ['ThingName', 'WidgetName'],
+  }),
+]);
+
+// Same-name PATH collision across two different semanticTypes: both
+// establishers mint a *path* identifier called `id`, but one is
+// `ThingId` and the other is `WidgetId`. Unlike body collisions, the
+// URL emitter goes through the alias loop, so the planner can
+// numerically suffix the second binding (`idVar2`) and the consumer
+// resolves correctly via its own placeholder names.
+const fixturePathSuffixSameName: OperationGraph = makeGraph([
+  makeOp('createThingViaPath', 'PUT', '/things/{id}', {
+    produces: ['ThingId'],
+    pathParameters: [{ name: 'id', semanticType: 'ThingId' }],
+    establishes: {
+      kind: 'Thing',
+      identifiedBy: [{ in: 'path', name: 'id', semanticType: 'ThingId' }],
+    },
+  }),
+  makeOp('createWidgetViaPath', 'PUT', '/widgets/{id}', {
+    produces: ['WidgetId'],
+    pathParameters: [{ name: 'id', semanticType: 'WidgetId' }],
+    establishes: {
+      kind: 'Widget',
+      identifiedBy: [{ in: 'path', name: 'id', semanticType: 'WidgetId' }],
+    },
+  }),
+  makeOp('linkThingToWidgetByIds', 'POST', '/links/{thingId}/{widgetId}', {
+    required: ['ThingId', 'WidgetId'],
+    pathParameters: [
+      { name: 'thingId', semanticType: 'ThingId' },
+      { name: 'widgetId', semanticType: 'WidgetId' },
+    ],
+  }),
+]);
+
 describe('planner contracts: x-semantic-establishes (#104)', () => {
   describe('simple establisher chain (createUser → getUser)', () => {
     it('produces a satisfied chain whose first step is the establisher', () => {
@@ -258,6 +339,71 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
       expect(fixtureEdgeRequiresComponentChains.establishersByType?.Username).toEqual([
         'createUser',
       ]);
+    });
+  });
+
+  describe('placeholder-name mismatch (establisher mints `username`, consumer uses `{userKey}`)', () => {
+    it('aliases the establisher value under the consumer-derived path-placeholder var', () => {
+      const result = generateScenariosForEndpoint(fixturePlaceholderNameMismatch, 'getUserByKey', {
+        maxScenarios: 10,
+      });
+      expect(result.unsatisfied).toBeFalsy();
+      expect(result.scenarios.length).toBeGreaterThan(0);
+      const scenario = result.scenarios[0];
+      expect(opIdsOf(scenario)).toEqual(['createUser', 'getUserByKey']);
+      const bindings = scenario.bindings ?? {};
+      // Both names point at the same value — the URL emitter looks up
+      // by placeholder name (`userKeyVar`), the establisher minted
+      // under its identifier name (`usernameVar`). Without the alias
+      // loop the URL would render with a literal `${userKeyVar}`.
+      expect(bindings.usernameVar).toBeDefined();
+      expect(bindings.userKeyVar).toBeDefined();
+      expect(bindings.userKeyVar).toBe(bindings.usernameVar);
+    });
+  });
+
+  describe('same-name body collision across different semanticTypes', () => {
+    it('does NOT chain two body-identifier establishers under the same body field name', () => {
+      // Class-scoped guard for the body-builder limitation: when the
+      // body builder cannot disambiguate `${nameVar}` per step, the
+      // planner must refuse to chain a second establisher whose body
+      // identifier collides with an already-minted different-semantic
+      // binding. The consumer becomes unreachable rather than getting
+      // a silently-wrong test.
+      const result = generateScenariosForEndpoint(
+        fixtureBodyCollisionSameName,
+        'linkThingToWidget',
+        { maxScenarios: 10 },
+      );
+      // No satisfied chain should contain BOTH establishers — that
+      // would imply they shared the `nameVar` slot.
+      const offending = result.scenarios.filter((s) => {
+        const ops = opIdsOf(s);
+        return ops.includes('createThing') && ops.includes('createWidget');
+      });
+      expect(offending).toEqual([]);
+    });
+  });
+
+  describe('same-name path collision across different semanticTypes', () => {
+    it('numerically suffixes the second binding so both path values survive', () => {
+      const result = generateScenariosForEndpoint(
+        fixturePathSuffixSameName,
+        'linkThingToWidgetByIds',
+        { maxScenarios: 10 },
+      );
+      expect(result.unsatisfied).toBeFalsy();
+      const scenario = result.scenarios.find((s) => {
+        const ops = opIdsOf(s);
+        return ops.includes('createThingViaPath') && ops.includes('createWidgetViaPath');
+      });
+      expect(scenario).toBeDefined();
+      const bindings = scenario?.bindings ?? {};
+      // Both establishers minted under `idVar`/`idVar2`; the alias
+      // loop mirrors them under the consumer's placeholder names.
+      expect(bindings.thingIdVar).toBeDefined();
+      expect(bindings.widgetIdVar).toBeDefined();
+      expect(bindings.thingIdVar).not.toBe(bindings.widgetIdVar);
     });
   });
 });

--- a/tests/fixtures/planner/planner-establishes.test.ts
+++ b/tests/fixtures/planner/planner-establishes.test.ts
@@ -47,7 +47,23 @@ function makeGraph(nodes: OperationNode[]): OperationGraph {
   const establishersByType: Record<string, string[]> = {};
   for (const node of nodes) {
     operations[node.operationId] = node;
+    // Mirror graphLoader after #104: synthesised semantics from
+    // `establishes.identifiedBy` stay on `node.produces` (so BFS
+    // produced-set propagation still marks them satisfied once the
+    // establisher is scheduled), but are EXCLUDED from the global
+    // `producersByType` index — the authoritative-producer contract.
+    // Without this exclusion these fixtures would expose establishers
+    // as ordinary producers, and the tests would stay green even if
+    // `scenarioGenerator` stopped consulting `establishersByType` —
+    // exactly the regression they are supposed to guard.
+    const synthesisedFromEstablishes = new Set<string>();
+    if (node.establishes && node.establishes.shape !== 'edge') {
+      for (const id of node.establishes.identifiedBy) {
+        synthesisedFromEstablishes.add(id.semanticType);
+      }
+    }
     for (const sem of node.produces) {
+      if (synthesisedFromEstablishes.has(sem)) continue;
       const list = producersByType[sem] ?? [];
       list.push(node.operationId);
       producersByType[sem] = list;

--- a/tests/fixtures/planner/planner-establishes.test.ts
+++ b/tests/fixtures/planner/planner-establishes.test.ts
@@ -523,4 +523,24 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
       expect(bindings.roleNameVar).not.toBe(bindings.usernameVar);
     });
   });
+
+  describe('producersByType immutability across planning (#112)', () => {
+    it('does not push establishers into the shared producersByType index', () => {
+      // Class-scoped guard for PR #112 review thread on
+      // scenarioGenerator.ts:482. The planner used to bind `producers`
+      // as a direct reference to `graph.producersByType[targetSemantic]`
+      // and then `push()` establishers into it, polluting the global
+      // authoritative-producer index across BFS iterations and across
+      // calls. The contract for `producersByType` is "authoritative
+      // producers only" — establishers must stay in `establishersByType`.
+      const graph = fixtureSimpleEstablisherChain;
+      const beforeUsername = [...(graph.producersByType['Username'] ?? [])];
+      generateScenariosForEndpoint(graph, 'getUser', { maxScenarios: 10 });
+      const afterUsername = graph.producersByType['Username'] ?? [];
+      // The establisher (`createUser`) must NOT have leaked into the
+      // global producer index for Username.
+      expect(afterUsername).toEqual(beforeUsername);
+      expect(afterUsername).not.toContain('createUser');
+    });
+  });
 });

--- a/tests/fixtures/planner/planner-establishes.test.ts
+++ b/tests/fixtures/planner/planner-establishes.test.ts
@@ -248,6 +248,62 @@ const fixturePathSuffixSameName: OperationGraph = makeGraph([
   }),
 ]);
 
+// Cross-endpoint alias-pollution defect class (PR #112 reviewer thread,
+// scenarioGenerator.ts:769). When establisher A mints a body identifier
+// and the alias loop mirrors the binding under every placeholder name in
+// the *entire graph* for that semanticType, the recorded alias slots
+// must NOT participate in the body-collision check that gates a *later*
+// establisher in the same chain. Otherwise an unrelated endpoint's path
+// placeholder name (here: `unrelatedListUsersByName` using `{name}` for
+// `Username`) reserves `nameVar` against the Username semantic, and a
+// subsequent body-identifier establisher for `RoleName` whose own raw
+// body field is also `name` is wrongly skipped — even though the chain
+// the BFS is exploring never visits the unrelated endpoint.
+const fixtureAliasPollutionAcrossEndpoints: OperationGraph = makeGraph([
+  // Body-identifier establisher #1: mints Username via body field
+  // `username`, so the primary slot it reserves is `usernameVar`. The
+  // alias loop will additionally mirror this value under any other
+  // placeholder name carrying semanticType=Username — including the
+  // unrelated endpoint below, whose `{name}` path param maps to
+  // `Username`, reserving `nameVar`.
+  makeOp('createUser', 'POST', '/users', {
+    produces: ['Username'],
+    establishes: {
+      kind: 'User',
+      identifiedBy: [{ in: 'body', name: 'username', semanticType: 'Username' }],
+    },
+  }),
+  // Unrelated endpoint that the consumer below never needs. It exists
+  // ONLY to bait the alias loop into reserving `nameVar` for Username.
+  makeOp('unrelatedListUsersByName', 'GET', '/users/by-name/{name}', {
+    required: ['Username'],
+    pathParameters: [{ name: 'name', semanticType: 'Username' }],
+  }),
+  // Body-identifier establisher #2: mints RoleName via body field
+  // `name` → primary slot `nameVar`, semantic RoleName. With the
+  // pre-fix behaviour, `nameVar` is already occupied by Username from
+  // the alias loop above; the body-collision guard then aborts this
+  // candidate and the consumer becomes unreachable.
+  makeOp('createRole', 'POST', '/roles', {
+    produces: ['RoleName'],
+    establishes: {
+      kind: 'Role',
+      identifiedBy: [{ in: 'body', name: 'name', semanticType: 'RoleName' }],
+    },
+  }),
+  // Consumer needs both Username (path: `userKey`) and RoleName (path:
+  // `roleName`). Crucially, neither path placeholder is named `name`,
+  // so the consumer itself does not exercise the polluted slot — only
+  // the unrelated endpoint above does.
+  makeOp('assignUserToRole', 'PUT', '/roles/{roleName}/users/{userKey}', {
+    required: ['Username', 'RoleName'],
+    pathParameters: [
+      { name: 'roleName', semanticType: 'RoleName' },
+      { name: 'userKey', semanticType: 'Username' },
+    ],
+  }),
+]);
+
 describe('planner contracts: x-semantic-establishes (#104)', () => {
   describe('simple establisher chain (createUser → getUser)', () => {
     it('produces a satisfied chain whose first step is the establisher', () => {
@@ -404,6 +460,38 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
       expect(bindings.thingIdVar).toBeDefined();
       expect(bindings.widgetIdVar).toBeDefined();
       expect(bindings.thingIdVar).not.toBe(bindings.widgetIdVar);
+    });
+  });
+
+  describe('cross-endpoint alias pollution does not gate body-collision check', () => {
+    it('chains both body-id establishers when only an unrelated endpoint exposes the colliding placeholder name', () => {
+      // Class-scoped guard for the alias-pollution defect identified in
+      // PR #112 review (scenarioGenerator.ts:769). The alias loop must
+      // not write into the same map the body-collision guard consults
+      // — otherwise an unrelated endpoint elsewhere in the graph using
+      // `{name}` for one semanticType reserves `nameVar` against that
+      // semantic and silently aborts a later body-id establisher whose
+      // own raw body field happens to be `name` for a different
+      // semantic, even though the chain the BFS is exploring never
+      // visits the unrelated endpoint.
+      const result = generateScenariosForEndpoint(
+        fixtureAliasPollutionAcrossEndpoints,
+        'assignUserToRole',
+        { maxScenarios: 20 },
+      );
+      expect(result.unsatisfied).toBeFalsy();
+      const satisfied = result.scenarios.find((s) => {
+        const ops = opIdsOf(s);
+        return ops.includes('createUser') && ops.includes('createRole');
+      });
+      expect(satisfied).toBeDefined();
+      const bindings = satisfied?.bindings ?? {};
+      // Both primary slots must be present and hold distinct values —
+      // the body builder will read `usernameVar` for createUser and
+      // `nameVar` for createRole at codegen time.
+      expect(bindings.usernameVar).toBeDefined();
+      expect(bindings.nameVar).toBeDefined();
+      expect(bindings.usernameVar).not.toBe(bindings.nameVar);
     });
   });
 });

--- a/tests/fixtures/planner/planner-establishes.test.ts
+++ b/tests/fixtures/planner/planner-establishes.test.ts
@@ -493,5 +493,34 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
       expect(bindings.nameVar).toBeDefined();
       expect(bindings.usernameVar).not.toBe(bindings.nameVar);
     });
+
+    it('mirrors the freshly-minted RoleName value into roleNameVar, not the stale Username alias', () => {
+      // Class-scoped guard for PR #112 review thread on
+      // scenarioGenerator.ts:833 (stale-alias overwrite branch). When
+      // a body-id establisher overwrites a primary slot that was
+      // previously held as an alias for a *different* semanticType,
+      // the alias-mirroring loop must propagate the FRESH primary
+      // value to other placeholder aliases for the new semanticType —
+      // not the stale value captured before the overwrite. Otherwise
+      // the consumer's URL placeholder for the new semantic (here
+      // `{roleName}` → roleNameVar for RoleName) would render with
+      // the old Username value, silently breaking the test.
+      const result = generateScenariosForEndpoint(
+        fixtureAliasPollutionAcrossEndpoints,
+        'assignUserToRole',
+        { maxScenarios: 20 },
+      );
+      const satisfied = result.scenarios.find((s) => {
+        const ops = opIdsOf(s);
+        return ops.includes('createUser') && ops.includes('createRole');
+      });
+      const bindings = satisfied?.bindings ?? {};
+      // The RoleName alias on the consumer's path placeholder must
+      // mirror the RoleName primary, not the previously-aliased
+      // Username value at the same slot name.
+      expect(bindings.roleNameVar).toBeDefined();
+      expect(bindings.roleNameVar).toBe(bindings.nameVar);
+      expect(bindings.roleNameVar).not.toBe(bindings.usernameVar);
+    });
   });
 });

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -1554,34 +1554,65 @@ describe('bundled-spec invariants: x-semantic-establishes (#104)', () => {
     ).toBe(specAnnotatedCount);
 
     if (establishersByType.size === 0) {
-      // Pre-annotation branch: nothing further to assert at the chain
-      // level. The parity check above is the live regression guard
-      // until the spec pin is bumped; the positive branch below takes
-      // over once `x-semantic-establishes` lands upstream.
+      // Pre-annotation branch: the parity check above
+      // (`specAnnotatedCount === graphAnnotatedCount`) is the active
+      // regression guard for the extractor surface. Two further
+      // sentinels protect the chain-level guarantees while the
+      // upstream spec carries no `x-semantic-establishes`:
+      //
+      // 1. The graph's `establishersByType` map MUST be absent or
+      //    empty — a non-empty map without source annotations would
+      //    indicate either a fixture leaked into the bundled spec or
+      //    the extractor is fabricating establisher entries from a
+      //    different annotation. Either is a defect.
+      const rawEstablishersByType = Reflect.get(rawGraph, 'establishersByType');
+      const fabricatedEstablishersByType =
+        rawEstablishersByType && typeof rawEstablishersByType === 'object'
+          ? Object.keys(rawEstablishersByType)
+          : [];
+      expect(
+        fabricatedEstablishersByType,
+        'pre-annotation sentinel: graph carries establishersByType entries despite the bundled spec having no x-semantic-establishes annotations',
+      ).toEqual([]);
+
+      // 2. No operation in the graph should carry a non-empty
+      //    `establishes` field — this is the per-operation analogue of
+      //    sentinel #1. If a single op surfaces `establishes` despite
+      //    the spec having no annotations, the extractor's intake or
+      //    the graph normalizer is fabricating it.
+      const fabricatedEstablishesOps = rawGraph.operations
+        .filter((o) => o.establishes && (o.establishes.identifiedBy?.length ?? 0) > 0)
+        .map((o) => o.operationId);
+      expect(
+        fabricatedEstablishesOps,
+        'pre-annotation sentinel: operations carry `establishes` despite the bundled spec having no x-semantic-establishes annotations',
+      ).toEqual([]);
       return;
     }
 
     // Post-annotation branch: every consumer endpoint that requires a
     // semantic with a non-edge establisher must (a) plan at least one
-    // satisfied chain, AND (b) for EACH established requirement, *some*
-    // satisfied scenario in the file must include one of that
-    // requirement's registered establishers. (a) on its own is too
-    // weak — an unrelated heuristic could still satisfy the chain via
-    // a different producer path, hiding a regression where
-    // x-semantic-establishes stops being consumed at all.
+    // satisfied chain, AND (b) at least one satisfied scenario must
+    // cover ALL of the endpoint's established requirements
+    // simultaneously, with each requirement routed through a
+    // registered establisher in that same chain. (a) on its own is
+    // too weak — an unrelated heuristic could still satisfy the chain
+    // via a different producer path. A weaker per-requirement check
+    // (each requirement covered by *some* satisfied scenario, not
+    // necessarily the same one) would also be inadequate: an endpoint
+    // that needs `[A, B]` could pass with one chain establishing only
+    // `A` and a second chain establishing only `B`, even though
+    // neither chain on its own gives the consumer the composite
+    // entity it needs.
     //
-    // We check per requirement (not the union across all requirements)
-    // because endpoints with multiple established requirements would
-    // otherwise pass when only one is routed through an establisher.
-    // We also iterate every satisfied scenario in the file (not just
-    // the first one) because endpoints commonly have both
-    // producer-driven and establisher-driven satisfied chains, and
-    // picking the first would be brittle if their order changes.
+    // We iterate every satisfied scenario (not just the first) because
+    // endpoints commonly have both producer-driven and establisher-
+    // driven satisfied chains, and the order is not stable.
     const files = readdirSync(SCENARIOS_DIR).filter((f) => f.endsWith('-scenarios.json'));
     const offenders: Array<{
       endpoint: string;
       missing: string[];
-      reason: 'no-satisfied-scenario' | 'no-establisher-in-chain';
+      reason: 'no-satisfied-scenario' | 'no-single-chain-covers-all';
     }> = [];
     let assertionsRun = 0;
     for (const file of files) {
@@ -1612,23 +1643,22 @@ describe('bundled-spec invariants: x-semantic-establishes (#104)', () => {
           selfEstablished.add(sem);
         }
       }
-      const unsatisfiedRequirements: string[] = [];
-      for (const sem of establishedRequirements) {
-        if (selfEstablished.has(sem)) continue;
-        const expected = new Set(establishersByType.get(sem) ?? []);
-        const usedByAnyScenario = satisfiedScenarios.some((s) => {
-          for (const op of s.operations) {
-            if (expected.has(op.operationId)) return true;
-          }
-          return false;
+      const requirementsToCover = establishedRequirements.filter((s) => !selfEstablished.has(s));
+      if (requirementsToCover.length === 0) continue;
+      // Look for at least one satisfied scenario whose operation set
+      // covers every required semantic via a registered establisher.
+      const anyChainCoversAll = satisfiedScenarios.some((s) => {
+        const chainOps = new Set(s.operations.map((o) => o.operationId));
+        return requirementsToCover.every((sem) => {
+          const expected = establishersByType.get(sem) ?? [];
+          return expected.some((opId) => chainOps.has(opId));
         });
-        if (!usedByAnyScenario) unsatisfiedRequirements.push(sem);
-      }
-      if (unsatisfiedRequirements.length) {
+      });
+      if (!anyChainCoversAll) {
         offenders.push({
           endpoint: scen.endpoint.operationId,
-          missing: unsatisfiedRequirements,
-          reason: 'no-establisher-in-chain',
+          missing: requirementsToCover,
+          reason: 'no-single-chain-covers-all',
         });
       }
     }

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -1448,3 +1448,101 @@ describe('bundled-spec invariants: emitted Playwright variant suite (#105)', () 
     expect(offenders).toEqual([]);
   });
 });
+
+describe('bundled-spec invariants: x-semantic-establishes (#104)', () => {
+  // Self-healing pattern (mirrors the camunda/camunda#52271 evaluateDecision
+  // guard). While the upstream spec carries no `x-semantic-establishes`
+  // annotations, the consumer endpoints (`getTenant`, `getUser`, `getGroup`,
+  // …) are structurally unreachable and the planner emits the sentinel
+  // `unsatisfied` scenario. Once the annotation lands and the spec pin is
+  // bumped, every endpoint whose required semantics has an establisher must
+  // plan a satisfied chain that ends in the establisher + endpoint pair.
+  //
+  // The bundled spec is loaded directly so we can detect both annotation
+  // presence (sentinel-vs-positive switch) and reachability (the chain
+  // shape the planner produces).
+  it('every consumer of an established semantic plans a chain through its establisher', () => {
+    const REPO_ROOT = join(import.meta.dirname, '..', '..');
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const rawGraph = JSON.parse(
+      readFileSync(
+        join(
+          REPO_ROOT,
+          'semantic-graph-extractor',
+          'dist',
+          'output',
+          'operation-dependency-graph.json',
+        ),
+        'utf8',
+      ),
+    ) as {
+      operations: Array<{
+        operationId: string;
+        path?: string;
+        establishes?: {
+          kind?: string;
+          shape?: string;
+          identifiedBy?: Array<{ in?: string; name?: string; semanticType?: string }>;
+        };
+      }>;
+    };
+
+    // Build establishersByType from the raw graph (same rule as
+    // graphLoader: skip shape:'edge' entries; their identifiedBy is
+    // pre-existing components, not values minted here).
+    const establishersByType = new Map<string, string[]>();
+    for (const op of rawGraph.operations) {
+      const est = op.establishes;
+      if (!est || !Array.isArray(est.identifiedBy) || est.shape === 'edge') continue;
+      for (const id of est.identifiedBy) {
+        if (typeof id?.semanticType !== 'string') continue;
+        const list = establishersByType.get(id.semanticType) ?? [];
+        if (!list.includes(op.operationId)) list.push(op.operationId);
+        establishersByType.set(id.semanticType, list);
+      }
+    }
+
+    if (establishersByType.size === 0) {
+      // Pre-annotation branch: the upstream spec carries no
+      // `x-semantic-establishes` annotations yet. There is nothing for
+      // this invariant to assert at the chain level — the existing
+      // `Key`-suffix / provider heuristics already satisfy several of
+      // the candidate consumer endpoints (e.g. getTenant via
+      // createTenant), and re-asserting that here would just duplicate
+      // existing invariants. The positive branch below carries the
+      // class-scoped regression guard once the spec pin is bumped.
+      // We still record that the branch was executed so a later silent
+      // disappearance of the annotation surface (e.g. a graphLoader
+      // regression that strips `establishes` before it reaches the
+      // planner) is visible in the test signal.
+      expect(rawGraph.operations.length).toBeGreaterThan(0);
+      return;
+    }
+
+    // Post-annotation branch: every consumer endpoint that requires a
+    // semantic with a non-edge establisher must plan a satisfied chain.
+    // Class-scoped: the offender list must be empty across the whole
+    // bundled spec, not just for one endpoint.
+    const files = readdirSync(SCENARIOS_DIR).filter((f) => f.endsWith('-scenarios.json'));
+    const offenders: Array<{ endpoint: string; missing: string[] }> = [];
+    let assertionsRun = 0;
+    for (const file of files) {
+      const scen = loadScenarioFile(file);
+      const required = scen.requiredSemanticTypes ?? [];
+      const establishedRequirements = required.filter((s) => establishersByType.has(s));
+      if (establishedRequirements.length === 0) continue;
+      assertionsRun++;
+      // The endpoint itself may be the establisher (e.g. createTenant) —
+      // its `requires` already had the established semantic dropped, so
+      // this loop only fires for downstream consumers.
+      const satisfied = scen.scenarios.find(
+        (s) => !s.missingSemanticTypes || s.missingSemanticTypes.length === 0,
+      );
+      if (!satisfied) {
+        offenders.push({ endpoint: scen.endpoint.operationId, missing: establishedRequirements });
+      }
+    }
+    expect(assertionsRun).toBeGreaterThan(0);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -1503,12 +1503,19 @@ describe('bundled-spec invariants: x-semantic-establishes (#104)', () => {
     }
 
     // Cross-check the extractor surface against the bundled spec:
-    // every `x-semantic-establishes` annotation in the source must
-    // produce a corresponding `establishes` entry in the operation
+    // every *valid* `x-semantic-establishes` annotation in the source
+    // must produce a corresponding `establishes` entry in the operation
     // graph. This guards against the "annotation surface disappeared"
     // failure mode (an extractor or loader regression that strips the
     // field) which a vacuous existence assertion would not catch —
     // and runs in *both* the pre- and post-annotation states.
+    //
+    // The extractor intentionally drops malformed annotations whole
+    // (kind not a string, identifiedBy not an array, any member with a
+    // wrong `in`/missing `name`/missing `semanticType`). Counting the
+    // raw spec field would falsely fail the moment upstream landed a
+    // malformed annotation; mirror the extractor's validity rule here
+    // so the parity check stays meaningful.
     // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
     const bundledSpec = JSON.parse(
       readFileSync(join(REPO_ROOT, 'spec', 'bundled', 'rest-api.bundle.json'), 'utf8'),
@@ -1518,16 +1525,32 @@ describe('bundled-spec invariants: x-semantic-establishes (#104)', () => {
         Record<string, { operationId?: string; 'x-semantic-establishes'?: unknown }>
       >;
     };
+    const isRecord = (v: unknown): v is Record<string, unknown> =>
+      !!v && typeof v === 'object' && !Array.isArray(v);
+    const isValidEstablishes = (raw: unknown): boolean => {
+      if (!isRecord(raw)) return false;
+      if (typeof raw.kind !== 'string') return false;
+      if (!Array.isArray(raw.identifiedBy) || raw.identifiedBy.length === 0) return false;
+      for (const id of raw.identifiedBy) {
+        if (!isRecord(id)) return false;
+        if (id.in !== 'body' && id.in !== 'path') return false;
+        if (typeof id.name !== 'string' || !id.name) return false;
+        if (typeof id.semanticType !== 'string' || !id.semanticType) return false;
+      }
+      return true;
+    };
     let specAnnotatedCount = 0;
     for (const methods of Object.values(bundledSpec.paths ?? {})) {
       for (const op of Object.values(methods)) {
-        if (op && typeof op === 'object' && op['x-semantic-establishes']) specAnnotatedCount++;
+        if (op && typeof op === 'object' && isValidEstablishes(op['x-semantic-establishes'])) {
+          specAnnotatedCount++;
+        }
       }
     }
     const graphAnnotatedCount = rawGraph.operations.filter((o) => o.establishes).length;
     expect(
       graphAnnotatedCount,
-      `extractor surface drift: bundled spec carries ${specAnnotatedCount} x-semantic-establishes annotations but only ${graphAnnotatedCount} reached the operation graph`,
+      `extractor surface drift: bundled spec carries ${specAnnotatedCount} valid x-semantic-establishes annotations but only ${graphAnnotatedCount} reached the operation graph`,
     ).toBe(specAnnotatedCount);
 
     if (establishersByType.size === 0) {
@@ -1539,13 +1562,21 @@ describe('bundled-spec invariants: x-semantic-establishes (#104)', () => {
     }
 
     // Post-annotation branch: every consumer endpoint that requires a
-    // semantic with a non-edge establisher must (a) plan a satisfied
-    // chain, AND (b) that satisfied chain must include one of the
-    // registered establishers for at least one of its established
-    // requirements. (a) on its own is too weak — an unrelated heuristic
-    // could still satisfy the chain via a different producer path,
-    // hiding a regression where x-semantic-establishes stops being
-    // consumed at all.
+    // semantic with a non-edge establisher must (a) plan at least one
+    // satisfied chain, AND (b) for EACH established requirement, *some*
+    // satisfied scenario in the file must include one of that
+    // requirement's registered establishers. (a) on its own is too
+    // weak — an unrelated heuristic could still satisfy the chain via
+    // a different producer path, hiding a regression where
+    // x-semantic-establishes stops being consumed at all.
+    //
+    // We check per requirement (not the union across all requirements)
+    // because endpoints with multiple established requirements would
+    // otherwise pass when only one is routed through an establisher.
+    // We also iterate every satisfied scenario in the file (not just
+    // the first one) because endpoints commonly have both
+    // producer-driven and establisher-driven satisfied chains, and
+    // picking the first would be brittle if their order changes.
     const files = readdirSync(SCENARIOS_DIR).filter((f) => f.endsWith('-scenarios.json'));
     const offenders: Array<{
       endpoint: string;
@@ -1558,20 +1589,11 @@ describe('bundled-spec invariants: x-semantic-establishes (#104)', () => {
       const required = scen.requiredSemanticTypes ?? [];
       const establishedRequirements = required.filter((s) => establishersByType.has(s));
       if (establishedRequirements.length === 0) continue;
-      // Skip if the endpoint is itself an establisher of all of its
-      // established requirements — its `requires` already had those
-      // dropped at load time, so the scenario stands on its own.
-      const expectedEstablishers = new Set<string>();
-      for (const sem of establishedRequirements) {
-        for (const opId of establishersByType.get(sem) ?? []) {
-          expectedEstablishers.add(opId);
-        }
-      }
       assertionsRun++;
-      const satisfied = scen.scenarios.find(
+      const satisfiedScenarios = scen.scenarios.filter(
         (s) => !s.missingSemanticTypes || s.missingSemanticTypes.length === 0,
       );
-      if (!satisfied) {
+      if (satisfiedScenarios.length === 0) {
         offenders.push({
           endpoint: scen.endpoint.operationId,
           missing: establishedRequirements,
@@ -1579,12 +1601,33 @@ describe('bundled-spec invariants: x-semantic-establishes (#104)', () => {
         });
         continue;
       }
-      const chainOps = new Set(satisfied.operations.map((o) => o.operationId));
-      const usesEstablisher = [...expectedEstablishers].some((e) => chainOps.has(e));
-      if (!usesEstablisher && !expectedEstablishers.has(scen.endpoint.operationId)) {
+      // The endpoint itself may be the establisher for some of its own
+      // requirements (graphLoader drops those from `requires` at load
+      // time, but the spec-side `requiredSemanticTypes` we read here
+      // can still surface them for self-establishing endpoints). Treat
+      // those as trivially satisfied at the per-requirement level.
+      const selfEstablished = new Set<string>();
+      for (const sem of establishedRequirements) {
+        if (establishersByType.get(sem)?.includes(scen.endpoint.operationId)) {
+          selfEstablished.add(sem);
+        }
+      }
+      const unsatisfiedRequirements: string[] = [];
+      for (const sem of establishedRequirements) {
+        if (selfEstablished.has(sem)) continue;
+        const expected = new Set(establishersByType.get(sem) ?? []);
+        const usedByAnyScenario = satisfiedScenarios.some((s) => {
+          for (const op of s.operations) {
+            if (expected.has(op.operationId)) return true;
+          }
+          return false;
+        });
+        if (!usedByAnyScenario) unsatisfiedRequirements.push(sem);
+      }
+      if (unsatisfiedRequirements.length) {
         offenders.push({
           endpoint: scen.endpoint.operationId,
-          missing: establishedRequirements,
+          missing: unsatisfiedRequirements,
           reason: 'no-establisher-in-chain',
         });
       }

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -1502,44 +1502,91 @@ describe('bundled-spec invariants: x-semantic-establishes (#104)', () => {
       }
     }
 
+    // Cross-check the extractor surface against the bundled spec:
+    // every `x-semantic-establishes` annotation in the source must
+    // produce a corresponding `establishes` entry in the operation
+    // graph. This guards against the "annotation surface disappeared"
+    // failure mode (an extractor or loader regression that strips the
+    // field) which a vacuous existence assertion would not catch —
+    // and runs in *both* the pre- and post-annotation states.
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const bundledSpec = JSON.parse(
+      readFileSync(join(REPO_ROOT, 'spec', 'bundled', 'rest-api.bundle.json'), 'utf8'),
+    ) as {
+      paths?: Record<
+        string,
+        Record<string, { operationId?: string; 'x-semantic-establishes'?: unknown }>
+      >;
+    };
+    let specAnnotatedCount = 0;
+    for (const methods of Object.values(bundledSpec.paths ?? {})) {
+      for (const op of Object.values(methods)) {
+        if (op && typeof op === 'object' && op['x-semantic-establishes']) specAnnotatedCount++;
+      }
+    }
+    const graphAnnotatedCount = rawGraph.operations.filter((o) => o.establishes).length;
+    expect(
+      graphAnnotatedCount,
+      `extractor surface drift: bundled spec carries ${specAnnotatedCount} x-semantic-establishes annotations but only ${graphAnnotatedCount} reached the operation graph`,
+    ).toBe(specAnnotatedCount);
+
     if (establishersByType.size === 0) {
-      // Pre-annotation branch: the upstream spec carries no
-      // `x-semantic-establishes` annotations yet. There is nothing for
-      // this invariant to assert at the chain level — the existing
-      // `Key`-suffix / provider heuristics already satisfy several of
-      // the candidate consumer endpoints (e.g. getTenant via
-      // createTenant), and re-asserting that here would just duplicate
-      // existing invariants. The positive branch below carries the
-      // class-scoped regression guard once the spec pin is bumped.
-      // We still record that the branch was executed so a later silent
-      // disappearance of the annotation surface (e.g. a graphLoader
-      // regression that strips `establishes` before it reaches the
-      // planner) is visible in the test signal.
-      expect(rawGraph.operations.length).toBeGreaterThan(0);
+      // Pre-annotation branch: nothing further to assert at the chain
+      // level. The parity check above is the live regression guard
+      // until the spec pin is bumped; the positive branch below takes
+      // over once `x-semantic-establishes` lands upstream.
       return;
     }
 
     // Post-annotation branch: every consumer endpoint that requires a
-    // semantic with a non-edge establisher must plan a satisfied chain.
-    // Class-scoped: the offender list must be empty across the whole
-    // bundled spec, not just for one endpoint.
+    // semantic with a non-edge establisher must (a) plan a satisfied
+    // chain, AND (b) that satisfied chain must include one of the
+    // registered establishers for at least one of its established
+    // requirements. (a) on its own is too weak — an unrelated heuristic
+    // could still satisfy the chain via a different producer path,
+    // hiding a regression where x-semantic-establishes stops being
+    // consumed at all.
     const files = readdirSync(SCENARIOS_DIR).filter((f) => f.endsWith('-scenarios.json'));
-    const offenders: Array<{ endpoint: string; missing: string[] }> = [];
+    const offenders: Array<{
+      endpoint: string;
+      missing: string[];
+      reason: 'no-satisfied-scenario' | 'no-establisher-in-chain';
+    }> = [];
     let assertionsRun = 0;
     for (const file of files) {
       const scen = loadScenarioFile(file);
       const required = scen.requiredSemanticTypes ?? [];
       const establishedRequirements = required.filter((s) => establishersByType.has(s));
       if (establishedRequirements.length === 0) continue;
+      // Skip if the endpoint is itself an establisher of all of its
+      // established requirements — its `requires` already had those
+      // dropped at load time, so the scenario stands on its own.
+      const expectedEstablishers = new Set<string>();
+      for (const sem of establishedRequirements) {
+        for (const opId of establishersByType.get(sem) ?? []) {
+          expectedEstablishers.add(opId);
+        }
+      }
       assertionsRun++;
-      // The endpoint itself may be the establisher (e.g. createTenant) —
-      // its `requires` already had the established semantic dropped, so
-      // this loop only fires for downstream consumers.
       const satisfied = scen.scenarios.find(
         (s) => !s.missingSemanticTypes || s.missingSemanticTypes.length === 0,
       );
       if (!satisfied) {
-        offenders.push({ endpoint: scen.endpoint.operationId, missing: establishedRequirements });
+        offenders.push({
+          endpoint: scen.endpoint.operationId,
+          missing: establishedRequirements,
+          reason: 'no-satisfied-scenario',
+        });
+        continue;
+      }
+      const chainOps = new Set(satisfied.operations.map((o) => o.operationId));
+      const usesEstablisher = [...expectedEstablishers].some((e) => chainOps.has(e));
+      if (!usesEstablisher && !expectedEstablishers.has(scen.endpoint.operationId)) {
+        offenders.push({
+          endpoint: scen.endpoint.operationId,
+          missing: establishedRequirements,
+          reason: 'no-establisher-in-chain',
+        });
       }
     }
     expect(assertionsRun).toBeGreaterThan(0);

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -1660,24 +1660,19 @@ describe('bundled-spec invariants: x-semantic-establishes (#104)', () => {
         });
         continue;
       }
-      // The endpoint itself may be the establisher for some of its own
-      // requirements (graphLoader drops those from `requires` at load
-      // time, but the spec-side `requiredSemanticTypes` we read here
-      // can still surface them for self-establishing endpoints). Treat
-      // those as trivially satisfied at the per-requirement level.
-      const selfEstablished = new Set<string>();
-      for (const sem of establishedRequirements) {
-        if (establishersByType.get(sem)?.includes(scen.endpoint.operationId)) {
-          selfEstablished.add(sem);
-        }
-      }
-      const requirementsToCover = establishedRequirements.filter((s) => !selfEstablished.has(s));
-      if (requirementsToCover.length === 0) continue;
+      // `requiredSemanticTypes` reaches us already filtered: graphLoader's
+      // `normalizeOp` strips self-established semantics from
+      // `op.requires.required` at load time, and the second-pass drop in
+      // `path-analyser/src/index.ts` re-applies the same filter after
+      // `loadOpenApiSemanticHints` re-introduces them from request-body
+      // `x-semantic-type` annotations. So a self-establishing endpoint's
+      // own minted semantic never appears in this list, and we can fold
+      // it directly into the chain-coverage check below.
       // Look for at least one satisfied scenario whose operation set
       // covers every required semantic via a registered establisher.
       const anyChainCoversAll = satisfiedScenarios.some((s) => {
         const chainOps = new Set(s.operations.map((o) => o.operationId));
-        return requirementsToCover.every((sem) => {
+        return establishedRequirements.every((sem) => {
           const expected = establishersByType.get(sem) ?? [];
           return expected.some((opId) => chainOps.has(opId));
         });
@@ -1685,7 +1680,7 @@ describe('bundled-spec invariants: x-semantic-establishes (#104)', () => {
       if (!anyChainCoversAll) {
         offenders.push({
           endpoint: scen.endpoint.operationId,
-          missing: requirementsToCover,
+          missing: establishedRequirements,
           reason: 'no-single-chain-covers-all',
         });
       }

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -1594,17 +1594,26 @@ describe('bundled-spec invariants: x-semantic-establishes (#104)', () => {
       // the graph loader — so the assertion was vacuous and could
       // not detect the fabrication mode it claimed to guard.)
       //
-      // No operation in the graph should carry a non-empty
-      // `establishes` field — if a single op surfaces `establishes`
-      // despite the spec having no non-edge annotations, the
-      // extractor's intake or the graph normalizer is fabricating
-      // it.
+      // No operation in the graph should carry a non-empty *non-edge*
+      // `establishes` field — if a single op surfaces a non-edge
+      // `establishes` despite the spec having no non-edge
+      // annotations, the extractor's intake or the graph normalizer
+      // is fabricating it. Edge establishers are excluded from this
+      // sentinel because the branch above gates on the *non-edge*
+      // count: a spec carrying only valid `shape: 'edge'` annotations
+      // legitimately surfaces edge `establishes` entries that this
+      // pre-annotation branch must NOT flag as fabricated.
       const fabricatedEstablishesOps = rawGraph.operations
-        .filter((o) => o.establishes && (o.establishes.identifiedBy?.length ?? 0) > 0)
+        .filter(
+          (o) =>
+            o.establishes &&
+            o.establishes.shape !== 'edge' &&
+            (o.establishes.identifiedBy?.length ?? 0) > 0,
+        )
         .map((o) => o.operationId);
       expect(
         fabricatedEstablishesOps,
-        'pre-annotation sentinel: operations carry `establishes` despite the bundled spec having no non-edge x-semantic-establishes annotations',
+        'pre-annotation sentinel: operations carry non-edge `establishes` despite the bundled spec having no non-edge x-semantic-establishes annotations',
       ).toEqual([]);
       return;
     }

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -1529,7 +1529,17 @@ describe('bundled-spec invariants: x-semantic-establishes (#104)', () => {
       !!v && typeof v === 'object' && !Array.isArray(v);
     const isValidEstablishes = (raw: unknown): boolean => {
       if (!isRecord(raw)) return false;
-      if (typeof raw.kind !== 'string') return false;
+      // Mirror the extractor's strict rules in
+      // `semantic-graph-extractor/schema-analyzer.ts`: `kind` must be
+      // a non-empty string; `shape`, if present, must be exactly
+      // `'edge'` (the only currently-known op-level shape — anything
+      // else, including a typo like `'edeg'`, is dropped wholesale by
+      // the extractor); `identifiedBy` must be a non-empty array and
+      // every member must validate. Counting an upstream annotation
+      // the extractor would intentionally reject would make the
+      // parity check fail for the wrong reason.
+      if (typeof raw.kind !== 'string' || raw.kind.length === 0) return false;
+      if (raw.shape !== undefined && raw.shape !== 'edge') return false;
       if (!Array.isArray(raw.identifiedBy) || raw.identifiedBy.length === 0) return false;
       for (const id of raw.identifiedBy) {
         if (!isRecord(id)) return false;

--- a/tests/regression/bundled-spec-invariants.test.ts
+++ b/tests/regression/bundled-spec-invariants.test.ts
@@ -1540,10 +1540,23 @@ describe('bundled-spec invariants: x-semantic-establishes (#104)', () => {
       return true;
     };
     let specAnnotatedCount = 0;
+    let specNonEdgeAnnotatedCount = 0;
     for (const methods of Object.values(bundledSpec.paths ?? {})) {
       for (const op of Object.values(methods)) {
         if (op && typeof op === 'object' && isValidEstablishes(op['x-semantic-establishes'])) {
           specAnnotatedCount++;
+          // Switch the pre-/post-annotation branch on the *non-edge*
+          // count, mirroring the graph-loader rule that drops edge
+          // entries from `establishersByType`. Equating
+          // `establishersByType.size === 0` with "no annotations at
+          // all" would fall into the pre-annotation branch the moment
+          // upstream lands a spec carrying ONLY `shape: 'edge'`
+          // annotations — and would then flag those legitimate edge
+          // `establishes` entries as fabricated.
+          const rawEstablishes = isRecord(op) ? op['x-semantic-establishes'] : undefined;
+          if (!isRecord(rawEstablishes) || rawEstablishes.shape !== 'edge') {
+            specNonEdgeAnnotatedCount++;
+          }
         }
       }
     }
@@ -1553,39 +1566,35 @@ describe('bundled-spec invariants: x-semantic-establishes (#104)', () => {
       `extractor surface drift: bundled spec carries ${specAnnotatedCount} valid x-semantic-establishes annotations but only ${graphAnnotatedCount} reached the operation graph`,
     ).toBe(specAnnotatedCount);
 
-    if (establishersByType.size === 0) {
+    if (specNonEdgeAnnotatedCount === 0) {
       // Pre-annotation branch: the parity check above
       // (`specAnnotatedCount === graphAnnotatedCount`) is the active
-      // regression guard for the extractor surface. Two further
-      // sentinels protect the chain-level guarantees while the
-      // upstream spec carries no `x-semantic-establishes`:
+      // regression guard for the extractor surface. The branch is
+      // gated on the *non-edge* spec count rather than
+      // `establishersByType.size` so that a spec carrying only valid
+      // `shape: 'edge'` annotations does NOT fall into this branch
+      // and flag those legitimate `establishes` entries as
+      // fabricated. The remaining sentinel below protects the
+      // chain-level guarantee while the upstream spec carries no
+      // *non-edge* `x-semantic-establishes`.
       //
-      // 1. The graph's `establishersByType` map MUST be absent or
-      //    empty — a non-empty map without source annotations would
-      //    indicate either a fixture leaked into the bundled spec or
-      //    the extractor is fabricating establisher entries from a
-      //    different annotation. Either is a defect.
-      const rawEstablishersByType = Reflect.get(rawGraph, 'establishersByType');
-      const fabricatedEstablishersByType =
-        rawEstablishersByType && typeof rawEstablishersByType === 'object'
-          ? Object.keys(rawEstablishersByType)
-          : [];
-      expect(
-        fabricatedEstablishersByType,
-        'pre-annotation sentinel: graph carries establishersByType entries despite the bundled spec having no x-semantic-establishes annotations',
-      ).toEqual([]);
-
-      // 2. No operation in the graph should carry a non-empty
-      //    `establishes` field — this is the per-operation analogue of
-      //    sentinel #1. If a single op surfaces `establishes` despite
-      //    the spec having no annotations, the extractor's intake or
-      //    the graph normalizer is fabricating it.
+      // (A previous sentinel on a top-level `establishersByType`
+      // field of the raw extractor JSON was removed: the extractor
+      // does not serialize that field — it is built at runtime by
+      // the graph loader — so the assertion was vacuous and could
+      // not detect the fabrication mode it claimed to guard.)
+      //
+      // No operation in the graph should carry a non-empty
+      // `establishes` field — if a single op surfaces `establishes`
+      // despite the spec having no non-edge annotations, the
+      // extractor's intake or the graph normalizer is fabricating
+      // it.
       const fabricatedEstablishesOps = rawGraph.operations
         .filter((o) => o.establishes && (o.establishes.identifiedBy?.length ?? 0) > 0)
         .map((o) => o.operationId);
       expect(
         fabricatedEstablishesOps,
-        'pre-annotation sentinel: operations carry `establishes` despite the bundled spec having no x-semantic-establishes annotations',
+        'pre-annotation sentinel: operations carry `establishes` despite the bundled spec having no non-edge x-semantic-establishes annotations',
       ).toEqual([]);
       return;
     }


### PR DESCRIPTION
Consume the upstream `x-semantic-establishes` annotation to plan entity-existence chains directly, without inferring "this op probably creates that thing" from naming heuristics alone.

Closes #104.

Needs this 18 PR chain to land on main in camunda/camunda before merging: https://github.com/camunda/camunda/pull/52322

## What

**Extractor (`semantic-graph-extractor`)**
- Parse `x-semantic-establishes` on each operation with type-guarded validation. Reject malformed annotations (missing `kind` / empty `identifiedBy` / unknown `in` / unknown `shape`) instead of surfacing partial state.
- Surface as `Operation.establishes = { kind, shape?, identifiedBy[] }`.

**Graph loader (`path-analyser`)**
- Build `establishersByType` parallel to `producersByType`. Skip `shape: 'edge'` entries — their `identifiedBy` components are pre-existing inputs, not values minted by the edge.
- For non-edge establishers, push each `identifiedBy.semanticType` into `produces` (the establisher self-satisfies that requirement at body-build time) and drop it from `requires` so the BFS does not chase an external producer.

**Scenario generator (`path-analyser`)**
- After the existing `Key`-suffix identifier heuristic, mint a deterministic binding keyed on the identifier `name` (e.g. `usernameVar`) so the body builder and the URL emitter find the same key without an alias step.
- Path-identifier collisions across different semanticTypes use numeric-suffix disambiguation (`idVar`, `idVar2`); body-identifier collisions abort the candidate (the body builder has no per-step override).

## Why

Acceptance criteria (a)–(d) from #104:

- (a) annotation surfaces on the operation graph ✔
- (b) `establishersByType` is consumed by the chain planner with a fresh client-minted binding ✔
- (c) self-healing positive-assertion test parallel to PR #98's `evaluateDecision` guard — sentinel-only branch while the spec is unannotated, positive branch once the spec pin is bumped ✔
- (d) PR #99 Bug C invariant remains green; remaining offenders match the documented Out-of-scope list ✔

## Trying it locally against the upstream PR stack

The upstream `x-semantic-establishes` annotations live on the [camunda/camunda#52322](https://github.com/camunda/camunda/pull/52322) stack (`feat/x-semantic-provider-coverage` — top of the 18-PR chain). To exercise the post-annotation L3 invariants and the full satisfied-chain output **before** the upstream stack lands on `camunda/camunda` `main`, point the spec bundler at the stack's head SHA:

```bash
# Top-of-stack SHA (camunda/camunda#52322 head). Bump if the stack rebases.
SPEC_REF=d0941f4de4b541bf300210816f7e23217c5c0598

# 1. Fetch + bundle the spec from the upstream branch
SPEC_REF="$SPEC_REF" npm run fetch-spec:ref

# 2. Regenerate pipeline outputs against that spec
TEST_SEED=snapshot-baseline npm run testsuite:generate
npm run generate:request-validation

# 3. Run the full suite — L3 invariants now exercise the post-annotation branch
npm test
```

Verify upstream:

```bash
git ls-remote https://github.com/camunda/camunda d0941f4de4b541bf300210816f7e23217c5c0598
# must print one line; if empty the stack rebased — re-read the head SHA from
# https://github.com/camunda/camunda/pull/52322 and try again.
```

What you should observe:

- `establishersByType` in `semantic-graph-extractor/dist/output/operation-dependency-graph.json` is non-empty and contains `Username`, `TenantId`, `GroupId`, `RoleId`, `MappingRuleId`, `ClusterVariableName`.
- Unsatisfied scenarios drop from **82 → 22** (see "Offender count" below).
- The L3 sentinel branch in `tests/regression/bundled-spec-invariants.test.ts` switches off and the positive branch runs — every consumer endpoint with an established requirement plans at least one satisfied chain that covers all established requirements simultaneously.

> ⚠️ **Do not bump `tests/regression/spec-pin.json`** as part of testing this PR. The pin bump is a separate, reviewed change that must wait for the upstream stack to land on `camunda/camunda` `main`. The instructions above let you exercise the post-annotation behaviour without touching the pin.

To return to the pinned spec after testing:

```bash
SPEC_REF="$(jq -r .specRef tests/regression/spec-pin.json)" npm run fetch-spec:ref
TEST_SEED=snapshot-baseline npm run testsuite:generate
npm run generate:request-validation
```

## Offender count

Unsatisfied scenarios drop from **82 → 22** once the upstream annotation is in place. The remaining 22 are exactly the issue's documented Out-of-scope set:

- `ClientId` — external-entity, no establisher possible
- `AuditLogKey`, `IncidentKey`, `UserTaskKey`, `VariableKey`, `ResourceKey` — engine-generated keys requiring deploy → start → poll, tracked separately

## Tests (layered)

- **L1 — extractor fixtures** (`tests/fixtures/extractor/extractor-establishes.test.ts`): body-identifier, edge (`shape: 'edge'`), composite path+body, malformed-annotation rejection, no-annotation absence, unknown-shape rejection.
- **L2 — planner contracts** (`tests/fixtures/planner/planner-establishes.test.ts`): simple establisher chain emits `[establisher, consumer]` with shared identifier binding; trivial scenario for the establisher endpoint itself; composite identifiers satisfy in one step; edge establisher requires component chains and does NOT register as the establisher of its own components; placeholder-name mismatch (consumer uses `{userKey}` for `Username`); same-name body collision aborts the chain; same-name path collision numerically suffixes the second binding.
- **L2 — integration** (`tests/fixtures/integration/establishes-hint-merge.test.ts`): exercises `loadOpenApiSemanticHints` against a tiny on-disk OpenAPI spec to guard the second-pass established-semantics drop in `path-analyser/src/index.ts`.
- **L3 — bundled-spec invariant, self-healing** (`tests/regression/bundled-spec-invariants.test.ts`): pre-annotation branch asserts the extractor surface is non-empty AND that no operation surfaces `establishes` while the bundled spec carries no annotations; once the spec pin carries `x-semantic-establishes`, the positive branch class-scope-asserts that every consumer endpoint whose required semantic has a non-edge establisher plans at least one satisfied chain that covers ALL established requirements simultaneously.

## Spec pin

Bundled spec stays at the existing pin (`2b2b962…`). The annotation is not yet present upstream — the L3 invariant runs in self-healing sentinel mode and will flip to positive assertions automatically once the upstream PR stack (camunda/camunda#52319, #52321, #52322) merges and the pin is bumped.

## Verification

```
npm run lint                       # clean
npx tsc --noEmit -p semantic-graph-extractor/tsconfig.json
npx tsc --noEmit -p path-analyser/tsconfig.json
npx tsc --noEmit -p request-validation/tsconfig.json
npx tsc --noEmit -p tests/tsconfig.json
TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation
npm test                           # 29 files, 212 passed
```

## Triage of upstream schema changes since this PR was opened

Two follow-on extensions landed on `feat/x-semantic-provider-coverage` after this PR was opened. Neither requires changes to the implementation in this PR; both are tracked separately:

- **`shape: 'external-entity'` (registry-side, [camunda/camunda@3185b1cc29b](https://github.com/camunda/camunda/commit/3185b1cc29b))** — adds a third registry shape in `semantic-kinds.json` for identifiers minted outside the Camunda API (e.g. `ClientId` under SaaS or OIDC). The op-level `x-semantic-establishes.shape` enum stays `[entity, edge]` — operations never `establishes: external-entity` — so the extractor surface is unchanged. The downstream effect is that ClientId-bearing membership edges (`assignClientToGroup`, etc.) remain correctly unsatisfied in the planner, which already matches the documented Out-of-scope list above ("`ClientId` — external-entity, no establisher possible").

- **`identifiedBy[].acceptsExternal: true` (per-tuple flag, [camunda/camunda@4346be3e68e](https://github.com/camunda/camunda/commit/4346be3e68e))** — encodes per-site bimodality where a tuple member can be satisfied either by an in-API producer or by an externally-minted ID (current sites: `assignGroupTo{Role,Tenant}` for BYOG/OIDC). The upstream Spectral rule already skips the producer-existence cross-reference for these tuples; the planner-side consumption (prefer-producer with external-fallback) is tracked in #134 as a separate enhancement and is **not** in scope for this PR.

## Review-comment fix-ups in this PR

Three Copilot review threads addressed in commit 989d3d6 (`chore: address PR #112 review`):

- **`scenarioGenerator.ts:769` — cross-endpoint alias pollution.** The placeholder-alias mirror loop wrote into `establisherBindingSemantics`, which the body-collision guard at the top of the same block consults; an unrelated endpoint elsewhere in the graph using `{name}` for one semanticType therefore reserved `nameVar` against that semantic and silently aborted a later body-id establisher whose own raw body field was also `name` for a different semantic. Fix: aliases now write to a separate `establisherAliasSemantics` side index; the body-collision guard reads only the primary map. New class-scoped fixture `cross-endpoint alias pollution does not gate body-collision check` in `tests/fixtures/planner/planner-establishes.test.ts` fails on `main` and passes on this branch.
- **`bundled-spec-invariants.test.ts:1561` — pre-/post-annotation branch trigger.** Switched from `establishersByType.size === 0` to a count of valid **non-edge** annotations in the bundled spec; an edge-only spec now correctly enters the post-annotation branch instead of flagging legitimate `shape: 'edge'` entries as fabricated.
- **`bundled-spec-invariants.test.ts:1582` — vacuous sentinel removed.** The "graph carries `establishersByType` entries despite no source annotations" sentinel read a top-level field that the extractor does not serialize (it is built at runtime by the graph loader), so the assertion was always vacuous. The per-operation sentinel (`fabricatedEstablishesOps`) on the field that *is* serialized continues to guard the actual extractor-surface defect class.
