### PR TITLE
fix: skip JSON-only mutations on multipart-only endpoints (#135)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -3006,3 +3006,114 @@ describeForThisConfig(
     }
   },
 );
+
+describeForThisConfig(
+  'bundled-spec invariants: multipart-only operations skip JSON-only mutations (#135)',
+  () => {
+    // Three negative-test mutation classes are nonsensical when wrapped
+    // as multipart form-data and produce 415s or false-positive 201s
+    // instead of 400s on the three multipart-only Camunda endpoints
+    // (createDeployment, createDocument, createDocuments):
+    //
+    //   1. body-top-type-mismatch — no JSON top-level type to invert.
+    //   2. type-mismatch on a `format: binary` part — any bytes satisfy
+    //      the schema.
+    //   3. constraint-violation on an array-typed part — array
+    //      mutations don't translate to multipart `files=...` repetition.
+    //
+    // The fix in request-validation/scripts/generate.ts drops these
+    // scenarios via shouldSkipForMultipart() rather than wrapping them.
+    // This invariant pins the observable result on the bundled spec
+    // (5 originally-emitted offenders → 0).
+    it('emits zero JSON-only mutations on multipart-only endpoints', () => {
+      const REQUEST_VALIDATION_DIR = join(
+        REPO_ROOT,
+        'generated',
+        CONFIG_NAME,
+        'request-validation',
+      );
+      if (!existsSync(REQUEST_VALIDATION_DIR)) {
+        throw new Error(
+          `Generated request-validation directory not found at ${REQUEST_VALIDATION_DIR}. ` +
+            `Run 'npm run generate:request-validation' (or 'npm run pipeline') first.`,
+        );
+      }
+
+      // The three multipart-only endpoints in the camunda-oca bundled
+      // spec. If upstream introduces a JSON variant for any of these,
+      // the assertion still holds vacuously, but the floor below
+      // catches the case where these ops disappear entirely.
+      const MULTIPART_ONLY_OPS = ['createDeployment', 'createDocument', 'createDocuments'];
+
+      // Scenario kinds that are nonsensical on multipart-only ops.
+      // qaEmitter writes the scenario kind as `scenarioKind: '<type>'`
+      // (single-quoted) inside each test block; we match that exactly.
+      const FORBIDDEN_KINDS = [
+        'body-top-type-mismatch',
+        'type-mismatch',
+        'constraint-violation',
+      ];
+
+      // Match a single emitted `test('...', async (...) => { ... });`
+      // block. Captures the title (group 1) and the body (group 2).
+      const TEST_BLOCK = /test\('([^']*)',\s*async[^]*?scenarioKind:\s*'([^']+)'[^]*?}\);/g;
+
+      interface Offender {
+        file: string;
+        title: string;
+        operationId: string;
+        scenarioKind: string;
+      }
+      const offenders: Offender[] = [];
+      const sawByOp = new Map<string, number>();
+
+      for (const f of readdirSync(REQUEST_VALIDATION_DIR)) {
+        if (!f.endsWith('-validation-api-tests.spec.ts')) continue;
+        const text = readFileSync(join(REQUEST_VALIDATION_DIR, f), 'utf8');
+        for (const match of text.matchAll(TEST_BLOCK)) {
+          const title = match[1];
+          const scenarioKind = match[2];
+          // Title format: `<operationId> - <suffix>` (qaEmitter.ts).
+          const opMatch = title.match(/^([A-Za-z_$][A-Za-z0-9_$]*)\s+-\s+/);
+          if (!opMatch) continue;
+          const operationId = opMatch[1];
+          if (!MULTIPART_ONLY_OPS.includes(operationId)) continue;
+          sawByOp.set(operationId, (sawByOp.get(operationId) ?? 0) + 1);
+          if (FORBIDDEN_KINDS.includes(scenarioKind)) {
+            // type-mismatch and constraint-violation are only forbidden
+            // when targeting binary or array multipart parts. We can't
+            // re-derive the schema from the spec text cheaply, so we
+            // rely on the operations' known shapes: createDeployment's
+            // only scalar non-binary part is `tenantId`; createDocument
+            // and createDocuments expose only binary/array parts at the
+            // top level. Anything not addressing tenantId is an
+            // offender for those two kinds.
+            if (scenarioKind === 'body-top-type-mismatch') {
+              offenders.push({ file: f, title, operationId, scenarioKind });
+              continue;
+            }
+            // Title for type-mismatch / constraint-violation is
+            // `<op> - Param <target> wrong type` /
+            // `<op> - Constraint violation <target> ...`
+            const targetMatch =
+              title.match(/Param\s+(\S+)\s+wrong type/) ??
+              title.match(/Constraint violation\s+(\S+)/);
+            const target = targetMatch?.[1] ?? '';
+            if (operationId === 'createDeployment' && target === 'tenantId') continue;
+            offenders.push({ file: f, title, operationId, scenarioKind });
+          }
+        }
+      }
+
+      // Sanity floor: every multipart-only op should still surface at
+      // least one negative scenario after the skip (e.g. missing-body,
+      // missing-required, additional-prop). A zero count signals the
+      // op vanished from the spec, the title format drifted, or the
+      // skip over-fires.
+      for (const op of MULTIPART_ONLY_OPS) {
+        expect(sawByOp.get(op) ?? 0, `expected ≥1 scenario for ${op}`).toBeGreaterThan(0);
+      }
+      expect(offenders).toEqual([]);
+    });
+  },
+);

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -3055,10 +3055,11 @@ describeForThisConfig(
       ];
 
       // Match a single emitted `test('...', async (...) => { ... });`
