### PR TITLE
fix: planner emits authoritative seedBindings list (#136)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -2095,10 +2095,12 @@ describeForThisConfig('bundled-spec invariants: scenario seed-binding completene
       scenarios: ScenarioLite[];
     }
 
+    // Mirrors path-analyser/src/codegen/playwright/emitter.ts:436 and
+    // path-analyser/src/seedBindings.ts: trivial lowercase-first-char
+    // only. Must stay aligned with the runtime emitter or this
+    // invariant will check the wrong *Var names.
     function camelCase(input: string): string {
-      return input
-        .replace(/[-_\s]+(.)?/g, (_, c) => (typeof c === "string" ? c.toUpperCase() : ""))
-        .replace(/^(.)/, (_, c) => (typeof c === "string" ? c.toLowerCase() : ""));
+      return input.charAt(0).toLowerCase() + input.slice(1);
     }
 
     function collectStringRefs(s: string, out: Set<string>): void {
@@ -2225,10 +2227,12 @@ describeForThisConfig('bundled-spec invariants: scenario seed-binding completene
       scenarios: ScenarioLite[];
     }
 
+    // Mirrors path-analyser/src/codegen/playwright/emitter.ts:436 and
+    // path-analyser/src/seedBindings.ts: trivial lowercase-first-char
+    // only. Must stay aligned with the runtime emitter or this
+    // invariant will check the wrong *Var names.
     function camelCase(input: string): string {
-      return input
-        .replace(/[-_\s]+(.)?/g, (_, c) => (typeof c === "string" ? c.toUpperCase() : ""))
-        .replace(/^(.)/, (_, c) => (typeof c === "string" ? c.toLowerCase() : ""));
+      return input.charAt(0).toLowerCase() + input.slice(1);
     }
 
     const graph = JSON.parse(readFileSync(GRAPH_PATH, 'utf8')) as GraphLite;

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -2046,3 +2046,266 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
     expect(offenders).toEqual([]);
   });
 });
