### PR TITLE
fix: elide path-param constraint violators that collapse URL into wrong route

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1918,10 +1918,41 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
     function isUrlCollapsingPathSegment(value: string): boolean {
       if (value.length === 0) return true;
       if (value === '.' || value === '..') return true;
+      // Mirror production `paramConstraintViolations.ts:isUrlCollapsingPathSegment`.
+      // `buildUrl` substitutes path-param values raw, so the predicate must
+      // reject any value that *literally* contains a routing-significant
+      // character or already-encoded segment splitter, in addition to the
+      // canonical-encoding check.
+      if (/[/\\?#]/.test(value)) return true;
+      if (/%2f|%5c/i.test(value)) return true;
       const encoded = encodeURIComponent(value);
-      if (encoded.includes('%2F') || encoded.includes('%2f')) return true;
-      if (encoded.includes('%5C') || encoded.includes('%5c')) return true;
+      if (/%2f|%5c/i.test(encoded)) return true;
       return false;
+    }
+
+    // Unescape a JavaScript string-literal body: collapse `\<char>` to `<char>`
+    // for the escapes we care about (`\\`, `\'`, `\"`, `\/`, `\n`, `\t`, `\r`,
+    // `\b`, `\f`). Hex/unicode escapes are not produced by the emitter, so we
+    // do not decode them; if they ever are, the predicate's raw-character
+    // checks remain conservative because the literal `\u` sequence is
+    // harmless on its own.
+    function unescapeJsString(s: string): string {
+      return s.replace(/\\(.)/g, (_m, c: string) => {
+        switch (c) {
+          case 'n':
+            return '\n';
+          case 't':
+            return '\t';
+          case 'r':
+            return '\r';
+          case 'b':
+            return '\b';
+          case 'f':
+            return '\f';
+          default:
+            return c; // \\, \', \", \/, etc.
+        }
+      });
     }
 
     // Match the `buildUrl(...)` call inside a `param-constraint-violation`
@@ -1929,10 +1960,18 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
     // literal; we capture the template string and the params literal.
     const TEST_BLOCK = /test\([^]*?scenarioKind:\s*'param-constraint-violation'[^]*?}\);/g;
     const BUILD_URL = /buildUrl\(\s*'([^']+)'\s*,\s*(\{[^}]*\})\s*\)/;
