### PR TITLE
feat: gate Playwright emitter's recordResponse calls behind configuration (#155)

### DIFF
--- a/configs.json
+++ b/configs.json
@@ -7,6 +7,12 @@
       "spec": {
         "source": "github:camunda/camunda",
         "$comment": "Pinned ref + expected hash live in configs/camunda-oca/spec-pin.json (kept as a separate file to preserve the spec-pin bump procedure documented in tests/regression/spec-pin.setup.ts)."
+      },
+      "codegen": {
+        "$comment": "Per-emitter codegen options. Resolved by getPlaywrightCodegenOptions() in path-analyser/src/configResolver.ts. Each subkey is the emitter id (see codegen/registry.ts). Missing keys default to behaviour that matches the pre-config baseline.",
+        "playwright": {
+          "recordResponses": true
+        }
       }
     }
   }

--- a/configs.json
+++ b/configs.json
@@ -9,9 +9,9 @@
         "$comment": "Pinned ref + expected hash live in configs/camunda-oca/spec-pin.json (kept as a separate file to preserve the spec-pin bump procedure documented in tests/regression/spec-pin.setup.ts)."
       },
       "codegen": {
-        "$comment": "Per-emitter codegen options. Resolved by getPlaywrightCodegenOptions() in path-analyser/src/configResolver.ts. Each subkey is the emitter id (see codegen/registry.ts). Missing keys default to behaviour that matches the pre-config baseline.",
+        "$comment": "Per-emitter codegen options. Resolved by getPlaywrightCodegenOptions() in path-analyser/src/configResolver.ts. Each subkey is the emitter id (see codegen/registry.ts). Missing keys default to behaviour that matches the pre-config baseline (recordResponses=true). camunda-oca opts out: the SDK example workflows that consume the emitted suite do not run observe:aggregate, so the recorder boilerplate is pure dead weight here. The aggregator workflow can be re-enabled by flipping this back to true.",
         "playwright": {
-          "recordResponses": true
+          "recordResponses": false
         }
       }
     }

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1376,6 +1376,33 @@ describeForThisConfig('bundled-spec invariants: emitted Playwright suite', () =>
     expect(totalExpected).toBeGreaterThan(0);
     expect(totalActual).toBe(totalExpected);
   });