-      // or `test("...", async (...) => { ... });` block. Captures the
-      // title (group 2) and the scenario kind (group 4).
+      // or `test("...", async (...) => { ... });` block. The single-
+      // quoted branch captures title/kind in groups 1/2; the double-
+      // quoted branch captures title/kind in groups 3/4.
       const TEST_BLOCK =
-        /test\((['"])([^'"]*)\1,\s*async[^]*?scenarioKind:\s*(['"])([^'"]+)\3[^]*?}\);/g;
+        /test\('([^']*)',\s*async[^]*?scenarioKind:\s*'([^']+)'[^]*?}\);|test\("([^"]*)",\s*async[^]*?scenarioKind:\s*"([^"]+)"[^]*?}\);/g;
 
       interface Offender {
         file: string;
@@ -3073,8 +3074,11 @@ describeForThisConfig(
         if (!f.endsWith('-validation-api-tests.spec.ts')) continue;
         const text = readFileSync(join(REQUEST_VALIDATION_DIR, f), 'utf8');
         for (const match of text.matchAll(TEST_BLOCK)) {
-          const title = match[2];
-          const scenarioKind = match[4];
+          const title = match[1] ?? match[3];
+          const scenarioKind = match[2] ?? match[4];
+          if (title === undefined || scenarioKind === undefined) {
+            continue;
+          }
           // Title format: `<operationId> - <suffix>` (qaEmitter.ts).
           const opMatch = title.match(/^([A-Za-z_$][A-Za-z0-9_$]*)\s+-\s+/);
           if (!opMatch) continue;

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -3046,8 +3046,8 @@ describeForThisConfig(
       const MULTIPART_ONLY_OPS = ['createDeployment', 'createDocument', 'createDocuments'];
 
       // Scenario kinds that are nonsensical on multipart-only ops.
-      // qaEmitter writes the scenario kind as `scenarioKind: '<type>'`
-      // (single-quoted) inside each test block; we match that exactly.
+      // Match either quote style so this invariant is not coupled to the
+      // emitter's current Prettier/singleQuote output.
       const FORBIDDEN_KINDS = [
         'body-top-type-mismatch',
         'type-mismatch',
@@ -3055,8 +3055,10 @@ describeForThisConfig(
       ];
 
       // Match a single emitted `test('...', async (...) => { ... });`
-      // block. Captures the title (group 1) and the body (group 2).
-      const TEST_BLOCK = /test\('([^']*)',\s*async[^]*?scenarioKind:\s*'([^']+)'[^]*?}\);/g;
+      // or `test("...", async (...) => { ... });` block. Captures the
+      // title (group 2) and the scenario kind (group 4).
+      const TEST_BLOCK =
+        /test\((['"])([^'"]*)\1,\s*async[^]*?scenarioKind:\s*(['"])([^'"]+)\3[^]*?}\);/g;
 
       interface Offender {
         file: string;
@@ -3071,8 +3073,8 @@ describeForThisConfig(
         if (!f.endsWith('-validation-api-tests.spec.ts')) continue;
         const text = readFileSync(join(REQUEST_VALIDATION_DIR, f), 'utf8');
         for (const match of text.matchAll(TEST_BLOCK)) {
-          const title = match[1];
-          const scenarioKind = match[2];
+          const title = match[2];
+          const scenarioKind = match[4];
           // Title format: `<operationId> - <suffix>` (qaEmitter.ts).
           const opMatch = title.match(/^([A-Za-z_$][A-Za-z0-9_$]*)\s+-\s+/);
           if (!opMatch) continue;

--- a/request-validation/scripts/generate.ts
+++ b/request-validation/scripts/generate.ts
@@ -40,6 +40,7 @@ import { emitQaTests } from '../src/emit/qaEmitter.js';
 import type { ValidationScenario } from '../src/model/types.js';
 import { loadSpec } from '../src/spec/loader.js';
 import { resolveSpecSource } from '../src/spec/source.js';
+import { shouldSkipForMultipart } from '../src/util/multipartSkip.js';
 
 interface CliOptions {
   only?: Set<string>;
@@ -429,6 +430,12 @@ async function main() {
       const hasMultipart = !!op.mediaTypes?.includes('multipart/form-data');
       const multipartOnly = hasMultipart && !hasJson;
       if (multipartOnly) {
+        // #135: drop scenarios whose mutations are nonsensical when
+        // wrapped as multipart form-data (body-top-type-mismatch,
+        // type-mismatch on binary parts, constraint-violation on
+        // array parts). Wrapping these produces 415s or false-positive
+        // 201s rather than the intended 400s.
+        if (shouldSkipForMultipart(s, op)) continue;
         const body = s.requestBody;
         const isJsonObjectBody =
           !!body && typeof body === 'object' && !Array.isArray(body) && !s.bodyEncoding;

--- a/request-validation/src/util/multipartSkip.ts
+++ b/request-validation/src/util/multipartSkip.ts
@@ -1,0 +1,76 @@
+import type { OperationModel, SchemaFragment, ValidationScenario } from '../model/types.js';
+
+/**
+ * Multipart-only operations need three classes of JSON-derived
+ * validation scenarios dropped before the multipart-adaptation pass
+ * tries to wrap them as form-data submissions (#135):
+ *
+ *   1. `body-top-type-mismatch` — there is no JSON top-level type to
+ *      invert. Wrapping `[]` / scalar bodies as form data produces a
+ *      meaningless multipart envelope; the broker returns 415 (or
+ *      occasionally 200/201) before body validation runs.
+ *
+ *   2. `type-mismatch` whose target is a top-level multipart part with
+ *      `format: binary` — any binary part still satisfies the schema
+ *      regardless of the bytes we put in it, so the wrapped form-data
+ *      submission yields 201 instead of the expected 400.
+ *
+ *   3. `constraint-violation` whose target is a top-level multipart
+ *      part with `type: array` — array-cardinality / item-shape
+ *      mutations don't translate to a multipart `files=...` repetition
+ *      pattern; the broker accepts the upload and returns 201.
+ *
+ * `shouldSkipForMultipart` returns `true` for scenarios that fall into
+ * any of those classes on a multipart-only operation. Other scenarios
+ * (additional-prop, missing-required, etc.) flow through the existing
+ * adaptation pass unchanged.
+ *
+ * A targeted multipart-aware mutation strategy (omit a required part,
+ * send wrong Content-Type per part, exceed declared size) is a separate
+ * larger feature and intentionally out of scope here — see #135.
+ */
+
+const TOP_LEVEL_FIELD_RE = /^[^.[\]]+$/;
+
+function isMultipartOnly(op: OperationModel): boolean {
+  const hasMultipart = !!op.mediaTypes?.includes('multipart/form-data');
+  const hasJson = !!op.mediaTypes?.includes('application/json');
+  return hasMultipart && !hasJson;
+}
+
+function topLevelMultipartPart(
+  op: OperationModel,
+  target: string | undefined,
+): SchemaFragment | undefined {
+  if (!target || !TOP_LEVEL_FIELD_RE.test(target)) return undefined;
+  const props = op.multipartSchema?.properties;
+  if (!props) return undefined;
+  const part = props[target];
+  return part && typeof part === 'object' ? part : undefined;
+}
+
+function isBinaryPart(schema: SchemaFragment | undefined): boolean {
+  if (!schema) return false;
+  const t = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+  return t === 'string' && schema.format === 'binary';
+}
+
+function isArrayPart(schema: SchemaFragment | undefined): boolean {
+  if (!schema) return false;
+  const t = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+  return t === 'array';
+}
+
+export function shouldSkipForMultipart(scenario: ValidationScenario, op: OperationModel): boolean {
+  if (!isMultipartOnly(op)) return false;
+  if (scenario.type === 'body-top-type-mismatch') return true;
+  if (scenario.type === 'type-mismatch') {
+    const part = topLevelMultipartPart(op, scenario.target);
+    if (isBinaryPart(part)) return true;
+  }
+  if (scenario.type === 'constraint-violation') {
+    const part = topLevelMultipartPart(op, scenario.target);
+    if (isArrayPart(part)) return true;
+  }
+  return false;
+}

--- a/tests/request-validation/multipart-skip.test.ts
+++ b/tests/request-validation/multipart-skip.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  OperationModel,
+  ValidationScenario,
+} from '../../request-validation/src/model/types.js';
+import { shouldSkipForMultipart } from '../../request-validation/src/util/multipartSkip.js';
+
+/**
+ * Layer-2 fixture for issue #135.
+ *
+ * Three negative-test mutation classes are meaningless on multipart-only
+ * endpoints (createDeployment, createDocument, createDocuments):
+ *
+ *   1. body-top-type-mismatch — no JSON top-level type to invert.
+ *   2. type-mismatch on a `format: binary` part — any bytes satisfy
+ *      the schema; mutation produces 201, not 400.
+ *   3. constraint-violation on an array-typed part — array-cardinality
+ *      mutations don't translate to multipart `files=...` repetition.
+ *
+ * `shouldSkipForMultipart` is the planner-side authority on whether
+ * the multipart-adaptation pass should drop a scenario instead of
+ * wrapping it as form data. These tests pin the contract directly so
+ * future analyses can call the helper without re-deriving the rule.
+ *
+ * Class-scoped: each `it` asserts ONE rule against synthetic operations
+ * standing in for the three real-world offenders, plus negative cases
+ * confirming we don't over-skip JSON operations or scalar multipart
+ * parts that can carry valid type-mismatch mutations.
+ */
+
+function multipartOnlyOp(partial: Partial<OperationModel> = {}): OperationModel {
+  return {
+    operationId: partial.operationId ?? 'createThing',
+    method: partial.method ?? 'POST',
+    path: partial.path ?? '/things',
+    tags: [],
+    parameters: [],
+    mediaTypes: ['multipart/form-data'],
+    ...partial,
+  };
+}
+
+function jsonOp(partial: Partial<OperationModel> = {}): OperationModel {
+  return {
+    operationId: partial.operationId ?? 'createJsonThing',
+    method: partial.method ?? 'POST',
+    path: partial.path ?? '/json-things',
+    tags: [],
+    parameters: [],
+    mediaTypes: ['application/json'],
+    ...partial,
+  };
+}
+
+function scenario(partial: Partial<ValidationScenario>): ValidationScenario {
+  return {
+    id: partial.id ?? 's1',
+    operationId: partial.operationId ?? 'createThing',
+    method: partial.method ?? 'POST',
+    path: partial.path ?? '/things',
+    type: partial.type ?? 'type-mismatch',
+    expectedStatus: partial.expectedStatus ?? 400,
+    description: partial.description ?? 'test scenario',
+    headersAuth: partial.headersAuth ?? true,
+    ...partial,
+  };
+}
+
+describe('shouldSkipForMultipart (#135)', () => {
+  it('skips body-top-type-mismatch on multipart-only ops (createDeployment / createDocument / createDocuments)', () => {
+    const op = multipartOnlyOp({
+      multipartSchema: { type: 'object', properties: { resources: { type: 'array' } } },
+    });
+    const s = scenario({ type: 'body-top-type-mismatch', requestBody: [] });
+    expect(shouldSkipForMultipart(s, op)).toBe(true);
+  });
+
+  it('skips type-mismatch on a top-level format:binary multipart part (createDocument file)', () => {
+    const op = multipartOnlyOp({
+      operationId: 'createDocument',
+      multipartSchema: {
+        type: 'object',
+        properties: {
+          file: { type: 'string', format: 'binary' },
+        },
+      },
+    });
+    const s = scenario({ type: 'type-mismatch', target: 'file', requestBody: { file: 123 } });
+    expect(shouldSkipForMultipart(s, op)).toBe(true);
+  });
+
+  it('skips constraint-violation on a top-level array multipart part (createDocuments files)', () => {
+    const op = multipartOnlyOp({
+      operationId: 'createDocuments',
+      multipartSchema: {
+        type: 'object',
+        properties: { files: { type: 'array', items: { type: 'string', format: 'binary' } } },
+      },
+    });
+    const s = scenario({
+      type: 'constraint-violation',
+      target: 'files',
+      requestBody: { files: [] },
+    });
+    expect(shouldSkipForMultipart(s, op)).toBe(true);
+  });
+
+  it('does NOT skip on JSON-only ops even when the scenario kind matches', () => {
+    const op = jsonOp({
+      requestBodySchema: { type: 'object', properties: { file: { type: 'string' } } },
+    });
+    const cases: ValidationScenario[] = [
+      scenario({ type: 'body-top-type-mismatch', requestBody: [] }),
+      scenario({ type: 'type-mismatch', target: 'file', requestBody: { file: 123 } }),
+      scenario({ type: 'constraint-violation', target: 'files', requestBody: { files: [] } }),
+    ];
+    for (const s of cases) {
+      expect(shouldSkipForMultipart(s, op)).toBe(false);
+    }
+  });
+
+  it('does NOT skip type-mismatch on a non-binary scalar multipart part', () => {
+    // E.g. a multipart endpoint with a stringy metadata field — wrapping
+    // the mutation as form data still produces a meaningful 400.
+    const op = multipartOnlyOp({
+      multipartSchema: {
+        type: 'object',
+        properties: { tenantId: { type: 'string' } },
+      },
+    });
+    const s = scenario({
+      type: 'type-mismatch',
+      target: 'tenantId',
+      requestBody: { tenantId: 123 },
+    });
+    expect(shouldSkipForMultipart(s, op)).toBe(false);
+  });
+
+  it('does NOT skip constraint-violation on a non-array scalar multipart part', () => {
+    const op = multipartOnlyOp({
+      multipartSchema: {
+        type: 'object',
+        properties: { tenantId: { type: 'string', maxLength: 32 } },
+      },
+    });
+    const s = scenario({
+      type: 'constraint-violation',
+      target: 'tenantId',
+      requestBody: { tenantId: 'x'.repeat(64) },
+    });
+    expect(shouldSkipForMultipart(s, op)).toBe(false);
+  });
+
+  it('does NOT skip nested-target type-mismatch / constraint-violation', () => {
+    // Only top-level multipart parts are governed by this rule. Anything
+    // nested (e.g. type-mismatch on metadata.foo where metadata is a
+    // JSON-string part) is left to the existing adapter to wrap.
+    const op = multipartOnlyOp({
+      multipartSchema: {
+        type: 'object',
+        properties: { metadata: { type: 'object', properties: { foo: { type: 'string' } } } },
+      },
+    });
+    const s = scenario({
+      type: 'type-mismatch',
+      target: 'metadata.foo',
+      requestBody: { metadata: { foo: 1 } },
+    });
+    expect(shouldSkipForMultipart(s, op)).toBe(false);
+  });
+
+  it('passes through scenario kinds that the adapter can wrap meaningfully (additional-prop, missing-required, …)', () => {
+    const op = multipartOnlyOp({
+      multipartSchema: {
+        type: 'object',
+        properties: { file: { type: 'string', format: 'binary' } },
+      },
+    });
+    const cases: ValidationScenario[] = [
+      scenario({ type: 'additional-prop', requestBody: { file: 'x', __extra__: 1 } }),
+      scenario({ type: 'missing-required', target: 'file', requestBody: {} }),
+      scenario({ type: 'missing-body' }),
+    ];
+    for (const s of cases) {
+      expect(shouldSkipForMultipart(s, op)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Closes #135.

## Problem

Three negative-test mutation classes were being emitted on the three multipart-only endpoints (`createDeployment`, `createDocument`, `createDocuments`), producing 415s or false-positive 201s instead of the intended 400s:

| Kind | Why it misbehaves on multipart-only |
|---|---|
| `body-top-type-mismatch` | Wrapping a non-object body as form-data has no JSON top-level type to invert; broker returns 415 (Unsupported Media Type). |
| `type-mismatch` on `format: binary` part | Any bytes satisfy the schema; mutation produces 201 Created. |
| `constraint-violation` on array part | Array-cardinality mutations don't translate to repeated multipart fields. |

Five offending scenarios were emitted against the bundled spec:

- `createDeployment - Body wrong top-level type`
- `createDocument - Body wrong top-level type`
- `createDocument - Param file wrong type`
- `createDocuments - Body wrong top-level type`
- `createDocuments - Constraint violation files`

## Fix

Add a pure `shouldSkipForMultipart(scenario, op)` helper consumed by the existing multipart-adaptation pass in `request-validation/scripts/generate.ts` to drop these scenarios instead of wrapping them.

Scalar non-binary parts (e.g. `createDeployment.tenantId` — `tenantId wrong type` and `Constraint violation tenantId` are still emitted) and unrelated scenario kinds (`additional-prop`, `missing-required`, etc.) pass through unchanged.

## Tests (red/green/class-scoped)

- **L1** — `tests/request-validation/multipart-skip.test.ts` (8 unit tests pinning the helper contract: skip the three offending kinds on multipart-only ops, pass through on JSON-only ops, scalar non-binary parts, nested targets, and unrelated kinds).
- **L3** — `configs/camunda-oca/regression-invariants.test.ts` ("bundled-spec invariants: multipart-only operations skip JSON-only mutations (#135)"): scans every emitted `*-validation-api-tests.spec.ts` and asserts zero offending scenarios on the three multipart-only ops, with a sanity floor of ≥1 retained scenario per op. Verified red without the wiring, green with it.

## Verification

```
npm run lint                                   # green (only pre-existing warnings)
npx tsc --noEmit -p {extractor,planner,rv,tests}/tsconfig.json   # green
TEST_SEED=snapshot-baseline npm run testsuite:generate
TEST_SEED=snapshot-baseline npm run generate:request-validation
npm test                                       # 267 passed (was 258, +9 from new L1+L3)
```

5 offending scenarios drop from the regenerated suites; total scenario count drops from 1042 to 1037.