### PR TITLE
fix: route query-param values to the query slot of buildUrl

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1804,4 +1804,83 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
     expect(stringValuesScanned).toBeGreaterThan(0);
     expect(offenders).toEqual([]);
   });
+
+  it('routes non-path-token params to the query slot of buildUrl (#127)', () => {
+    // Class-scoped guard for issue #127. `buildUrl(path, pathParams,
+    // queryParams)` only substitutes entries whose key matches a `{token}`
+    // in the path template; non-token keys passed in slot 2 are silently
+    // dropped from the request. Scan every emitted `param-*-violation`
+    // test in the request-validation suite, parse its `buildUrl(...)`
+    // call, and reject any second-arg key that is NOT a path token of the
+    // template.
+    //
+    // Catches the original `searchVariables - Param query.truncateValues
+    // wrong type` case (path `/variables/search` carrying `truncateValues`
+    // in slot 2) and any sibling emitter regression.
+    const REQUEST_VALIDATION_DIR = join(
+      REPO_ROOT,
+      'generated',
+      CONFIG_NAME,
+      'request-validation',
+    );
+    if (!existsSync(REQUEST_VALIDATION_DIR)) {
+      throw new Error(
+        `Generated request-validation directory not found at ${REQUEST_VALIDATION_DIR}. ` +
+          `Run 'npm run generate:request-validation' (or 'npm run pipeline') first.`,
+      );
+    }
+
+    // Match any param-* validation test block (type-mismatch, constraint-
+    // violation, enum-violation). The block ends at the closing `});` of
+    // the inner test arrow function call.
+    const TEST_BLOCK =
+      /test\([^]*?scenarioKind:\s*'param-(?:type-mismatch|constraint-violation|enum-violation)'[^]*?}\);/g;
+    const BUILD_URL = /buildUrl\(\s*'([^']+)'(?:\s*,\s*(\{[^}]*\}|undefined))?(?:\s*,\s*(\{[^}]*\}))?\s*\)/;
+    const PARAM_KEY = /(\b[a-zA-Z_$][a-zA-Z0-9_$]*)\s*:/g;
+
+    interface Offender {
+      file: string;
+      template: string;
+      orphanKey: string;
+    }
+    const offenders: Offender[] = [];
+    let blocksScanned = 0;
+    let pathParamSlotsScanned = 0;
+    for (const f of readdirSync(REQUEST_VALIDATION_DIR)) {
+      if (!f.endsWith('.spec.ts')) continue;
+      const src = readFileSync(join(REQUEST_VALIDATION_DIR, f), 'utf8');
+      let block: RegExpExecArray | null;
+      TEST_BLOCK.lastIndex = 0;
+      while ((block = TEST_BLOCK.exec(src)) !== null) {
+        blocksScanned++;
+        const urlMatch = BUILD_URL.exec(block[0]);
+        if (!urlMatch) continue;
+        const [, template, pathParamsLiteral] = urlMatch;
+        if (!pathParamsLiteral || pathParamsLiteral === 'undefined') continue;
+        pathParamSlotsScanned++;
+        const pathTokens = new Set<string>();
+        const tokenRe = /\{([^}]+)}/g;
+        let t: RegExpExecArray | null;
+        while ((t = tokenRe.exec(template)) !== null) pathTokens.add(t[1]);
+        PARAM_KEY.lastIndex = 0;
+        let kv: RegExpExecArray | null;
+        while ((kv = PARAM_KEY.exec(pathParamsLiteral)) !== null) {
+          const key = kv[1];
+          if (!pathTokens.has(key)) {
+            offenders.push({
+              file: relative(REPO_ROOT, join(REQUEST_VALIDATION_DIR, f)),
+              template,
+              orphanKey: key,
+            });
+          }
+        }
+      }
+    }
+    // Vacuous-truth guards: prove both regexes still match the emitted
+    // syntax. The camunda-oca suite has hundreds of param-* blocks with
+    // at least one path-params slot.
+    expect(blocksScanned).toBeGreaterThan(0);
+    expect(pathParamSlotsScanned).toBeGreaterThan(0);
+    expect(offenders).toEqual([]);
+  });
 });

--- a/request-validation/src/emit/qaEmitter.ts
+++ b/request-validation/src/emit/qaEmitter.ts
@@ -134,13 +134,35 @@ function buildFile(
   return lines.join('\n');
 }
 
