### PR TITLE
feat: add enumCaseInsensitive request-validation config (default false)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1682,3 +1682,101 @@ describeForThisConfig('bundled-spec invariants: x-semantic-establishes (#104)', 
     expect(offenders).toEqual([]);
   });
 });
+
+describeForThisConfig('bundled-spec invariants: emitted request-validation suite (#129)', () => {
+  it('emits zero case-only enum mutations when enumCaseInsensitive is true', () => {
+    // The camunda-oca config sets `enumCaseInsensitive: true` in
+    // configs/camunda-oca/request-validation.json because the upstream
+    // Camunda 8 OCA parser accepts string-enum values case-insensitively
+    // (camunda/camunda#52409). Class-scoped guard: scan every emitted
+    // enum-violation test block (across every operation in every spec
+    // file) and assert that no inlined string body value differs from a
+    // valid enum member only by ASCII case. Catches any future analyser
+    // (e.g. a sibling oneOf/anyOf walker) that re-introduces a case-only
+    // mutation.
+    const REQUEST_VALIDATION_DIR = join(
+      REPO_ROOT,
+      'generated',
+      CONFIG_NAME,
+      'request-validation',
+    );
+    if (!existsSync(REQUEST_VALIDATION_DIR)) {
+      throw new Error(
+        `Generated request-validation directory not found at ${REQUEST_VALIDATION_DIR}. ` +
+          `Run 'npm run generate:request-validation' (or 'npm run pipeline') first.`,
+      );
+    }
+
+    interface Spec {
+      paths?: unknown;
+      components?: unknown;
+    }
+    function isObject(v: unknown): v is Record<string, unknown> {
+      return typeof v === 'object' && v !== null && !Array.isArray(v);
+    }
+    const bundlePath = join(getSpecBundleDir(REPO_ROOT), 'rest-api.bundle.json');
+    const rawSpec: unknown = JSON.parse(readFileSync(bundlePath, 'utf8'));
+    if (!isObject(rawSpec)) {
+      throw new Error(`Bundled spec at ${bundlePath} is not a JSON object.`);
+    }
+    // Build the universe of valid string-enum members from the bundled
+    // spec. Membership is by exact string; the lower-cased index drives
+    // the case-collision check.
+    const validMembers = new Set<string>();
+    const enumLowerSet = new Set<string>();
+    function walk(node: unknown): void {
+      if (Array.isArray(node)) {
+        for (const item of node) walk(item);
+        return;
+      }
+      if (!isObject(node)) return;
+      const e = node.enum;
+      if (Array.isArray(e)) {
+        for (const member of e) {
+          if (typeof member === 'string') {
+            validMembers.add(member);
+            enumLowerSet.add(member.toLowerCase());
+          }
+        }
+      }
+      for (const v of Object.values(node)) walk(v);
+    }
+    walk(rawSpec);
+
+    function isCaseOnlyFalsePositive(value: string): boolean {
+      if (validMembers.has(value)) return false;
+      return enumLowerSet.has(value.toLowerCase());
+    }
+
+    // Locate each test block whose closing assertion has
+    // `scenarioKind: 'enum-violation'`. For each such block, extract
+    // every JSON-quoted string literal from the inlined `requestBody`
+    // and check it for case-only collision with a valid enum member.
+    // A regex pass is sufficient because the emitter inlines the body
+    // as a TypeScript object literal with double-quoted string values.
+    const TEST_BLOCK = /test\([^]*?scenarioKind:\s*'enum-violation'[^]*?}\);/g;
+    const QUOTED_STRING = /"([^"\\\n]+)"/g;
+    const offenders: { file: string; sample: string }[] = [];
+    for (const f of readdirSync(REQUEST_VALIDATION_DIR)) {
+      if (!f.endsWith('.spec.ts')) continue;
+      const src = readFileSync(join(REQUEST_VALIDATION_DIR, f), 'utf8');
+      let block: RegExpExecArray | null;
+      TEST_BLOCK.lastIndex = 0;
+      while ((block = TEST_BLOCK.exec(src)) !== null) {
+        QUOTED_STRING.lastIndex = 0;
+        let q: RegExpExecArray | null;
+        while ((q = QUOTED_STRING.exec(block[0])) !== null) {
+          const candidate = q[1];
+          if (isCaseOnlyFalsePositive(candidate)) {
+            offenders.push({
+              file: relative(REPO_ROOT, join(REQUEST_VALIDATION_DIR, f)),
+              sample: candidate,
+            });
+            break;
+          }
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1754,16 +1754,20 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
     // emission, see request-validation/src/emit/qaEmitter.ts). For each such
     // block, scope extraction to the inlined `const requestBody = { ... };`
     // literal so we don't pick up unrelated quoted strings (operationId,
-    // method, scenarioKind itself, etc.) and check every JSON-quoted string
-    // value for case-only collision with a valid enum member.
+    // method, scenarioKind itself, etc.) and check every quoted string
+    // *value* for case-only collision with a valid enum member.
+    //
+    // Prettier is configured (or falls back to) `singleQuote: true`, so
+    // emitted body strings are single-quoted (`field: 'creationDate_INVALID'`).
+    // Match both styles defensively in case prettier config drifts.
     const TEST_BLOCK = /test\([^]*?scenarioKind:\s*'enum-violation'[^]*?}\);/g;
     const REQUEST_BODY_LITERAL = /const requestBody\s*=\s*([\s\S]*?);\n/;
-    // Match `: "value"` so we capture string *values* in the body literal,
-    // not object keys (object keys are emitted unquoted by prettier for
-    // valid identifiers; this also skips any keys that happen to be quoted).
-    const STRING_VALUE = /:\s*"([^"\\\n]+)"/g;
+    // `: 'value'` or `: "value"` — captures the inner string regardless of
+    // quote style, but stays after the `:` so we don't pick up object keys.
+    const STRING_VALUE = /:\s*(?:'([^'\\\n]*)'|"([^"\\\n]*)")/g;
     const offenders: { file: string; sample: string }[] = [];
     let blocksScanned = 0;