+
+describeForThisConfig('bundled-spec invariants: scenario seed-binding completeness (#136)', () => {
+  // Class-scoped invariant pinning the planner-side fix for #136.
+  //
+  // Defect class: a request-plan step references a binding (in its
+  // body, multipart payload, or path template) that has no value at
+  // the time the step runs. Pre-#136 the Playwright emitter swallowed
+  // body-only identifier bindings whose value was ALSO extracted from
+  // the same step's response (e.g. createUser sending
+  // `username: ctx.usernameVar` while extracting `usernameVar` from
+  // its own response) — the body went out as `undefined` and the
+  // broker rejected it 400. The planner now stamps `seedBindings`
+  // (path-analyser/src/seedBindings.ts) on every scenario; any
+  // emitter just iterates it.
+  //
+  // The invariant: for every feature-output scenario, every `${var}`
+  // referenced by step S must be resolvable at S's request time —
+  // either a literal in `bindings`, or extracted by a strictly
+  // earlier step, or listed in `scenario.seedBindings`. An offender
+  // means SOME emitter would render an unseeded variable; the
+  // contract is emitter-agnostic so this catches the bug class for
+  // every present and future emitter.
+  it('every step references only bindings that are literal, earlier-extracted, or in seedBindings', () => {
+    if (!existsSync(FEATURE_SCENARIOS_DIR)) {
+      throw new Error(
+        `Feature-output directory not found at ${FEATURE_SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+      );
+    }
+    interface ExtractLite {
+      bind: string;
+    }
+    interface RequestStepLite {
+      operationId: string;
+      pathTemplate: string;
+      bodyTemplate?: unknown;
+      multipartTemplate?: unknown;
+      extract?: ExtractLite[];
+    }
+    interface ScenarioLite {
+      id: string;
+      bindings?: Record<string, string>;
+      seedBindings?: string[];
+      requestPlan?: RequestStepLite[];
+    }
+    interface CollectionLite {
+      endpoint: { operationId: string };
+      scenarios: ScenarioLite[];
+    }
+
+    function camelCase(input: string): string {
+      return input
+        .replace(/[-_\s]+(.)?/g, (_, c) => (typeof c === "string" ? c.toUpperCase() : ""))
+        .replace(/^(.)/, (_, c) => (typeof c === "string" ? c.toLowerCase() : ""));
+    }
+
+    function collectStringRefs(s: string, out: Set<string>): void {
+      for (const m of s.matchAll(/\$\{([^}]+)\}/g)) out.add(m[1]);
+    }
+    function walkTemplate(value: unknown, out: Set<string>): void {
+      if (typeof value === 'string') {
+        collectStringRefs(value, out);
+        return;
+      }
+      if (Array.isArray(value)) {
+        for (const v of value) walkTemplate(v, out);
+        return;
+      }
+      if (value && typeof value === 'object') {
+        for (const v of Object.values(value)) walkTemplate(v, out);
+      }
+    }
+    function readsOf(step: RequestStepLite): Set<string> {
+      const out = new Set<string>();
+      walkTemplate(step.bodyTemplate, out);
+      walkTemplate(step.multipartTemplate, out);
+      for (const m of step.pathTemplate.matchAll(/\{([^}]+)\}/g)) {
+        out.add(`${camelCase(m[1])}Var`);
+      }
+      return out;
+    }
+
+    interface Offender {
+      file: string;
+      scenarioId: string;
+      stepIndex: number;
+      operationId: string;
+      missing: string;
+    }
+    const offenders: Offender[] = [];
+    let scenariosScanned = 0;
+    let stepsScanned = 0;
+
+    for (const f of readdirSync(FEATURE_SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      const collection = JSON.parse(
+        readFileSync(join(FEATURE_SCENARIOS_DIR, f), 'utf8'),
+      ) as CollectionLite;
+      for (const scenario of collection.scenarios) {
+        if (!scenario.requestPlan?.length) continue;
+        scenariosScanned++;
+        const literals = new Set<string>();
+        for (const [k, v] of Object.entries(scenario.bindings ?? {})) {
+          if (v !== '__PENDING__') literals.add(k);
+        }
+        const seeds = new Set(scenario.seedBindings ?? []);
+        const extractedSoFar = new Set<string>();
+        for (let i = 0; i < scenario.requestPlan.length; i++) {
+          const step = scenario.requestPlan[i];
+          stepsScanned++;
+          for (const v of readsOf(step)) {
+            if (literals.has(v) || extractedSoFar.has(v) || seeds.has(v)) continue;
+            offenders.push({
+              file: f,
+              scenarioId: scenario.id,
+              stepIndex: i,
+              operationId: step.operationId,
+              missing: v,
+            });
+          }
+          for (const ex of step.extract ?? []) extractedSoFar.add(ex.bind);
+        }
+      }
+    }
+
+    // Vacuous-truth guard: the camunda-oca bundle has thousands of
+    // scenarios and tens of thousands of `${var}` reads. If either
+    // count is suspiciously low the invariant has stopped exercising
+    // the property.
+    expect(scenariosScanned).toBeGreaterThan(100);
+    expect(stepsScanned).toBeGreaterThan(scenariosScanned);
+    expect(offenders).toEqual([]);
+  });
+
+  // Narrower companion invariant pinning the exact #136 reproducer:
+  // an establisher operation whose endpoint scenario echoes a body
+  // identifier in its response. Pre-#136 every such operation was a
+  // live-broker 201→400 (46 of them in the issue's enumeration). Even
+  // if the broader invariant above is later relaxed, this one keeps
+  // the named defect class permanently red on regression.
+  it('every establisher endpoint scenario seeds its own body identifier bindings', () => {
+    if (!existsSync(FEATURE_SCENARIOS_DIR) || !existsSync(GRAPH_PATH)) {
+      throw new Error(
+        `Required pipeline output not found. Run 'npm run pipeline' first.`,
+      );
+    }
+    interface IdentifiedBy {
+      in: 'body' | 'path' | 'header' | 'query';
+      name: string;
+      semanticType: string;
+    }
+    interface EstablishesSpec {
+      kind: string;
+      shape?: 'edge' | 'aggregate';
+      identifiedBy: IdentifiedBy[];
+    }
+    interface OperationNodeLite {
+      operationId: string;
+      establishes?: EstablishesSpec;
+    }
+    interface GraphLite {
+      operations: OperationNodeLite[];
+    }
+    interface RequestStepLite {
+      operationId: string;
+      bodyTemplate?: unknown;
+      multipartTemplate?: unknown;
+    }
+    interface ScenarioLite {
+      id: string;
+      operations: { operationId: string }[];
+      bindings?: Record<string, string>;
+      seedBindings?: string[];
+      requestPlan?: RequestStepLite[];
+    }
+    interface CollectionLite {
+      endpoint: { operationId: string };
+      scenarios: ScenarioLite[];
+    }
+
+    function camelCase(input: string): string {
+      return input
+        .replace(/[-_\s]+(.)?/g, (_, c) => (typeof c === "string" ? c.toUpperCase() : ""))
+        .replace(/^(.)/, (_, c) => (typeof c === "string" ? c.toLowerCase() : ""));
+    }
+
+    const graph = JSON.parse(readFileSync(GRAPH_PATH, 'utf8')) as GraphLite;
+    const opsById = new Map(graph.operations.map((o) => [o.operationId, o]));
+    interface Offender {
+      file: string;
+      scenarioId: string;
+      operationId: string;
+      bodyIdentifier: string;
+      missingBinding: string;
+    }
+    const offenders: Offender[] = [];
+    let establisherScenariosScanned = 0;
+
+    for (const f of readdirSync(FEATURE_SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      const collection = JSON.parse(
+        readFileSync(join(FEATURE_SCENARIOS_DIR, f), 'utf8'),
+      ) as CollectionLite;
+      const endpointNode = opsById.get(collection.endpoint.operationId);
+      const establishes = endpointNode?.establishes;
+      if (!establishes || establishes.shape === 'edge') continue;
+      const bodyIdents = establishes.identifiedBy.filter((id) => id.in === 'body');
+      if (bodyIdents.length === 0) continue;
+
+      for (const scenario of collection.scenarios) {
+        if (!scenario.requestPlan?.length) continue;
+        const firstStep = scenario.requestPlan[0];
+        if (firstStep.operationId !== collection.endpoint.operationId) continue;
+        // Collect ${var} references actually emitted by the body /
+        // multipart template — that is the surface where #136 produced
+        // unbound reads. Body identifiers omitted from the body
+        // template entirely are an orthogonal body-builder defect and
+        // out of scope for this invariant.
+        const bodyRefs = new Set<string>();
+        const collectVarRefs = (node: unknown): void => {
+          if (typeof node === 'string') {
+            for (const m of node.matchAll(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g)) {
+              bodyRefs.add(m[1]);
+            }
+            return;
+          }
+          if (Array.isArray(node)) {
+            for (const item of node) collectVarRefs(item);
+            return;
+          }
+          if (node !== null && typeof node === 'object') {
+            for (const v of Object.values(node)) collectVarRefs(v);
+          }
+        };
+        collectVarRefs(firstStep.bodyTemplate);
+        collectVarRefs(firstStep.multipartTemplate);
+        establisherScenariosScanned++;
+        const literals = new Set<string>();
+        for (const [k, v] of Object.entries(scenario.bindings ?? {})) {
+          if (v !== '__PENDING__') literals.add(k);
+        }
+        const seeds = new Set(scenario.seedBindings ?? []);
+        for (const id of bodyIdents) {
+          const expectedVar = `${camelCase(id.name)}Var`;
+          if (!bodyRefs.has(expectedVar)) continue;
+          if (literals.has(expectedVar) || seeds.has(expectedVar)) continue;
+          offenders.push({
+            file: f,
+            scenarioId: scenario.id,
+            operationId: collection.endpoint.operationId,
+            bodyIdentifier: id.name,
+            missingBinding: expectedVar,
+          });
+        }
+      }
+    }
+    // Sanity floor: the bundled spec has multiple body-identifier
+    // establishers (createUser, createMappingRule, createRole,
+    // createGroup, createAdminUser, createAuthorization, …). If the
+    // count drops below this floor the invariant is silently vacuous.
+    expect(establisherScenariosScanned).toBeGreaterThanOrEqual(5);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -198,59 +198,54 @@ function renderScenarioTest(
   // numeric keys, structured response payloads). Reads from ctx flow into
   // request bodies that are themselves untyped, so no narrowing is needed.
   body.push(`  const ctx: Record<string, unknown> = {};`);
-  // Collect extraction target variable names across all steps
-  const extractionVars = new Set<string>();
-  if (s.requestPlan) {
-    for (const step of s.requestPlan) {
-      if (step.extract) {
-        for (const ex of step.extract) extractionVars.add(ex.bind);
-      }
-    }
-  }
+  // Issue #136: scenario.seedBindings is the planner's authoritative
+  // answer to "which bindings need a runtime seedBinding() call before
+  // step 0". Pre-#136 the emitter re-derived this from
+  // `bindings ∪ requestPlan` and skipped any PENDING binding that
+  // appeared as an extract target anywhere in the plan — which broke
+  // the establisher's own base scenario, where the body input is
+  // also extracted from the same step's response (extract runs AFTER
+  // the request body is built, so no seed → undefined → 400). We now
+  // trust the planner. The `bindings` loop below still emits literal
+  // (non-PENDING) values for compatibility with downstream lookup, but
+  // delegates "should this be seeded at runtime" entirely to
+  // `seedBindings`.
+  const seedBindingsList = s.seedBindings ?? [];
   if (s.bindings && Object.keys(s.bindings).length) {
     body.push('  // Seed scenario bindings');
-    // Collect vars referenced in body/multipart templates so we can auto-seed PENDING ones actually used.
-    const templateVars = new Set<string>();
-    function collectVarsFromTemplate(obj: unknown) {
-      if (!obj || typeof obj !== 'object') return;
-      for (const val of Object.values(obj)) {
-        if (typeof val === 'string') {
-          const m = val.match(/^\$\{([^}]+)\}$/); // "${varName}"
-          if (m) templateVars.add(m[1]);
-        } else if (typeof val === 'object') collectVarsFromTemplate(val);
-      }
-    }
-    if (s.requestPlan) {
-      for (const step of s.requestPlan) {
-        if (step.bodyTemplate) collectVarsFromTemplate(step.bodyTemplate);
-        if (step.multipartTemplate) collectVarsFromTemplate(step.multipartTemplate);
-      }
-    }
     for (const [k, v] of Object.entries(s.bindings)) {
-      if (v === '__PENDING__') {
-        if (!templateVars.has(k)) continue; // Not referenced in a template
-        if (extractionVars.has(k)) continue; // Will be provided by extraction
-        // Use centralized seeding util at runtime (generate inside test execution for deterministic mode support)
-        body.push(`  if (ctx['${k}'] === undefined) { ctx['${k}'] = seedBinding('${k}'); }`);
-        continue;
-      }
-      if (extractionVars.has(k)) continue;
+      if (v === '__PENDING__') continue; // handled by seedBindings below
+      // Literal bindings flow into ctx unconditionally so any later
+      // step (or the same step's body) can read the planner-minted
+      // value before any extract overwrites it. The seedBindings list
+      // never contains literals (computeSeedBindings filters them
+      // out), so emitting both is safe.
       body.push(`  ctx['${k}'] = ${JSON.stringify(v)};`);
+    }
+  }
+  if (seedBindingsList.length) {
+    if (!s.bindings || !Object.keys(s.bindings).length) {
+      body.push('  // Seed scenario bindings');
+    }
+    for (const k of seedBindingsList) {
+      // `=== undefined` (not `??`) so a literal-bound binding above
+      // that happens to share a name with a seedBindings entry — not
+      // possible today (computeSeedBindings filters literals) but
+      // belt-and-braces — does not get re-seeded.
+      body.push(`  if (ctx['${k}'] === undefined) { ctx['${k}'] = seedBinding('${k}'); }`);
     }
   }
   // Universal-seed prologue derived from domain-semantics.json#globalContextSeeds.
   // Each entry emits a single nullish-coalesced assignment that is idempotent
-  // over all three bindings-loop outcomes above:
+  // over both bindings-loop outcomes above:
   //   - literal binding (`ctx['<k>'] = "value";`) — `??` short-circuits, value preserved
-  //   - `__PENDING__` already seeded by the in-loop `=== undefined` guard — `??` short-circuits
-  //   - no bindings-loop assignment at all (fresh `ctx`) — `??` falls through to seedBinding(...)
-  // This replaces the pre-#86 unconditional `if (ctx[...] === undefined) { ... }`
-  // form, which was dead code in the third case. `??` (not `=== undefined`) is
-  // intentional: any nullish binding value (`null` or `undefined`) is treated
-  // as missing and triggers seeding. The planner does not currently emit `null`
-  // literals in `s.bindings` for any global seed; revisit before tightening to
-  // `=== undefined` if a future seed ever needs `null` to remain distinct from
-  // "missing".
+  //   - seedBindings entry already seeded by the `=== undefined` guard — `??` short-circuits
+  //   - no assignment at all (fresh `ctx`) — `??` falls through to seedBinding(...)
+  // `??` (not `=== undefined`) is intentional: any nullish binding value
+  // (`null` or `undefined`) is treated as missing and triggers seeding.
+  // The planner does not currently emit `null` literals in `s.bindings`
+  // for any global seed; revisit before tightening to `=== undefined`
+  // if a future seed ever needs `null` to remain distinct from "missing".
   //
   // Entries that declare a defaultSentinel + stripFromMultipartWhenDefault
   // also emit a `__<fieldName>IsDefault` local that drives the multipart

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -16,6 +16,7 @@ import {
   generateOptionalSubShapeVariants,
   generateScenariosForEndpoint,
 } from './scenarioGenerator.js';
+import { computeSeedBindings } from './seedBindings.js';
 import type {
   EndpointScenario,
   GenerationSummary,
@@ -160,6 +161,7 @@ async function main() {
           requestIndex.byOperation,
           successStatusByOp,
         );
+        s.seedBindings = computeSeedBindings(s);
       }
     }
     const fileName = normalizeEndpointFileName(op.method, op.path);
@@ -272,6 +274,7 @@ async function main() {
         requestIndex.byOperation,
         successStatusByOp,
       );
+      s.seedBindings = computeSeedBindings(s);
       // Validation: for JSON requests with oneOf groups, non-negative scenarios must set exactly one variant's required keys
       try {
         const final = s.requestPlan?.[s.requestPlan.length - 1];
@@ -383,6 +386,7 @@ async function main() {
           requestIndex.byOperation,
           successStatusByOp,
         );
+        s.seedBindings = computeSeedBindings(s);
       }
       if (variantCollection.scenarios.length) {
         await writeFile(

--- a/path-analyser/src/seedBindings.ts
+++ b/path-analyser/src/seedBindings.ts
@@ -1,0 +1,113 @@
+/**
+ * Computes the per-scenario seed list for issue #136.
+ *
+ * The planner is the authority on "which bindings does the scenario need
+ * to seed before its first request" — emitters consume the list verbatim.
+ * Without a planner-side answer, every emitter has to re-derive the seed
+ * list from `bindings` + `requestPlan.extract`, and the Playwright
+ * emitter's pre-#136 derivation got it wrong for an establisher's own
+ * base scenario: it skipped any PENDING binding that appeared as an
+ * extract target anywhere in the plan, even when the very same step
+ * needed the binding as a body input. The server then received
+ * `username: undefined` and rejected the request 400.
+ *
+ * Algorithm:
+ *
+ *   1. Walk every step's body / multipart template and pathTemplate to
+ *      collect the var names each step *reads*.
+ *   2. Walk every step's `extract` list to record which var names each
+ *      step *produces*.
+ *   3. A binding `X` needs seeding iff some step S reads `X` and no
+ *      strictly-earlier step extracts `X`, AND `bindings[X]` is not a
+ *      literal value (literals are emitted directly via
+ *      `ctx.X = "literal";`).
+ *
+ * The returned list is ordered by first-read for stable output.
+ */
+import type { EndpointScenario, RequestStep } from './types.ts';
+
+const PLACEHOLDER_RE = /\$\{([^}]+)\}/g;
+const PATH_PLACEHOLDER_RE = /\{([^}]+)\}/g;
+
+function camelCase(input: string): string {
+  return input
+    .replace(/[-_\s]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ''))
+    .replace(/^(.)/, (_, c) => c.toLowerCase());
+}
+
+function collectStringRefs(s: string, out: Set<string>): void {
+  // Match every ${name} placeholder in the string, not just whole-string
+  // matches — body fields can interpolate multiple vars or embed them
+  // mid-string (e.g. URL fragments, composite identifiers).
+  for (const m of s.matchAll(PLACEHOLDER_RE)) {
+    out.add(m[1]);
+  }
+}
+
+function walkTemplate(value: unknown, out: Set<string>): void {
+  if (typeof value === 'string') {
+    collectStringRefs(value, out);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const v of value) walkTemplate(v, out);
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const v of Object.values(value)) walkTemplate(v, out);
+  }
+}
+
+function collectPathRefs(pathTemplate: string, out: Set<string>): void {
+  // Mirrors emitter.ts:buildUrlExpression — each {placeholder} is read
+  // as `ctx[camelCase(placeholder) + 'Var']` at runtime, so the binding
+  // the scenario must seed is `<camelCase>Var`.
+  for (const m of pathTemplate.matchAll(PATH_PLACEHOLDER_RE)) {
+    out.add(`${camelCase(m[1])}Var`);
+  }
+}
+
+function readsOfStep(step: RequestStep): Set<string> {
+  const out = new Set<string>();
+  walkTemplate(step.bodyTemplate, out);
+  walkTemplate(step.multipartTemplate, out);
+  collectPathRefs(step.pathTemplate, out);
+  return out;
+}
+
+function extractsOfStep(step: RequestStep): Set<string> {
+  const out = new Set<string>();
+  for (const ex of step.extract ?? []) out.add(ex.bind);
+  return out;
+}
+
+export function computeSeedBindings(scenario: EndpointScenario): string[] {
+  const requestPlan = scenario.requestPlan;
+  if (!requestPlan || requestPlan.length === 0) return [];
+
+  const literalBindings = new Set<string>();
+  for (const [k, v] of Object.entries(scenario.bindings ?? {})) {
+    // `__PENDING__` is the body-builder's marker for "needs runtime
+    // seeding" (path-analyser/src/index.ts:482, :879, :911). Anything
+    // else is a literal value the emitter writes as
+    // `ctx['k'] = "<literal>";`, so it is already satisfied at scenario
+    // start without a seedBinding() call.
+    if (v !== '__PENDING__') literalBindings.add(k);
+  }
+
+  const need = new Set<string>();
+  const ordered: string[] = [];
+  const extractedSoFar = new Set<string>();
+  for (const step of requestPlan) {
+    const reads = readsOfStep(step);
+    for (const v of reads) {
+      if (literalBindings.has(v)) continue;
+      if (extractedSoFar.has(v)) continue;
+      if (need.has(v)) continue;
+      need.add(v);
+      ordered.push(v);
+    }
+    for (const v of extractsOfStep(step)) extractedSoFar.add(v);
+  }
+  return ordered;
+}

--- a/path-analyser/src/seedBindings.ts
+++ b/path-analyser/src/seedBindings.ts
@@ -24,15 +24,19 @@
  *
  * The returned list is ordered by first-read for stable output.
  */
-import type { EndpointScenario, RequestStep } from './types.ts';
+import type { EndpointScenario, RequestStep } from './types.js';
 
 const PLACEHOLDER_RE = /\$\{([^}]+)\}/g;
 const PATH_PLACEHOLDER_RE = /\{([^}]+)\}/g;
 
+// Mirror of camelCase() in path-analyser/src/index.ts and
+// codegen/playwright/emitter.ts. Kept intentionally trivial (lowercase
+// the first character only) so this helper produces exactly the same
+// binding names the emitter reads at runtime. Do not "improve" it to
+// fold `-`/`_`/spaces — that would diverge from the emitter and create
+// bindings the runtime never reads.
 function camelCase(input: string): string {
-  return input
-    .replace(/[-_\s]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ''))
-    .replace(/^(.)/, (_, c) => c.toLowerCase());
+  return input.charAt(0).toLowerCase() + input.slice(1);
 }
 
 function collectStringRefs(s: string, out: Set<string>): void {

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -222,6 +222,15 @@ export interface EndpointScenario {
     { name: string; type: string; required?: boolean; nullable?: boolean }[]
   >;
   requestPlan?: RequestStep[]; // concrete request assembly plan per operation (ordered)
+  // Issue #136: ordered list of binding names that the scenario must seed
+  // (via a `seedBinding(name)` call) at scenario start, before step 0
+  // runs. Computed by the planner from `requestPlan` + `bindings` so every
+  // emitter renders the same prologue and no emitter has to re-derive
+  // "which inputs are unsatisfied at step N" from the bindings/extracts
+  // heuristic. Empty/absent means no PENDING bindings need seeding (all
+  // inputs are either literal in `bindings` or supplied by an extract
+  // before their first use).
+  seedBindings?: string[];
   // Duplicate invocation testing (for conditional idempotency / duplicatePolicy conflict)
   duplicateTest?: {
     mode: 'conditional' | 'conflict';

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -98,33 +98,34 @@ describe('PlaywrightEmitter (Emitter contract)', () => {
   });
 });
 
-// Regression guard for PR #79 / issue #80 (no `__seededTenant` flag) and
-// issue #86 (universal-seed prologue collapsed to nullish-coalesce).
+// Regression guard for PR #79 / issue #80 (no `__seededTenant` flag),
+// issue #86 (universal-seed prologue collapsed to nullish-coalesce), and
+// issue #136 (planner-authoritative seedBindings list).
 //
 // The universal-seed prologue derived from globalContextSeeds emits one
 // idempotent line per seed:
 //   ctx['<binding>'] = ctx['<binding>'] ?? seedBinding('<seedRule>');
 // `??` short-circuits over both literal assignments from the bindings loop
-// and the `__PENDING__`-guarded auto-seed (which still uses `=== undefined`
-// in the bindings loop because it runs *before* the universal-seed prologue
-// and a duplicate seedBinding call there would be wasteful). When no
-// bindings-loop assignment exists for the seed, `??` falls through to
-// seedBinding(...). This replaces the pre-#86 unconditional `=== undefined`
-// guard, which was dead code in the no-assignment case.
+// and the `=== undefined`-guarded auto-seed driven by
+// `scenario.seedBindings` (issue #136 — runs *before* the universal-seed
+// prologue so a duplicate seedBinding call there would be wasteful). When
+// neither shape applies, `??` falls through to seedBinding(...). This
+// replaces the pre-#86 unconditional `=== undefined` guard, which was
+// dead code in the no-assignment case.
 //
 // These tests exercise the three shapes the bindings loop can produce for
-// `tenantIdVar` (literal value, __PENDING__ auto-seed, extracted-by-an-
-// earlier-step) plus a control with no `tenantIdVar` binding at all,
-// asserting the `??` line appears exactly once, the universal-seed prologue
-// never re-emits the `=== undefined` form for that binding, and
-// `__seededTenant` never appears anywhere in the output.
-describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? form, #86)', () => {
+// `tenantIdVar` (literal value, __PENDING__-from-seedBindings auto-seed,
+// extracted-by-an-earlier-step) plus a control with no `tenantIdVar`
+// binding at all, asserting the `??` line appears exactly once, the
+// universal-seed prologue never re-emits the `=== undefined` form for
+// that binding, and `__seededTenant` never appears anywhere in the output.
+describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? form, #86; planner seedBindings, #136)', () => {
   const TENANT_FALLBACK = `ctx['tenantIdVar'] = ctx['tenantIdVar'] ?? seedBinding('tenantIdVar');`;
   // The pre-#86 universal-seed-prologue form. The bindings loop *also* emits
-  // exactly this string for a `__PENDING__` binding referenced by a template,
-  // so absence is asserted by counting occurrences (0 for every shape *except*
-  // __PENDING__-referenced-by-template, where the count is exactly 1 — proving
-  // the prologue did not also emit it).
+  // exactly this string for a `__PENDING__` binding listed in
+  // `scenario.seedBindings`, so absence is asserted by counting occurrences
+  // (0 for every shape *except* __PENDING__-with-seedBindings, where the
+  // count is exactly 1 — proving the prologue did not also emit it).
   const FULL_TENANT_GUARD = `if (ctx['tenantIdVar'] === undefined) { ctx['tenantIdVar'] = seedBinding('tenantIdVar'); }`;
 
   // Count occurrences of `needle` in `haystack` without regex escaping.
@@ -142,7 +143,11 @@ describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? 
 
   function buildCollectionWithBindings(
     bindings: Record<string, string>,
-    extras: { templateRefsTenant?: boolean; extractsTenant?: boolean } = {},
+    extras: {
+      templateRefsTenant?: boolean;
+      extractsTenant?: boolean;
+      seedBindings?: string[];
+    } = {},
   ): EndpointScenarioCollection {
     return {
       endpoint: { operationId: 'createWidget', method: 'POST', path: '/widgets' },
@@ -156,6 +161,7 @@ describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? 
           producedSemanticTypes: [],
           satisfiedSemanticTypes: [],
           bindings,
+          seedBindings: extras.seedBindings,
           requestPlan: [
             {
               operationId: 'createWidget',
@@ -163,7 +169,7 @@ describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? 
               pathTemplate: '/widgets',
               expect: { status: 200 },
               bodyTemplate: extras.templateRefsTenant
-                ? { tenantId: '${' + 'tenantIdVar}' }
+                ? { tenantId: `${'$'}{tenantIdVar}` }
                 : { name: 'static' },
               extract: extras.extractsTenant
                 ? [{ fieldPath: 'tenantId', bind: 'tenantIdVar' }]
@@ -195,13 +201,17 @@ describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? 
     expect(content).not.toMatch(/__seededTenant/);
   });
 
-  test('__PENDING__ tenantIdVar referenced by a template emits a guarded auto-seed and the ?? fallback exactly once', async () => {
+  test('__PENDING__ tenantIdVar listed in seedBindings emits a guarded auto-seed and the ?? fallback exactly once', async () => {
     const content = await renderFirst(
-      buildCollectionWithBindings({ tenantIdVar: '__PENDING__' }, { templateRefsTenant: true }),
+      buildCollectionWithBindings(
+        { tenantIdVar: '__PENDING__' },
+        { templateRefsTenant: true, seedBindings: ['tenantIdVar'] },
+      ),
     );
-    // The in-bindings-loop `=== undefined` guard for __PENDING__ is intentional —
-    // it runs *before* the universal-seed prologue, and a duplicate seedBinding
-    // call there would be wasted. The ?? line then short-circuits over it.
+    // Issue #136: the planner-emitted seedBindings list is now the
+    // authority. The emitter's seedBindings prologue runs *before* the
+    // universal-seed prologue, so a duplicate seedBinding call there
+    // would be wasted. The `??` line then short-circuits over it.
     //
     // Asserting exactly-one occurrence is a class-scoped guard against the
     // emitter regressing and re-emitting the pre-#86 guard form in the
@@ -211,17 +221,24 @@ describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? 
     expect(content).not.toMatch(/__seededTenant/);
   });
 
-  test('extractionVars tenantIdVar skips eager seeding but still emits the ?? fallback exactly once', async () => {
+  test('literal tenantIdVar still seeds even when an extract targets the same binding (#136)', async () => {
+    // Pre-#136 the emitter skipped this literal assignment because
+    // `tenantIdVar` appeared in `extractionVars` — that was the defect.
+    // The extract runs AFTER the request body is built, so the body
+    // would have referenced an unseeded `ctx.tenantIdVar` (=
+    // undefined) and the broker would 400. The literal MUST be
+    // emitted; the extract just overwrites it post-response with
+    // whatever the server echoed.
     const content = await renderFirst(
       buildCollectionWithBindings(
-        { tenantIdVar: 'ignored-because-extracted' },
-        { extractsTenant: true },
+        { tenantIdVar: 'acme' },
+        { templateRefsTenant: true, extractsTenant: true },
       ),
     );
-    expect(content).not.toContain(`ctx['tenantIdVar'] = "ignored-because-extracted";`);
+    expect(content).toContain(`ctx['tenantIdVar'] = "acme";`);
     expect(countOccurrences(content, TENANT_FALLBACK)).toBe(1);
-    // Bindings loop skips this case (extraction wins); prologue must not
-    // re-emit the pre-#86 guard either.
+    // No `=== undefined` guard either: the literal already covers the
+    // pre-request need, and the universal-seed `??` short-circuits.
     expect(countOccurrences(content, FULL_TENANT_GUARD)).toBe(0);
     expect(content).not.toMatch(/__seededTenant/);
   });

--- a/tests/fixtures/planner/planner-seed-bindings.test.ts
+++ b/tests/fixtures/planner/planner-seed-bindings.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Planner contract fixtures — seedBindings (camunda/api-test-generator#136).
+ *
+ * The planner is the authority on which scenario bindings need a runtime
+ * `seedBinding(name)` call before step 0. Emitters consume
+ * `scenario.seedBindings` verbatim. These fixtures pin the contract on
+ * synthetic `EndpointScenario` shapes so the planner-side answer is
+ * tested independently of any specific emitter.
+ *
+ * Class-scoped invariant guarded here: every binding read by some step
+ * S of the request plan whose value is not a literal in
+ * `scenario.bindings` and is not produced by an extract on a strictly
+ * earlier step must appear in `scenario.seedBindings`. The defect class
+ * #136 reproduces is exactly this property failing for the establisher's
+ * own base scenario, where the body input is also extracted from the
+ * response of the same step.
+ */
+import { describe, expect, it } from 'vitest';
+import { computeSeedBindings } from '../../../path-analyser/src/seedBindings.ts';
+import type { EndpointScenario } from '../../../path-analyser/src/types.ts';
+
+function scenarioOf(partial: Partial<EndpointScenario>): EndpointScenario {
+  return {
+    id: partial.id ?? 'scenario-1',
+    operations: partial.operations ?? [],
+    producedSemanticTypes: partial.producedSemanticTypes ?? [],
+    satisfiedSemanticTypes: partial.satisfiedSemanticTypes ?? [],
+    bindings: partial.bindings,
+    requestPlan: partial.requestPlan,
+  };
+}
+
+describe('computeSeedBindings (#136)', () => {
+  describe("establisher's own base scenario echoes input in response", () => {
+    it('lists the body-input binding even when the same step extracts it', () => {
+      // Mirrors createUser: body sends `username: ${usernameVar}`, and
+      // the same step extracts `username` from the response into
+      // `usernameVar`. Pre-#136 the Playwright emitter dropped the
+      // seedBinding line on the assumption that the extract would
+      // supply the value — but the extract runs AFTER the request
+      // body is built, so without a seed the body sends `undefined`.
+      const scenario = scenarioOf({
+        bindings: { usernameVar: '__PENDING__' },
+        requestPlan: [
+          {
+            operationId: 'createUser',
+            method: 'POST',
+            pathTemplate: '/v2/users',
+            expect: { status: 201 },
+            bodyKind: 'json',
+            bodyTemplate: { username: '${usernameVar}', password: '${passwordVar}' },
+            extract: [{ fieldPath: 'username', bind: 'usernameVar', semantic: 'Username' }],
+          },
+        ],
+      });
+      const seeds = computeSeedBindings(scenario);
+      expect(seeds).toContain('usernameVar');
+      // Class-scoped: passwordVar (PENDING, not extracted) must also be
+      // listed. Without this assertion a fix that only special-cased
+      // "extracted-and-input on the same step" would still leave a
+      // hole for unrelated PENDING body inputs.
+      expect(seeds).toContain('passwordVar');
+    });
+  });
+
+  describe('chained producer + consumer', () => {
+    it('omits a binding extracted by an earlier step', () => {
+      // createUser (step 0) extracts usernameVar from its response;
+      // getUser (step 1) reads `${usernameVar}` from its path. The
+      // consumer step does not need a runtime seed because the producer
+      // step supplies the value before the consumer runs. The producer
+      // itself still needs the binding seeded at scenario start
+      // because step 0's body is built before step 0's extract runs.
+      const scenario = scenarioOf({
+        bindings: { usernameVar: '__PENDING__' },
+        requestPlan: [
+          {
+            operationId: 'createUser',
+            method: 'POST',
+            pathTemplate: '/v2/users',
+            expect: { status: 201 },
+            bodyKind: 'json',
+            bodyTemplate: { username: '${usernameVar}' },
+            extract: [{ fieldPath: 'username', bind: 'usernameVar' }],
+          },
+          {
+            operationId: 'getUser',
+            method: 'GET',
+            pathTemplate: '/v2/users/{username}',
+            expect: { status: 200 },
+          },
+        ],
+      });
+      const seeds = computeSeedBindings(scenario);
+      // Step 0 reads usernameVar; nothing extracts it before step 0
+      // runs, so it must be seeded.
+      expect(seeds).toEqual(['usernameVar']);
+    });
+  });
+
+  describe('literal binding values', () => {
+    it('omits bindings whose value is a non-PENDING literal', () => {
+      // Establisher chained as a producer mints a deterministic value
+      // into bindings (scenarioGenerator.ts:867-952), so the binding
+      // is a literal string, not __PENDING__. Emitters render this as
+      // `ctx['k'] = "<value>";` directly — no seedBinding() call.
+      const scenario = scenarioOf({
+        bindings: { tenantIdVar: 'tenant-abc123', usernameVar: '__PENDING__' },
+        requestPlan: [
+          {
+            operationId: 'createUser',
+            method: 'POST',
+            pathTemplate: '/v2/users',
+            expect: { status: 201 },
+            bodyKind: 'json',
+            bodyTemplate: { username: '${usernameVar}', tenantId: '${tenantIdVar}' },
+          },
+        ],
+      });
+      expect(computeSeedBindings(scenario)).toEqual(['usernameVar']);
+    });
+  });
+
+  describe('path placeholders', () => {
+    it('lists placeholder-derived var names that no step extracts', () => {
+      // pathTemplate `/v2/users/{userKey}` is rendered as
+      // `ctx.userKeyVar` by the URL emitter. If no producer step
+      // extracts userKeyVar, it must be seeded at scenario start —
+      // otherwise the URL contains a literal `${userKey}` that the
+      // broker rejects.
+      const scenario = scenarioOf({
+        bindings: { userKeyVar: '__PENDING__' },
+        requestPlan: [
+          {
+            operationId: 'getUser',
+            method: 'GET',
+            pathTemplate: '/v2/users/{userKey}',
+            expect: { status: 200 },
+          },
+        ],
+      });
+      expect(computeSeedBindings(scenario)).toEqual(['userKeyVar']);
+    });
+  });
+
+  describe('multipart templates', () => {
+    it('treats multipart fields the same as JSON body fields', () => {
+      const scenario = scenarioOf({
+        bindings: { fileNameVar: '__PENDING__' },
+        requestPlan: [
+          {
+            operationId: 'createDocument',
+            method: 'POST',
+            pathTemplate: '/v2/documents',
+            expect: { status: 201 },
+            bodyKind: 'multipart',
+            multipartTemplate: { fileName: '${fileNameVar}' },
+          },
+        ],
+      });
+      expect(computeSeedBindings(scenario)).toEqual(['fileNameVar']);
+    });
+  });
+
+  describe('first-read order is preserved', () => {
+    it('orders entries by first appearance across the plan', () => {
+      const scenario = scenarioOf({
+        bindings: {
+          aVar: '__PENDING__',
+          bVar: '__PENDING__',
+          cVar: '__PENDING__',
+        },
+        requestPlan: [
+          {
+            operationId: 'op1',
+            method: 'POST',
+            pathTemplate: '/x',
+            expect: { status: 201 },
+            bodyKind: 'json',
+            bodyTemplate: { b: '${bVar}', a: '${aVar}' },
+          },
+          {
+            operationId: 'op2',
+            method: 'POST',
+            pathTemplate: '/y',
+            expect: { status: 201 },
+            bodyKind: 'json',
+            bodyTemplate: { c: '${cVar}', a: '${aVar}' },
+          },
+        ],
+      });
+      // Object.values iterates in insertion order, so op1 reads bVar
+      // before aVar; op2 introduces cVar. aVar must not be re-listed.
+      expect(computeSeedBindings(scenario)).toEqual(['bVar', 'aVar', 'cVar']);
+    });
+  });
+
+  describe('absent / empty plan', () => {
+    it('returns [] when there is no request plan', () => {
+      expect(computeSeedBindings(scenarioOf({}))).toEqual([]);
+    });
+    it('returns [] when the plan is empty', () => {
+      expect(computeSeedBindings(scenarioOf({ requestPlan: [] }))).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #136

## Summary

Establisher base scenarios were not seeding body-only identifier bindings (e.g. `usernameVar` in `createUser`), causing 46 live-broker operations to send `undefined` as a required field and receive 400 where 201 was expected.

## Root cause

Each emitter independently rederived which bindings need a `seedBinding(...)` call before step 0. The Playwright emitter's heuristic — *skip any binding that is also an extraction target* — wrongly dropped the seed for endpoint-establishers that read the same binding they later extract from the response.

## Fix

Make `seedBindings` a first-class field on `EndpointScenario`, computed once by the planner via a pure helper (`computeSeedBindings`) that walks every step's body / multipart / pathTemplate, filters out literals and earlier-extracted bindings, and returns the ordered list of names needing a seed call. The Playwright emitter now iterates that list verbatim. Future emitters get the right answer for free instead of repeating the bug.

## Tests (red / green / class-scoped)

- **L2 fixture** (`tests/fixtures/planner/planner-seed-bindings.test.ts`): 8 unit tests pin the helper contract.
- **L3 invariants** (`configs/camunda-oca/regression-invariants.test.ts`): every step references only resolvable bindings; every establisher endpoint scenario seeds body identifiers it actually references in the body template.
- **Codegen test** (`tests/codegen/playwright-emitter.test.ts`): asserts a literal binding is still emitted when an extract targets the same name (the exact #136 reproducer at the emitter layer).

All 254 tests pass. Pre-push checklist (lint + 4 typechecks + regen + tests) clean.