### PR TITLE
fix: canonical request body preserves wrapping props alongside allOf (#152)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -2313,3 +2313,140 @@ describeForThisConfig('bundled-spec invariants: scenario seed-binding completene
     expect(offenders).toEqual([]);
   });
 });
+
+// #152: required body identifiers must always appear in the body
+// template. Pre-fix, `path-analyser/src/canonicalSchemas.ts:resolveSchema`
+// dropped wrapping-schema `properties`/`required` when an `allOf` was
+// present, so e.g. `MappingRuleCreateRequest.mappingRuleId` and
+// `GlobalTaskListenerCreateRequest.id` never reached the planner's
+// canonical request shape, and the body template was emitted without
+// them. Live broker rejected the request 400. This invariant is the
+// inverse of the #136 invariant above: not only must referenced
+// bindings be seeded, required body identifiers must also be referenced.
+describeForThisConfig(
+  'bundled-spec invariants: establisher body-identifier presence (#152)',
+  () => {
+    it('every establisher endpoint scenario references its required body identifiers', () => {
+      if (!existsSync(FEATURE_SCENARIOS_DIR) || !existsSync(GRAPH_PATH)) {
+        throw new Error(
+          `Required pipeline output not found. Run 'npm run pipeline' first.`,
+        );
+      }
+      interface IdentifiedBy {
+        in: 'body' | 'path' | 'header' | 'query';
+        name: string;
+        semanticType: string;
+      }
+      interface EstablishesSpec {
+        kind: string;
+        shape?: 'edge' | 'aggregate';
+        identifiedBy: IdentifiedBy[];
+      }
+      interface RequestSemanticType {
+        fieldPath: string;
+        required?: boolean;
+      }
+      interface OperationNodeLite {
+        operationId: string;
+        establishes?: EstablishesSpec;
+        requestBodySemanticTypes?: RequestSemanticType[];
+      }
+      interface GraphLite {
+        operations: OperationNodeLite[];
+      }
+      interface RequestStepLite {
+        operationId: string;
+        bodyTemplate?: unknown;
+        multipartTemplate?: unknown;
+      }
+      interface ScenarioLite {
+        id: string;
+        operations: { operationId: string }[];
+        requestPlan?: RequestStepLite[];
+      }
+      interface CollectionLite {
+        endpoint: { operationId: string };
+        scenarios: ScenarioLite[];
+      }
+
+      function camelCase(input: string): string {
+        return input.charAt(0).toLowerCase() + input.slice(1);
+      }
+
+      function collectVarRefs(node: unknown, out: Set<string>): void {
+        if (typeof node === 'string') {
+          for (const m of node.matchAll(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g)) {
+            out.add(m[1]);
+          }
+          return;
+        }
+        if (Array.isArray(node)) {
+          for (const item of node) collectVarRefs(item, out);
+          return;
+        }
+        if (node !== null && typeof node === 'object') {
+          for (const v of Object.values(node)) collectVarRefs(v, out);
+        }
+      }
+
+      const graph = JSON.parse(readFileSync(GRAPH_PATH, 'utf8')) as GraphLite;
+      const opsById = new Map(graph.operations.map((o) => [o.operationId, o]));
+      interface Offender {
+        file: string;
+        scenarioId: string;
+        operationId: string;
+        bodyIdentifier: string;
+        missingVar: string;
+      }
+      const offenders: Offender[] = [];
+      let establisherScenariosScanned = 0;
+
+      for (const f of readdirSync(FEATURE_SCENARIOS_DIR)) {
+        if (!f.endsWith('-scenarios.json')) continue;
+        const collection = JSON.parse(
+          readFileSync(join(FEATURE_SCENARIOS_DIR, f), 'utf8'),
+        ) as CollectionLite;
+        const endpointNode = opsById.get(collection.endpoint.operationId);
+        const establishes = endpointNode?.establishes;
+        if (!establishes || establishes.shape === 'edge') continue;
+        const bodyIdents = establishes.identifiedBy.filter((id) => id.in === 'body');
+        if (bodyIdents.length === 0) continue;
+        // Only check identifiers that are actually required by the
+        // request body schema. An identifier the spec marks optional in
+        // the request body is out of scope for this invariant — the
+        // planner is free to omit it, and absence won't 400 at the broker.
+        const requiredBodyPaths = new Set(
+          (endpointNode?.requestBodySemanticTypes ?? [])
+            .filter((e) => e.required)
+            .map((e) => e.fieldPath),
+        );
+        const requiredIdents = bodyIdents.filter((id) => requiredBodyPaths.has(id.name));
+        if (requiredIdents.length === 0) continue;
+
+        for (const scenario of collection.scenarios) {
+          if (!scenario.requestPlan?.length) continue;
+          const firstStep = scenario.requestPlan[0];
+          if (firstStep.operationId !== collection.endpoint.operationId) continue;
+          establisherScenariosScanned++;
+          const refs = new Set<string>();
+          collectVarRefs(firstStep.bodyTemplate, refs);
+          collectVarRefs(firstStep.multipartTemplate, refs);
+          for (const id of requiredIdents) {
+            const expectedVar = `${camelCase(id.name)}Var`;
+            if (refs.has(expectedVar)) continue;
+            offenders.push({
+              file: f,
+              scenarioId: scenario.id,
+              operationId: collection.endpoint.operationId,
+              bodyIdentifier: id.name,
+              missingVar: expectedVar,
+            });
+          }
+        }
+      }
+      expect(establisherScenariosScanned).toBeGreaterThanOrEqual(5);
+      expect(offenders).toEqual([]);
+    });
+  },
+);
+