+    let stringValuesScanned = 0;
     for (const f of readdirSync(REQUEST_VALIDATION_DIR)) {
       if (!f.endsWith('.spec.ts')) continue;
       const src = readFileSync(join(REQUEST_VALIDATION_DIR, f), 'utf8');
@@ -1777,7 +1781,9 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
         STRING_VALUE.lastIndex = 0;
         let q: RegExpExecArray | null;
         while ((q = STRING_VALUE.exec(bodyLiteral)) !== null) {
-          const candidate = q[1];
+          const candidate = q[1] ?? q[2];
+          if (candidate === undefined) continue;
+          stringValuesScanned++;
           if (isCaseOnlyFalsePositive(candidate)) {
             offenders.push({
               file: relative(REPO_ROOT, join(REQUEST_VALIDATION_DIR, f)),
@@ -1789,10 +1795,13 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
       }
     }
     // Guard against the invariant becoming vacuously true (e.g. emitter
-    // changes the syntax of the assertion context). The camunda-oca suite
-    // currently emits 100+ enum-violation blocks; any non-zero baseline is
-    // sufficient to prove the regex still matches.
+    // changes the syntax of the assertion context, or prettier's quote
+    // style drifts and the value regex stops matching). The camunda-oca
+    // suite currently emits 100+ enum-violation blocks containing many
+    // string values; any non-zero baseline is enough to prove both
+    // regexes still match.
     expect(blocksScanned).toBeGreaterThan(0);
+    expect(stringValuesScanned).toBeGreaterThan(0);
     expect(offenders).toEqual([]);
   });
 });

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1749,23 +1749,34 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
     }
 
     // Locate each test block whose closing assertion has
