### PR TITLE
fix: emitter drops redundant `=== undefined` guard for bindings covered by globalContextSeeds (#157)

### DIFF
--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -210,7 +210,17 @@ function renderScenarioTest(
   // (non-PENDING) values for compatibility with downstream lookup, but
   // delegates "should this be seeded at runtime" entirely to
   // `seedBindings`.
-  const seedBindingsList = s.seedBindings ?? [];
+  //
+  // Issue #157: when a binding name is also a globalContextSeeds entry,
+  // the universal-seed prologue below (`??` form) is authoritative —
+  // it covers both `null` and `undefined`, uses the explicit `seedRule`
+  // from domain-semantics (which can differ from the binding name), and
+  // runs unconditionally before step 0. The seedBindings loop's
+  // `=== undefined` form would be strictly redundant for those bindings,
+  // so we filter them out here. The seedBindings loop now handles only
+  // bindings the universal-seed prologue does NOT cover.
+  const globalSeedNames = new Set(globalContextSeeds.map((seed) => seed.binding));
+  const seedBindingsList = (s.seedBindings ?? []).filter((k) => !globalSeedNames.has(k));
   if (s.bindings && Object.keys(s.bindings).length) {
     body.push('  // Seed scenario bindings');
     for (const [k, v] of Object.entries(s.bindings)) {
@@ -239,8 +249,10 @@ function renderScenarioTest(
   // Each entry emits a single nullish-coalesced assignment that is idempotent
   // over both bindings-loop outcomes above:
   //   - literal binding (`ctx['<k>'] = "value";`) — `??` short-circuits, value preserved
-  //   - seedBindings entry already seeded by the `=== undefined` guard — `??` short-circuits
   //   - no assignment at all (fresh `ctx`) — `??` falls through to seedBinding(...)
+  // The seedBindings loop above no longer overlaps with this prologue
+  // (#157 — globalContextSeeds names are filtered out of seedBindingsList),
+  // so this is the authoritative pre-step-0 seeder for every entry here.
   // `??` (not `=== undefined`) is intentional: any nullish binding value
   // (`null` or `undefined`) is treated as missing and triggers seeding.
   // The planner does not currently emit `null` literals in `s.bindings`

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -198,27 +198,36 @@ function renderScenarioTest(
   // numeric keys, structured response payloads). Reads from ctx flow into
   // request bodies that are themselves untyped, so no narrowing is needed.
   body.push(`  const ctx: Record<string, unknown> = {};`);
-  // Issue #136: scenario.seedBindings is the planner's authoritative
-  // answer to "which bindings need a runtime seedBinding() call before
-  // step 0". Pre-#136 the emitter re-derived this from
-  // `bindings ∪ requestPlan` and skipped any PENDING binding that
-  // appeared as an extract target anywhere in the plan — which broke
-  // the establisher's own base scenario, where the body input is
-  // also extracted from the same step's response (extract runs AFTER
-  // the request body is built, so no seed → undefined → 400). We now
-  // trust the planner. The `bindings` loop below still emits literal
-  // (non-PENDING) values for compatibility with downstream lookup, but
-  // delegates "should this be seeded at runtime" entirely to
-  // `seedBindings`.
+  // Runtime seeding has two distinct sources, both of which must complete
+  // before step 0 begins:
   //
-  // Issue #157: when a binding name is also a globalContextSeeds entry,
-  // the universal-seed prologue below (`??` form) is authoritative —
-  // it covers both `null` and `undefined`, uses the explicit `seedRule`
-  // from domain-semantics (which can differ from the binding name), and
-  // runs unconditionally before step 0. The seedBindings loop's
-  // `=== undefined` form would be strictly redundant for those bindings,
-  // so we filter them out here. The seedBindings loop now handles only
-  // bindings the universal-seed prologue does NOT cover.
+  //   1. Planner-driven (`scenario.seedBindings`, #136): the planner is
+  //      the authority on which bindings need a `seedBinding()` call
+  //      because a later step references them but no extract has
+  //      produced them yet. Pre-#136 the emitter re-derived this from
+  //      `bindings ∪ requestPlan` and skipped any PENDING binding that
+  //      appeared as an extract target anywhere in the plan — which broke
+  //      the establisher's own base scenario, where the body input is
+  //      also extracted from the same step's response (extract runs AFTER
+  //      the request body is built, so no seed → undefined → 400). We now
+  //      trust the planner's list verbatim.
+  //
+  //   2. Config-driven (`globalContextSeeds`, sourced from
+  //      `domain-semantics.json`): every emitted scenario must seed
+  //      certain universal bindings (e.g. the default-tenant identifier
+  //      under single-tenant mode). Handled by the "universal-seed
+  //      prologue" further down.
+  //
+  // When the same binding name appears in BOTH lists, the universal-seed
+  // prologue is authoritative (#157): its `??` form is strictly more
+  // defensive (covers `null` and `undefined`), uses the explicit
+  // `seedRule` from the config (which can differ from the binding name),
+  // and runs unconditionally before step 0. We therefore filter such
+  // names out of `seedBindingsList` so the redundant `=== undefined`
+  // guard isn't emitted. The `bindings` loop still emits literal
+  // (non-PENDING) values; the seedBindings list never contains literals
+  // (computeSeedBindings filters them out), so the loops are
+  // non-overlapping.
   const globalSeedNames = new Set(globalContextSeeds.map((seed) => seed.binding));
   const seedBindingsList = (s.seedBindings ?? []).filter((k) => !globalSeedNames.has(k));
   if (s.bindings && Object.keys(s.bindings).length) {

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -201,24 +201,46 @@ describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? 
     expect(content).not.toMatch(/__seededTenant/);
   });
 
-  test('__PENDING__ tenantIdVar listed in seedBindings emits a guarded auto-seed and the ?? fallback exactly once', async () => {
+  test('__PENDING__ tenantIdVar in seedBindings emits only the ?? fallback when tenantIdVar is also a globalContextSeeds entry (#157)', async () => {
     const content = await renderFirst(
       buildCollectionWithBindings(
         { tenantIdVar: '__PENDING__' },
         { templateRefsTenant: true, seedBindings: ['tenantIdVar'] },
       ),
     );
-    // Issue #136: the planner-emitted seedBindings list is now the
-    // authority. The emitter's seedBindings prologue runs *before* the
-    // universal-seed prologue, so a duplicate seedBinding call there
-    // would be wasted. The `??` line then short-circuits over it.
+    // Issue #157: when the same binding name appears in BOTH scenario.seedBindings
+    // (planner output) and globalContextSeeds (config), the universal-seed
+    // prologue's `??` form is authoritative — it covers both `null` and
+    // `undefined`, uses the explicit `seedRule` from the config (which can
+    // differ from the binding name), and runs unconditionally before step 0.
+    // The seedBindings loop must skip the binding so the emitted suite has
+    // no `=== undefined` guard for it.
     //
-    // Asserting exactly-one occurrence is a class-scoped guard against the
-    // emitter regressing and re-emitting the pre-#86 guard form in the
-    // universal-seed prologue as well (which would push the count to 2).
-    expect(countOccurrences(content, FULL_TENANT_GUARD)).toBe(1);
+    // Pre-#157 the emitter emitted both the guard and the `??` fallback for
+    // every overlapping binding — three lines of dead code per scenario step.
+    expect(countOccurrences(content, FULL_TENANT_GUARD)).toBe(0);
     expect(countOccurrences(content, TENANT_FALLBACK)).toBe(1);
     expect(content).not.toMatch(/__seededTenant/);
+  });
+
+  test('seedBindings entry NOT in globalContextSeeds still emits the `=== undefined` guard (#157 — pin both directions of the filter)', async () => {
+    // Class-scoped guard for the new filter. The fix in #157 must only
+    // drop bindings covered by globalContextSeeds; bindings that the
+    // planner needs seeded pre-step-0 but which have no domain-semantics
+    // entry must still produce the `=== undefined` guard form, because
+    // the universal-seed prologue won't cover them.
+    //
+    // A binding NOT in globalContextSeeds and listed in seedBindings:
+    const widgetKeyGuard = `if (ctx['widgetKeyVar'] === undefined) { ctx['widgetKeyVar'] = seedBinding('widgetKeyVar'); }`;
+    const content = await renderFirst(
+      buildCollectionWithBindings(
+        { widgetKeyVar: '__PENDING__' },
+        { seedBindings: ['widgetKeyVar'] },
+      ),
+    );
+    expect(countOccurrences(content, widgetKeyGuard)).toBe(1);
+    // And it does NOT receive a `??` line (because it's not in globalContextSeeds).
+    expect(content).not.toContain(`ctx['widgetKeyVar'] = ctx['widgetKeyVar'] ?? seedBinding(`);
   });
 
   test('literal tenantIdVar still seeds even when an extract targets the same binding (#136)', async () => {


### PR DESCRIPTION
## Summary

- For any binding name that appears in **both** `scenario.seedBindings` (planner output) and `globalContextSeeds[].binding` (domain-semantics config), the emitter was producing two pre-step-0 assignments to `ctx[<name>]`. The first is dead — `??` covers both `null` and `undefined`, runs unconditionally before step 0, and uses the explicit `seedRule` from the config (which can differ from the binding name).
- Filters `seedBindings` to drop names covered by `globalContextSeeds`. The universal-seed prologue (`??` form) becomes authoritative for those bindings; the seedBindings loop continues to handle bindings the prologue does NOT cover.

Closes #157

## Reproducer (before this PR)

Every emitted scenario for an operation whose body references `${tenantIdVar}` contained:

```ts
if (ctx['tenantIdVar'] === undefined) {
  ctx['tenantIdVar'] = seedBinding('tenantIdVar');
}
ctx['tenantIdVar'] = ctx['tenantIdVar'] ?? seedBinding('tenantIdVar');
```

After this PR (regenerated `generated/camunda-oca/playwright/deleteProcessInstance.feature.spec.ts:15`):

```ts
ctx.tenantIdVar = ctx.tenantIdVar ?? seedBinding('tenantIdVar');
```

Class-scoped sweep across all 186 regenerated `*.feature.spec.ts`: zero instances of the redundant `=== undefined` guard for `tenantIdVar`; 186 of the `??` fallback.

## Red / green / class-scoped

Per AGENTS.md bug-fix discipline:

1. **Red** — re-targeted the existing #136 test ([tests/codegen/playwright-emitter.test.ts:204](tests/codegen/playwright-emitter.test.ts#L204)) to assert `FULL_TENANT_GUARD` count is 0 (was: 1). Confirmed failing on `main`'s emitter logic before the production change:

   ```
   AssertionError: expected 1 to be +0 // Object.is equality
   - Expected   0
   + Received   1
   ```

2. **Green** — filter applied at [path-analyser/src/codegen/playwright/emitter.ts:233](path-analyser/src/codegen/playwright/emitter.ts#L233):

   ```ts
   const globalSeedNames = new Set(globalContextSeeds.map((seed) => seed.binding));
   const seedBindingsList = (s.seedBindings ?? []).filter((k) => !globalSeedNames.has(k));
   ```

3. **Class-scoped** — new sibling test pins the opposite direction: a binding in `seedBindings` but NOT in `globalContextSeeds` must still receive the `=== undefined` guard form (because the prologue won't cover it). Uses `widgetKeyVar` (no domain-semantics entry) as the witness. Catches a future regression that over-filters and drops legitimate seedBindings emissions.

## Intentional behaviour change to an existing fixture

Per AGENTS.md ("Behaviour tests are the regression guard ... If a change intentionally modifies observable behaviour ..., update the affected fixtures/invariants and explicitly document and justify the intended behaviour change in the PR"):

The #136 test previously asserted `FULL_TENANT_GUARD` count = 1 with the justification "the planner-emitted seedBindings list is now the authority". This PR narrows that authority: the planner is authoritative *for bindings without a `globalContextSeeds` entry*. For bindings covered by both lists, the universal-seed prologue is canonical (it carries strictly more information — explicit `seedRule`, `??` semantics).

The other three tests in the same `describe` block (literal-binding, literal+extract, no-binding) were unaffected and continue to pass.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` for all three workspace tsconfigs — clean
- [x] `TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation` — clean
- [x] `npm test` — 35 files / 259 passed / 6 skipped
- [x] Spot-checked `generated/camunda-oca/playwright/deleteProcessInstance.feature.spec.ts:15` — single `??` line, no preceding guard
- [x] Class-scoped grep across all 186 regenerated `*.feature.spec.ts`: 0 redundant guards, 186 `??` fallbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)