### PR TITLE
feat: fixture selection by required state instead of preferJobType heuristic (#159 PR A)

### DIFF
--- a/configs/camunda-oca/domain-semantics.json
+++ b/configs/camunda-oca/domain-semantics.json
@@ -33,6 +33,13 @@
       "producedBy": ["createProcessInstance"],
       "requires": ["ProcessDefinitionDeployed"]
     },
+    "ProcessInstanceCompleted": {
+      "kind": "state",
+      "parameter": "processInstanceKey",
+      "producedBy": ["createProcessInstance"],
+      "requires": ["ProcessDefinitionDeployed"],
+      "$comment": "Holds when a created instance has reached COMPLETED without external coordination. Provided by deploying a BPMN model whose execution path reaches an end event with no service tasks / user tasks / external blockers (e.g. bpmn/simple.bpmn). PR A of #159 introduces this state and uses it for the fixture selector; PR B will mark it `eventual` and inject an awaitEventually(getProcessInstance, body.state === 'COMPLETED') wait between producer and consumer."
+    },
     "JobAvailableForActivation": {
       "kind": "state",
       "parameters": ["jobType", "processDefinitionId"],
@@ -81,6 +88,9 @@
     "searchProcessInstances": {
       "requires": ["ProcessInstanceExists"]
     },
+    "deleteProcessInstance": {
+      "requires": ["ProcessInstanceCompleted"]
+    },
     "createDeployment": {
       "valueBindings": {
         "response.deployments[].processDefinition.processDefinitionId": "ProcessDefinitionDeployed.processDefinitionId",
@@ -94,7 +104,9 @@
   },
   "artifactKinds": {
     "bpmnProcess": {
-      "producesStates": ["ProcessDefinitionDeployed", "ModelHasServiceTaskType"],
+      "$comment": "Kind-level producesStates lists what EVERY bpmnProcess fixture deploys. producibleStates lists what SOME fixture of this kind can deliver (planner uses producesStates ∪ producibleStates for chain-feasibility BFS; the selector matches per-fixture providesStates in path-analyser/fixtures/deployment-artifacts.json at emission time). See #159.",
+      "producesStates": ["ProcessDefinitionDeployed"],
+      "producibleStates": ["ModelHasServiceTaskType", "ProcessInstanceCompleted"],
       "producesSemantics": ["ProcessDefinitionKey"],
       "identifierType": "ProcessDefinitionId",
       "deploymentSlices": ["processDefinition"]

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1409,6 +1409,112 @@ describeForThisConfig('bundled-spec invariants: emitted Playwright suite', () =>
   });
 });
 
+describeForThisConfig('bundled-spec invariants: fixture selection by required state (#159)', () => {
+  // PR A of #159: fixture selection generalises the `preferJobType=true`
+  // hack into state-based matching. The chosen `*.bpmn` for each
+  // `createDeployment` step must satisfy the chain's effective requirement
+  // set — driven by the consumer ops' `operationRequirements.X.requires`.
+  //
+  // The two invariants below pin both directions:
+  //   1. deleteProcessInstance requires ProcessInstanceCompleted; only
+  //      bpmn/simple.bpmn provides it. The emitted spec MUST reference
+  //      simple.bpmn.
+  //   2. activateJobs requires ModelHasServiceTaskType; only
+  //      bpmn/service-task.bpmn provides it. The emitted spec MUST keep
+  //      referencing service-task.bpmn (regression guard for the move of
+  //      ModelHasServiceTaskType from artifactKinds-level to per-fixture).
+  // Together they prove the selector actually discriminates between
+  // fixtures — not just "always returns the first one".
+
+  it('deleteProcessInstance.feature.spec.ts deploys bpmn/simple.bpmn (requires ProcessInstanceCompleted)', () => {
+    const spec = join(GENERATED_TESTS_DIR, 'deleteProcessInstance.feature.spec.ts');
+    if (!existsSync(spec)) {
+      throw new Error(`expected emitted spec ${spec} not found — run 'npm run testsuite:generate'`);
+    }
+    const src = readFileSync(spec, 'utf8');
+    expect(src, 'deleteProcessInstance must deploy the instantly-completing fixture').toContain(
+      '@@FILE:bpmn/simple.bpmn',
+    );
+    expect(src, 'deleteProcessInstance must NOT deploy service-task.bpmn').not.toContain(
+      '@@FILE:bpmn/service-task.bpmn',
+    );
+  });
+
+  it('activateJobs.feature.spec.ts still deploys bpmn/service-task.bpmn (requires ModelHasServiceTaskType)', () => {
+    const spec = join(GENERATED_TESTS_DIR, 'activateJobs.feature.spec.ts');
+    if (!existsSync(spec)) {
+      throw new Error(`expected emitted spec ${spec} not found — run 'npm run testsuite:generate'`);
+    }
+    const src = readFileSync(spec, 'utf8');
+    expect(src, 'activateJobs must deploy the service-task fixture').toContain(
+      '@@FILE:bpmn/service-task.bpmn',
+    );
+  });
+
+  it('every entry in deployment-artifacts.json#providesStates is acknowledged by its kind (#159)', () => {
+    // Class-scoped coherence check between the fixture registry and
+    // domain-semantics. For every registry entry e, every state in
+    // e.providesStates MUST appear in either
+    // artifactKinds.<e.kind>.producibleStates or .producesStates — and
+    // be declared in runtimeStates ∪ capabilities. Catches typos and
+    // half-finished registry edits before they reach a codegen run.
+    interface RegistryEntry {
+      kind: string;
+      path: string;
+      providesStates?: string[];
+    }
+    interface ArtifactKindSpec {
+      producesStates?: string[];
+      producibleStates?: string[];
+    }
+    interface DomainSemanticsShape {
+      runtimeStates?: Record<string, unknown>;
+      capabilities?: Record<string, unknown>;
+      artifactKinds?: Record<string, ArtifactKindSpec>;
+    }
+    const registryPath = join(REPO_ROOT, 'path-analyser', 'fixtures', 'deployment-artifacts.json');
+    const registryRaw = readFileSync(registryPath, 'utf8');
+    // biome-ignore lint/plugin: parsed JSON is a runtime contract boundary
+    const registry = JSON.parse(registryRaw) as { artifacts?: RegistryEntry[] };
+
+    const dsPath = join(REPO_ROOT, 'configs', CONFIG_NAME, 'domain-semantics.json');
+    const dsRaw = readFileSync(dsPath, 'utf8');
+    // biome-ignore lint/plugin: parsed JSON is a runtime contract boundary
+    const ds = JSON.parse(dsRaw) as DomainSemanticsShape;
+    const declaredStates = new Set<string>([
+      ...Object.keys(ds.runtimeStates ?? {}),
+      ...Object.keys(ds.capabilities ?? {}),
+    ]);
+
+    const offenders: { entry: string; state: string; reason: string }[] = [];
+    for (const e of registry.artifacts ?? []) {
+      for (const state of e.providesStates ?? []) {
+        if (!declaredStates.has(state)) {
+          offenders.push({
+            entry: e.path,
+            state,
+            reason: 'not declared in runtimeStates or capabilities',
+          });
+          continue;
+        }
+        const kindSpec = ds.artifactKinds?.[e.kind];
+        const ack = new Set<string>([
+          ...(kindSpec?.producesStates ?? []),
+          ...(kindSpec?.producibleStates ?? []),
+        ]);
+        if (!ack.has(state)) {
+          offenders.push({
+            entry: e.path,
+            state,
+            reason: `not in artifactKinds.${e.kind}.producibleStates or .producesStates`,
+          });
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
 describeForThisConfig('bundled-spec invariants: emitted Playwright variant suite (#105)', () => {
   it('every variant scenario file is materialised as a *.variant.spec.ts (#105)', () => {
     // Class-scoped guard for Phase 3 of #105: the codegen pipeline must

--- a/path-analyser/domain-semantics.schema.json
+++ b/path-analyser/domain-semantics.schema.json
@@ -65,13 +65,14 @@
       }
     },
     "artifactKinds": {
-      "description": "Declarations of deployable artifact kinds (e.g. bpmnProcess). `producesStates` and `producesSemantics` cross-references are enforced at load time by domainSemanticsValidator.ts.",
+      "description": "Declarations of deployable artifact kinds (e.g. bpmnProcess). `producesStates`, `producibleStates`, and `producesSemantics` cross-references are enforced at load time by domainSemanticsValidator.ts.",
       "type": "object",
       "additionalProperties": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
           "producesStates": {"type": "array", "items": {"type": "string"}},
+          "producibleStates": {"type": "array", "items": {"type": "string"}},
           "producesSemantics": {"type": "array", "items": {"type": "string"}},
           "identifierType": {"type": "string"},
           "deploymentSlices": {"type": "array", "items": {"type": "string"}}

--- a/path-analyser/fixtures/deployment-artifacts.json
+++ b/path-analyser/fixtures/deployment-artifacts.json
@@ -1,10 +1,18 @@
 {
+  "$comment": "Fixture registry consumed by chooseFixtureFromRegistry() in path-analyser/src/index.ts. Each entry's `providesStates` lists the runtime characteristics this specific fixture provides BEYOND what its `kind` already guarantees in artifactKinds.<kind>.producesStates. The selector picks the entry whose effective providesStates (entry ∪ kind) covers the chain's required states; ties break by smallest providesStates set, then by array order here. See #159.",
   "artifacts": [
     {
       "kind": "bpmnProcess",
       "path": "bpmn/service-task.bpmn",
-      "description": "BPMN process with a service task and zeebe:taskDefinition type sampleJobType",
+      "description": "BPMN process with a service task and zeebe:taskDefinition type sampleJobType. Selected for chains whose consumer ops require ModelHasServiceTaskType (e.g. activateJobs, completeJob, failJob).",
+      "providesStates": ["ModelHasServiceTaskType"],
       "parameters": { "jobType": "sampleJobType" }
+    },
+    {
+      "kind": "bpmnProcess",
+      "path": "bpmn/simple.bpmn",
+      "description": "Start → end only. An instance created from this BPMN reaches COMPLETED without external coordination (no service tasks, no user tasks, no timer events). Selected for chains whose consumer ops require ProcessInstanceCompleted (e.g. deleteProcessInstance).",
+      "providesStates": ["ProcessInstanceCompleted"]
     },
     {
       "kind": "form",

--- a/path-analyser/src/domainSemanticsValidator.ts
+++ b/path-analyser/src/domainSemanticsValidator.ts
@@ -42,6 +42,7 @@ const SemanticTypeSpecSchema = z
 const ArtifactKindSpecSchema = z
   .object({
     producesStates: z.array(z.string()).optional(),
+    producibleStates: z.array(z.string()).optional(),
     producesSemantics: z.array(z.string()).optional(),
   })
   .passthrough();
@@ -119,6 +120,18 @@ function checkArtifactKindStateDeclared(d: DomainSemanticsShape): CrossRefIssue[
         issues.push({
           code: 'artifactKindStateDeclared',
           message: `artifactKinds.${kind}.producesStates references "${state}", which is not declared in runtimeStates or capabilities`,
+        });
+      }
+    }
+    // #159: producibleStates carries the same cross-reference invariant
+    // as producesStates — the planner's chain-feasibility BFS reads both,
+    // so an undeclared state name would silently break the BFS rather
+    // than surface as a config error at load time.
+    for (const state of spec.producibleStates ?? []) {
+      if (!declared.has(state)) {
+        issues.push({
+          code: 'artifactKindStateDeclared',
+          message: `artifactKinds.${kind}.producibleStates references "${state}", which is not declared in runtimeStates or capabilities`,
         });
       }
     }

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1271,9 +1271,13 @@ function chooseFixtureFromRegistry(
   // Fall back to the first registered candidate when the requirement is
   // unsatisfiable — the caller still gets a runnable suite, and the
   // misconfiguration surfaces through the L3 invariant rather than as a
-  // generator crash.
-  const ranked = covers.length > 0 ? covers : candidates;
-  const best = ranked.reduce((acc, e) => {
+  // generator crash. Skipping the tie-break here keeps fallback behaviour
+  // deterministic and matches the docstring.
+  if (covers.length === 0) {
+    const fallback = candidates[0];
+    return { ref: `@@FILE:${fallback.path}`, params: fallback.parameters };
+  }
+  const best = covers.reduce((acc, e) => {
     const accSize = acc.providesStates?.length ?? 0;
     const eSize = e.providesStates?.length ?? 0;
     return eSize < accSize ? e : acc;
@@ -1285,8 +1289,10 @@ function chooseFixtureFromRegistry(
  * Compute the set of runtime states the `createDeployment` step in a chain
  * must provide. Walks every operation in the scenario chain, accumulating
  * required states from `operationRequirements.<op>.requires`, then subtracts
- * states produced earlier in the chain by non-deployment ops (those are
- * satisfied by their own producer step, not by the deployment).
+ * states produced by any non-deployment op in the chain (those are
+ * satisfied by their own producer step, not by the deployment). The chain
+ * is BFS-ordered with producers before their consumers, so a simple
+ * unordered subtraction is equivalent to a left-to-right walk here.
  *
  * Returns the residual — states that have to come from the
  * `createDeployment` step's fixture selection. An empty set means any

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -18,6 +18,7 @@ import {
 } from './scenarioGenerator.js';
 import { computeSeedBindings } from './seedBindings.js';
 import type {
+  DomainSemantics,
   EndpointScenario,
   GenerationSummary,
   GenerationSummaryEntry,
@@ -1032,10 +1033,20 @@ function buildRequestBodyFromCanonical(
         dmnDecision: '@@FILE:dmn/decision.dmn',
         dmnDrd: '@@FILE:dmn/drd.dmn',
       };
-      // Prefer registry-defined artifact if available for this kind
-      // If downstream requires ModelHasServiceTaskType/JobType, prefer an entry carrying a jobType parameter
-      const preferJobType = true; // simple heuristic: jobs-related ops exist; could inspect scenario.operations
-      const regHit = chooseFixtureFromRegistry(kind, preferJobType);
+      // Pick the registry entry whose effective providesStates covers the
+      // states this createDeployment step must produce for the chain (#159).
+      // requiredStates is derived from operationRequirements.<op>.requires
+      // across the chain, minus states produced by non-deployment ops.
+      // The selector then filters registry entries by `kind` and effective
+      // providesStates (entry-level ∪ kind-level), tie-breaking by smallest
+      // entry.providesStates so a chain that doesn't impose any runtime
+      // characteristics on the fixture falls through to the most generic
+      // candidate.
+      const requiredStates = computeDeploymentRequiredStates(scenario, graph.domain);
+      const kindLevelProvides = new Set<string>(
+        kind ? (graph.domain?.artifactKinds?.[kind]?.producesStates ?? []) : [],
+      );
+      const regHit = chooseFixtureFromRegistry(kind, requiredStates, kindLevelProvides);
       const fileRef = regHit?.ref || defaultFixtures[kind || ''] || '@@FILE:bpmn/simple.bpmn';
       // If registry provides a jobType parameter, bind it for later request body use
       if (regHit?.params && typeof regHit.params.jobType === 'string') {
@@ -1085,6 +1096,13 @@ type ArtifactRegistryEntry = {
   path: string;
   description?: string;
   parameters?: Record<string, unknown>;
+  /**
+   * Runtime characteristics this specific fixture provides BEYOND what
+   * `artifactKinds.<kind>.producesStates` declares for the kind. The
+   * selector picks the entry whose effective providesStates (entry ∪
+   * kind) covers the chain's required states (#159).
+   */
+  providesStates?: string[];
 };
 let artifactsRegistryCache: ArtifactRegistryEntry[] | undefined;
 function getArtifactsRegistry(): ArtifactRegistryEntry[] {
@@ -1109,6 +1127,7 @@ function getArtifactsRegistry(): ArtifactRegistryEntry[] {
         path: e.path,
         description: e.description,
         parameters: e.parameters,
+        providesStates: Array.isArray(e.providesStates) ? [...e.providesStates] : undefined,
       }));
       return artifactsRegistryCache || [];
     } catch {}
@@ -1207,17 +1226,93 @@ function resolveProvider(opId: string, field: string, scenario: EndpointScenario
   }
 }
 
+/**
+ * Pick the fixture registry entry whose effective providesStates (per-entry ∪
+ * kind-level `artifactKinds.<kind>.producesStates`) covers `requiredStates`.
+ *
+ * Selection algorithm (#159, PR A):
+ *   1. Filter to entries whose `kind` matches.
+ *   2. Of those, keep entries whose effective providesStates is a superset of
+ *      `requiredStates`. An empty `requiredStates` matches every entry — so
+ *      chains that don't impose runtime characteristics on the fixture fall
+ *      through to step 3 with all candidates.
+ *   3. Tie-break: smallest |entry.providesStates| wins (most specific match;
+ *      fewer extra states the chain didn't ask for). Ties at that point
+ *      break by array order in the registry.
+ *
+ * Returns the chosen entry's `@@FILE:<path>` ref plus its parameters, or
+ * `undefined` when no entry of the right kind exists at all (the caller then
+ * falls back to a hard-coded default).
+ *
+ * When no entry of the right kind covers `requiredStates` (a real
+ * misconfiguration — the chain asked for a state nothing provides), the
+ * function still returns the first entry of that kind so the caller can
+ * emit a runnable suite; the diagnostic should be caught earlier by the
+ * fixture-registry validator or the bundled-spec invariants.
+ */
 function chooseFixtureFromRegistry(
-  kind?: string,
-  preferJobType = false,
+  kind: string | undefined,
+  requiredStates: ReadonlySet<string>,
+  kindLevelProvides: ReadonlySet<string>,
 ): { ref: string; params?: Record<string, unknown> } | undefined {
   if (!kind) return undefined;
-  const reg = getArtifactsRegistry();
-  let hit = reg.find(
-    (e) =>
-      e.kind === kind && preferJobType && e.parameters && typeof e.parameters.jobType === 'string',
-  );
-  if (!hit) hit = reg.find((e) => e.kind === kind);
-  if (hit?.path) return { ref: `@@FILE:${hit.path}`, params: hit.parameters };
-  return undefined;
+  const candidates = getArtifactsRegistry().filter((e) => e.kind === kind);
+  if (candidates.length === 0) return undefined;
+
+  const covers = candidates.filter((e) => {
+    const provides = new Set<string>(kindLevelProvides);
+    for (const s of e.providesStates ?? []) provides.add(s);
+    for (const r of requiredStates) {
+      if (!provides.has(r)) return false;
+    }
+    return true;
+  });
+
+  // Fall back to the first registered candidate when the requirement is
+  // unsatisfiable — the caller still gets a runnable suite, and the
+  // misconfiguration surfaces through the L3 invariant rather than as a
+  // generator crash.
+  const ranked = covers.length > 0 ? covers : candidates;
+  const best = ranked.reduce((acc, e) => {
+    const accSize = acc.providesStates?.length ?? 0;
+    const eSize = e.providesStates?.length ?? 0;
+    return eSize < accSize ? e : acc;
+  });
+  return { ref: `@@FILE:${best.path}`, params: best.parameters };
+}
+
+/**
+ * Compute the set of runtime states the `createDeployment` step in a chain
+ * must provide. Walks every operation in the scenario chain, accumulating
+ * required states from `operationRequirements.<op>.requires`, then subtracts
+ * states produced earlier in the chain by non-deployment ops (those are
+ * satisfied by their own producer step, not by the deployment).
+ *
+ * Returns the residual — states that have to come from the
+ * `createDeployment` step's fixture selection. An empty set means any
+ * fixture of the right kind is acceptable.
+ */
+function computeDeploymentRequiredStates(
+  scenario: { operations?: ReadonlyArray<{ operationId: string }> } | undefined,
+  domain: DomainSemantics | undefined,
+): Set<string> {
+  const result = new Set<string>();
+  if (!scenario?.operations || !domain?.operationRequirements) return result;
+  const opReqs = domain.operationRequirements;
+  for (const opRef of scenario.operations) {
+    const req = opReqs[opRef.operationId];
+    if (!req) continue;
+    for (const s of req.requires ?? []) result.add(s);
+  }
+  // States produced by non-deployment ops earlier in the chain are
+  // satisfied by their own producer step; the deployment doesn't need to
+  // provide them.
+  for (const opRef of scenario.operations) {
+    if (opRef.operationId === 'createDeployment') continue;
+    const req = opReqs[opRef.operationId];
+    if (!req) continue;
+    for (const s of req.produces ?? []) result.delete(s);
+    for (const s of req.implicitAdds ?? []) result.delete(s);
+  }
+  return result;
 }

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -1497,10 +1497,16 @@ function enumerateRuleSemantics(rule: ArtifactRule, graph: OperationGraph): stri
 }
 
 function enumerateRuleStates(rule: ArtifactRule, graph: OperationGraph): string[] {
+  // Chain-feasibility view: a `createDeployment` step is treated as capable
+  // of producing any state listed at the kind level — including
+  // `producibleStates` (which only SOME fixture of this kind actually
+  // provides, #159). The selector picks the right fixture at emission
+  // time; the planner just needs to know the chain is reachable.
   const states: string[] = [];
   if (rule.producesStates) states.push(...rule.producesStates);
-  const domainProduces = graph.domain?.artifactKinds?.[rule.artifactKind]?.producesStates;
-  if (domainProduces) states.push(...domainProduces);
+  const spec = graph.domain?.artifactKinds?.[rule.artifactKind];
+  if (spec?.producesStates) states.push(...spec.producesStates);
+  if (spec?.producibleStates) states.push(...spec.producibleStates);
   return [...new Set(states)];
 }
 

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -444,7 +444,25 @@ export interface OperationDomainRequirements {
 }
 
 export interface ArtifactKindSpec {
+  /**
+   * States that EVERY fixture of this kind deploys, regardless of fixture
+   * contents (e.g. `ProcessDefinitionDeployed` for `bpmnProcess`). Both the
+   * planner and the selector treat these as unconditional outputs of a
+   * successful `createDeployment` step.
+   */
   producesStates?: string[];
+  /**
+   * States that some fixture of this kind CAN provide, depending on which
+   * specific file the selector picks (#159). The planner reads this for
+   * chain-feasibility BFS — a chain is satisfiable if requires can be
+   * covered by `producesStates ∪ producibleStates`. The selector then
+   * matches the chain's required states against per-entry `providesStates`
+   * in `path-analyser/fixtures/deployment-artifacts.json` to choose the
+   * fitting file. Example: bpmnProcess can produce `ModelHasServiceTaskType`
+   * (via `service-task.bpmn`) or `ProcessInstanceCompleted` (via
+   * `simple.bpmn`), but neither is unconditional.
+   */
+  producibleStates?: string[];
   producesSemantics?: string[];
   identifierType?: string;
   deploymentSlices?: string[]; // e.g., ["processDefinition"] or ["decisionDefinition","decisionRequirements"]


### PR DESCRIPTION
## Summary

PR A of #159. Generalises fixture selection: each fixture registry entry now declares a `providesStates` list; the selector picks the entry whose effective providesStates covers the chain's required states. Replaces the hard-coded `preferJobType=true` branch in [path-analyser/src/index.ts](path-analyser/src/index.ts).

Driving case: [generated/camunda-oca/playwright/deleteProcessInstance.feature.spec.ts](generated/camunda-oca/playwright/deleteProcessInstance.feature.spec.ts) now deploys `bpmn/simple.bpmn` (start → end only) instead of `bpmn/service-task.bpmn` (which needs a worker to complete). Backwards-compat: every other chain still picks its previous fixture — including `activateJobs`, `completeJob`, `failJob`, `throwJobError`, `updateJob`, etc. (28 specs still reference service-task.bpmn; only 1 switched to simple.bpmn — the one we wanted).

Closes part 1 of #159. PR B will add `eventual` + `witness` for the wait injection.

## Design

The split between planner view and selector view:

| Field | Where | Meaning |
|---|---|---|
| `artifactKinds.<kind>.producesStates` | `domain-semantics.json` | states EVERY fixture of this kind provides (e.g. `ProcessDefinitionDeployed` for `bpmnProcess`). |
| `artifactKinds.<kind>.producibleStates` (new) | `domain-semantics.json` | states SOME fixture of this kind can deliver. Planner BFS unions `producesStates ∪ producibleStates` for chain feasibility. |
| `registry[i].providesStates` (new) | `deployment-artifacts.json` | states THIS specific fixture actually provides. Selector matches against this. |

The planner stays optimistic (any fitting fixture might exist); the selector picks the file at emission time.

### Selection algorithm

`chooseFixtureFromRegistry(kind, requiredStates, kindLevelProvides)`:

1. Filter to entries whose `kind` matches.
2. Keep entries whose `(entry.providesStates ∪ kindLevelProvides) ⊇ requiredStates`. On no match, fall back to all candidates so the suite stays runnable; the misconfiguration surfaces via the L3 invariant.
3. Tie-break: smallest `|entry.providesStates|`, then registry array order.

`requiredStates` is computed from the scenario chain: `⋃ operationRequirements.<op>.requires` minus states produced by non-deployment ops earlier in the chain.

### Class-scoped guards (Layer-3 invariants)

1. `deleteProcessInstance.feature.spec.ts` deploys `bpmn/simple.bpmn`.
2. `activateJobs.feature.spec.ts` still deploys `bpmn/service-task.bpmn` (regression guard for moving `ModelHasServiceTaskType` from artifactKinds-level to per-fixture).
3. Every registry entry's `providesStates` is declared in `runtimeStates ∪ capabilities` AND acknowledged by the kind's `producibleStates ∪ producesStates`. Catches typos and half-finished registry edits.

Also: `domainSemanticsValidator.checkArtifactKindStateDeclared` now walks `producibleStates` too (same cross-reference invariant as `producesStates`).

## Caveat (the wait is PR B)

PR A alone fixes the FIXTURE choice. The test still races at runtime because `createProcessInstance` returns 200 immediately but the engine state (`COMPLETED`) lands asynchronously — there's no wait yet. PR B will mark `ProcessInstanceCompleted` as `eventual: true` with a `witness: { operationId: 'getProcessInstance', predicate: \"body.state === 'COMPLETED'\" }` and inject `awaitEventually(...)` between producer and consumer.

Both halves needed to close the motivating case; each generalises independently.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` for all three workspace tsconfigs — clean
- [x] `TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation` — clean
- [x] `npm test` — 37 files / 280 passed / 6 skipped (was 276 on main; +3 new fixture-selection invariants + planner-feasibility tests passing through `producibleStates`)
- [x] Spot-check: `generated/camunda-oca/playwright/deleteProcessInstance.feature.spec.ts` now references `bpmn/simple.bpmn`
- [x] Class-scoped sweep: 28 specs reference `bpmn/service-task.bpmn`, 1 references `bpmn/simple.bpmn` — exactly the desired delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)