--- a/path-analyser/src/canonicalSchemas.ts
+++ b/path-analyser/src/canonicalSchemas.ts
@@ -29,6 +29,10 @@ interface SchemaObject {
   anyOf?: SchemaObject[];
   oneOf?: SchemaObject[];
   'x-semantic-provider'?: boolean;
+  // Permissive escape hatch so the allOf merger can copy over arbitrary
+  // OpenAPI keywords (description, example, format, …) without per-key
+  // typing or unsafe casts.
+  [key: string]: unknown;
 }
 
 interface MediaObject {
@@ -194,6 +198,25 @@ function walkSchema(
   }
 }
 
+function mergeSchemaInto(acc: SchemaObject, part: SchemaObject): SchemaObject {
+  // Property-wise merge so two allOf branches both contributing
+  // `properties` don't lose each other's keys, and `required` is the
+  // union across branches. Other fields take last-write-wins, which
+  // matches the semantics we want when a branch overrides e.g. `type`.
+  if (part.properties) {
+    acc.properties = { ...(acc.properties ?? {}), ...part.properties };
+  }
+  if (part.required) {
+    const merged = new Set<string>([...(acc.required ?? []), ...part.required]);
+    acc.required = [...merged];
+  }
+  for (const k of Object.keys(part)) {
+    if (k === 'properties' || k === 'required') continue;
+    acc[k] = part[k];
+  }
+  return acc;
+}
+
 function resolveSchema(
   schema: SchemaObject,
   components: Record<string, SchemaObject>,
@@ -206,9 +229,17 @@ function resolveSchema(
     if (target) return resolveSchema(target, components, depth + 1);
   }
   if (schema.allOf && Array.isArray(schema.allOf)) {
+    // #152: the wrapping schema may declare its own `properties` /
+    // `required` alongside `allOf` (e.g. `MappingRuleCreateRequest`,
+    // `GlobalTaskListenerCreateRequest`). Seed the merge with the
+    // wrapping schema (minus `allOf` / `$ref` so we don't recurse) so
+    // those fields survive into the canonical shape.
+    const { allOf: _allOf, $ref: _ref, ...rest } = schema;
+    const seed: SchemaObject = {};
+    mergeSchemaInto(seed, rest);
     return schema.allOf.reduce<SchemaObject>(
-      (acc, part) => Object.assign(acc, resolveSchema(part, components, depth + 1)),
-      {},
+      (acc, part) => mergeSchemaInto(acc, resolveSchema(part, components, depth + 1)),
+      seed,
     );
   }
   return schema;

--- a/tests/fixtures/planner/canonical-allof-merge.test.ts
+++ b/tests/fixtures/planner/canonical-allof-merge.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Canonical-schema merge fixtures — camunda/api-test-generator#152.
+ *
+ * `path-analyser/src/canonicalSchemas.ts:resolveSchema` collapses an
+ * `allOf` composition into a fresh `{}` and folds each branch with
+ * `Object.assign`. That silently drops any `properties` / `required`
+ * defined on the *wrapping* schema itself.
+ *
+ * The bundled spec hits this for every "type: object + allOf + own
+ * properties" CRUD-create body, e.g. `MappingRuleCreateRequest`,
+ * `GlobalTaskListenerCreateRequest`, where the wrapping schema's only
+ * job is to add the establisher identifier (`mappingRuleId`, `id`).
+ * Pre-fix: identifier missing from canonical request → planner emits a
+ * body without it → live-broker 400.
+ *
+ * Class-scoped invariant guarded here: any property declared on a
+ * wrapping schema with both `allOf` and its own `properties` must
+ * appear in the canonical request shape, with its `required` flag
+ * preserved.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildCanonicalShapes } from '../../../path-analyser/src/canonicalSchemas.ts';
+
+interface ScratchDir {
+  root: string;
+  specPath: string;
+  prevEnv: string | undefined;
+}
+
+function scratchSpec(spec: object): ScratchDir {
+  const root = mkdtempSync(join(tmpdir(), 'canonical-allof-'));
+  const specPath = join(root, 'rest-api.bundle.json');
+  writeFileSync(specPath, JSON.stringify(spec));
+  const prevEnv = process.env.OPENAPI_SPEC_PATH;
+  process.env.OPENAPI_SPEC_PATH = specPath;
+  return { root, specPath, prevEnv };
+}
+
+function teardown(s: ScratchDir): void {
+  if (s.prevEnv === undefined) delete process.env.OPENAPI_SPEC_PATH;
+  else process.env.OPENAPI_SPEC_PATH = s.prevEnv;
+  rmSync(s.root, { recursive: true, force: true });
+}
+
+describe('canonicalSchemas: allOf wrapper preserves wrapping properties (#152)', () => {
+  let scratch: ScratchDir | undefined;
+  afterEach(() => {
+    if (scratch) teardown(scratch);
+    scratch = undefined;
+  });
+
+  it('preserves wrapping properties when wrapping schema has allOf and own properties', async () => {
+    scratch = scratchSpec({
+      openapi: '3.0.0',
+      paths: {
+        '/widgets': {
+          post: {
+            operationId: 'createWidget',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/WidgetCreateRequest' },
+                },
+              },
+            },
+            responses: { '201': { description: 'ok' } },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          WidgetBase: {
+            type: 'object',
+            properties: { color: { type: 'string' }, size: { type: 'integer' } },
+            required: ['color'],
+          },
+          WidgetCreateRequest: {
+            type: 'object',
+            allOf: [{ $ref: '#/components/schemas/WidgetBase' }],
+            properties: {
+              widgetId: { type: 'string', description: 'minted by client' },
+            },
+            required: ['widgetId'],
+          },
+        },
+      },
+    });
+
+    const shapes = await buildCanonicalShapes('/unused-because-env-overrides');
+    const json = shapes.createWidget?.requestByMediaType?.['application/json'];
+    expect(json).toBeDefined();
+    const leaves = (json ?? []).map((n) => ({ path: n.path, required: n.required }));
+    // Wrapping schema's own property must survive the allOf merge.
+    expect(leaves).toContainEqual({ path: 'widgetId', required: true });
+    // allOf branch contributions must also survive.
+    expect(leaves).toContainEqual({ path: 'color', required: true });
+    expect(leaves).toContainEqual({ path: 'size', required: false });
+  });
+
+  it("unions 'required' across allOf branches and the wrapping schema", async () => {
+    scratch = scratchSpec({
+      openapi: '3.0.0',
+      paths: {
+        '/items': {
+          post: {
+            operationId: 'createItem',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/ItemCreate' },
+                },
+              },
+            },
+            responses: { '201': { description: 'ok' } },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          ItemCreate: {
+            type: 'object',
+            allOf: [
+              {
+                type: 'object',
+                properties: { a: { type: 'string' }, b: { type: 'string' } },
+                required: ['a'],
+              },
+              {
+                type: 'object',
+                properties: { c: { type: 'string' } },
+                required: ['c'],
+              },
+            ],
+            properties: { d: { type: 'string' } },
+            required: ['d'],
+          },
+        },
+      },
+    });
+
+    const shapes = await buildCanonicalShapes('/unused');
+    const json = shapes.createItem?.requestByMediaType?.['application/json'] ?? [];
+    const byPath = new Map(json.map((n) => [n.path, n.required]));
+    expect(byPath.get('a')).toBe(true);
+    expect(byPath.get('b')).toBe(false);
+    expect(byPath.get('c')).toBe(true);
+    expect(byPath.get('d')).toBe(true);
+  });
+
+  it('merges nested object properties across allOf branches without dropping siblings', async () => {
+    // Defensive: confirm the merge is property-wise, not last-write-wins
+    // on the whole `properties` object.
+    scratch = scratchSpec({
+      openapi: '3.0.0',
+      paths: {
+        '/things': {
+          post: {
+            operationId: 'createThing',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/ThingCreate' },
+                },
+              },
+            },
+            responses: { '201': { description: 'ok' } },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          ThingCreate: {
+            type: 'object',
+            allOf: [
+              { type: 'object', properties: { x: { type: 'string' } } },
+              { type: 'object', properties: { y: { type: 'string' } } },
+            ],
+          },
+        },
+      },
+    });
+
+    const shapes = await buildCanonicalShapes('/unused');
+    const paths = (shapes.createThing?.requestByMediaType?.['application/json'] ?? []).map(
+      (n) => n.path,
+    );
+    expect(paths).toContain('x');
+    expect(paths).toContain('y');
+  });
+});