-    // `: 'value'` — path-param values are always single-quoted strings in
-    // the emitted suite (prettier `singleQuote: true`). Defensive against
-    // double quotes in case prettier config drifts.
-    const PARAM_KV = /(\b[a-zA-Z_$][a-zA-Z0-9_$]*)\s*:\s*(?:'([^'\\\n]*)'|"([^"\\\n]*)")/g;
+    // `<key>: <value>` — key is either a bare identifier or a quoted
+    // string (in case prettier ever quotes a non-identifier key); value is
+    // a single- or double-quoted string literal that *may contain
+    // backslash escapes* (PR #148 review). Both halves capture the
+    // escape-aware body; the caller unescapes before predicate checks.
+    const STR_BODY_SQ = "'((?:\\\\.|[^'\\\\])*)'";
+    const STR_BODY_DQ = '"((?:\\\\.|[^"\\\\])*)"';
+    const KEY_BARE = '\\b[a-zA-Z_$][a-zA-Z0-9_$]*';
+    const PARAM_KV = new RegExp(
+      `(?:(${KEY_BARE})|${STR_BODY_SQ}|${STR_BODY_DQ})\\s*:\\s*(?:${STR_BODY_SQ}|${STR_BODY_DQ})`,
+      'g',
+    );
 
     interface Offender {
       file: string;
@@ -1963,11 +2002,13 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
         PARAM_KV.lastIndex = 0;
         let kv: RegExpExecArray | null;
         while ((kv = PARAM_KV.exec(paramsLiteral)) !== null) {
-          const [, key, sq, dq] = kv;
-          const value = sq ?? dq;
-          if (value === undefined) continue;
+          const [, bareKey, sqKey, dqKey, sqVal, dqVal] = kv;
+          const key = bareKey ?? sqKey ?? dqKey;
+          const rawValue = sqVal ?? dqVal;
+          if (key === undefined || rawValue === undefined) continue;
           if (!pathTokens.has(key)) continue;
           pathParamsScanned++;
+          const value = unescapeJsString(rawValue);
           if (isUrlCollapsingPathSegment(value)) {
             offenders.push({
               file: relative(REPO_ROOT, join(REQUEST_VALIDATION_DIR, f)),

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1883,4 +1883,106 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
     expect(pathParamSlotsScanned).toBeGreaterThan(0);
     expect(offenders).toEqual([]);
   });
+
+  it('emits zero URL-collapsing path-param values in param-constraint-violation tests (#147)', () => {
+    // Class-scoped guard for issue #147. Path-param constraint scenarios
+    // whose synthesised invalid value does not survive URL substitution
+    // as a single non-empty path segment never reach Camunda's request
+    // validator — Spring's router resolves the malformed URL as a
+    // different route and answers 404 from the static-resource handler.
+    // The expected 400 then fails for a reason unrelated to validation.
+    //
+    // Scan every emitted `param-constraint-violation` test block, parse
+    // its `buildUrl('/template', { param: 'value' })` call, and reject
+    // any value bound to a `{param}` token in the template that:
+    //   - is the empty string,
+    //   - is `.` or `..`,
+    //   - percent-encodes to contain `/` (`%2F`/`%2f`) or `\` (`%5C`/`%5c`).
+    //
+    // Catches not just the original `minLength: 1` empty-string emission
+    // (paramConstraintViolations.ts) but any sibling code path that
+    // synthesises a path-routing-significant violator in future.
+    const REQUEST_VALIDATION_DIR = join(
+      REPO_ROOT,
+      'generated',
+      CONFIG_NAME,
+      'request-validation',
+    );
+    if (!existsSync(REQUEST_VALIDATION_DIR)) {
+      throw new Error(
+        `Generated request-validation directory not found at ${REQUEST_VALIDATION_DIR}. ` +
+          `Run 'npm run generate:request-validation' (or 'npm run pipeline') first.`,
+      );
+    }
+
+    function isUrlCollapsingPathSegment(value: string): boolean {
+      if (value.length === 0) return true;
+      if (value === '.' || value === '..') return true;
+      const encoded = encodeURIComponent(value);
+      if (encoded.includes('%2F') || encoded.includes('%2f')) return true;
+      if (encoded.includes('%5C') || encoded.includes('%5c')) return true;
+      return false;
+    }
+
+    // Match the `buildUrl(...)` call inside a `param-constraint-violation`
+    // block. The emitter inlines path params as a single-line object
+    // literal; we capture the template string and the params literal.
+    const TEST_BLOCK = /test\([^]*?scenarioKind:\s*'param-constraint-violation'[^]*?}\);/g;
+    const BUILD_URL = /buildUrl\(\s*'([^']+)'\s*,\s*(\{[^}]*\})\s*\)/;
+    // `: 'value'` — path-param values are always single-quoted strings in
+    // the emitted suite (prettier `singleQuote: true`). Defensive against
+    // double quotes in case prettier config drifts.
+    const PARAM_KV = /(\b[a-zA-Z_$][a-zA-Z0-9_$]*)\s*:\s*(?:'([^'\\\n]*)'|"([^"\\\n]*)")/g;
+
+    interface Offender {
+      file: string;
+      param: string;
+      value: string;
+    }
+    const offenders: Offender[] = [];
+    let blocksScanned = 0;
+    let pathParamsScanned = 0;
+    for (const f of readdirSync(REQUEST_VALIDATION_DIR)) {
+      if (!f.endsWith('.spec.ts')) continue;
+      const src = readFileSync(join(REQUEST_VALIDATION_DIR, f), 'utf8');
+      let block: RegExpExecArray | null;
+      TEST_BLOCK.lastIndex = 0;
+      while ((block = TEST_BLOCK.exec(src)) !== null) {
+        blocksScanned++;
+        const urlMatch = BUILD_URL.exec(block[0]);
+        if (!urlMatch) continue;
+        const [, template, paramsLiteral] = urlMatch;
+        // Only path-param tokens — `{name}` substrings — are routing-
+        // significant. Query-only scenarios pass an empty `{}` and are
+        // ignored automatically.
+        const pathTokens = new Set<string>();
+        const tokenRe = /\{([^}]+)}/g;
+        let t: RegExpExecArray | null;
+        while ((t = tokenRe.exec(template)) !== null) pathTokens.add(t[1]);
+        if (pathTokens.size === 0) continue;
+        PARAM_KV.lastIndex = 0;
+        let kv: RegExpExecArray | null;
+        while ((kv = PARAM_KV.exec(paramsLiteral)) !== null) {
+          const [, key, sq, dq] = kv;
+          const value = sq ?? dq;
+          if (value === undefined) continue;
+          if (!pathTokens.has(key)) continue;
+          pathParamsScanned++;
+          if (isUrlCollapsingPathSegment(value)) {
+            offenders.push({
+              file: relative(REPO_ROOT, join(REQUEST_VALIDATION_DIR, f)),
+              param: key,
+              value,
+            });
+          }
+        }
+      }
+    }
+    // Vacuous-truth guard: prove both regexes still match the emitted
+    // syntax. The camunda-oca suite has hundreds of param-constraint
+    // blocks with at least one path-param each.
+    expect(blocksScanned).toBeGreaterThan(0);
+    expect(pathParamsScanned).toBeGreaterThan(0);
+    expect(offenders).toEqual([]);
+  });
 });

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1897,7 +1897,9 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
     // any value bound to a `{param}` token in the template that:
     //   - is the empty string,
     //   - is `.` or `..`,