-    // `scenarioKind: 'enum-violation'`. For each such block, extract
-    // every JSON-quoted string literal from the inlined `requestBody`
-    // and check it for case-only collision with a valid enum member.
-    // A regex pass is sufficient because the emitter inlines the body
-    // as a TypeScript object literal with double-quoted string values.
+    // `scenarioKind: 'enum-violation'` (single quotes — emitter writes
+    // `JSON.stringify(s.type)` and prettier rewrites to single quotes during
+    // emission, see request-validation/src/emit/qaEmitter.ts). For each such
+    // block, scope extraction to the inlined `const requestBody = { ... };`
+    // literal so we don't pick up unrelated quoted strings (operationId,
+    // method, scenarioKind itself, etc.) and check every JSON-quoted string
+    // value for case-only collision with a valid enum member.
     const TEST_BLOCK = /test\([^]*?scenarioKind:\s*'enum-violation'[^]*?}\);/g;
-    const QUOTED_STRING = /"([^"\\\n]+)"/g;
+    const REQUEST_BODY_LITERAL = /const requestBody\s*=\s*([\s\S]*?);\n/;
+    // Match `: "value"` so we capture string *values* in the body literal,
+    // not object keys (object keys are emitted unquoted by prettier for
+    // valid identifiers; this also skips any keys that happen to be quoted).
+    const STRING_VALUE = /:\s*"([^"\\\n]+)"/g;
     const offenders: { file: string; sample: string }[] = [];
+    let blocksScanned = 0;
     for (const f of readdirSync(REQUEST_VALIDATION_DIR)) {
       if (!f.endsWith('.spec.ts')) continue;
       const src = readFileSync(join(REQUEST_VALIDATION_DIR, f), 'utf8');
       let block: RegExpExecArray | null;
       TEST_BLOCK.lastIndex = 0;
       while ((block = TEST_BLOCK.exec(src)) !== null) {
-        QUOTED_STRING.lastIndex = 0;
+        blocksScanned++;
+        const bodyMatch = REQUEST_BODY_LITERAL.exec(block[0]);
+        if (!bodyMatch) continue;
+        const bodyLiteral = bodyMatch[1];
+        STRING_VALUE.lastIndex = 0;
         let q: RegExpExecArray | null;
-        while ((q = QUOTED_STRING.exec(block[0])) !== null) {
+        while ((q = STRING_VALUE.exec(bodyLiteral)) !== null) {
           const candidate = q[1];
           if (isCaseOnlyFalsePositive(candidate)) {
             offenders.push({
@@ -1777,6 +1788,11 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
         }
       }
     }
+    // Guard against the invariant becoming vacuously true (e.g. emitter
+    // changes the syntax of the assertion context). The camunda-oca suite
+    // currently emits 100+ enum-violation blocks; any non-zero baseline is
+    // sufficient to prove the regex still matches.
+    expect(blocksScanned).toBeGreaterThan(0);
     expect(offenders).toEqual([]);
   });
 });

--- a/configs/camunda-oca/request-validation.json
+++ b/configs/camunda-oca/request-validation.json
@@ -1,0 +1,4 @@
+{
+  "$comment": "Per-config request-validation settings for camunda-oca. The Camunda 8 Orchestration Cluster API parser accepts string-enum values case-insensitively (camunda/camunda#52409), so case-only mutations would be false 400 expectations. See api-test-generator#129.",
+  "enumCaseInsensitive": true
+}

--- a/request-validation/scripts/generate.ts
+++ b/request-validation/scripts/generate.ts
@@ -35,6 +35,7 @@ import {
 } from '../src/analysis/parameters.js';
 import { generateTypeMismatch } from '../src/analysis/typeMismatch.js';
 import { generateUnionViolations } from '../src/analysis/unionViolations.js';
+import { loadRequestValidationConfig } from '../src/config.js';
 import { emitQaTests } from '../src/emit/qaEmitter.js';
 import type { ValidationScenario } from '../src/model/types.js';
 import { loadSpec } from '../src/spec/loader.js';