+/**
+ * Test-only export of the per-scenario renderer. Used by Layer-2 fixtures
+ * (e.g. tests/request-validation/query-param-buildurl-slot.test.ts for
+ * issue #127) that need to assert on the emitted `buildUrl(...)` shape
+ * without spinning up the full file-emission pipeline.
+ */
+export function renderScenarioForTest(s: ValidationScenario, title: string): string {
+  return renderScenario(s, title, true);
+}
+
 function renderScenario(s: ValidationScenario, title: string, standalone: boolean): string {
   const lines: string[] = [];
   const fixtureArg = standalone ? '({request}, testInfo)' : '({request})';
   lines.push(`  test(${JSON.stringify(title)}, async ${fixtureArg} => {`);
-  const paramsLit = s.params ? JSON.stringify(s.params) : 'undefined';
+  // Split params into path-tokens vs everything-else (query/header keys).
+  // `buildUrl(path, pathParams, queryParams)` substitutes only entries whose
+  // key matches a `{token}` in the template; non-token keys passed in slot 2
+  // are silently dropped. Routing them to slot 3 makes them surface as a
+  // query string. See issue #127.
   const pathLit = JSON.stringify(s.path.replace(/\{([^}]+)}/g, '{$1}'));
-  const urlCall = `buildUrl(${pathLit}, ${paramsLit})`;
+  const { pathParams, queryParams } = splitParamsBySlot(s.path, s.params);
+  const pathArg = pathParams ? JSON.stringify(pathParams) : 'undefined';
+  const queryArg = queryParams ? JSON.stringify(queryParams) : undefined;
+  const urlCall =
+    queryArg !== undefined
+      ? `buildUrl(${pathLit}, ${pathArg}, ${queryArg})`
+      : pathParams
+        ? `buildUrl(${pathLit}, ${pathArg})`
+        : `buildUrl(${pathLit})`;
   lines.push(`    const url = ${urlCall};`);
   if (s.bodyEncoding === 'multipart' && s.multipartForm) {
     const formLit = JSON.stringify(s.multipartForm, null, 2);
@@ -195,6 +217,39 @@ function renderScenario(s: ValidationScenario, title: string, standalone: boolea
   }
   lines.push('  });');
   return lines.join('\n');
+}
+
+/**
+ * Split a flat `params` map into the two slots that `buildUrl` expects:
+ * keys matching a `{token}` in the path template go to the path-params
+ * slot, everything else goes to the query slot. Either side is `undefined`
+ * when empty so the emitter can drop unused arguments. See issue #127.
+ */
+function splitParamsBySlot(
+  path: string,
+  params: Record<string, string> | undefined,
+): {
+  pathParams: Record<string, string> | undefined;
+  queryParams: Record<string, string> | undefined;
+} {
+  if (!params) return { pathParams: undefined, queryParams: undefined };
+  const pathTokens = new Set<string>();
+  const tokenRe = /\{([^}]+)}/g;
+  let m: RegExpExecArray | null = tokenRe.exec(path);
+  while (m !== null) {
+    pathTokens.add(m[1]);
+    m = tokenRe.exec(path);
+  }
+  const pathParams: Record<string, string> = {};
+  const queryParams: Record<string, string> = {};
+  for (const [k, v] of Object.entries(params)) {
+    if (pathTokens.has(k)) pathParams[k] = v;
+    else queryParams[k] = v;
+  }
+  return {
+    pathParams: Object.keys(pathParams).length ? pathParams : undefined,
+    queryParams: Object.keys(queryParams).length ? queryParams : undefined,
+  };
 }
 
 function methodFn(m: string): string {

--- a/tests/request-validation/query-param-buildurl-slot.test.ts
+++ b/tests/request-validation/query-param-buildurl-slot.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { renderScenarioForTest } from '../../request-validation/src/emit/qaEmitter.js';
+import type { ValidationScenario } from '../../request-validation/src/model/types.js';
+
+/**
+ * Layer-2 fixture for issue #127.
+ *
+ * `buildUrl(path, pathParams, queryParams)` substitutes only those entries
+ * in `pathParams` whose key matches a `{token}` in `path`. Anything else
+ * is silently dropped. The emitter previously rendered every value of
+ * `s.params` into the second arg, so query-parameter `param-*` scenarios
+ * dropped their value from the request, the server defaulted it, and the
+ * test saw 200 instead of the asserted 400.
+ *
+ * Class of defect: any scenario where `s.params` includes keys that are
+ * NOT path tokens of `s.path`. Those keys are query (or header) params
+ * and must be passed as the third `buildUrl` argument.
+ *
+ * Reference: camunda/api-test-generator#127.
+ *
+ * Note: `renderScenario` emits JSON.stringify literals (double quotes);
+ * Prettier rewrites those to single quotes on the file-level emission
+ * pipeline, so these regexes match the pre-Prettier shape.
+ */
+
+function buildScenario(overrides: Partial<ValidationScenario> = {}): ValidationScenario {
+  return {
+    id: 'test',
+    operationId: 'searchVariables',
+    method: 'POST',
+    path: '/variables/search',
+    type: 'param-type-mismatch',
+    target: 'query.truncateValues',
+    expectedStatus: 400,
+    description: 'Type mismatch for query parameter truncateValues',
+    headersAuth: true,
+    source: 'query',
+    ...overrides,
+  };
+}
+
+describe('request-validation: query-param buildUrl-slot guard (#127)', () => {
+  it('reproducer: searchVariables truncateValues lands in the query slot, not the path slot', () => {
+    const s = buildScenario({ params: { truncateValues: 'notBoolean' } });
+    const out = renderScenarioForTest(s, 'searchVariables - Param query.truncateValues wrong type');
+    const buildUrlCall = out.match(/buildUrl\([^;]+\)/)?.[0] ?? '';
+    expect(buildUrlCall, 'no buildUrl call rendered').toMatch(/buildUrl\(/);
+    // The path-params slot for a tokenless template must be `undefined` or
+    // `{}` — never a record carrying the query key. The query key must
+    // appear in the third (query) slot.
+    expect(
+      buildUrlCall,
+      'query-param value must be in the query (3rd) slot, not the path-params (2nd) slot',
+    ).toMatch(/,\s*(undefined|\{\s*\})\s*,\s*\{[^}]*"truncateValues":\s*"notBoolean"/);
+  });
+
+  it('class-scoped: mixed path-token + query-key scenario splits across slots', () => {
+    // /groups/{groupId}/users/search with a tokenless query param.
+    // pathParams slot must contain only `groupId`; query slot must contain
+    // only `pageSize`. Catches sibling defects where any non-path key
+    // accidentally lands in the path-params slot.
+    const s = buildScenario({
+      operationId: 'searchUsersForGroup',
+      method: 'POST',
+      path: '/groups/{groupId}/users/search',
+      params: { groupId: 'g1', pageSize: 'NaNValue' },
+      target: 'query.pageSize',
+    });
+    const out = renderScenarioForTest(s, 'searchUsersForGroup - Param query.pageSize wrong type');
+    const buildUrlCall = out.match(/buildUrl\([^;]+\)/)?.[0] ?? '';
+    // groupId stays in path-params slot (slot 2).
+    expect(buildUrlCall).toMatch(
+      /buildUrl\("\/groups\/\{groupId\}\/users\/search",\s*\{[^}]*"groupId":/,
+    );
+    // pageSize moves to query slot (slot 3).
+    expect(buildUrlCall).toMatch(/,\s*\{[^}]*"pageSize":\s*"NaNValue"[^}]*\}\s*\)$/);
+    // pageSize must NOT appear in the path-params slot.
+    const pathParamsLiteral = buildUrlCall.match(/buildUrl\("[^"]+",\s*(\{[^}]*\})/)?.[1] ?? '';
+    expect(pathParamsLiteral).not.toContain('pageSize');
+  });
+
+  it('regression guard: pure path-param scenarios still emit in the path-params slot', () => {
+    // Issue #127's fix must not break path-param scenarios (the only ones
+    // whose values genuinely belong in slot 2). Catches over-eager fixes
+    // that move every param into slot 3.
+    const s = buildScenario({
+      operationId: 'getGroup',
+      method: 'GET',
+      path: '/groups/{groupId}',
+      params: { groupId: 'aaaaaaaaa' },
+      target: 'path.groupId',
+      type: 'param-constraint-violation',
+      source: 'path',
+    });
+    const out = renderScenarioForTest(s, 'getGroup - Path param groupId length-max violation');
+    const buildUrlCall = out.match(/buildUrl\([^;]+\)/)?.[0] ?? '';
+    expect(buildUrlCall).toMatch(
+      /buildUrl\("\/groups\/\{groupId\}",\s*\{[^}]*"groupId":\s*"aaaaaaaaa"[^}]*\}/,
+    );
+    // groupId must not also appear in a third arg.
+    expect(buildUrlCall).not.toMatch(/,\s*\{[^}]*"groupId":[^}]*\}\s*,\s*\{[^}]*"groupId"/);
+  });
+});