### PR DESCRIPTION
Closes #152

## Symptom

For `createMappingRule` (`POST /mapping-rules`) and `createGlobalTaskListener` (`POST /global-task-listeners`), the planner emitted a request body that omitted the establisher's body identifier (`mappingRuleId`, `id`) — even though the OpenAPI spec marks it `required`. Live broker rejected the request 400.

## Root cause

`path-analyser/src/canonicalSchemas.ts:resolveSchema` collapsed an `allOf` composition into a fresh `{}` and folded each branch with `Object.assign`. That silently dropped any `properties` / `required` defined on the **wrapping** schema itself.

Both affected schemas wrap an `allOf` with their own `properties` + `required` to add the create-only identifier:

```yaml
MappingRuleCreateRequest:
  type: object
  allOf:
    - $ref: MappingRuleCreateUpdateRequest   # claimName, claimValue, name
  properties:
    mappingRuleId: { ... }                     # ← dropped pre-fix
  required:
    - mappingRuleId                            # ← dropped pre-fix
```

## Fix

Seed the `allOf` merge with the wrapping schema's own keys, and merge each branch property-wise (`properties` unioned key-by-key, `required` unioned across branches, other keywords last-write-wins). Adds an index signature to the permissive `SchemaObject` so the merger can copy arbitrary OpenAPI keywords without unsafe casts.

## Tests (red / green / class-scoped)

- **L1 fixture** (`tests/fixtures/planner/canonical-allof-merge.test.ts`, 3 tests): wrapping properties survive; `required` is unioned; sibling properties from multiple branches are preserved.
- **L3 invariant** (`configs/camunda-oca/regression-invariants.test.ts`, '#152'): every establisher endpoint scenario whose endpoint has body-shaped `identifiedBy` entries marked `required` must reference `\${camelCase(name)}Var` in the first step's body / multipart template.

  Verified red→green: with the fix reverted and the pipeline regenerated, the invariant fires on exactly `createMappingRule` and `createGlobalTaskListener` (the two operations named in #152). Re-applying the fix turns it green.

  This is the inverse of the #136 invariant landed in #151: not only must referenced bindings be seeded, but required body identifiers must also be referenced.

All 258 tests pass. Pre-push checklist (lint + 4 typechecks + regen + tests) clean.