@@ -122,6 +123,16 @@ function parseArgs(): CliOptions {
 
 async function main() {
   const opts = parseArgs();
+  const repoRoot = findRepoRoot(process.cwd());
+  if (!repoRoot) {
+    throw new Error(`[generate] Could not locate configs.json starting from ${process.cwd()}.`);
+  }
+  const configName = getActiveConfigName(repoRoot);
+  const rvConfig = loadRequestValidationConfig(repoRoot, configName);
+  console.log(
+    `[generate] Active config: ${configName} ` +
+      `(enumCaseInsensitive=${rvConfig.enumCaseInsensitive})`,
+  );
   const { specPath, specProvenance, source } = resolveSpecSource();
   console.log(`[generate] Using spec from ${source}: ${specPath}`);
   const model = await loadSpec(specPath);
@@ -208,6 +219,7 @@ async function main() {
         ...generateEnumViolations(model.operations, {
           capPerOperation: undefined,
           onlyOperations: opts.onlyOperations,
+          enumCaseInsensitive: rvConfig.enumCaseInsensitive,
         }),
       );
     }

--- a/request-validation/scripts/generate.ts
+++ b/request-validation/scripts/generate.ts
@@ -123,12 +123,23 @@ function parseArgs(): CliOptions {
 
 async function main() {
   const opts = parseArgs();
+  // Per-config request-validation settings live at <repoRoot>/configs/<name>/request-validation.json.
+  // If we can't find the repo root, this script is being run from outside the
+  // checkout (likely with --out-dir pointing somewhere bespoke). In that case,
+  // fall back to defaults rather than aborting — the previous --out-dir
+  // workflow did not require repoRoot for anything.
   const repoRoot = findRepoRoot(process.cwd());
-  if (!repoRoot) {
-    throw new Error(`[generate] Could not locate configs.json starting from ${process.cwd()}.`);
+  let configName = '(unknown)';
+  let rvConfig = { enumCaseInsensitive: false };
+  if (repoRoot) {
+    configName = getActiveConfigName(repoRoot);
+    rvConfig = loadRequestValidationConfig(repoRoot, configName);
+  } else {
+    console.warn(
+      `[generate] Could not locate configs.json from ${process.cwd()} — ` +
+        'using request-validation defaults. Pass --out-dir explicitly.',
+    );
   }
-  const configName = getActiveConfigName(repoRoot);
-  const rvConfig = loadRequestValidationConfig(repoRoot, configName);
   console.log(
     `[generate] Active config: ${configName} ` +
       `(enumCaseInsensitive=${rvConfig.enumCaseInsensitive})`,

--- a/request-validation/src/analysis/enumViolations.ts
+++ b/request-validation/src/analysis/enumViolations.ts
@@ -17,8 +17,9 @@ interface Opts {
 
 /**
  * Test whether an invalid candidate `m` differs from any member of `members`
- * only by ASCII case. The caller is responsible for ensuring `m ∉ members`
- * (the membership check is the cheaper test and lives at the call site).
+ * only by ASCII case. Callers filter `m ∉ members` before invoking this so
+ * that a mutation which happens to equal a valid member is rejected by the
+ * cheaper `Array.includes` check at the call site rather than re-walked here.
  */
 function isCaseOnlyMutation(m: unknown, members: readonly unknown[]): boolean {
   if (typeof m !== 'string') return false;
@@ -62,6 +63,11 @@ export function generateEnumViolations(ops: OperationModel[], opts: Opts): Valid
           const invalids = buildInvalidVariants(node.enum[0]);
           for (const inv of invalids) {
             if (opts.capPerOperation && produced >= opts.capPerOperation) break;
+            // Defense in depth: if the synthesized "invalid" candidate is in fact
+            // a valid enum member (e.g. enum is `['Foo', 'foo']` so the lower-case
+            // mutation collides with a member, or a real enum literally contains
+            // `${first}_INVALID`), skip it — emitting it would be a false 400.
+            if (node.enum.includes(inv)) continue;
             if (opts.enumCaseInsensitive && isCaseOnlyMutation(inv, node.enum)) continue;
             const body = structuredClone(baseline);
             if (!setAtPath(body, path, inv)) continue;
@@ -95,6 +101,9 @@ export function generateEnumViolations(ops: OperationModel[], opts: Opts): Valid
           const invalids = buildInvalidVariants(schema.enum[0]);
           for (const inv of invalids) {
             if (opts.capPerOperation && produced >= (opts.capPerOperation ?? Infinity)) break;
+            // Same defense as the main walk: skip candidates that happen to be
+            // valid enum members of this oneOf-variant property.
+            if (schema.enum.includes(inv)) continue;
             if (opts.enumCaseInsensitive && isCaseOnlyMutation(inv, schema.enum)) continue;
             const body = structuredClone(base);
             body[prop] = inv;

--- a/request-validation/src/analysis/enumViolations.ts
+++ b/request-validation/src/analysis/enumViolations.ts
@@ -6,6 +6,27 @@ import { makeId, setAtPath } from './common.js';
 interface Opts {
   onlyOperations?: Set<string>;
   capPerOperation?: number;
+  /**
+   * When `true`, skip case-only enum mutations (issue #129). A mutation `m`
+   * for an enum with members `E` is "case-only" iff `m ∉ E` and
+   * `∃ e ∈ E. e.toLowerCase() === m.toLowerCase()`. Suffix mutations
+   * (`${value}_INVALID`) and totally unrelated values are still emitted.
+   */
+  enumCaseInsensitive?: boolean;
+}
+
+/**
+ * Test whether an invalid candidate `m` differs from any member of `members`
+ * only by ASCII case. The caller is responsible for ensuring `m ∉ members`
+ * (the membership check is the cheaper test and lives at the call site).
+ */
+function isCaseOnlyMutation(m: unknown, members: readonly unknown[]): boolean {
+  if (typeof m !== 'string') return false;
+  const lower = m.toLowerCase();
+  for (const e of members) {
+    if (typeof e === 'string' && e.toLowerCase() === lower) return true;
+  }
+  return false;
 }
 
 // Permissive subset of an OpenAPI schema fragment used by the oneOf fallback walker.
@@ -41,6 +62,7 @@ export function generateEnumViolations(ops: OperationModel[], opts: Opts): Valid
           const invalids = buildInvalidVariants(node.enum[0]);
           for (const inv of invalids) {
             if (opts.capPerOperation && produced >= opts.capPerOperation) break;
+            if (opts.enumCaseInsensitive && isCaseOnlyMutation(inv, node.enum)) continue;
             const body = structuredClone(baseline);
             if (!setAtPath(body, path, inv)) continue;
             out.push(makeScenario(op, path.join('.'), body, produced));
@@ -73,6 +95,7 @@ export function generateEnumViolations(ops: OperationModel[], opts: Opts): Valid
           const invalids = buildInvalidVariants(schema.enum[0]);
           for (const inv of invalids) {
             if (opts.capPerOperation && produced >= (opts.capPerOperation ?? Infinity)) break;
+            if (opts.enumCaseInsensitive && isCaseOnlyMutation(inv, schema.enum)) continue;
             const body = structuredClone(base);
             body[prop] = inv;
             out.push({

--- a/request-validation/src/config.ts
+++ b/request-validation/src/config.ts
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Per-config request-validation settings.
+ *
+ * Loaded from `configs/<active>/request-validation.json` (relative to the
+ * repository root). When the file is absent or any field is missing, defaults
+ * are used. The defaults are conservative — they preserve the
+ * pre-issue-#129 behaviour so that adding the loader is observably a no-op
+ * for any config that does not opt in.
+ *
+ * See issue #129 for the `enumCaseInsensitive` semantics.
+ */
+export interface RequestValidationConfig {
+  /**
+   * When `true`, the negative-test generator skips every case-only enum
+   * mutation — i.e. an input string `m` for an enum with members `E` where
+   *   `m ∉ E` (a 400 candidate by membership), and
+   *   `∃ e ∈ E. e.toLowerCase() === m.toLowerCase()` (only differs by case).
+   *
+   * Mutations that change non-case characters (`${value}_INVALID`, totally
+   * unrelated values like `NOPE`, etc.) are still emitted regardless.
+   *
+   * Default: `false` — case-only mutations are emitted as 400-expecting
+   * tests. Set this to `true` for APIs whose parser accepts enum values
+   * case-insensitively (the upstream Camunda 8 OCA parser does — see
+   * camunda/camunda#52409).
+   */
+  enumCaseInsensitive: boolean;
+}
+
+const DEFAULTS: RequestValidationConfig = {
+  enumCaseInsensitive: false,
+};
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Load `configs/<config>/request-validation.json` and merge with defaults.
+ * `repoRoot` must be the directory containing `configs.json`.
+ * `configName` is the resolved active config name.
+ *
+ * Throws if the file exists but is malformed (parse error, non-object root,
+ * or wrong-typed known field). A missing file is not an error — defaults apply.
+ */
+export function loadRequestValidationConfig(
+  repoRoot: string,
+  configName: string,
+): RequestValidationConfig {
+  const configPath = path.join(repoRoot, 'configs', configName, 'request-validation.json');
+  if (!fs.existsSync(configPath)) {
+    return { ...DEFAULTS };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  } catch (err) {
+    throw new Error(
+      `Failed to parse ${configPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!isPlainObject(parsed)) {
+    throw new Error(`Malformed ${configPath}: expected a JSON object at the root.`);
+  }
+  const merged: RequestValidationConfig = { ...DEFAULTS };
+  if ('enumCaseInsensitive' in parsed) {
+    const v = parsed.enumCaseInsensitive;
+    if (typeof v !== 'boolean') {
+      throw new Error(
+        `Invalid ${configPath}: "enumCaseInsensitive" must be a boolean, got ${typeof v}.`,
+      );
+    }
+    merged.enumCaseInsensitive = v;
+  }
+  return merged;
+}

--- a/tests/request-validation/enum-case-insensitive.test.ts
+++ b/tests/request-validation/enum-case-insensitive.test.ts
@@ -60,8 +60,8 @@ function isSuffixMutation(value: unknown, members: readonly string[]): boolean {
 
 function extractFlag(body: unknown): unknown {
   if (!body || typeof body !== 'object' || Array.isArray(body)) return undefined;
-  const rec: Record<string, unknown> = body;
-  return rec.flag;
+  if (!('flag' in body)) return undefined;
+  return body.flag;
 }
 
 describe('request-validation: enumCaseInsensitive flag (#129)', () => {

--- a/tests/request-validation/enum-case-insensitive.test.ts
+++ b/tests/request-validation/enum-case-insensitive.test.ts
@@ -58,9 +58,12 @@ function isSuffixMutation(value: unknown, members: readonly string[]): boolean {
   return typeof value === 'string' && members.some((m) => value === `${m}_INVALID`);
 }
 
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
 function extractFlag(body: unknown): unknown {
-  if (!body || typeof body !== 'object' || Array.isArray(body)) return undefined;
-  if (!('flag' in body)) return undefined;
+  if (!isPlainObject(body)) return undefined;
   return body.flag;
 }
 

--- a/tests/request-validation/enum-case-insensitive.test.ts
+++ b/tests/request-validation/enum-case-insensitive.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { generateEnumViolations } from '../../request-validation/src/analysis/enumViolations.js';
+import type { OperationModel } from '../../request-validation/src/model/types.js';
+
+/**
+ * Layer-2 fixture for issue #129.
+ *
+ * The negative-test generator emits, for every string-enum field, three
+ * mutations: a `${value}_INVALID` suffix variant, an UPPER variant, and a
+ * lower variant. The latter two are case-only mutations (they differ from a
+ * valid enum member only by ASCII case) and are false 400-expecting tests
+ * for any API whose parser accepts enums case-insensitively (the upstream
+ * Camunda 8 OCA parser does — see camunda/camunda#52409).
+ *
+ * The new `enumCaseInsensitive` request-validation config lets the
+ * generator skip those case-only mutations. This file pins both directions:
+ *
+ *   - default (false)  → at least one case-only mutation per
+ *                        mixed/lower-case enum value is emitted.
+ *   - explicit (true)  → zero case-only mutations across the entire
+ *                        emitted scenario set, but suffix mutations and
+ *                        non-string `__INVALID_ENUM__` mutations remain.
+ *
+ * The "true" assertion is class-scoped: it scans every emitted scenario
+ * (any ScenarioKind that runs through generateEnumViolations) and rejects
+ * any value that case-collides with the source enum. This guards against
+ * regressions where a sibling code path (e.g. the oneOf fallback walker)
+ * grows its own case mutation in the future.
+ */
+
+function buildOp(enumMembers: readonly string[]): OperationModel {
+  return {
+    operationId: 'enumCaseProbe',
+    method: 'POST',
+    path: '/probe',
+    tags: [],
+    bodyRequired: true,
+    requiredProps: ['flag'],
+    requestBodySchema: {
+      type: 'object',
+      required: ['flag'],
+      properties: {
+        flag: { type: 'string', enum: [...enumMembers] },
+      },
+    },
+    parameters: [],
+  };
+}
+
+function isCaseOnly(value: unknown, members: readonly string[]): boolean {
+  if (typeof value !== 'string') return false;
+  if (members.includes(value)) return false;
+  const lower = value.toLowerCase();
+  return members.some((m) => m.toLowerCase() === lower);
+}
+
+function isSuffixMutation(value: unknown, members: readonly string[]): boolean {
+  return typeof value === 'string' && members.some((m) => value === `${m}_INVALID`);
+}
+
+function extractFlag(body: unknown): unknown {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return undefined;
+  const rec: Record<string, unknown> = body;
+  return rec.flag;
+}
+
+describe('request-validation: enumCaseInsensitive flag (#129)', () => {
+  // `Foo` is mixed-case so both upper (`FOO`) and lower (`foo`) variants
+  // are case-only mutations the generator currently emits as 400-expecting
+  // tests against `enum[0]`.
+  const MEMBERS = ['Foo', 'bar'] as const;
+
+  it('emits >=2 case-only mutations when enumCaseInsensitive is false (default)', () => {
+    const op = buildOp(MEMBERS);
+    const scenarios = generateEnumViolations([op], {});
+    const offendingValues = scenarios
+      .map((s) => extractFlag(s.requestBody))
+      .filter((v) => isCaseOnly(v, [...MEMBERS]));
+    expect(offendingValues.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('emits 0 case-only mutations when enumCaseInsensitive is true', () => {
+    const op = buildOp(MEMBERS);
+    const scenarios = generateEnumViolations([op], { enumCaseInsensitive: true });
+    const offendingValues = scenarios
+      .map((s) => extractFlag(s.requestBody))
+      .filter((v) => isCaseOnly(v, [...MEMBERS]));
+    expect(offendingValues).toEqual([]);
+  });
+
+  it('still emits suffix mutations when enumCaseInsensitive is true', () => {
+    const op = buildOp(MEMBERS);
+    const scenarios = generateEnumViolations([op], { enumCaseInsensitive: true });
+    const suffixValues = scenarios
+      .map((s) => extractFlag(s.requestBody))
+      .filter((v) => isSuffixMutation(v, [...MEMBERS]));
+    expect(suffixValues.length).toBeGreaterThan(0);
+  });
+
+  it('does not skip non-case mutations of non-string enums', () => {
+    // Numeric enums fall through buildInvalidVariants's else-branch and
+    // emit `__INVALID_ENUM__` regardless of the flag.
+    const op: OperationModel = {
+      operationId: 'numericEnumProbe',
+      method: 'POST',
+      path: '/probe',
+      tags: [],
+      bodyRequired: true,
+      requiredProps: ['n'],
+      requestBodySchema: {
+        type: 'object',
+        required: ['n'],
+        properties: { n: { type: 'integer', enum: [1, 2, 3] } },
+      },
+      parameters: [],
+    };
+    const scenarios = generateEnumViolations([op], { enumCaseInsensitive: true });
+    expect(scenarios.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #129.

## Summary

Adds a per-config `enumCaseInsensitive` flag to the request-validation generator. When set to `true` for a config, the negative-test generator skips case-only enum mutations — values that differ from a valid enum member only by ASCII case, which would surface as false 400 expectations against an API whose parser accepts enums case-insensitively.

The `camunda-oca` config opts in (`enumCaseInsensitive: true`) because the upstream Camunda 8 OCA parser accepts string-enum values case-insensitively (camunda/camunda#52409). All other configs default to `false` and emit identically to before.

## Formal rule

A mutation `m` for an enum with members `E` is "case-only" iff:

```
m ∉ E  ∧  ∃ e ∈ E. e.toLowerCase() === m.toLowerCase()
```

Suffix mutations (`${value}_INVALID`) and unrelated/structural mutations are unaffected.

## Implementation

| File | Change |
|---|---|
| `request-validation/src/config.ts` (new) | `loadRequestValidationConfig(repoRoot, configName)`. Reads `configs/<name>/request-validation.json`. Missing file → defaults; malformed → throws (no silent degradation). |
| `request-validation/src/analysis/enumViolations.ts` | Extend `Opts` with `enumCaseInsensitive`, add `isCaseOnlyMutation(m, members)` helper, gate emission in both the main walk loop and the `oneOf` fallback loop. `buildInvalidVariants` is unchanged — the skip lives at the call site so the full enum array is in scope. |
| `request-validation/scripts/generate.ts` | Load per-config request-validation.json once at startup and thread the flag through `generateEnumViolations(...)`. Active config + flag are logged for visibility. |
| `configs/camunda-oca/request-validation.json` (new) | `{ "enumCaseInsensitive": true }` |

## Tests

- **Layer 2** (`tests/request-validation/enum-case-insensitive.test.ts`) — hand-built minimal `OperationModel` fixtures covering both flag values and a numeric-enum control. Class-scoped: asserts the property holds across mixed-case enums and non-string enums in the same suite.
- **Layer 3** (`configs/camunda-oca/regression-invariants.test.ts`) — scans every emitted enum-violation test block in the camunda-oca request-validation suite and asserts no inlined string body value case-collides with a valid enum member from the bundled spec. Catches any future analyser (e.g. a sibling `oneOf`/`anyOf` walker) that re-introduces a case-only mutation.

## Behaviour change

For `camunda-oca`, the negative-suite enum-violation count drops:

| | before | after |
|---|---:|---:|
| `enum-violation` | 238 | **103** |
| total scenarios | 1177 | **1042** |

The removed scenarios were false 400 expectations against an API that returns 200 on case-mismatched enum input. Layer-3 invariants in `configs/camunda-oca/regression-invariants.test.ts` continue to pass after the regen (no hard-coded counts depended on the case-only mutations).

Other configs are unaffected — the default is `false`.

## Pre-push gate

```
✓ npm run lint                                            (Biome — info-only diagnostics; pre-existing)
✓ npx tsc --noEmit -p {request-validation,path-analyser,semantic-graph-extractor}/tsconfig.json
✓ TEST_SEED=snapshot-baseline npm run testsuite:generate
✓ TEST_SEED=snapshot-baseline npm run generate:request-validation
✓ npm test                                                235 passed | 6 skipped
```