### PR DESCRIPTION
Closes #127.

## Defect class

`buildUrl(path, pathParams, queryParams)` substitutes only those entries in `pathParams` whose key matches a `{token}` in `path`. Anything else is silently dropped. The emitter previously rendered every value of `s.params` into the second arg, so query-parameter `param-*` scenarios (`param-type-mismatch`, `param-constraint-violation`, `param-enum-violation`) on tokenless paths omitted their value from the request entirely. The server defaulted the param and answered 200; the asserted 400 then failed for a reason unrelated to validation.

Original reproducer: `searchVariables - Param query.truncateValues wrong type`. Path `/variables/search` has no `{token}`, so `{ truncateValues: 'notBoolean' }` in slot 2 was dropped. Manual curl with the param in the right slot returns 400 as expected.

The class scope is broader than the single failing test the issue surfaced: every query-param `param-*` scenario emits the same broken shape. ~80 tests in `generated/camunda-oca/request-validation/` were passing or failing for the wrong reason on `main`.

## Fix

In `request-validation/src/emit/qaEmitter.ts` (`renderScenario`), split `s.params` using path-template tokens — keys matching `{token}` go to the path-params slot, everything else to the query slot. Render `buildUrl(path, pathParams, queryParams)` with `undefined` for empty maps.

No scenario-shape changes; analysers continue to emit a flat `params` map. The split happens at the rendering boundary where the path template is known.