-    //   - percent-encodes to contain `/` (`%2F`/`%2f`) or `\` (`%5C`/`%5c`).
+    //   - literally contains a routing-significant `/`, `\`, `?`, or `#`,
+    //   - already contains encoded `/` (`%2F`/`%2f`) or `\` (`%5C`/`%5c`),
+    //   - or percent-encodes to contain `/` (`%2F`/`%2f`) or `\` (`%5C`/`%5c`).
     //
     // Catches not just the original `minLength: 1` empty-string emission
     // (paramConstraintViolations.ts) but any sibling code path that

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1930,36 +1930,50 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
       return false;
     }
 
-    // Unescape a JavaScript string-literal body: collapse `\<char>` to `<char>`
-    // for the escapes we care about (`\\`, `\'`, `\"`, `\/`, `\n`, `\t`, `\r`,
-    // `\b`, `\f`). Hex/unicode escapes are not produced by the emitter, so we
-    // do not decode them; if they ever are, the predicate's raw-character
-    // checks remain conservative because the literal `\u` sequence is
-    // harmless on its own.
-    function unescapeJsString(s: string): string {
-      return s.replace(/\\(.)/g, (_m, c: string) => {
-        switch (c) {
-          case 'n':
-            return '\n';
-          case 't':
-            return '\t';
-          case 'r':
-            return '\r';
-          case 'b':
-            return '\b';
-          case 'f':
-            return '\f';
-          default:
-            return c; // \\, \', \", \/, etc.
-        }
-      });
+    // Unescape a JavaScript string-literal body. The emitter writes path
+    // params via `JSON.stringify`, then prettier may re-quote the outer
+    // quotes (`singleQuote: true`). For correctness across the full set of
+    // JSON escapes (`\\`, `\"`, `\/`, `\n`, `\t`, `\r`, `\b`, `\f`, and
+    // `\uXXXX` — which can decode to routing-significant chars like `/` =
+    // `\u002F`), we round-trip through `JSON.parse`. PR #148 review: the
+    // previous hand-rolled `replace(/\\(.)/, ...)` returned just `<char>`
+    // for any `\<char>`, which would have decoded `\u002F` to `u002F` and
+    // hidden a real slash from the URL-collapsing predicate.
+    function unescapeJsString(rawBody: string, quote: "'" | '"'): string {
+      // Convert the captured body to a valid JSON string body. JSON requires
+      // double-quoted strings with `\"` for embedded quotes; it does not
+      // allow `\'` (a JS-only escape). For single-quoted source: unescape
+      // `\'` to `'`, then escape any unescaped `"` to `\"`.
+      let jsonBody: string;
+      if (quote === '"') {
+        jsonBody = rawBody;
+      } else {
+        jsonBody = rawBody
+          .replace(/\\'/g, "'")
+          .replace(/(^|[^\\])((?:\\\\)*)"/g, '$1$2\\"');
+      }
+      try {
+        const parsed: unknown = JSON.parse(`"${jsonBody}"`);
+        if (typeof parsed === 'string') return parsed;
+      } catch {
+        // Fall through to raw return below — predicate's raw-character
+        // checks (`/`, `\`, `?`, `#`, `%2f`, `%5c`) remain conservative
+        // even on un-decoded escape sequences.
+      }
+      return rawBody;
     }
 
     // Match the `buildUrl(...)` call inside a `param-constraint-violation`
-    // block. The emitter inlines path params as a single-line object
-    // literal; we capture the template string and the params literal.
+    // block. The emitter accepts both the 2-arg form
+    // `buildUrl(path, pathParams)` and the 3-arg form
+    // `buildUrl(path, pathParams, queryParams)` (#127). We only care about
+    // the path-params slot for this invariant; slot 3 is captured-and-
+    // discarded so the regex still matches when it exists. PR #148 review:
+    // the previous regex required exactly two args and silently skipped
+    // every block with a query-params slot, weakening coverage.
     const TEST_BLOCK = /test\([^]*?scenarioKind:\s*'param-constraint-violation'[^]*?}\);/g;
-    const BUILD_URL = /buildUrl\(\s*'([^']+)'\s*,\s*(\{[^}]*\})\s*\)/;
+    const BUILD_URL =
+      /buildUrl\(\s*'([^']+)'(?:\s*,\s*(\{[^}]*\}|undefined))(?:\s*,\s*(?:\{[^}]*\}|undefined))?\s*\)/;
     // `<key>: <value>` — key is either a bare identifier or a quoted
     // string (in case prettier ever quotes a non-identifier key); value is
     // a single- or double-quoted string literal that *may contain
@@ -1992,8 +2006,10 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
         if (!urlMatch) continue;
         const [, template, paramsLiteral] = urlMatch;
         // Only path-param tokens — `{name}` substrings — are routing-
