### PR TITLE
chore: collapse setLeafPlaceholder guard to optional chain

### DIFF
--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -565,7 +565,7 @@ function mergePopulatesSubShapeIntoFinalBody(
   steps: RequestStep[],
 ): void {
   const sub = scenario.populatesSubShape;
-  if (!sub || !sub.leafPaths?.length) return;
+  if (!sub?.leafPaths?.length) return;
   if (!steps.length) return;
   const finalStep = steps[steps.length - 1];
   if (finalStep.bodyKind !== 'json') return;


### PR DESCRIPTION
## Summary

Eliminates the lone `useOptionalChain` biome warning that has been surfacing on every local lint run on `main`:

```
path-analyser/src/index.ts:586:7 lint/complexity/useOptionalChain
  if (!sub || !sub.leafPaths?.length) return;
```

becomes:

```ts
if (!sub?.leafPaths?.length) return;
```

## Why

- Behaviour-preserving — both forms short-circuit identically when `sub` is nullish (the right-hand operand was already an optional chain, so a `null`/`undefined` `sub` already produced `undefined.length` → falsy via short-circuit).
- The auto-fix is marked unsafe by Biome only because it cannot statically prove the equivalence in the general case; here the equivalence is trivial (same nullish test, same property access).
- Keeps `npm run lint` clean so future PRs don't have a noisy "1 warning" baseline that masks new regressions.

## Verification

- `npx biome check` → zero errors, zero warnings
- 4 × `tsc --noEmit` clean (semantic-graph-extractor, path-analyser, request-validation, tests)
- `TEST_SEED=snapshot-baseline npm run testsuite:generate` + `npm run generate:request-validation` regenerated cleanly
- `npm test` → 193/193 passing

## Risk

Minimal — single-line behaviour-preserving refactor inside a guard clause.