+
+  it('every emitted feature spec records responses (camunda-oca config has recordResponses=true)', () => {
+    // configs.json#configs.camunda-oca.codegen.playwright.recordResponses is
+    // intentionally `true` so the observe:aggregate workflow can consume
+    // dist/runtime-observations/responses.jsonl. This invariant locks that
+    // default — flipping it to false in configs.json would drop the per-step
+    // recordResponse() block from every emitted spec, and this assertion
+    // would catch it. The check is class-scoped: it asserts that *every*
+    // feature spec contains at least one `await recordResponse(`, not just
+    // the spec the change happened to touch.
+    if (!existsSync(GENERATED_TESTS_DIR)) {
+      throw new Error(
+        `Generated tests directory not found at ${GENERATED_TESTS_DIR}. Run 'npm run testsuite:generate' first.`,
+      );
+    }
+    const specs = readdirSync(GENERATED_TESTS_DIR).filter((f) => f.endsWith('.feature.spec.ts'));
+    expect(specs.length, 'at least one feature spec must be emitted').toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+    for (const f of specs) {
+      const src = readFileSync(join(GENERATED_TESTS_DIR, f), 'utf8');
+      if (!src.includes('await recordResponse(')) {
+        offenders.push(relative(REPO_ROOT, join(GENERATED_TESTS_DIR, f)));
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
 });
 
 describeForThisConfig('bundled-spec invariants: emitted Playwright variant suite (#105)', () => {

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1377,15 +1377,19 @@ describeForThisConfig('bundled-spec invariants: emitted Playwright suite', () =>
     expect(totalActual).toBe(totalExpected);
   });
 
-  it('every emitted feature spec records responses (camunda-oca config has recordResponses=true)', () => {
+  it('no emitted feature spec records responses (camunda-oca config has recordResponses=false)', () => {
     // configs.json#configs.camunda-oca.codegen.playwright.recordResponses is
-    // intentionally `true` so the observe:aggregate workflow can consume
-    // dist/runtime-observations/responses.jsonl. This invariant locks that
-    // default — flipping it to false in configs.json would drop the per-step
-    // recordResponse() block from every emitted spec, and this assertion
-    // would catch it. The check is class-scoped: it asserts that *every*
-    // feature spec contains at least one `await recordResponse(`, not just
-    // the spec the change happened to touch.
+    // intentionally `false`: SDK example workflows that consume the emitted
+    // suite do not run observe:aggregate, so the per-step recordResponse()
+    // block plus the recorder.ts vendoring are pure dead weight here. This
+    // invariant locks that choice — flipping the config back to true would
+    // re-introduce the boilerplate, and this assertion would catch it.
+    //
+    // The check is class-scoped: it asserts that *no* feature spec contains
+    // `recordResponse` anywhere (call site or import), not just the spec the
+    // change happened to touch. Catches partial-gating regressions (e.g. a
+    // future refactor that re-emits the import without the call, or vice
+    // versa) the same way the original direction did.
     if (!existsSync(GENERATED_TESTS_DIR)) {
       throw new Error(
         `Generated tests directory not found at ${GENERATED_TESTS_DIR}. Run 'npm run testsuite:generate' first.`,
@@ -1397,7 +1401,7 @@ describeForThisConfig('bundled-spec invariants: emitted Playwright suite', () =>
     const offenders: string[] = [];
     for (const f of specs) {
       const src = readFileSync(join(GENERATED_TESTS_DIR, f), 'utf8');
-      if (!src.includes('await recordResponse(')) {
+      if (src.includes('recordResponse')) {
         offenders.push(relative(REPO_ROOT, join(GENERATED_TESTS_DIR, f)));
       }
     }

--- a/path-analyser/README.md
+++ b/path-analyser/README.md
@@ -74,7 +74,7 @@ The emitted suite at `generated/<config>/playwright/` is now a self-contained, r
 - `tsconfig.json`
 - `.env.example` (documents `API_BASE_URL`)
 - `README.md` (run instructions)
-- `support/` (vendored runtime helpers — `env.ts`, `recorder.ts`, `seeding.ts`, `seed-rules.json`)
+- `support/` (vendored runtime helpers — `env.ts`, `seeding.ts`, `seed-rules.json`, and `recorder.ts` when `recordResponses` is enabled — see "Response Shape Recorder" below)
 
 So you can install and run the suite in place against any reachable Camunda cluster:
 
@@ -140,7 +140,12 @@ Purpose
 - Capture real runtime responses from generated tests to inform schema defaults, error mappings, and which fields are actually present.
 - Persist a sanitized JSONL log you can aggregate into a compact summary.
 
-How it works
+Configuration
+
+- The recorder is gated by `configs.<name>.codegen.playwright.recordResponses` in [configs.json](../configs.json). Default when omitted: `true`. The active `camunda-oca` config sets it to `false`, so the SDK example workflows that consume the emitted suite do not pay for the recorder boilerplate they never aggregate. Set it back to `true` for a config (or branch) to re-enable.
+- When disabled, the emitter omits the `recordResponse`/`sanitizeBody` import, every per-step `recordResponse({...})` block, and the `recorder.ts` vendoring under `support/`.
+
+How it works (when enabled)
 
 - The Playwright emitter automatically logs every request via two helpers:
   - `recordResponse({...})` appends one JSON line per request to `dist/runtime-observations/responses.jsonl`.
@@ -155,7 +160,7 @@ Paths
 
 Usage
 
-1) Generate and run tests (recorder is built-in):
+1) Enable the recorder for the active config (set `configs.<name>.codegen.playwright.recordResponses` to `true` in `configs.json`), then generate and run tests:
 
 ```bash
 npm run codegen:playwright -- <operationId>

--- a/path-analyser/README.md
+++ b/path-analyser/README.md
@@ -74,7 +74,7 @@ The emitted suite at `generated/<config>/playwright/` is now a self-contained, r
 - `tsconfig.json`
 - `.env.example` (documents `API_BASE_URL`)
 - `README.md` (run instructions)
-- `support/` (vendored runtime helpers — `env.ts`, `seeding.ts`, `seed-rules.json`, and `recorder.ts` when `recordResponses` is enabled — see "Response Shape Recorder" below)
+- `support/` (vendored runtime helpers — `env.ts`, `seeding.ts`, `fixtures.ts`, `seed-rules.json`, `await-eventually.ts`, and `recorder.ts` when `recordResponses` is enabled — see "Response Shape Recorder" below; the full list lives in `SUPPORT_TEMPLATE_FILES` in `materialize-support.ts`)
 
 So you can install and run the suite in place against any reachable Camunda cluster:
 

--- a/path-analyser/src/codegen/emitter.ts
+++ b/path-analyser/src/codegen/emitter.ts
@@ -23,6 +23,16 @@ export interface EmitContext {
    * universal-seed prologue and no multipart strip branches.
    */
   globalContextSeeds?: readonly GlobalContextSeed[];
+  /**
+   * Whether the emitted suite should record every response observation by
+   * calling `recordResponse({...})` (and importing it / `sanitizeBody` from
+   * `./support/recorder`). Sourced from
+   * `configs.json#configs.<active>.codegen.playwright.recordResponses`.
+   *
+   * Optional with a default of `true` — omitting the field preserves the
+   * pre-config behaviour. Only the Playwright emitter consumes this today.
+   */
+  recordResponses?: boolean;
 }
 
 /**

--- a/path-analyser/src/codegen/index.ts
+++ b/path-analyser/src/codegen/index.ts
@@ -117,24 +117,28 @@ async function run() {
     process.exit(1);
   }
 
-  // Per-config Playwright codegen options (configs.json#configs.<active>.codegen.playwright).
-  // Resolved once here and forwarded to both materializeSupport (which skips
-  // recorder.ts when recordResponses=false) and every writeEmitted call so the
-  // emitted suite and its vendored support/ stay consistent.
-  const codegenOpts = getPlaywrightCodegenOptions(repoRoot);
-
   // Wipe before write so emitted spec files left over from a previous spec
   // version cannot survive into the current run. Without this, local
   // pre-push validation can diverge from CI (which always sees a fresh tree).
   // The support/ tree, README.md, and responses.json are re-materialised below.
   await fs.rm(outDir, { recursive: true, force: true });
   await fs.mkdir(outDir, { recursive: true });
+  // Per-config Playwright codegen options
+  // (configs.json#configs.<active>.codegen.playwright). Resolved INSIDE the
+  // emitter.id check so a malformed `codegen.playwright` block cannot fail
+  // codegen runs that target a non-Playwright emitter and don't consume
+  // these options. Declared with the wider scope so writeEmitted below can
+  // forward it; non-Playwright targets see `undefined`, which the
+  // EmitContext schema already treats as "use the default".
+  let recordResponses: boolean | undefined;
   // Vendor the runtime support helpers into <outDir>/support/ so the
   // emitted suite is self-contained (no imports back into this generator).
   // Only the Playwright emitter currently needs these; gate on the emitter id
   // so future targets that don't depend on these helpers don't pay the cost.
   if (emitter.id === 'playwright') {
-    const excludeSupportFiles = codegenOpts.recordResponses ? undefined : ['recorder.ts'];
+    const codegenOpts = getPlaywrightCodegenOptions(repoRoot);
+    recordResponses = codegenOpts.recordResponses;
+    const excludeSupportFiles = recordResponses ? undefined : ['recorder.ts'];
     await materializeSupport(outDir, undefined, undefined, true, excludeSupportFiles);
     // Also extract response-body schemas alongside the emitted specs so the
     // generated `validateResponse(...)` calls have a schema source. Co-located
@@ -158,7 +162,7 @@ async function run() {
           suiteName: parsed.endpoint.operationId,
           mode: 'feature',
           globalContextSeeds,
-          recordResponses: codegenOpts.recordResponses,
+          recordResponses,
         });
         count++;
       } catch (e) {
@@ -193,7 +197,7 @@ async function run() {
           suiteName: parsed.endpoint.operationId,
           mode: 'variant',
           globalContextSeeds,
-          recordResponses: codegenOpts.recordResponses,
+          recordResponses,
         });
         variantCount++;
       } catch (e) {
@@ -231,7 +235,7 @@ async function run() {
     suiteName: endpointOpId,
     mode: 'feature',
     globalContextSeeds,
-    recordResponses: codegenOpts.recordResponses,
+    recordResponses,
   });
   console.log('Generated test suite for', endpointOpId, 'at', outDir, `(target: ${emitter.id})`);
 }

--- a/path-analyser/src/codegen/index.ts
+++ b/path-analyser/src/codegen/index.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import {
   getActiveConfigDir,
   getFeatureOutputDir,
+  getPlaywrightCodegenOptions,
   getPlaywrightSuiteDir,
   getVariantOutputDir,
 } from '../configResolver.js';
@@ -116,6 +117,12 @@ async function run() {
     process.exit(1);
   }
 
+  // Per-config Playwright codegen options (configs.json#configs.<active>.codegen.playwright).
+  // Resolved once here and forwarded to both materializeSupport (which skips
+  // recorder.ts when recordResponses=false) and every writeEmitted call so the
+  // emitted suite and its vendored support/ stay consistent.
+  const codegenOpts = getPlaywrightCodegenOptions(repoRoot);
+
   // Wipe before write so emitted spec files left over from a previous spec
   // version cannot survive into the current run. Without this, local
   // pre-push validation can diverge from CI (which always sees a fresh tree).
@@ -127,7 +134,8 @@ async function run() {
   // Only the Playwright emitter currently needs these; gate on the emitter id
   // so future targets that don't depend on these helpers don't pay the cost.
   if (emitter.id === 'playwright') {
-    await materializeSupport(outDir);
+    const excludeSupportFiles = codegenOpts.recordResponses ? undefined : ['recorder.ts'];
+    await materializeSupport(outDir, undefined, undefined, true, excludeSupportFiles);
     // Also extract response-body schemas alongside the emitted specs so the
     // generated `validateResponse(...)` calls have a schema source. Co-located
     // here (rather than a separate npm script) so every codegen run produces
@@ -150,6 +158,7 @@ async function run() {
           suiteName: parsed.endpoint.operationId,
           mode: 'feature',
           globalContextSeeds,
+          recordResponses: codegenOpts.recordResponses,
         });
         count++;
       } catch (e) {
@@ -184,6 +193,7 @@ async function run() {
           suiteName: parsed.endpoint.operationId,
           mode: 'variant',
           globalContextSeeds,
+          recordResponses: codegenOpts.recordResponses,
         });
         variantCount++;
       } catch (e) {
@@ -221,6 +231,7 @@ async function run() {
     suiteName: endpointOpId,
     mode: 'feature',
     globalContextSeeds,
+    recordResponses: codegenOpts.recordResponses,
   });
   console.log('Generated test suite for', endpointOpId, 'at', outDir, `(target: ${emitter.id})`);
 }

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -78,7 +78,14 @@ export async function emitPlaywrightSuite(
   opts: EmitOptions,
 ) {
   await fs.mkdir(opts.outDir, { recursive: true });
-  await materializeSupport(opts.outDir);
+  // Keep the legacy entry point aligned with the new recordResponses contract:
+  // when the caller opts out of the recorder, the per-step block and the
+  // `recorder` import are already absent from the rendered source, so
+  // recorder.ts must also be absent from the vendored support/ directory.
+  // Default true (preserves pre-config behaviour, matching renderPlaywrightSuite).
+  const recordResponses = opts.recordResponses ?? true;
+  const excludeSupportFiles = recordResponses ? undefined : ['recorder.ts'];
+  await materializeSupport(opts.outDir, undefined, undefined, true, excludeSupportFiles);
   const file = path.join(opts.outDir, playwrightSuiteFileName(collection, opts.mode || 'feature'));
   const code = renderPlaywrightSuite(collection, opts);
   await fs.writeFile(file, code, 'utf8');

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -20,6 +20,13 @@ interface EmitOptions {
    * produce identical output for the same inputs.
    */
   globalContextSeeds?: readonly GlobalContextSeed[];
+  /**
+   * See {@link EmitContext.recordResponses}. Default `true` (preserves
+   * pre-config behaviour); set to `false` to drop the per-step
+   * `recordResponse({...})` block and the `recorder` import from the
+   * emitted suite.
+   */
+  recordResponses?: boolean;
 }
 
 /**
@@ -44,6 +51,7 @@ export function renderPlaywrightSuite(
     suiteName?: string;
     mode?: 'feature' | 'integration' | 'variant';
     globalContextSeeds?: readonly GlobalContextSeed[];
+    recordResponses?: boolean;
   },
 ): string {
   return buildSuiteSource(collection, {
@@ -51,6 +59,7 @@ export function renderPlaywrightSuite(
     suiteName: opts.suiteName,
     mode: opts.mode,
     globalContextSeeds: opts.globalContextSeeds,
+    recordResponses: opts.recordResponses,
   });
 }
 
@@ -88,6 +97,7 @@ export const PlaywrightEmitter: Emitter = {
       suiteName: ctx.suiteName,
       mode: ctx.mode,
       globalContextSeeds: ctx.globalContextSeeds,
+      recordResponses: ctx.recordResponses,
     });
     return [
       {
@@ -135,6 +145,11 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   // (we never await a step that's expected to produce an error response).
   const needsAwaitEventually = collection.scenarios.some((s) => stepNeedsAwait(s).length > 0);
 
+  // Default `recordResponses` to true so callers that omit the option keep
+  // the pre-config behaviour. Threaded down into renderScenarioTest so the
+  // per-step block tracks the same flag as the import statement.
+  const recordResponses = opts.recordResponses ?? true;
+
   // Import only test & expect; request fixture is provided per-test via parameters
   lines.push("import { test, expect } from '@playwright/test';");
   if (needsValidation) {
@@ -144,7 +159,9 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   // materializeSupport() copies these files alongside the emitted specs so
   // the generated suite has no dependency on this generator project.
   lines.push("import { buildBaseUrl, authHeaders } from './support/env';");
-  lines.push("import { recordResponse, sanitizeBody } from './support/recorder';");
+  if (recordResponses) {
+    lines.push("import { recordResponse, sanitizeBody } from './support/recorder';");
+  }
   lines.push("import { extractInto, seedBinding } from './support/seeding';");
   lines.push("import { resolveFixture } from './support/fixtures';");
   if (needsAwaitEventually) {
@@ -162,7 +179,7 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   lines.push(`test.describe('${suiteName}', () => {`);
   const seeds = opts.globalContextSeeds ?? [];
   for (const scenario of collection.scenarios) {
-    lines.push(renderScenarioTest(scenario, seeds));
+    lines.push(renderScenarioTest(scenario, seeds, recordResponses));
   }
   lines.push('});');
   return lines.join('\n');
@@ -171,6 +188,7 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
 function renderScenarioTest(
   s: EndpointScenario,
   globalContextSeeds: readonly GlobalContextSeed[],
+  recordResponses: boolean,
 ): string {
   const title = `${s.id} - ${escapeQuotes(s.name || 'scenario')}`;
   const body: string[] = [];
@@ -363,34 +381,36 @@ function renderScenarioTest(
     body.push(`    }`);
     body.push(`    expect(${varName}.status()).toBe(${step.expect.status});`);
     // Record observation for this step (best-effort). Only capture response shapes for 200 responses.
-    body.push(`    try {`);
-    body.push(`      const __status = ${varName}.status();`);
-    // `unknown` + assigned-or-stays-undefined; the subsequent
-    // `bodyJson !== undefined` guard before sanitizeBody() preserves the
-    // contract. Drops both the noExplicitAny error and the
-    // noUselessUndefinedInitialization info from the generated suite.
-    body.push(`      let bodyJson: unknown;`);
-    body.push(
-      `      if (__status === 200) { try { bodyJson = await ${varName}.json(); } catch {} }`,
-    );
-    body.push(`      await recordResponse({`);
-    body.push(`        timestamp: new Date().toISOString(),`);
-    // Use the step's declared operationId instead of indexing scenario.operations (which may have fewer entries than request steps, e.g. duplicate tests)
-    body.push(`        operationId: '${step.operationId}',`);
-    body.push(`        scenarioId: '${s.id}',`);
-    body.push(`        scenarioName: ${JSON.stringify(s.name || '')},`);
-    body.push(`        stepIndex: ${idx},`);
-    body.push(`        isFinal: ${isFinal},`);
-    body.push(`        method: '${step.method}',`);
-    body.push(`        pathTemplate: ${JSON.stringify(step.pathTemplate)},`);
-    body.push(`        status: __status,`);
-    body.push(`        expectedStatus: ${step.expect.status},`);
-    body.push(`        errorScenario: ${s.expectedResult && s.expectedResult.kind === 'error'},`);
-    body.push(
-      `        bodyShape: (__status === 200 && bodyJson !== undefined) ? sanitizeBody(bodyJson) : undefined`,
-    );
-    body.push(`      });`);
-    body.push(`    } catch {}`);
+    if (recordResponses) {
+      body.push(`    try {`);
+      body.push(`      const __status = ${varName}.status();`);
+      // `unknown` + assigned-or-stays-undefined; the subsequent
+      // `bodyJson !== undefined` guard before sanitizeBody() preserves the
+      // contract. Drops both the noExplicitAny error and the
+      // noUselessUndefinedInitialization info from the generated suite.
+      body.push(`      let bodyJson: unknown;`);
+      body.push(
+        `      if (__status === 200) { try { bodyJson = await ${varName}.json(); } catch {} }`,
+      );
+      body.push(`      await recordResponse({`);
+      body.push(`        timestamp: new Date().toISOString(),`);
+      // Use the step's declared operationId instead of indexing scenario.operations (which may have fewer entries than request steps, e.g. duplicate tests)
+      body.push(`        operationId: '${step.operationId}',`);
+      body.push(`        scenarioId: '${s.id}',`);
+      body.push(`        scenarioName: ${JSON.stringify(s.name || '')},`);
+      body.push(`        stepIndex: ${idx},`);
+      body.push(`        isFinal: ${isFinal},`);
+      body.push(`        method: '${step.method}',`);
+      body.push(`        pathTemplate: ${JSON.stringify(step.pathTemplate)},`);
+      body.push(`        status: __status,`);
+      body.push(`        expectedStatus: ${step.expect.status},`);
+      body.push(`        errorScenario: ${s.expectedResult && s.expectedResult.kind === 'error'},`);
+      body.push(
+        `        bodyShape: (__status === 200 && bodyJson !== undefined) ? sanitizeBody(bodyJson) : undefined`,
+      );
+      body.push(`      });`);
+      body.push(`    } catch {}`);
+    }
     // If this is the final step and scenario expects a success body, validate response shape
     const isErrorScenario = s.expectedResult && s.expectedResult.kind === 'error';
     if (isFinal && hasShape && !isErrorScenario) {

--- a/path-analyser/src/codegen/playwright/materialize-support.ts
+++ b/path-analyser/src/codegen/playwright/materialize-support.ts
@@ -111,7 +111,13 @@ function defaultProjectTemplatesDir(): string {
  *                            Used by callers that have configured the emitter
  *                            to drop a runtime helper (e.g. `recorder.ts`
  *                            when `recordResponses=false`). Names must match
- *                            entries in {@link SUPPORT_TEMPLATE_FILES}.
+ *                            entries in {@link SUPPORT_TEMPLATE_FILES} — unknown
+ *                            names throw to surface typos rather than silently
+ *                            no-op. When a name is excluded, any pre-existing
+ *                            file by the same name under `<outDir>/support/`
+ *                            is also removed, so re-running the materializer
+ *                            over an existing suite cannot leave a stale
+ *                            helper behind.
  * @returns                   Path to the support directory under `outDir`.
  */
 export async function materializeSupport(
@@ -125,11 +131,27 @@ export async function materializeSupport(
   const destDir = path.join(outDir, SUPPORT_DIR_NAME);
   await fs.mkdir(destDir, { recursive: true });
 
+  const validNames: ReadonlySet<string> = new Set(SUPPORT_TEMPLATE_FILES);
   const exclude = new Set(excludeSupportFiles ?? []);
+  for (const name of exclude) {
+    if (!validNames.has(name)) {
+      throw new Error(
+        `materializeSupport: excludeSupportFiles contains unknown name ${JSON.stringify(name)}. ` +
+          `Allowed: ${[...validNames].join(', ')}.`,
+      );
+    }
+  }
   // Always overwrite support/ — these are part of the generator's contract.
+  // For excluded names, actively remove any pre-existing destination file
+  // so a previous run with the helper enabled does not leave a stale copy
+  // behind. `fs.rm({ force: true })` is a no-op when the file is absent.
   for (const name of SUPPORT_TEMPLATE_FILES) {
-    if (exclude.has(name)) continue;
-    await fs.copyFile(path.join(srcDir, name), path.join(destDir, name));
+    const dest = path.join(destDir, name);
+    if (exclude.has(name)) {
+      await fs.rm(dest, { force: true });
+      continue;
+    }
+    await fs.copyFile(path.join(srcDir, name), dest);
   }
 
   // Project root scaffolding: overwritten by default; opt-out preserves user edits.

--- a/path-analyser/src/codegen/playwright/materialize-support.ts
+++ b/path-analyser/src/codegen/playwright/materialize-support.ts
@@ -106,6 +106,12 @@ function defaultProjectTemplatesDir(): string {
  *                            written if they don't already exist. Support
  *                            files are always overwritten regardless.
  *                            Default: true.
+ * @param excludeSupportFiles Optional list of support-template file names to
+ *                            skip when copying into `<outDir>/support/`.
+ *                            Used by callers that have configured the emitter
+ *                            to drop a runtime helper (e.g. `recorder.ts`
+ *                            when `recordResponses=false`). Names must match
+ *                            entries in {@link SUPPORT_TEMPLATE_FILES}.
  * @returns                   Path to the support directory under `outDir`.
  */
 export async function materializeSupport(
@@ -113,13 +119,16 @@ export async function materializeSupport(
   templatesDir?: string,
   projectTemplatesDir?: string,
   overwriteRoot: boolean = true,
+  excludeSupportFiles?: readonly string[],
 ): Promise<string> {
   const srcDir = templatesDir ?? defaultTemplatesDir();
   const destDir = path.join(outDir, SUPPORT_DIR_NAME);
   await fs.mkdir(destDir, { recursive: true });
 
+  const exclude = new Set(excludeSupportFiles ?? []);
   // Always overwrite support/ — these are part of the generator's contract.
   for (const name of SUPPORT_TEMPLATE_FILES) {
+    if (exclude.has(name)) continue;
     await fs.copyFile(path.join(srcDir, name), path.join(destDir, name));
   }
 

--- a/path-analyser/src/configResolver.ts
+++ b/path-analyser/src/configResolver.ts
@@ -81,6 +81,71 @@ export function getActiveConfigDir(repoRoot: string): string {
 }
 
 /**
+ * Options that control the Playwright emitter, sourced from
+ * `configs.json#configs.<active>.codegen.playwright`.
+ *
+ * Every field is optional in the on-disk schema and defaults to a value
+ * that preserves pre-config behaviour. Missing `codegen` / `codegen.playwright`
+ * blocks yield an all-defaults result without throwing.
+ */
+export interface PlaywrightCodegenOptions {
+  /**
+   * When true, every emitted scenario step appends a `recordResponse({...})`
+   * call (and the suite imports `recordResponse`/`sanitizeBody` from
+   * `./support/recorder`). When false, neither the call nor the import is
+   * emitted, and `recorder.ts` is not vendored into the suite's `support/`
+   * directory.
+   *
+   * Default: true (preserves the behaviour that existed before this option
+   * was introduced).
+   */
+  recordResponses: boolean;
+}
+
+/**
+ * Resolve the Playwright codegen options for the active config. Strict
+ * shape-checking on the `codegen.playwright` block — a non-object, or a
+ * non-boolean `recordResponses`, throws. Missing keys default.
+ */
+export function getPlaywrightCodegenOptions(repoRoot: string): PlaywrightCodegenOptions {
+  const index = loadConfigsIndex(repoRoot);
+  const name = getActiveConfigName(repoRoot);
+  const entry = index.configs[name];
+  if (!isRecord(entry)) {
+    return { recordResponses: true };
+  }
+  if (!('codegen' in entry)) {
+    return { recordResponses: true };
+  }
+  const codegen = entry.codegen;
+  if (!isRecord(codegen)) {
+    throw new Error(
+      `Malformed configs.json: configs.${name}.codegen must be an object, got ${typeof codegen}.`,
+    );
+  }
+  if (!('playwright' in codegen)) {
+    return { recordResponses: true };
+  }
+  const playwright = codegen.playwright;
+  if (!isRecord(playwright)) {
+    throw new Error(
+      `Malformed configs.json: configs.${name}.codegen.playwright must be an object, got ${typeof playwright}.`,
+    );
+  }
+  let recordResponses = true;
+  if ('recordResponses' in playwright) {
+    const v = playwright.recordResponses;
+    if (typeof v !== 'boolean') {
+      throw new Error(
+        `Malformed configs.json: configs.${name}.codegen.playwright.recordResponses must be a boolean, got ${typeof v}.`,
+      );
+    }
+    recordResponses = v;
+  }
+  return { recordResponses };
+}
+
+/**
  * Per-config layout helpers (#128 PR 2 — output partitioning).
  *
  * Convention:

--- a/path-analyser/src/configResolver.ts
+++ b/path-analyser/src/configResolver.ts
@@ -48,16 +48,15 @@ function loadConfigsIndex(repoRoot: string): ConfigsIndex {
 }
 
 /**
- * Resolve the active config name. Reads `configs.json` at `repoRoot`
- * to:
- *   - look up the default name when `CONFIG` is unset
- *   - validate `CONFIG` against the declared allowlist
+ * Resolve the active config name against an already-loaded {@link ConfigsIndex}.
  *
- * @param repoRoot Absolute path to the api-test-generator repository
- *   root (the directory containing `configs.json`).
+ * Split out from {@link getActiveConfigName} so callers that also need other
+ * fields from the index (e.g. {@link getPlaywrightCodegenOptions}) can load
+ * `configs.json` exactly once per invocation. A second read could see a
+ * different on-disk snapshot (TOCTOU), validate against one and look up the
+ * config entry from another.
  */
-export function getActiveConfigName(repoRoot: string): string {
-  const index = loadConfigsIndex(repoRoot);
+function resolveActiveConfigName(index: ConfigsIndex): string {
   const fromEnv = process.env.CONFIG?.trim();
   const name = fromEnv && fromEnv.length > 0 ? fromEnv : index.default;
 
@@ -74,6 +73,19 @@ export function getActiveConfigName(repoRoot: string): string {
     );
   }
   return name;
+}
+
+/**
+ * Resolve the active config name. Reads `configs.json` at `repoRoot`
+ * to:
+ *   - look up the default name when `CONFIG` is unset
+ *   - validate `CONFIG` against the declared allowlist
+ *
+ * @param repoRoot Absolute path to the api-test-generator repository
+ *   root (the directory containing `configs.json`).
+ */
+export function getActiveConfigName(repoRoot: string): string {
+  return resolveActiveConfigName(loadConfigsIndex(repoRoot));
 }
 
 export function getActiveConfigDir(repoRoot: string): string {
@@ -108,8 +120,12 @@ export interface PlaywrightCodegenOptions {
  * non-boolean `recordResponses`, throws. Missing keys default.
  */
 export function getPlaywrightCodegenOptions(repoRoot: string): PlaywrightCodegenOptions {
+  // Single-pass: load configs.json exactly once and resolve the active
+  // config name against that same snapshot. Calling getActiveConfigName()
+  // here would re-read the file and could observe a different on-disk
+  // state from the one we then index into below.
   const index = loadConfigsIndex(repoRoot);
-  const name = getActiveConfigName(repoRoot);
+  const name = resolveActiveConfigName(index);
   const entry = index.configs[name];
   if (!isRecord(entry)) {
     return { recordResponses: true };

--- a/tests/codegen/config-resolver-codegen-options.test.ts
+++ b/tests/codegen/config-resolver-codegen-options.test.ts
@@ -1,0 +1,76 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { getPlaywrightCodegenOptions } from '../../path-analyser/src/configResolver.ts';
+
+// Each test materialises a fresh temp directory containing a configs.json
+// with a single active config named "scratch", then invokes
+// getPlaywrightCodegenOptions against it. The active config name comes from
+// process.env.CONFIG; we set it explicitly per test and restore the
+// previous value so other tests in the suite aren't affected.
+
+describe('getPlaywrightCodegenOptions', () => {
+  let tmp: string;
+  let prevConfig: string | undefined;
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'configres-'));
+    prevConfig = process.env.CONFIG;
+    process.env.CONFIG = 'scratch';
+  });
+
+  afterEach(async () => {
+    if (prevConfig === undefined) delete process.env.CONFIG;
+    else process.env.CONFIG = prevConfig;
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  async function writeConfig(scratchEntry: unknown): Promise<void> {
+    const content = {
+      default: 'scratch',
+      configs: { scratch: scratchEntry },
+    };
+    await fs.writeFile(path.join(tmp, 'configs.json'), JSON.stringify(content), 'utf8');
+  }
+
+  test('defaults to recordResponses=true when the config has no codegen block', async () => {
+    await writeConfig({ description: 'test' });
+    expect(getPlaywrightCodegenOptions(tmp)).toEqual({ recordResponses: true });
+  });
+
+  test('defaults to recordResponses=true when codegen has no playwright block', async () => {
+    await writeConfig({ codegen: {} });
+    expect(getPlaywrightCodegenOptions(tmp)).toEqual({ recordResponses: true });
+  });
+
+  test('defaults to recordResponses=true when playwright omits recordResponses', async () => {
+    await writeConfig({ codegen: { playwright: {} } });
+    expect(getPlaywrightCodegenOptions(tmp)).toEqual({ recordResponses: true });
+  });
+
+  test('returns recordResponses=true when explicitly set', async () => {
+    await writeConfig({ codegen: { playwright: { recordResponses: true } } });
+    expect(getPlaywrightCodegenOptions(tmp)).toEqual({ recordResponses: true });
+  });
+
+  test('returns recordResponses=false when explicitly set', async () => {
+    await writeConfig({ codegen: { playwright: { recordResponses: false } } });
+    expect(getPlaywrightCodegenOptions(tmp)).toEqual({ recordResponses: false });
+  });
+
+  test('throws when codegen is a non-object', async () => {
+    await writeConfig({ codegen: 'invalid' });
+    expect(() => getPlaywrightCodegenOptions(tmp)).toThrow(/codegen must be an object/);
+  });
+
+  test('throws when codegen.playwright is a non-object', async () => {
+    await writeConfig({ codegen: { playwright: 'invalid' } });
+    expect(() => getPlaywrightCodegenOptions(tmp)).toThrow(/playwright must be an object/);
+  });
+
+  test('throws when recordResponses is a non-boolean', async () => {
+    await writeConfig({ codegen: { playwright: { recordResponses: 'yes' } } });
+    expect(() => getPlaywrightCodegenOptions(tmp)).toThrow(/recordResponses must be a boolean/);
+  });
+});

--- a/tests/codegen/materialize-support.test.ts
+++ b/tests/codegen/materialize-support.test.ts
@@ -123,6 +123,31 @@ describe('materializeSupport', () => {
     expect(entries).toEqual(expected);
   });
 
+  test('excludeSupportFiles removes a stale file left from a previous run', async () => {
+    // Review-comment guard (#156 review): production pipelines wipe outDir
+    // before materializing, but the legacy emitPlaywrightSuite entry point
+    // does not, and a hand-call against an existing suite must not silently
+    // ship a helper the caller meant to exclude. Materialize once with the
+    // recorder included, then re-materialize with it excluded and assert
+    // the stale recorder.ts is gone.
+    await materializeSupport(tmp);
+    expect(existsSync(path.join(tmp, SUPPORT_DIR_NAME, 'recorder.ts'))).toBe(true);
+    await materializeSupport(tmp, undefined, undefined, true, ['recorder.ts']);
+    expect(existsSync(path.join(tmp, SUPPORT_DIR_NAME, 'recorder.ts'))).toBe(false);
+    // And the non-excluded files are still present.
+    expect(existsSync(path.join(tmp, SUPPORT_DIR_NAME, 'seeding.ts'))).toBe(true);
+  });
+
+  test('excludeSupportFiles rejects names that are not in SUPPORT_TEMPLATE_FILES', async () => {
+    // Review-comment guard (#156 review): typos in excludeSupportFiles
+    // would otherwise silently no-op and the caller would keep shipping
+    // the helper they thought they were excluding. The validator surfaces
+    // the bad name in the error message so the fix site is obvious.
+    await expect(
+      materializeSupport(tmp, undefined, undefined, true, ['no-such-file.ts']),
+    ).rejects.toThrow(/excludeSupportFiles contains unknown name "no-such-file\.ts"/);
+  });
+
   test('fails with a clear filesystem error when a required support template is missing', async () => {
     const fakeSrc = await fs.mkdtemp(path.join(os.tmpdir(), 'mat-support-src-'));
     try {

--- a/tests/codegen/materialize-support.test.ts
+++ b/tests/codegen/materialize-support.test.ts
@@ -112,6 +112,17 @@ describe('materializeSupport', () => {
     }
   });
 
+  test('excludeSupportFiles skips listed files in support/ but keeps the rest', async () => {
+    // Exercises the gate behind configs.json#codegen.playwright.recordResponses=false:
+    // the call site drops recorder.ts when no recordResponse() call will be
+    // emitted into the suite. Other support files must remain — they're part
+    // of the suite's runtime contract regardless of the recorder option.
+    await materializeSupport(tmp, undefined, undefined, true, ['recorder.ts']);
+    const entries = (await fs.readdir(path.join(tmp, SUPPORT_DIR_NAME))).sort();
+    const expected = SUPPORT_TEMPLATE_FILES.filter((f) => f !== 'recorder.ts').sort();
+    expect(entries).toEqual(expected);
+  });
+
   test('fails with a clear filesystem error when a required support template is missing', async () => {
     const fakeSrc = await fs.mkdtemp(path.join(os.tmpdir(), 'mat-support-src-'));
     try {

--- a/tests/codegen/playwright-record-responses.test.ts
+++ b/tests/codegen/playwright-record-responses.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test } from 'vitest';
+import { existsSync, promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import {
+  emitPlaywrightSuite,
   PlaywrightEmitter,
   renderPlaywrightSuite,
 } from '../../path-analyser/src/codegen/playwright/emitter.ts';
@@ -101,5 +105,50 @@ describe('emitter: recordResponses option gates recorder import + per-step call'
     });
     expect(off).not.toContain('recordResponse');
     expect(on).toContain('await recordResponse({');
+  });
+});
+
+// Review-comment guard (#156): the legacy filesystem-writing entry point
+// emitPlaywrightSuite() must keep the suite source and the vendored
+// support/ in sync with the recordResponses option. Pre-fix it always
+// called materializeSupport() without forwarding the option, so a caller
+// with recordResponses=false would get a suite without the import/call
+// but still ship recorder.ts on disk.
+describe('emitPlaywrightSuite legacy entry point keeps support/ in sync with recordResponses', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'emit-pw-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  test('recordResponses=false produces a suite whose support/ does not contain recorder.ts', async () => {
+    await emitPlaywrightSuite(COLLECTION_WITH_STEP, {
+      outDir: tmp,
+      suiteName: 'createWidget',
+      mode: 'feature',
+      recordResponses: false,
+    });
+    expect(existsSync(path.join(tmp, 'support', 'recorder.ts'))).toBe(false);
+    // Spec source must also be free of recorder references — the two
+    // halves of the gate (rendered source + vendored helpers) must move
+    // together.
+    const spec = await fs.readFile(path.join(tmp, 'createWidget.feature.spec.ts'), 'utf8');
+    expect(spec).not.toContain('recordResponse');
+  });
+
+  test('recordResponses=true (and default) still vendors recorder.ts alongside the spec', async () => {
+    await emitPlaywrightSuite(COLLECTION_WITH_STEP, {
+      outDir: tmp,
+      suiteName: 'createWidget',
+      mode: 'feature',
+      // recordResponses omitted — default-true path.
+    });
+    expect(existsSync(path.join(tmp, 'support', 'recorder.ts'))).toBe(true);
+    const spec = await fs.readFile(path.join(tmp, 'createWidget.feature.spec.ts'), 'utf8');
+    expect(spec).toContain('await recordResponse({');
   });
 });

--- a/tests/codegen/playwright-record-responses.test.ts
+++ b/tests/codegen/playwright-record-responses.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'vitest';
+import {
+  PlaywrightEmitter,
+  renderPlaywrightSuite,
+} from '../../path-analyser/src/codegen/playwright/emitter.ts';
+import type { EndpointScenarioCollection } from '../../path-analyser/src/types.ts';
+
+// Class-scoped guard for the `recordResponses` codegen option
+// (configs.json#configs.<active>.codegen.playwright.recordResponses). The
+// option gates two related emissions in lockstep — the import statement
+// for `recordResponse`/`sanitizeBody` and the per-step
+// `try { ... await recordResponse({...}) ... } catch {}` block — so a future
+// regression that flips only one of them (leaving a dangling import or an
+// orphan call) will fail one of the assertions below.
+const COLLECTION_WITH_STEP: EndpointScenarioCollection = {
+  endpoint: { operationId: 'createWidget', method: 'POST', path: '/widgets' },
+  requiredSemanticTypes: [],
+  optionalSemanticTypes: [],
+  scenarios: [
+    {
+      id: 'sc1',
+      name: 'happy path',
+      operations: [{ operationId: 'createWidget', method: 'POST', path: '/widgets' }],
+      producedSemanticTypes: [],
+      satisfiedSemanticTypes: [],
+      requestPlan: [
+        {
+          operationId: 'createWidget',
+          method: 'POST',
+          pathTemplate: '/widgets',
+          expect: { status: 200 },
+          bodyTemplate: { name: 'static' },
+        },
+      ],
+    },
+  ],
+};
+
+describe('emitter: recordResponses option gates recorder import + per-step call', () => {
+  test('recordResponses=true emits both the import and the per-step recordResponse block', async () => {
+    const [file] = await PlaywrightEmitter.emit(COLLECTION_WITH_STEP, {
+      outDir: '/unused',
+      suiteName: 'createWidget',
+      mode: 'feature',
+      recordResponses: true,
+    });
+    expect(file.content).toContain(
+      "import { recordResponse, sanitizeBody } from './support/recorder';",
+    );
+    expect(file.content).toContain('await recordResponse({');
+    expect(file.content).toContain('sanitizeBody(bodyJson)');
+  });
+
+  test('recordResponses=false drops both the import and the per-step recordResponse block', async () => {
+    const [file] = await PlaywrightEmitter.emit(COLLECTION_WITH_STEP, {
+      outDir: '/unused',
+      suiteName: 'createWidget',
+      mode: 'feature',
+      recordResponses: false,
+    });
+    // Neither symbol may appear anywhere — the gate must lift the import
+    // (otherwise the suite has a dead import that biome would flag) AND
+    // the call (otherwise the suite references an unimported symbol).
+    expect(file.content).not.toContain('recordResponse');
+    expect(file.content).not.toContain('sanitizeBody');
+    expect(file.content).not.toContain("from './support/recorder'");
+  });
+
+  test('recordResponses omitted defaults to the recording behaviour (preserves pre-config emit)', async () => {
+    // Defaulting to `true` keeps the pre-option output byte-stable: a caller
+    // that never sets the field must see the same suite the previous
+    // generator emitted.
+    const [withDefault] = await PlaywrightEmitter.emit(COLLECTION_WITH_STEP, {
+      outDir: '/unused',
+      suiteName: 'createWidget',
+      mode: 'feature',
+    });
+    const [withExplicitTrue] = await PlaywrightEmitter.emit(COLLECTION_WITH_STEP, {
+      outDir: '/unused',
+      suiteName: 'createWidget',
+      mode: 'feature',
+      recordResponses: true,
+    });
+    expect(withDefault.content).toBe(withExplicitTrue.content);
+    expect(withDefault.content).toContain('await recordResponse({');
+  });
+
+  test('renderPlaywrightSuite honours the option independently of the Emitter wrapper', async () => {
+    // The pure render function and the Emitter wrapper both flow through
+    // buildSuiteSource; the assertion below guards against the option being
+    // wired to only one entry point.
+    const off = renderPlaywrightSuite(COLLECTION_WITH_STEP, {
+      suiteName: 'createWidget',
+      mode: 'feature',
+      recordResponses: false,
+    });
+    const on = renderPlaywrightSuite(COLLECTION_WITH_STEP, {
+      suiteName: 'createWidget',
+      mode: 'feature',
+      recordResponses: true,
+    });
+    expect(off).not.toContain('recordResponse');
+    expect(on).toContain('await recordResponse({');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `configs.<name>.codegen.playwright.recordResponses` (boolean) to [configs.json](configs.json). When `false`, the Playwright emitter omits the `import { recordResponse, sanitizeBody } from './support/recorder';` line, the per-step `try { ... await recordResponse({...}) ... } catch {}` block, and the `recorder.ts` vendoring under the suite's `support/` directory — all in lockstep.
- **Sets `camunda-oca` explicitly to `false`.** The SDK example workflows that consume the emitted suite don't run `observe:aggregate`, so the recorder boilerplate is dead weight here. Flipping the config back to `true` re-enables it for any consumer that wants the JSONL.
- Resolver-level default for any future config stays `true` (preserves the pre-config emit for callers that omit the option entirely) — see `getPlaywrightCodegenOptions(repoRoot)` in [path-analyser/src/configResolver.ts](path-analyser/src/configResolver.ts) with strict shape validation: malformed `codegen` / `codegen.playwright` / non-boolean `recordResponses` throws; missing keys default.
- Locks the `camunda-oca` choice with a Layer-3 invariant: **no** emitted `*.feature.spec.ts` may contain the substring `recordResponse`. Flipping the config back to `true` without updating the invariant fails loudly. The substring guard also catches partial-gating regressions (import without call, or vice versa).
- Refreshes [path-analyser/README.md](path-analyser/README.md) so the "Response Shape Recorder" section documents the new gate and notes the camunda-oca default.

Closes #155

## Why

The recorder is build-time policy of one downstream workflow (`observe:aggregate`), not a runtime requirement of the emitted suite. Consumers who don't aggregate observations inherit ~30 lines of `try/recordResponse/catch` per step, a runtime helper in `support/`, and a `dist/runtime-observations/` write side-effect for nothing. The active `camunda-oca` config falls in that bucket today, so it opts out by default.

## Observable-behaviour change

For `camunda-oca`: every regenerated `*.feature.spec.ts` loses the per-step recorder block and the `recorder` import; `recorder.ts` is no longer vendored under `support/`. Re-enabled by setting `configs.camunda-oca.codegen.playwright.recordResponses` back to `true`.

`observe:aggregate` itself still exists and works — it just operates on whatever JSONL is present, which will be empty until a config opts back in.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` for all three workspace tsconfigs — clean
- [x] `SPEC_REF=<pinned> npm run fetch-spec:ref && TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation` — clean
- [x] `npm test` — 37 files / 272 passed / 6 skipped
- [x] Spot-checked a regenerated spec: `grep -c recordResponse generated/camunda-oca/playwright/deleteProcessInstance.feature.spec.ts` → 0; `support/` no longer contains `recorder.ts`
- [x] New emitter unit tests in [tests/codegen/playwright-record-responses.test.ts](tests/codegen/playwright-record-responses.test.ts) — assert on/off/omitted/render-entry-point parity (4 tests)
- [x] New configResolver unit tests in [tests/codegen/config-resolver-codegen-options.test.ts](tests/codegen/config-resolver-codegen-options.test.ts) — 5 valid-input cases (defaults at three levels + explicit true/false), 3 throw cases for malformed input
- [x] Extended `materialize-support.test.ts` — `excludeSupportFiles` skips listed file but keeps the rest
- [x] Inverted Layer-3 invariant in [configs/camunda-oca/regression-invariants.test.ts](configs/camunda-oca/regression-invariants.test.ts) — class-scoped guard that **no** emitted spec contains `recordResponse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)