-        // significant. Query-only scenarios pass an empty `{}` and are
-        // ignored automatically.
+        // significant. Query-only scenarios pass `undefined` for slot 2
+        // (the 3-arg form, post-#127) or an empty `{}` (legacy 2-arg) and
+        // are ignored automatically.
+        if (!paramsLiteral || paramsLiteral === 'undefined') continue;
         const pathTokens = new Set<string>();
         const tokenRe = /\{([^}]+)}/g;
         let t: RegExpExecArray | null;
@@ -2008,7 +2024,8 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
           if (key === undefined || rawValue === undefined) continue;
           if (!pathTokens.has(key)) continue;
           pathParamsScanned++;
-          const value = unescapeJsString(rawValue);
+          const quote: "'" | '"' = sqVal !== undefined ? "'" : '"';
+          const value = unescapeJsString(rawValue, quote);
           if (isUrlCollapsingPathSegment(value)) {
             offenders.push({
               file: relative(REPO_ROOT, join(REQUEST_VALIDATION_DIR, f)),

--- a/request-validation/src/analysis/paramConstraintViolations.ts
+++ b/request-validation/src/analysis/paramConstraintViolations.ts
@@ -68,15 +68,36 @@ function buildValidValue(r: ResolvedParamSchema): string {
  * a different route and returns 404 from a static-resource handler before
  * the request validator runs).
  *
- * Class-scoped check: covers empty segment, `.`, `..`, and any value that
- * percent-encodes to contain `/` or `\` (segment splitters). See issue #147.
+ * `buildUrl()` substitutes path-param values raw (no encoding), so the
+ * predicate must reject any value that *literally* contains a routing-
+ * significant character, plus any value whose `encodeURIComponent` form
+ * contains an encoded segment splitter.
+ *
+ * Class-scoped check (issue #147 + PR #148 review):
+ *   - empty segment
+ *   - `.` / `..` (path traversal)
+ *   - raw `/` or `\` (forward / back slash)
+ *   - raw `?` or `#` (query / fragment delimiters)
+ *   - already-encoded `%2F` / `%5C` (case-insensitive) in the value as
+ *     supplied — the server may decode these to `/` or `\`
+ *   - any value whose `encodeURIComponent` form contains `%2F`/`%5C`
+ *     (catches values that contain raw separators not covered above —
+ *     defence in depth in case the rules above drift).
  */
 function isUrlCollapsingPathSegment(value: string): boolean {
   if (value.length === 0) return true;
   if (value === '.' || value === '..') return true;
+  // Raw routing-significant characters (no encoding by buildUrl).
+  if (/[/\\?#]/.test(value)) return true;
+  // Already-encoded separators in the supplied value — buildUrl substitutes
+  // the value as-is, and the server (or any intermediate proxy) may decode
+  // %2F / %5C back to / or \. `encodeURIComponent` would re-encode the `%`
+  // to `%25`, so check the raw value directly.
+  if (/%2f|%5c/i.test(value)) return true;
+  // Defence in depth: catch any value whose canonical encoding contains a
+  // segment splitter not flagged above.
   const encoded = encodeURIComponent(value);
-  if (encoded.includes('%2F') || encoded.includes('%2f')) return true;
-  if (encoded.includes('%5C') || encoded.includes('%5c')) return true;
+  if (/%2f|%5c/i.test(encoded)) return true;
   return false;
 }
 

--- a/request-validation/src/analysis/paramConstraintViolations.ts
+++ b/request-validation/src/analysis/paramConstraintViolations.ts
@@ -123,7 +123,15 @@ function buildViolations(
   }
   // Length violations
   if (typeof r.minLength === 'number' && r.minLength > 0) {
-    const tooShort = ''.padEnd(Math.max(0, r.minLength - 1), '');
+    // PR #148 review: previously `''.padEnd(N, '')` returned `''` for any
+    // `minLength > 0` because `padEnd` with an empty pad string is a no-op.
+    // Use a non-empty pad so we synthesise a genuinely-too-short value
+    // (length `minLength - 1`); for `minLength: 1` the result is still `''`
+    // (length 0), and `accept()` will elide that for path params via
+    // `isUrlCollapsingPathSegment`. For `minLength: 3` we now correctly
+    // emit `'aa'` instead of `''`, exercising the validator on a
+    // non-collapsing shorter value.
+    const tooShort = 'a'.repeat(r.minLength - 1);
     accept('length-min', tooShort);
   }
   if (typeof r.maxLength === 'number') {

--- a/request-validation/src/analysis/paramConstraintViolations.ts
+++ b/request-validation/src/analysis/paramConstraintViolations.ts
@@ -61,32 +61,59 @@ function buildValidValue(r: ResolvedParamSchema): string {
   return 'x';
 }
 
+/**
+ * Returns true if `value`, after URL substitution into a path template,
+ * would not survive as a single non-empty path segment — making any
+ * resulting 400 expectation noise (Spring's router resolves the request as
+ * a different route and returns 404 from a static-resource handler before
+ * the request validator runs).
+ *
+ * Class-scoped check: covers empty segment, `.`, `..`, and any value that
+ * percent-encodes to contain `/` or `\` (segment splitters). See issue #147.
+ */
+function isUrlCollapsingPathSegment(value: string): boolean {
+  if (value.length === 0) return true;
+  if (value === '.' || value === '..') return true;
+  const encoded = encodeURIComponent(value);
+  if (encoded.includes('%2F') || encoded.includes('%2f')) return true;
+  if (encoded.includes('%5C') || encoded.includes('%5c')) return true;
+  return false;
+}
+
 function buildViolations(
   p: ParameterModel,
   r: ResolvedParamSchema,
 ): { kind: string; invalid: string }[] {
   const out: { kind: string; invalid: string }[] = [];
+  const isPath = p.in === 'path';
+  const accept = (kind: string, invalid: string): void => {
+    // Path-param scenarios that collapse the URL never reach the validator
+    // (Spring routes them to a different handler and returns 404). Elide
+    // them so the 400 assertion isn't a noisy false-fail. See issue #147.
+    if (isPath && isUrlCollapsingPathSegment(invalid)) return;
+    out.push({ kind, invalid });
+  };
   // Pattern violation
   if (r.pattern) {
     const invalid = buildGuaranteedPatternMismatch(r.pattern, {
-      pathSegmentSafe: p.in === 'path',
+      pathSegmentSafe: isPath,
     });
-    if (invalid) out.push({ kind: 'pattern', invalid });
+    if (invalid) accept('pattern', invalid);
   }
   // Length violations
   if (typeof r.minLength === 'number' && r.minLength > 0) {
     const tooShort = ''.padEnd(Math.max(0, r.minLength - 1), '');
-    out.push({ kind: 'length-min', invalid: tooShort });
+    accept('length-min', tooShort);
   }
   if (typeof r.maxLength === 'number') {
     const tooLong = 'a'.repeat(r.maxLength + 10);
-    out.push({ kind: 'length-max', invalid: tooLong });
+    accept('length-max', tooLong);
   }
   // Enum violation (only if enum present)
   if (r.enumValues?.length) {
     let inval = `${String(r.enumValues[0])}_X`;
     if (r.pattern === '^-?[0-9]+$') inval = '9999999999999999999999999'; // excessively long number string
-    out.push({ kind: 'enum', invalid: inval });
+    accept('enum', inval);
   }
   return out;
 }

--- a/tests/request-validation/path-param-url-collapse.test.ts
+++ b/tests/request-validation/path-param-url-collapse.test.ts
@@ -133,4 +133,34 @@ describe('request-validation: path-param URL-collapse guard (#147)', () => {
     );
     expect(queryScenarios.length).toBeGreaterThan(0);
   });
+
+  it('emits genuinely-too-short values for minLength > 1 (PR #148 review)', () => {
+    // Class-scoped guard: previously `tooShort = ''.padEnd(N, '')` returned
+    // the empty string for ANY `minLength > 0`, because `padEnd` with an
+    // empty pad string is a no-op. That meant every `length-min` path-param
+    // scenario was elided by the URL-collapse filter, even when a non-empty
+    // shorter value existed (e.g. `'aa'` for `minLength: 3`). The fix
+    // synthesises `'a'.repeat(minLength - 1)` so we exercise the validator
+    // on a real shorter-than-allowed value; only `minLength: 1` (whose
+    // shorter value is `''`) remains elided.
+    //
+    // Assert both sides of the boundary: `minLength: 3` → `'aa'` survives;
+    // `minLength: 1` → `''` is correctly elided.
+    const op = buildOp('/v2/a/{three}/b/{one}', [
+      buildPathParam('three', { type: 'string', minLength: 3 }),
+      buildPathParam('one', { type: 'string', minLength: 1 }),
+    ]);
+
+    const scenarios = generateParamConstraintViolations([op], {});
+    const lengthMin = scenarios.filter(
+      (s) => s.type === 'param-constraint-violation' && s.constraintKind === 'length-min',
+    );
+
+    const threeScenarios = lengthMin.filter((s) => s.target === 'path.three');
+    expect(threeScenarios).toHaveLength(1);
+    expect(threeScenarios[0].params?.three).toBe('aa');
+
+    const oneScenarios = lengthMin.filter((s) => s.target === 'path.one');
+    expect(oneScenarios).toEqual([]);
+  });
 });

--- a/tests/request-validation/path-param-url-collapse.test.ts
+++ b/tests/request-validation/path-param-url-collapse.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { generateParamConstraintViolations } from '../../request-validation/src/analysis/paramConstraintViolations.js';
+import type { OperationModel, ParameterModel } from '../../request-validation/src/model/types.js';
+
+/**
+ * Layer-2 fixture for issue #147.
+ *
+ * `generateParamConstraintViolations` synthesises invalid values for path
+ * parameters that are then substituted into the operation's path template
+ * by the test scaffold. If the synthesised value does not survive URL
+ * substitution as a single non-empty path segment (empty string, slash, dot,
+ * percent-encoded slash, etc.), the resulting URL has a different shape from
+ * the operation's contract — Spring's router resolves it as a different
+ * route and answers 404 from a static-resource handler. The 400 expectation
+ * is then unmet for a reason unrelated to validation, producing a noisy
+ * false-fail.
+ *
+ * Concrete trigger: `minLength: 1` produces `tooShort = ''.padEnd(0)` = `''`.
+ * Substituted into `/v2/roles/{roleId}/groups/{groupId}` you get
+ * `/v2/roles/x/groups/`, which Spring serves through the static-resource
+ * handler with `404 No static resource v2/roles/x/groups`.
+ *
+ * The class-scoped guard asserts that **no** emitted path-param constraint
+ * scenario carries a value that collapses the URL — empty, `.`, `..`, or
+ * containing a `/` (or `%2F`/`%2f`) after percent-encoding. This protects
+ * against four sibling causes (length, slash-permitting pattern,
+ * dot-permitting pattern, and encoded slash) with one assertion.
+ */
+
+function buildPathParam(name: string, schema: ParameterModel['schema']): ParameterModel {
+  return { name, in: 'path', required: true, schema };
+}
+
+function buildOp(path: string, parameters: ParameterModel[]): OperationModel {
+  return {
+    operationId: 'pathParamProbe',
+    method: 'DELETE',
+    path,
+    tags: [],
+    parameters,
+  };
+}
+
+function isUrlCollapsing(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  if (value.length === 0) return true;
+  if (value === '.' || value === '..') return true;
+  const encoded = encodeURIComponent(value);
+  if (encoded.includes('%2F') || encoded.includes('%2f')) return true;
+  if (encoded.includes('%5C') || encoded.includes('%5c')) return true;
+  return false;
+}
+
+describe('request-validation: path-param URL-collapse guard (#147)', () => {
+  it('does not emit empty-string violator for minLength:1 on path params', () => {
+    // Mirrors the unassignRoleFromGroup failure: `groupId` has minLength: 1.
+    // The only "shorter than 1" value is the empty string, which collapses
+    // the URL into a different route. The scenario must be elided.
+    const op = buildOp('/v2/roles/{roleId}/groups/{groupId}', [
+      buildPathParam('roleId', { type: 'string', pattern: '^[a-z]+$' }),
+      buildPathParam('groupId', { type: 'string', minLength: 1, maxLength: 256 }),
+    ]);
+
+    const scenarios = generateParamConstraintViolations([op], {});
+
+    const groupIdScenarios = scenarios.filter(
+      (s) => s.type === 'param-constraint-violation' && s.target === 'path.groupId',
+    );
+    const offending = groupIdScenarios.filter((s) => s.params?.groupId === '');
+    expect(offending).toEqual([]);
+  });
+
+  it('does not emit any URL-collapsing path-param violator across all constraint kinds', () => {
+    // Class-scoped: covers length-min, length-max, pattern, and enum.
+    // The pattern below admits `/` (the inverted character class is a
+    // single non-`.` character; the pattern-mismatch helper is free to pick
+    // a slash). Likewise the enum is open-ended. The guard must filter any
+    // emitted invalid that, post-substitution, would not be a single
+    // non-empty path segment.
+    const op = buildOp('/v2/a/{slashy}/b/{dotty}/c/{lengthy}/d/{enummy}/e', [
+      buildPathParam('slashy', { type: 'string', pattern: '^[^.]+$' }),
+      buildPathParam('dotty', { type: 'string', pattern: '^[^/]+$' }),
+      buildPathParam('lengthy', { type: 'string', minLength: 1 }),
+      buildPathParam('enummy', { type: 'string', enum: ['ok'] }),
+    ]);
+
+    const scenarios = generateParamConstraintViolations([op], {});
+
+    const offending: { target?: string; value: unknown }[] = [];
+    for (const s of scenarios) {
+      if (s.type !== 'param-constraint-violation') continue;
+      if (s.source !== 'path') continue;
+      // Identify which param this scenario violates from `target`.
+      const paramName = s.target?.split('.')[1];
+      if (!paramName) continue;
+      const value = s.params?.[paramName];
+      if (isUrlCollapsing(value)) offending.push({ target: s.target, value });
+    }
+
+    expect(offending).toEqual([]);
+  });
+
+  it('does not regress: query-param empty-string violators are still emitted', () => {
+    // Query params are *not* substituted into the URL path, so an empty
+    // value is a legitimate validator probe (`?q=`). The guard must apply
+    // to path params only.
+    const op: OperationModel = {
+      operationId: 'queryParamProbe',
+      method: 'GET',
+      path: '/v2/things',
+      tags: [],
+      parameters: [
+        { name: 'q', in: 'query', required: true, schema: { type: 'string', minLength: 1 } },
+      ],
+    };
+
+    const scenarios = generateParamConstraintViolations([op], {});
+    const queryScenarios = scenarios.filter(
+      (s) => s.source === 'query' && s.target === 'query.q' && s.constraintKind === 'length-min',
+    );
+    expect(queryScenarios.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/request-validation/path-param-url-collapse.test.ts
+++ b/tests/request-validation/path-param-url-collapse.test.ts
@@ -15,10 +15,14 @@ import type { OperationModel, ParameterModel } from '../../request-validation/sr
  * is then unmet for a reason unrelated to validation, producing a noisy
  * false-fail.
  *
- * Concrete trigger: `minLength: 1` produces `tooShort = ''.padEnd(0)` = `''`.
- * Substituted into `/v2/roles/{roleId}/groups/{groupId}` you get
+ * Concrete trigger: `minLength: 1` produces `tooShort = 'a'.repeat(0)` =
+ * `''`. Substituted into `/v2/roles/{roleId}/groups/{groupId}` you get
  * `/v2/roles/x/groups/`, which Spring serves through the static-resource
- * handler with `404 No static resource v2/roles/x/groups`.
+ * handler with `404 No static resource v2/roles/x/groups`. (PR #148 review:
+ * the synthesis was previously `''.padEnd(N, '')`, which is a no-op for
+ * any `N`; it is now `'a'.repeat(N - 1)`, which still yields `''` for
+ * `minLength: 1` but produces a non-empty shorter value for
+ * `minLength > 1`.)
  *
  * The class-scoped guard asserts that **no** emitted path-param constraint
  * scenario carries a value that would change the URL shape after raw

--- a/tests/request-validation/path-param-url-collapse.test.ts
+++ b/tests/request-validation/path-param-url-collapse.test.ts
@@ -21,10 +21,13 @@ import type { OperationModel, ParameterModel } from '../../request-validation/sr
  * handler with `404 No static resource v2/roles/x/groups`.
  *
  * The class-scoped guard asserts that **no** emitted path-param constraint
- * scenario carries a value that collapses the URL — empty, `.`, `..`, or
- * containing a `/` (or `%2F`/`%2f`) after percent-encoding. This protects
- * against four sibling causes (length, slash-permitting pattern,
- * dot-permitting pattern, and encoded slash) with one assertion.
+ * scenario carries a value that would change the URL shape after raw
+ * substitution — empty, `.`, `..`, or containing any routing-significant
+ * character (`/`, `\`, `?`, `#`) or already-encoded separator (`%2F`,
+ * `%5C`). This protects against the four sibling causes (length, pattern,
+ * enum, and any future synthesiser) with one assertion. PR #148 review:
+ * the predicate must check the *raw* value as well, because `buildUrl()`
+ * substitutes path params without encoding.
  */
 
 function buildPathParam(name: string, schema: ParameterModel['schema']): ParameterModel {
@@ -45,9 +48,13 @@ function isUrlCollapsing(value: unknown): boolean {
   if (typeof value !== 'string') return false;
   if (value.length === 0) return true;
   if (value === '.' || value === '..') return true;
+  // Raw routing-significant characters (no encoding by buildUrl).
+  if (/[/\\?#]/.test(value)) return true;
+  // Already-encoded segment splitters in the supplied value.
+  if (/%2f|%5c/i.test(value)) return true;
+  // Defence in depth: canonical encoding contains a separator.
   const encoded = encodeURIComponent(value);
-  if (encoded.includes('%2F') || encoded.includes('%2f')) return true;
-  if (encoded.includes('%5C') || encoded.includes('%5c')) return true;
+  if (/%2f|%5c/i.test(encoded)) return true;
   return false;
 }
 
@@ -72,11 +79,17 @@ describe('request-validation: path-param URL-collapse guard (#147)', () => {
 
   it('does not emit any URL-collapsing path-param violator across all constraint kinds', () => {
     // Class-scoped: covers length-min, length-max, pattern, and enum.
-    // The pattern below admits `/` (the inverted character class is a
-    // single non-`.` character; the pattern-mismatch helper is free to pick
-    // a slash). Likewise the enum is open-ended. The guard must filter any
-    // emitted invalid that, post-substitution, would not be a single
-    // non-empty path segment.
+    //
+    // Note that pattern-mismatch synthesis for `in: 'path'` already passes
+    // `pathSegmentSafe: true` to `buildGuaranteedPatternMismatch`, which
+    // filters `/` and `\` at the synthesis layer. The pattern cases here
+    // therefore exercise the helper boundary (the synthesiser may still
+    // legitimately pick `.` or `..` for `^[^.]+$`); the empty-string is
+    // produced by `length-min`. The `accept()` filter in
+    // `paramConstraintViolations` is the second line of defence and the
+    // one this guard locks in: any future synthesiser (or relaxed
+    // `pathSegmentSafe` setting) cannot emit a URL-collapsing value
+    // without this test failing.
     const op = buildOp('/v2/a/{slashy}/b/{dotty}/c/{lengthy}/d/{enummy}/e', [
       buildPathParam('slashy', { type: 'string', pattern: '^[^.]+$' }),
       buildPathParam('dotty', { type: 'string', pattern: '^[^/]+$' }),


### PR DESCRIPTION
Closes #147.

## Defect class

Path-parameter `param-constraint-violation` scenarios whose synthesised invalid value does not survive URL substitution as a single non-empty path segment never reach Camunda's request validator. Spring's router resolves the malformed URL as a different route (or the static-resource handler) and answers `404`. The expected `400` then fails for a reason unrelated to validation, producing noisy false-positive failures in the emitted suite.

The original reproducer (issue #147): a path param with `minLength: 1` produces the empty string as its length-min violator. `'/v2/groups/{groupId}/roles/x'` substituted with `groupId: ''` collapses to `'/v2/groups//roles/x'`, which the router can't match.

Sibling causes (same defect class) are also handled:

| cause                                | example value | substituted shape         |
|--------------------------------------|---------------|---------------------------|
| empty string (`minLength: 1`)        | `''`          | `/a//b` — collapses       |
| `.` / `..` segment                   | `'.'`, `'..'` | path-traversal-resolved   |
| pattern allowing slash               | `'a/b'`       | extra segment             |
| pattern allowing backslash (Windows) | `'a\b'`       | encoded path separator    |

## Fix

In `request-validation/src/analysis/paramConstraintViolations.ts`, route every push site (pattern, length-min, length-max, enum) through a local `accept()` closure that drops the violation when `p.in === 'path'` and the value would not survive URL substitution as a single non-empty path segment. Query-param violators with the same shapes are unaffected — empty strings and slashes are legitimate query values.

The predicate (`isUrlCollapsingPathSegment`) returns `true` for empty, `.`, `..`, or values whose `encodeURIComponent` includes `%2F`/`%2f`/`%5C`/`%5c`.

## Behaviour change (corrected from earlier description)

In `camunda-oca`, every path param with `minLength` also carries `maxLength`. Downstream emitter keeps **one violation per `(operation, param)`** combination (first wins by id), so the observable change isn't elision — it's a **swap**:

- **Before** (main): `length-min` wins the slot → emits `groupId: ''` → URL collapses → 404 false-positive.
- **After** (this branch): the URL-collapsing `length-min` is dropped, `length-max` takes the slot → emits `groupId: 'aaaa…'` → server returns 400 → real validation tested.

Generated test count is unchanged (~46 path-param length-* tests). Playwright result delta against a live cluster: **-1 failure, +1 pass** (most swapped scenarios now exercise real `maxLength` validation; one previously-failing length-min path-param case is replaced by a passing length-max case). For specs where a path param has only `minLength` (no `maxLength`), the violation would be elided rather than swapped — the L3 invariant guards both shapes.

Pattern-violation false-positives (`'!'`-style values returning 404 because the path resolves to a non-existent ID) are a separate defect class and out of scope here.

## Tests (red/green/class-scoped)

Following the standing red/green discipline:

- **L2 fixture** — `tests/request-validation/path-param-url-collapse.test.ts` (3 `it` blocks):
  1. `unassignRoleFromGroup`-shaped reproducer (the original `minLength: 1` empty-string emission).
  2. Class-scoped scan — synthesises an operation with all four sibling causes (slash-permitting pattern, dot-permitting pattern, `minLength: 1`, single-element enum forcing flip) and asserts every emitted invalid for a path param is non-collapsing.
  3. Negative guard — query-param violators with the same shapes still emit. Verified red (2 of 3 failing) on pre-fix code; green on post-fix code.
- **L3 invariant** — `configs/camunda-oca/regression-invariants.test.ts`. New `describeForThisConfig` block scans every emitted `param-constraint-violation` test in `generated/camunda-oca/request-validation/*.spec.ts`, parses the `buildUrl('/template', { … })` call, and rejects any value bound to a `{token}` in the template that matches the predicate. Includes vacuous-truth guards (`blocksScanned > 0`, `pathParamsScanned > 0`).

## Pre-push verification

- ✅ `npm run lint` — 0 errors (2 pre-existing infos in `tests/fixtures/planner/planner-establishes.test.ts`, unchanged from `main`).
- ✅ All three `tsc --noEmit` typechecks.
- ✅ `TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation`.
- ✅ `npm test` — 239 passed | 6 skipped (32 files).
- ✅ Confirmed in regenerated suite: zero path-param `length-min` violation tests emitted (was 9 on main); the corresponding 9 `(operation, groupId)` slots now emit `length-max` instead. Net Playwright result vs main: 78 failed / 964 passed (was 79 / 963).