Helper extracted: `splitParamsBySlot(path, params)`. Renderer also exports `renderScenarioForTest` for the L2 fixture.

## Behaviour change

The emitted `searchVariables - Param query.truncateValues wrong type` test (and ~80 sibling query-param scenarios) now actually sends the malformed query string. Confirmed live:

```
✓ 1040 generated/camunda-oca/request-validation/variables-validation-api-tests.spec.ts:121:3 ›
  Variables Validation API Tests › searchVariables - Param query.truncateValues wrong type (4ms)
```

Net Playwright failure count vs `main` is unchanged (78 / 964) — some tests that previously passed for the wrong reason (server defaulted the dropped param) now properly exercise validation; some uncovered real product gaps are exposed for the first time. The fix corrects the **what is being tested**, not just the failure tally.

## Tests (red/green/class-scoped)

Following the standing red/green discipline:

- **L2 fixture** — `tests/request-validation/query-param-buildurl-slot.test.ts` (3 `it` blocks):
  1. **Reproducer** — `searchVariables`-shape scenario; asserts the query value lands in slot 3, not slot 2.
  2. **Class-scoped** — mixed path-token + query-key scenario (`/groups/{groupId}/users/search` with `pageSize`); asserts `groupId` stays in slot 2 and `pageSize` moves to slot 3.
  3. **Negative guard** — pure path-param scenario still emits in slot 2 only.

  Verified red on pre-fix code (2 of 3 failing); green after fix (3 of 3).

- **L3 invariant** — `configs/camunda-oca/regression-invariants.test.ts`. Scans every emitted `param-*-violation` test in `generated/camunda-oca/request-validation/*.spec.ts`, parses the `buildUrl(template, pathParamsLiteral)` call, and rejects any key in the path-params literal that is not a `{token}` of the template. Includes vacuous-truth guards (`blocksScanned > 0`, `pathParamSlotsScanned > 0`).

## Pre-push verification

- ✅ `npm run lint` — 0 errors (2 pre-existing infos in `tests/fixtures/planner/planner-establishes.test.ts`, unchanged from `main`).
- ✅ All three `tsc --noEmit` typechecks.
- ✅ `TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation`.
- ✅ `npm test` — 239 passed | 6 skipped (32 files).
- ✅ Live reproducer flips from red to green; total Playwright count unchanged.
