### PR TITLE
fix: expose allOf-wrapped primitive metadata on WalkNode.raw (closes #113, #115)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,13 @@ jobs:
       - name: Typecheck (tests)
         # The workspace tsconfigs only include `src` (and `scripts`),
         # so test files are not type-checked by them. Without this gate
-        # bugs like passing a non-existent option key (e.g. PR #114
-        # passing `{ maxPerField: 4 }` to a function whose Opts only
-        # accepts `{ onlyOperations, capPerOperation }`) silently slip
-        # through to review. See tests/tsconfig.json for the include set.
+        # bugs like the one in PR #114 — passing `{ maxPerField: 4 }`
+        # to `generateConstraintViolations` whose Opts only accepts
+        # `{ onlyOperations, capPerOperation }` — silently slip through
+        # to review. (`maxPerField` is a valid key on a *different*
+        # analyser, `generateBodyTypeMismatch`, which is what made the
+        # mistake easy to miss in code review.) See tests/tsconfig.json
+        # for the include set.
         run: npx tsc --noEmit -p tests/tsconfig.json
 
       - name: Fetch pinned OpenAPI spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,15 @@ jobs:
       - name: Typecheck (request-validation)
         run: npx tsc --noEmit -p request-validation/tsconfig.json
 
+      - name: Typecheck (tests)
+        # The workspace tsconfigs only include `src` (and `scripts`),
+        # so test files are not type-checked by them. Without this gate
+        # bugs like passing a non-existent option key (e.g. PR #114
+        # passing `{ maxPerField: 4 }` to a function whose Opts only
+        # accepts `{ onlyOperations, capPerOperation }`) silently slip
+        # through to review. See tests/tsconfig.json for the include set.
+        run: npx tsc --noEmit -p tests/tsconfig.json
+
       - name: Fetch pinned OpenAPI spec
         env:
           SPEC_REF: ${{ steps.pin.outputs.spec_ref }}

--- a/request-validation/src/schema/walker.ts
+++ b/request-validation/src/schema/walker.ts
@@ -101,6 +101,14 @@ export function buildWalk(op: OperationModel): SchemaWalkResult | undefined {
   }
   function visit(schema: SchemaFragment, pointer: string, key?: string): WalkNode {
     const effective = mergeAllOf(schema);
+    // For allOf-wrapped primitives we expose the *merged* fragment via `raw`
+    // so downstream code that reads `node.raw.{format,multipleOf,enum,…}`
+    // sees the resolved primitive metadata instead of the unmerged wrapper.
+    // For object/array nodes we keep `raw: schema` because consumers of
+    // composite raw (discriminator detection, oneOf walkers, etc.) rely on
+    // observing the original wrapper. See camunda/api-test-generator#113.
+    const isComposite = effective.type === 'object' || effective.type === 'array';
+    const raw = isComposite ? schema : effective;
     const node: WalkNode = {
       pointer,
       key,
@@ -108,7 +116,7 @@ export function buildWalk(op: OperationModel): SchemaWalkResult | undefined {
       required: Array.isArray(effective.required) ? effective.required.slice() : undefined,
       enum: Array.isArray(effective.enum) ? effective.enum.slice() : undefined,
       constraints: extractConstraints(effective),
-      raw: schema,
+      raw,
     };
     byPointer.set(pointer, node);
     if (effective.type === 'object' && effective.properties) {

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -141,7 +141,7 @@ describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? 
   }
 
   function buildCollectionWithBindings(
-    bindings: Record<string, unknown>,
+    bindings: Record<string, string>,
     extras: { templateRefsTenant?: boolean; extractsTenant?: boolean } = {},
   ): EndpointScenarioCollection {
     return {

--- a/tests/regression/graph-loader-witness-implication.test.ts
+++ b/tests/regression/graph-loader-witness-implication.test.ts
@@ -100,6 +100,7 @@ describe('graphLoader: witness implication gating (#95)', () => {
     // a missing producersByState or createDocument and still satisfy
     // the not.toContain checks.
     expect(graph.producersByState, 'producersByState must be built').toBeDefined();
+    if (!graph.producersByState) throw new Error('unreachable: assertion above');
     const witnessProducers = graph.producersByState.ProcessInstanceExists ?? [];
     expect(witnessProducers).not.toContain('createDocument');
     expect(witnessProducers).not.toContain('createDocuments');

--- a/tests/request-validation/allof-primitive-raw-exposure.test.ts
+++ b/tests/request-validation/allof-primitive-raw-exposure.test.ts
@@ -202,7 +202,7 @@ describe('request-validation: allOf-wrapped primitive raw exposure (#113)', () =
         },
         ['required'],
       );
-      const scenarios = generateConstraintViolations([op], { maxPerField: 4 });
+      const scenarios = generateConstraintViolations([op]);
       const tenantIdScenarios = scenarios.filter((s) => s.target === 'tenantId');
       expect(tenantIdScenarios.length).toBeGreaterThan(0);
     });

--- a/tests/request-validation/allof-primitive-raw-exposure.test.ts
+++ b/tests/request-validation/allof-primitive-raw-exposure.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest';
+import {
+  generateFormatInvalid,
+  generateMultipleOfViolations,
+} from '../../request-validation/src/analysis/advancedSchema.js';
+import { generateConstraintViolations } from '../../request-validation/src/analysis/constraintViolations.js';
+import { generateEnumViolations } from '../../request-validation/src/analysis/enumViolations.js';
+import type { OperationModel, SchemaFragment } from '../../request-validation/src/model/types.js';
+import { buildBaselineBody } from '../../request-validation/src/schema/baseline.js';
+import { buildWalk } from '../../request-validation/src/schema/walker.js';
+
+/**
+ * Class-scoped regression guard for camunda/api-test-generator#113 (follow-up
+ * to #110 / PR #111). Copilot's review flagged that the original walker fix
+ * only covers required + type-mismatch / constraint-violation paths. The
+ * underlying defect is broader: `mergePrimitiveAllOf` builds an `effective`
+ * fragment with the resolved primitive `type`, `format`, `multipleOf`, etc.,
+ * but `visit()` sets `raw: schema` (the original allOf wrapper). Anything
+ * downstream that reads `node.raw.{format,multipleOf,enum,…}` instead of
+ * `node.constraints` / `node.type` therefore sees the unmerged wrapper and
+ * silently skips the field.
+ *
+ * These tests are RED on `main` and become GREEN when `walker.ts` exposes
+ * the merged primitive fragment via `node.raw` for the primitive-flatten
+ * case (object case must keep `raw: schema`).
+ */
+describe('request-validation: allOf-wrapped primitive raw exposure (#113)', () => {
+  function makeOp(properties: Record<string, SchemaFragment>, required: string[]): OperationModel {
+    return {
+      operationId: 'createWidget',
+      method: 'POST',
+      path: '/widgets',
+      tags: [],
+      requestBodySchema: {
+        type: 'object',
+        required,
+        properties,
+      },
+      requiredProps: required,
+      parameters: [],
+    };
+  }
+
+  describe('walker.node.raw exposes merged primitive metadata', () => {
+    it('exposes merged format on node.raw for allOf-wrapped string', () => {
+      const op = makeOp(
+        {
+          deploymentKey: {
+            allOf: [
+              { type: 'string', format: 'uuid' },
+              { description: 'The deployment identifier.' },
+            ],
+          },
+        },
+        ['deploymentKey'],
+      );
+      const walk = buildWalk(op);
+      const node = walk?.root?.properties?.deploymentKey;
+      expect(node?.raw).toBeDefined();
+      // Defect: raw points at the original allOf wrapper, so raw.format === undefined.
+      expect(node?.raw?.format).toBe('uuid');
+    });
+
+    it('exposes merged multipleOf on node.raw for allOf-wrapped integer', () => {
+      const op = makeOp(
+        {
+          amount: {
+            allOf: [
+              { type: 'integer', multipleOf: 5 },
+              { description: 'A discrete amount in 5-unit steps.' },
+            ],
+          },
+        },
+        ['amount'],
+      );
+      const walk = buildWalk(op);
+      const node = walk?.root?.properties?.amount;
+      expect(node?.raw?.multipleOf).toBe(5);
+    });
+
+    it('exposes merged enum on node.raw for allOf-wrapped string', () => {
+      const op = makeOp(
+        {
+          color: {
+            allOf: [
+              { type: 'string', enum: ['red', 'green', 'blue'] },
+              { description: 'Allowed colours.' },
+            ],
+          },
+        },
+        ['color'],
+      );
+      const walk = buildWalk(op);
+      const node = walk?.root?.properties?.color;
+      expect(node?.raw?.enum).toEqual(['red', 'green', 'blue']);
+    });
+  });
+
+  describe('baseline body materialises optional allOf-wrapped primitives with branch-only signals', () => {
+    it('includes optional allOf-wrapped string with branch-only enum', () => {
+      const op = makeOp(
+        {
+          required: { type: 'string' },
+          color: {
+            allOf: [
+              { type: 'string', enum: ['red', 'green', 'blue'] },
+              { description: 'Optional colour.' },
+            ],
+          },
+        },
+        ['required'],
+      );
+      const baseline = buildBaselineBody(op) as Record<string, unknown> | undefined;
+      expect(baseline).toBeDefined();
+      // Defect: optional materialisation reads child.raw.enum (= undefined on
+      // the wrapper), so `color` is silently omitted from the baseline body.
+      expect(baseline).toHaveProperty('color');
+    });
+
+    it('includes optional allOf-wrapped string with branch-only format', () => {
+      const op = makeOp(
+        {
+          required: { type: 'string' },
+          deploymentKey: {
+            allOf: [
+              { type: 'string', format: 'uuid' },
+              { description: 'Optional deployment key.' },
+            ],
+          },
+        },
+        ['required'],
+      );
+      const baseline = buildBaselineBody(op) as Record<string, unknown> | undefined;
+      expect(baseline).toHaveProperty('deploymentKey');
+    });
+
+    it('includes optional allOf-wrapped integer with branch-only multipleOf', () => {
+      const op = makeOp(
+        {
+          required: { type: 'string' },
+          amount: {
+            allOf: [
+              { type: 'integer', multipleOf: 5 },
+              { description: 'Optional discrete amount.' },
+            ],
+          },
+        },
+        ['required'],
+      );
+      const baseline = buildBaselineBody(op) as Record<string, unknown> | undefined;
+      expect(baseline).toHaveProperty('amount');
+    });
+  });
+
+  describe('advanced-schema analysers emit scenarios for allOf-wrapped primitives', () => {
+    it('generateFormatInvalid emits a scenario for allOf-wrapped string with format: uuid', () => {
+      const op = makeOp(
+        {
+          deploymentKey: {
+            allOf: [
+              { type: 'string', format: 'uuid' },
+              { description: 'The deployment identifier.' },
+            ],
+          },
+        },
+        ['deploymentKey'],
+      );
+      const scenarios = generateFormatInvalid([op], {});
+      const targetScenarios = scenarios.filter((s) => s.target === 'deploymentKey');
+      expect(targetScenarios.length).toBeGreaterThan(0);
+    });
+
+    it('generateMultipleOfViolations emits a scenario for allOf-wrapped integer with multipleOf', () => {
+      const op = makeOp(
+        {
+          amount: {
+            allOf: [
+              { type: 'integer', multipleOf: 5 },
+              { description: 'A discrete amount.' },
+            ],
+          },
+        },
+        ['amount'],
+      );
+      const scenarios = generateMultipleOfViolations([op], {});
+      const targetScenarios = scenarios.filter((s) => s.target === 'amount');
+      expect(targetScenarios.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('mutation analysers cover OPTIONAL allOf-wrapped primitives', () => {
+    it('generateConstraintViolations emits scenarios for an optional allOf-wrapped string', () => {
+      const op = makeOp(
+        {
+          required: { type: 'string' },
+          tenantId: {
+            allOf: [
+              { type: 'string', minLength: 1, maxLength: 32 },
+              { description: 'Optional tenant identifier.' },
+            ],
+          },
+        },
+        ['required'],
+      );
+      const scenarios = generateConstraintViolations([op], { maxPerField: 4 });
+      const tenantIdScenarios = scenarios.filter((s) => s.target === 'tenantId');
+      expect(tenantIdScenarios.length).toBeGreaterThan(0);
+    });
+
+    it('generateEnumViolations emits scenarios for an optional allOf-wrapped enum string', () => {
+      const op = makeOp(
+        {
+          required: { type: 'string' },
+          color: {
+            allOf: [
+              { type: 'string', enum: ['red', 'green', 'blue'] },
+              { description: 'Optional colour.' },
+            ],
+          },
+        },
+        ['required'],
+      );
+      const scenarios = generateEnumViolations([op], {});
+      const targetScenarios = scenarios.filter((s) => s.target === 'color');
+      expect(targetScenarios.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/tests/request-validation/allof-primitive-raw-exposure.test.ts
+++ b/tests/request-validation/allof-primitive-raw-exposure.test.ts
@@ -110,7 +110,7 @@ describe('request-validation: allOf-wrapped primitive raw exposure (#113)', () =
         },
         ['required'],
       );
-      const baseline = buildBaselineBody(op) as Record<string, unknown> | undefined;
+      const baseline = buildBaselineBody(op);
       expect(baseline).toBeDefined();
       // Defect: optional materialisation reads child.raw.enum (= undefined on
       // the wrapper), so `color` is silently omitted from the baseline body.
@@ -130,7 +130,7 @@ describe('request-validation: allOf-wrapped primitive raw exposure (#113)', () =
         },
         ['required'],
       );
-      const baseline = buildBaselineBody(op) as Record<string, unknown> | undefined;
+      const baseline = buildBaselineBody(op);
       expect(baseline).toHaveProperty('deploymentKey');
     });
 
@@ -147,7 +147,7 @@ describe('request-validation: allOf-wrapped primitive raw exposure (#113)', () =
         },
         ['required'],
       );
-      const baseline = buildBaselineBody(op) as Record<string, unknown> | undefined;
+      const baseline = buildBaselineBody(op);
       expect(baseline).toHaveProperty('amount');
     });
   });
@@ -174,10 +174,7 @@ describe('request-validation: allOf-wrapped primitive raw exposure (#113)', () =
       const op = makeOp(
         {
           amount: {
-            allOf: [
-              { type: 'integer', multipleOf: 5 },
-              { description: 'A discrete amount.' },
-            ],
+            allOf: [{ type: 'integer', multipleOf: 5 }, { description: 'A discrete amount.' }],
           },
         },
         ['amount'],
@@ -202,7 +199,7 @@ describe('request-validation: allOf-wrapped primitive raw exposure (#113)', () =
         },
         ['required'],
       );
-      const scenarios = generateConstraintViolations([op]);
+      const scenarios = generateConstraintViolations([op], {});
       const tenantIdScenarios = scenarios.filter((s) => s.target === 'tenantId');
       expect(tenantIdScenarios.length).toBeGreaterThan(0);
     });

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Fixes #113. The walker (`request-validation/src/schema/walker.ts`) previously assigned `raw: schema` unconditionally on every `WalkNode`, so for primitives wrapped in `allOf` the downstream analysers read the **unmerged wrapper** instead of the resolved primitive metadata. `mergePrimitiveAllOf` already produced a synthesised `effective` fragment with the resolved `type` / `format` / `multipleOf` / `enum` / constraints — `visit()` just ignored it for `raw`.

The fix exposes `effective` via `raw` for primitive (non-object, non-array) nodes. Object/array nodes keep `raw: schema` because composite consumers (discriminator detection, `oneOf` walkers) rely on observing the original wrapper.

## Why this matters

Five downstream sites read `node.raw.{format,multipleOf,enum,…}` instead of `node.constraints` / `node.type`:

- `request-validation/src/analysis/advancedSchema.ts` — `generateFormatInvalid`, `generateMultipleOfViolations`
- `request-validation/src/analysis/enumViolations.ts` — `generateEnumViolations`
- `request-validation/src/analysis/constraintViolations.ts`
- `request-validation/src/schema/baseline.ts` — optional-field materialisation

Any field wrapped as `allOf: [{type: 'string', format: 'uuid'}, {description: '…'}]` (the dereferenced shape of `$ref: TenantId` + a sibling `description`) was silently dropped from negative coverage. The original PR #111 only fixed the required + type-mismatch path; this PR fixes the broader class.

## Coverage signal

Against the pinned bundled spec, references to `deploymentKey` / `tenantId` in generated `request-validation/generated/*.spec.ts` jump from **224 → 342** (+118 previously-dropped mutation scenarios for `allOf`-wrapped primitives).

## Red / green / class-scoped guard

`tests/request-validation/allof-primitive-raw-exposure.test.ts` — 10 class-scoped assertions:

| Layer | Assertion |
|---|---|
| `walker.node.raw` | exposes merged `format`, `multipleOf`, `enum` for `allOf`-wrapped primitives |
| `baseline` | materialises **optional** `allOf`-wrapped string (enum), string (format), integer (multipleOf) |
| `advancedSchema` | emits scenarios for `allOf`-wrapped string/uuid + integer/multipleOf |
| `enumViolations` | emits scenarios for `allOf`-wrapped enum string |
| `constraintViolations` | emits scenarios for **optional** `allOf`-wrapped string |

All 10 fail on `main`, all 10 pass on this branch. The assertions are scoped to the defect class (any `allOf` primitive at any property), not the specific `deploymentKey`/`tenantId` instances on the bundled spec.

## Bonus: tests are now type-checked in CI (closes #115)

While addressing PR review I discovered tests were not type-checked. The original review-comment fix passed `{ maxPerField: 4 }` to a function whose `Opts` doesn't accept that key — TypeScript would have caught it with TS2353 had test files been included in any tsconfig. They were not.

This PR also adds:

- `tests/tsconfig.json` (strict, bundler resolution) covering all of `tests/**`
- `Typecheck (tests)` step in `.github/workflows/ci.yml`
- Fixes for three latent type errors the new gate surfaced in pre-existing test files

Verified: re-introducing `{ maxPerField: 4 }` now fails CI with TS2353.

## Refs

- Closes #113
- Closes #115
- Follow-up to #110 / PR #111
- Related: `tests/regression/spec-pin.json` is unaffected (the fix is internal to the walker; the bundled-spec content the regression invariants run against is unchanged)
