### PR TITLE
feat: inject awaitEventually wait for eventual runtime states (#159 PR B)

### DIFF
--- a/configs/camunda-oca/domain-semantics.json
+++ b/configs/camunda-oca/domain-semantics.json
@@ -38,7 +38,15 @@
       "parameter": "processInstanceKey",
       "producedBy": ["createProcessInstance"],
       "requires": ["ProcessDefinitionDeployed"],
-      "$comment": "Holds when a created instance has reached COMPLETED without external coordination. Provided by deploying a BPMN model whose execution path reaches an end event with no service tasks / user tasks / external blockers (e.g. bpmn/simple.bpmn). PR A of #159 introduces this state and uses it for the fixture selector; PR B will mark it `eventual` and inject an awaitEventually(getProcessInstance, body.state === 'COMPLETED') wait between producer and consumer."
+      "$comment": "Holds when a created instance has reached COMPLETED without external coordination. Provided by deploying a BPMN model whose execution path reaches an end event with no service tasks / user tasks / external blockers (e.g. bpmn/simple.bpmn). PR B of #159 marks this state as `eventual` and declares the witness: the planner inserts an awaitEventually(getProcessInstance) wait between the createProcessInstance producer step and any consumer step that requires this state (e.g. deleteProcessInstance).",
+      "eventual": true,
+      "witness": {
+        "operationId": "getProcessInstance",
+        "predicate": {
+          "path": "state",
+          "equals": "COMPLETED"
+        }
+      }
     },
     "JobAvailableForActivation": {
       "kind": "state",

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1451,6 +1451,36 @@ describeForThisConfig('bundled-spec invariants: fixture selection by required st
     );
   });
 
+  it('deleteProcessInstance.feature.spec.ts injects an awaitEventually wait between createProcessInstance and deleteProcessInstance (#159 PR B)', () => {
+    // PR B of #159: ProcessInstanceCompleted is declared `eventual: true`
+    // with a `witness` shape that polls getProcessInstance until
+    // `body.state === 'COMPLETED'`. The planner annotates the
+    // createProcessInstance step with `eventualWaitsAfter`; the emitter
+    // renders an `awaitEventually(...)` call immediately after that step
+    // and before the deleteProcessInstance step.
+    //
+    // Pre-PR-B the chain ran straight from create → delete with no wait,
+    // so the delete raced a still-ACTIVE instance and 4xx'd. The assertion
+    // pins the wait's POSITION (must be in the create→delete window) and
+    // its SHAPE (calls the witness operationId).
+    const spec = join(GENERATED_TESTS_DIR, 'deleteProcessInstance.feature.spec.ts');
+    if (!existsSync(spec)) {
+      throw new Error(`expected emitted spec ${spec} not found — run 'npm run testsuite:generate'`);
+    }
+    const src = readFileSync(spec, 'utf8');
+    const createIdx = src.indexOf('Step 2: createProcessInstance');
+    const deleteIdx = src.indexOf('Step 3: deleteProcessInstance');
+    expect(createIdx, 'createProcessInstance step marker not found').toBeGreaterThan(0);
+    expect(deleteIdx, 'deleteProcessInstance step marker not found').toBeGreaterThan(createIdx);
+    const between = src.slice(createIdx, deleteIdx);
+    expect(between, 'awaitEventually wait must appear between create and delete').toContain(
+      'awaitEventually(',
+    );
+    expect(between, 'wait must invoke the getProcessInstance witness').toContain(
+      "operationId: 'getProcessInstance'",
+    );
+  });
+
   it('every entry in deployment-artifacts.json#providesStates is acknowledged by its kind (#159)', () => {
     // Class-scoped coherence check between the fixture registry and
     // domain-semantics. For every registry entry e, every state in

--- a/path-analyser/domain-semantics.schema.json
+++ b/path-analyser/domain-semantics.schema.json
@@ -49,7 +49,42 @@
           "parameter": {"type": "string"},
           "parameters": {"type": "array", "items": {"type": "string"}},
           "producedBy": {"type": "array", "items": {"type": "string"}},
-          "requires": {"type": "array", "items": {"type": "string"}}
+          "requires": {"type": "array", "items": {"type": "string"}},
+          "$comment": {"type": "string"},
+          "eventual": {
+            "type": "boolean",
+            "description": "When true, the state lags behind its producer's response. The planner inserts an awaitEventually(witness) wait between producer and consumer steps (#159 PR B). Requires `witness`."
+          },
+          "witness": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["operationId", "predicate"],
+            "description": "Witness used by the awaitEventually wait when `eventual === true`. Polls the named operation until the structured predicate holds.",
+            "properties": {
+              "operationId": {"type": "string", "minLength": 1},
+              "predicate": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["path", "equals"],
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*$",
+                    "description": "Single top-level field on the response body (PR B: no nested paths)."
+                  },
+                  "equals": {
+                    "oneOf": [
+                      {"type": "string"},
+                      {"type": "number"},
+                      {"type": "boolean"}
+                    ]
+                  }
+                }
+              },
+              "waitUpToMs": {"type": "integer", "minimum": 1},
+              "pollIntervalMs": {"type": "integer", "minimum": 1}
+            }
+          }
         }
       }
     },

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -479,9 +479,12 @@ function renderScenarioTest(
     // the producer's `{ ... }`) so its locals (`witnessUrl`, etc.) don't
     // collide with the producer's, and so the wait is visible at the same
     // indentation depth as the request steps it sits between in the source.
-    for (const wait of step.eventualWaitsAfter ?? []) {
-      body.push(...renderEventualWait(wait));
-    }
+    // The index is forwarded so the per-wait response variable
+    // (`witnessRespN`) stays unique when a single producer step has
+    // multiple eventual waits.
+    (step.eventualWaitsAfter ?? []).forEach((wait, waitIdx) => {
+      body.push(...renderEventualWait(wait, waitIdx));
+    });
   });
   body.push('});');
   return body.join('\n');
@@ -526,9 +529,10 @@ function camelCase(s: string) {
  * round-tripped through JSON.stringify, which produces a valid TS
  * literal for each of those scalar shapes.
  */
-function renderEventualWait(wait: EventualWaitSpec): string[] {
+function renderEventualWait(wait: EventualWaitSpec, idx: number): string[] {
   const out: string[] = [];
   const w = wait.witness;
+  const respVar = `witnessResp${idx + 1}`;
   out.push(`  // Wait for ${wait.state} (eventual; witness: ${w.operationId})`);
   out.push(`  {`);
   out.push(`    const witnessUrl = baseUrl + ${buildUrlExpression(w.pathTemplate)};`);
@@ -549,7 +553,15 @@ function renderEventualWait(wait: EventualWaitSpec): string[] {
         return v === ${JSON.stringify(w.predicate.equals)};
       }`);
   const method = w.method.toLowerCase();
-  out.push(`    await awaitEventually(`);
+  // Capture awaitEventually's return value and assert on the status the
+  // same way request-step blocks do. awaitEventually returns early
+  // (without throwing) on hard-fail statuses (400/401/403/409/422/5xx)
+  // so the caller can produce a useful diff via expect(...).toBe(200);
+  // ignoring the response (the pre-review shape) would let the scenario
+  // proceed to the consumer step and attribute the eventual failure to
+  // the wrong place. The 200 assertion below tags the failure to the
+  // witness wait. (#159 PR B review.)
+  out.push(`    const ${respVar} = await awaitEventually(`);
   out.push(`      async () => request.${method}(witnessUrl, { headers: await authHeaders() }),`);
   out.push(`      {`);
   for (let i = 0; i < optionFields.length; i++) {
@@ -558,6 +570,12 @@ function renderEventualWait(wait: EventualWaitSpec): string[] {
   }
   out.push(`      },`);
   out.push(`    );`);
+  out.push(`    if (${respVar}.status() !== 200) {`);
+  out.push(
+    `      try { console.error('Witness response body:', await ${respVar}.text()); } catch {}`,
+  );
+  out.push(`    }`);
+  out.push(`    expect(${respVar}.status()).toBe(200);`);
   out.push(`  }`);
   return out;
 }

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -4,6 +4,7 @@ import { assertSafeGlobalContextSeeds } from '../../domainSemanticsValidator.js'
 import type {
   EndpointScenario,
   EndpointScenarioCollection,
+  EventualWaitSpec,
   GlobalContextSeed,
   RequestStep,
 } from '../../types.js';
@@ -145,12 +146,21 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   );
 
   // Determine upfront whether any scenario will wrap a step with
-  // awaitEventually() so we can conditionally include the import. A step
-  // is wrapped when `stepNeedsAwait()` identifies it as belonging to an
-  // eventually consistent operation (derived from
-  // `s.operations[].eventuallyConsistent`) and the step expects a 200
-  // (we never await a step that's expected to produce an error response).
-  const needsAwaitEventually = collection.scenarios.some((s) => stepNeedsAwait(s).length > 0);
+  // awaitEventually() so we can conditionally include the import. Two
+  // wrap-triggers fire today:
+  //   1. stepNeedsAwait() — a read-shape step belonging to an eventually
+  //      consistent operation (`s.operations[].eventuallyConsistent`,
+  //      from the `x-eventually-consistent` vendor extension).
+  //   2. eventualWaitsAfter — a producer step has been annotated with an
+  //      eventual-state wait by the planner (#159 PR B). The wait is
+  //      rendered as a standalone `awaitEventually(...)` block after the
+  //      producer's request/expect block; this trigger ensures the
+  //      import is present even when no step is itself an EC read.
+  const needsAwaitEventually = collection.scenarios.some(
+    (s) =>
+      stepNeedsAwait(s).length > 0 ||
+      (s.requestPlan ?? []).some((step) => (step.eventualWaitsAfter?.length ?? 0) > 0),
+  );
 
   // Default `recordResponses` to true so callers that omit the option keep
   // the pre-config behaviour. Threaded down into renderScenarioTest so the
@@ -464,6 +474,14 @@ function renderScenarioTest(
       }
     }
     body.push('  }');
+    // #159 PR B: render planner-annotated eventual-state waits AFTER the
+    // producer step's block. Emitted as a sibling block (not nested inside
+    // the producer's `{ ... }`) so its locals (`witnessUrl`, etc.) don't
+    // collide with the producer's, and so the wait is visible at the same
+    // indentation depth as the request steps it sits between in the source.
+    for (const wait of step.eventualWaitsAfter ?? []) {
+      body.push(...renderEventualWait(wait));
+    }
   });
   body.push('});');
   return body.join('\n');
@@ -483,6 +501,65 @@ function escapeQuotes(s: string): string {
 }
 function camelCase(s: string) {
   return s.charAt(0).toLowerCase() + s.slice(1);
+}
+
+/**
+ * Render a planner-annotated eventual-state wait as a sibling block to a
+ * producer step (#159 PR B). The emitted code:
+ *
+ *   - resolves the witness URL with the same ctx-binding rewrite the
+ *     request steps use (`buildUrlExpression`), so a witness referencing
+ *     `{processInstanceKey}` picks up `ctx.processInstanceKeyVar` already
+ *     extracted from the producer's response;
+ *   - wraps the witness fetch in `awaitEventually(...)` with a structured
+ *     predicate generated from the spec — no user-supplied predicate
+ *     string is interpolated, so the on-disk config cannot smuggle
+ *     arbitrary code into the emitted suite.
+ *
+ * Returns the source lines (no trailing newlines) for direct push onto
+ * the scenario body buffer.
+ *
+ * Safety: the witness predicate's `path` is validated against
+ * `/^[A-Za-z_$][A-Za-z0-9_$]*$/` by the domain-semantics validator
+ * (`WitnessPredicateSchema`), so the bracket-access key emitted below
+ * is identifier-safe. `equals` is constrained to string|number|boolean,
+ * round-tripped through JSON.stringify, which produces a valid TS
+ * literal for each of those scalar shapes.
+ */
+function renderEventualWait(wait: EventualWaitSpec): string[] {
+  const out: string[] = [];
+  const w = wait.witness;
+  out.push(`  // Wait for ${wait.state} (eventual; witness: ${w.operationId})`);
+  out.push(`  {`);
+  out.push(`    const witnessUrl = baseUrl + ${buildUrlExpression(w.pathTemplate)};`);
+  const optionFields: string[] = [
+    `method: '${w.method.toUpperCase()}'`,
+    `operationId: '${w.operationId}'`,
+  ];
+  if (typeof w.waitUpToMs === 'number') optionFields.push(`waitUpToMs: ${w.waitUpToMs}`);
+  if (typeof w.pollIntervalMs === 'number')
+    optionFields.push(`pollIntervalMs: ${w.pollIntervalMs}`);
+  // Predicate body: narrow `unknown` to a record, read the configured
+  // top-level field, compare with the configured scalar. Indentation
+  // matches the surrounding `await awaitEventually(...)` call so the
+  // emitted file passes biome's formatter without a separate pass.
+  optionFields.push(`predicate: (body) => {
+        if (body === null || typeof body !== 'object') return false;
+        const v = (body as Record<string, unknown>)['${w.predicate.path}'];
+        return v === ${JSON.stringify(w.predicate.equals)};
+      }`);
+  const method = w.method.toLowerCase();
+  out.push(`    await awaitEventually(`);
+  out.push(`      async () => request.${method}(witnessUrl, { headers: await authHeaders() }),`);
+  out.push(`      {`);
+  for (let i = 0; i < optionFields.length; i++) {
+    const sep = i === optionFields.length - 1 ? '' : ',';
+    out.push(`        ${optionFields[i]}${sep}`);
+  }
+  out.push(`      },`);
+  out.push(`    );`);
+  out.push(`  }`);
+  return out;
 }
 
 /**

--- a/path-analyser/src/domainSemanticsValidator.ts
+++ b/path-analyser/src/domainSemanticsValidator.ts
@@ -47,6 +47,38 @@ const ArtifactKindSpecSchema = z
   })
   .passthrough();
 
+// #159 PR B: structured predicate shape. `path` must be a safe identifier
+// because the emitter renders it as a TS bracket-access key (`b['<path>']`)
+// without an escape pass; `equals` is constrained to primitives so the
+// emitter can JSON.stringify it directly.
+const WitnessPredicateSchema = z.object({
+  path: z.string().regex(/^[A-Za-z_$][A-Za-z0-9_$]*$/, {
+    message: 'witness.predicate.path must match /^[A-Za-z_$][A-Za-z0-9_$]*$/',
+  }),
+  equals: z.union([z.string(), z.number(), z.boolean()]),
+});
+
+const WitnessSpecSchema = z
+  .object({
+    operationId: z.string().min(1),
+    predicate: WitnessPredicateSchema,
+    waitUpToMs: z.number().int().positive().optional(),
+    pollIntervalMs: z.number().int().positive().optional(),
+  })
+  .strict();
+
+const RuntimeStateSpecSchema = z
+  .object({
+    kind: z.literal('state').optional(),
+    producedBy: z.array(z.string()).optional(),
+    parameter: z.string().optional(),
+    parameters: z.array(z.string()).optional(),
+    requires: z.array(z.string()).optional(),
+    eventual: z.boolean().optional(),
+    witness: WitnessSpecSchema.optional(),
+  })
+  .passthrough();
+
 const OperationDomainRequirementsSchema = z
   .object({
     requires: z.array(z.string()).optional(),
@@ -77,7 +109,7 @@ export const GlobalContextSeedSchema = z
 // flow through unmodified.
 const DomainSemanticsShape = z
   .object({
-    runtimeStates: z.record(z.string(), z.unknown()).optional(),
+    runtimeStates: z.record(z.string(), RuntimeStateSpecSchema).optional(),
     capabilities: z.record(z.string(), z.unknown()).optional(),
     semanticTypes: z.record(z.string(), SemanticTypeSpecSchema).optional(),
     artifactKinds: z.record(z.string(), ArtifactKindSpecSchema).optional(),
@@ -311,6 +343,32 @@ function checkGlobalContextSeedsCoherent(d: DomainSemanticsShape): CrossRefIssue
   return issues;
 }
 
+// #159 PR B: a runtimeState marked `eventual: true` must declare a
+// `witness` so the planner has something to wait on. Without this check,
+// flipping `eventual` true on a state without a witness would silently
+// produce a chain with no wait injected (and the consumer step would
+// still race the producer's projection lag).
+function checkEventualStateWitnessShape(d: DomainSemanticsShape): CrossRefIssue[] {
+  const issues: CrossRefIssue[] = [];
+  for (const [name, spec] of Object.entries(d.runtimeStates ?? {})) {
+    const eventual = spec.eventual === true;
+    const witness = spec.witness;
+    if (eventual && (witness === undefined || witness === null)) {
+      issues.push({
+        code: 'eventualStateWitnessShape',
+        message: `runtimeStates.${name} sets eventual: true but has no witness — the planner would inject no wait. Declare a witness { operationId, predicate } or unset eventual.`,
+      });
+    }
+    if (!eventual && witness !== undefined && witness !== null) {
+      issues.push({
+        code: 'eventualStateWitnessShape',
+        message: `runtimeStates.${name} declares a witness but eventual is not true — the witness will not be used. Set eventual: true or remove the witness.`,
+      });
+    }
+  }
+  return issues;
+}
+
 const CROSS_REF_CHECKS = [
   checkArtifactKindStateDeclared,
   checkArtifactKindWitnessDeclared,
@@ -319,6 +377,7 @@ const CROSS_REF_CHECKS = [
   checkDisjunctionNotWitnessRedundant,
   checkDisjunctionMemberResolves,
   checkGlobalContextSeedsCoherent,
+  checkEventualStateWitnessShape,
 ] as const;
 
 // Composed schema: structural shape + every cross-reference invariant.

--- a/path-analyser/src/domainSemanticsValidator.ts
+++ b/path-analyser/src/domainSemanticsValidator.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { OperationGraph } from './types.js';
 
 // ---------------------------------------------------------------------------
 // path-analyser/src/domainSemanticsValidator.ts
@@ -50,13 +51,19 @@ const ArtifactKindSpecSchema = z
 // #159 PR B: structured predicate shape. `path` must be a safe identifier
 // because the emitter renders it as a TS bracket-access key (`b['<path>']`)
 // without an escape pass; `equals` is constrained to primitives so the
-// emitter can JSON.stringify it directly.
-const WitnessPredicateSchema = z.object({
-  path: z.string().regex(/^[A-Za-z_$][A-Za-z0-9_$]*$/, {
-    message: 'witness.predicate.path must match /^[A-Za-z_$][A-Za-z0-9_$]*$/',
-  }),
-  equals: z.union([z.string(), z.number(), z.boolean()]),
-});
+// emitter can JSON.stringify it directly. `.strict()` aligns this runtime
+// schema with the on-disk JSON schema's `additionalProperties: false` —
+// extra keys are almost always a typo (e.g. `equal` for `equals`) and
+// silently dropping them would mask the typo until the emitted predicate
+// misbehaved at runtime.
+const WitnessPredicateSchema = z
+  .object({
+    path: z.string().regex(/^[A-Za-z_$][A-Za-z0-9_$]*$/, {
+      message: 'witness.predicate.path must match /^[A-Za-z_$][A-Za-z0-9_$]*$/',
+    }),
+    equals: z.union([z.string(), z.number(), z.boolean()]),
+  })
+  .strict();
 
 const WitnessSpecSchema = z
   .object({
@@ -460,4 +467,55 @@ export function assertSafeGlobalContextSeeds(seeds: unknown): void {
     const formatted = issues.map((i) => `  - [${i.code}] ${i.message}`).join('\n');
     throw new Error(`globalContextSeeds failed coherence validation:\n${formatted}`);
   }
+}
+
+/**
+ * Validate cross-references between `domain.runtimeStates[*].witness` and
+ * the loaded operation graph (#159 PR B review).
+ *
+ * The structural validator (`validateDomainSemantics`) can only see the
+ * domain-semantics sidecar in isolation — it has no visibility into the
+ * operation graph, so a witness `operationId` that doesn't resolve to a
+ * real operation slips through it. Pre-this-check the planner silently
+ * skipped unknown witnesses; the user got back an emitted suite missing
+ * the wait it expected, and the racing-broker symptom returned.
+ *
+ * Two invariants:
+ *   1. `witnessOperationResolves` — every eventual state's `witness.operationId`
+ *      must resolve to a real entry in `graph.operations`.
+ *   2. `witnessOperationIsGet` — PR B only supports GET-shape witnesses
+ *      (the emitter renders `request.get(...)` and `awaitEventually`'s
+ *      retry semantics assume a read). Non-GET witnesses are rejected
+ *      now so the gap is visible at load time rather than as an emitted
+ *      suite that calls `request.post(...)` against a witness URL with
+ *      no body.
+ *
+ * Returns the empty array on success. Designed to be called after
+ * `loadGraph` has assembled `graph.operations` and `graph.domain`.
+ */
+export function validateRuntimeStateWitnessGraphRefs(
+  graph: OperationGraph,
+): DomainSemanticsValidationError[] {
+  const issues: DomainSemanticsValidationError[] = [];
+  const states = graph.domain?.runtimeStates;
+  if (!states) return issues;
+  for (const [stateName, spec] of Object.entries(states)) {
+    if (spec.eventual !== true || !spec.witness) continue;
+    const witnessOp = graph.operations[spec.witness.operationId];
+    if (!witnessOp) {
+      issues.push({
+        invariant: 'witnessOperationResolves',
+        message: `runtimeStates.${stateName}.witness.operationId references "${spec.witness.operationId}", which does not resolve to a known operation in the bundled spec.`,
+      });
+      continue;
+    }
+    const method = witnessOp.method?.toUpperCase?.() ?? '';
+    if (method !== 'GET') {
+      issues.push({
+        invariant: 'witnessOperationIsGet',
+        message: `runtimeStates.${stateName}.witness.operationId "${spec.witness.operationId}" is ${method || 'an unknown method'}; PR B (#159) supports GET-shape witnesses only.`,
+      });
+    }
+  }
+  return issues;
 }

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -2,7 +2,10 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import { getActiveConfigDir, getGraphDir, getSpecBundleDir } from './configResolver.js';
-import { validateDomainSemantics } from './domainSemanticsValidator.js';
+import {
+  validateDomainSemantics,
+  validateRuntimeStateWitnessGraphRefs,
+} from './domainSemanticsValidator.js';
 import type { BootstrapSequence, DomainSemantics, OperationGraph, OperationNode } from './types.js';
 
 class DomainSemanticsValidationFailure extends Error {
@@ -437,7 +440,7 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     }
   }
 
-  return {
+  const graph: OperationGraph = {
     operations,
     producersByType,
     responseProducersByType,
@@ -447,6 +450,22 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     establishersByType: Object.keys(establishersByType).length ? establishersByType : undefined,
     externalEntityIdentifiers,
   };
+  // #159 PR B (review): the structural domain-semantics validator can't
+  // see the graph, so a witness operationId that doesn't resolve (typo,
+  // renamed-upstream op, etc.) would slip through it and the planner
+  // would silently skip the wait — reintroducing the racing-broker bug.
+  // Run the graph-cross-ref check here, after the graph is fully
+  // assembled, and fail fast with the same exception type as the
+  // structural validator so the diagnostic surfaces with one well-known
+  // shape regardless of which check fired.
+  const witnessIssues = validateRuntimeStateWitnessGraphRefs(graph);
+  if (witnessIssues.length > 0) {
+    const detail = witnessIssues.map((i) => `  - [${i.invariant}] ${i.message}`).join('\n');
+    throw new DomainSemanticsValidationFailure(
+      `domain-semantics.json failed cross-reference validation against the bundled spec:\n${detail}`,
+    );
+  }
+  return graph;
 }
 
 function normalizeOp(opId: string, op: RawOp): OperationNode {

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -589,7 +589,73 @@ function buildRequestPlan(
   // alias extract on that producer step bound to the placeholder-derived
   // name. Keeps the emitter dumb and the alias visible in scenario JSON.
   aliasProducerExtractsToPlaceholders(scenario, steps, graph);
+  // #159 PR B: for each consumer step whose requires names an eventual
+  // state, find the most recent earlier producer step in the chain and
+  // annotate it with `eventualWaitsAfter` so the emitter inserts an
+  // `awaitEventually(witness)` block between producer and consumer.
+  annotateEventualWaits(steps, graph);
   return steps;
+}
+
+/**
+ * Walk a built request plan and stamp `eventualWaitsAfter` on every
+ * producer step whose response advances an `eventual: true` state that a
+ * later step requires. The annotation is self-contained — it carries the
+ * witness's method + pathTemplate resolved against the graph here — so
+ * the emitter does not need to re-consult `graph.operations` at
+ * emission time (#159).
+ *
+ * Invariants:
+ *   - The wait is attached to the producer step (earliest event-shape
+ *     anchor), not the consumer, so emitter order is producer-block →
+ *     wait-block → consumer-block without lookahead.
+ *   - Duplicates are deduped per (producer step, state) — multiple
+ *     downstream consumers that require the same eventual state collapse
+ *     to a single wait.
+ *   - Misconfigurations (eventual with no witness, unknown witness opId)
+ *     are skipped silently here; the domain-semantics validator already
+ *     catches them at load time.
+ */
+function annotateEventualWaits(steps: RequestStep[], graph: OperationGraph): void {
+  const states = graph.domain?.runtimeStates;
+  const opReqs = graph.domain?.operationRequirements;
+  if (!states || !opReqs) return;
+  for (let i = 0; i < steps.length; i++) {
+    const consumerOp = steps[i].operationId;
+    const requires = opReqs[consumerOp]?.requires ?? [];
+    for (const stateName of requires) {
+      const state = states[stateName];
+      if (!state?.eventual || !state.witness) continue;
+      const producers = new Set(state.producedBy ?? []);
+      let producerIdx = -1;
+      for (let j = i - 1; j >= 0; j--) {
+        if (producers.has(steps[j].operationId)) {
+          producerIdx = j;
+          break;
+        }
+      }
+      if (producerIdx < 0) continue; // no producer earlier in the chain
+      const witnessOp = graph.operations[state.witness.operationId];
+      if (!witnessOp) continue; // unknown witness — validator should have caught
+      const producerStep = steps[producerIdx];
+      producerStep.eventualWaitsAfter ||= [];
+      if (producerStep.eventualWaitsAfter.some((w) => w.state === stateName)) continue;
+      producerStep.eventualWaitsAfter.push({
+        state: stateName,
+        witness: {
+          operationId: state.witness.operationId,
+          method: witnessOp.method,
+          pathTemplate: witnessOp.path,
+          predicate: {
+            path: state.witness.predicate.path,
+            equals: state.witness.predicate.equals,
+          },
+          waitUpToMs: state.witness.waitUpToMs,
+          pollIntervalMs: state.witness.pollIntervalMs,
+        },
+      });
+    }
+  }
 }
 
 function mergePopulatesSubShapeIntoFinalBody(

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -612,9 +612,13 @@ function buildRequestPlan(
  *   - Duplicates are deduped per (producer step, state) — multiple
  *     downstream consumers that require the same eventual state collapse
  *     to a single wait.
- *   - Misconfigurations (eventual with no witness, unknown witness opId)
- *     are skipped silently here; the domain-semantics validator already
- *     catches them at load time.
+ *   - Misconfigurations (eventual with no witness, unknown witness opId,
+ *     non-GET witness method) are caught at load time:
+ *     `validateDomainSemantics` rejects the eventual-without-witness
+ *     shape, and `validateRuntimeStateWitnessGraphRefs` (called from
+ *     `loadGraph`) rejects unknown opIds and non-GET methods. The
+ *     defensive `continue` branches below are belt-and-braces for tests
+ *     that build partial graphs without going through the loader.
  */
 function annotateEventualWaits(steps: RequestStep[], graph: OperationGraph): void {
   const states = graph.domain?.runtimeStates;

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -347,6 +347,40 @@ export interface RequestStep {
   notes?: string;
   // Optional: expected slices in deployments[] for createDeployment responses, derived from domain sidecar
   expectedDeploymentSlices?: string[];
+  /**
+   * Eventual-state waits the emitter must render immediately after this
+   * step's request/expect block, before moving to the next step. Populated
+   * by the planner when this step produces an eventual state (one with
+   * `runtimeStates.<state>.eventual === true`) that a later step requires
+   * (#159 PR B). Each entry carries everything the emitter needs to
+   * render one `awaitEventually(...)` block without re-consulting the
+   * graph or the domain sidecar.
+   */
+  eventualWaitsAfter?: EventualWaitSpec[];
+}
+
+/**
+ * Single planner-annotated wait for an eventual state transition.
+ * Self-contained: includes the witness's resolved HTTP method and
+ * pathTemplate so the emitter doesn't need to look the witness operation
+ * up in the graph at emission time.
+ */
+export interface EventualWaitSpec {
+  /** The eventual state being waited for (used in the emitted comment). */
+  state: string;
+  /** Witness fetch details, resolved against the graph at plan time. */
+  witness: {
+    operationId: string;
+    /** HTTP method of the witness op (PR B: 'GET' only). */
+    method: string;
+    /** Path template of the witness op, with `{paramName}` placeholders
+     *  the emitter substitutes via the same ctx-binding rewrite used for
+     *  request URLs. */
+    pathTemplate: string;
+    predicate: WitnessPredicate;
+    waitUpToMs?: number;
+    pollIntervalMs?: number;
+  };
 }
 
 // Filter dimension details for feature coverage
@@ -433,6 +467,52 @@ export interface RuntimeStateSpec {
   parameter?: string; // single parameter name
   parameters?: string[]; // multi parameters
   requires?: string[]; // prerequisite states
+  /**
+   * When true, the state's external observability LAGS behind its producer's
+   * response — the broker accepts the write at 200 but the projected state
+   * (e.g. ProcessInstanceCompleted) only lands after asynchronous engine
+   * progression. The planner inserts an `awaitEventually(witness)` wait
+   * between the producer step and any consumer step that requires this state
+   * (#159 PR B). Requires `witness` to be set.
+   */
+  eventual?: boolean;
+  /**
+   * Witness used by the awaitEventually wait when `eventual === true`.
+   * The witness invokes a read-shape operation (today: GET-by-key only) and
+   * polls until the predicate holds against the response body.
+   */
+  witness?: WitnessSpec;
+}
+
+export interface WitnessSpec {
+  /** Operation invoked to observe the state. Must reference a real
+   *  operationId in the graph. PR B constrains this to GET-shape ops. */
+  operationId: string;
+  /** Predicate over the parsed response body that holds when the state is
+   *  observable. */
+  predicate: WitnessPredicate;
+  /** Optional total wait budget in ms; defaults to the awaitEventually
+   *  helper's built-in default (10_000). */
+  waitUpToMs?: number;
+  /** Optional poll interval in ms; defaults to the helper's built-in
+   *  default (500). */
+  pollIntervalMs?: number;
+}
+
+/**
+ * Structured predicate — the emitter generates a typed arrow function from
+ * this rather than interpolating a user-supplied string, so the on-disk
+ * config can't smuggle arbitrary code into the emitted suite. PR B only
+ * supports single-segment `path` (the response body's top-level field).
+ * Nested-path support can be added later as a separate field shape.
+ */
+export interface WitnessPredicate {
+  /** Top-level field on the response body. Must match
+   *  `/^[A-Za-z_$][A-Za-z0-9_$]*$/` so it can be safely emitted as a
+   *  bracket-access key (`b['<path>']`). */
+  path: string;
+  /** Expected scalar compared with `===`. */
+  equals: string | number | boolean;
 }
 
 export interface OperationDomainRequirements {

--- a/tests/codegen/playwright-eventual-wait.test.ts
+++ b/tests/codegen/playwright-eventual-wait.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'vitest';
+import { renderPlaywrightSuite } from '../../path-analyser/src/codegen/playwright/emitter.ts';
+import type { EndpointScenarioCollection } from '../../path-analyser/src/types.ts';
+
+// Layer-2 guards for the eventual-state wait injection (#159 PR B).
+//
+// The emitter renders a planner-annotated `eventualWaitsAfter` as an
+// `awaitEventually(witnessUrl, { predicate })` block immediately after
+// the producer step. The tests below pin both the shape of the emitted
+// block AND the "import + render in lockstep" contract — the
+// `await-eventually` import must be present whenever any step carries
+// an eventualWaitsAfter, even when no step is itself an EC read.
+
+function buildCollectionWithWait(): EndpointScenarioCollection {
+  return {
+    endpoint: { operationId: 'deleteWidget', method: 'POST', path: '/widgets/{id}/deletion' },
+    requiredSemanticTypes: [],
+    optionalSemanticTypes: [],
+    scenarios: [
+      {
+        id: 'sc1',
+        name: 'create then delete with wait',
+        operations: [
+          { operationId: 'createWidget', method: 'POST', path: '/widgets' },
+          { operationId: 'deleteWidget', method: 'POST', path: '/widgets/{id}/deletion' },
+        ],
+        producedSemanticTypes: [],
+        satisfiedSemanticTypes: [],
+        requestPlan: [
+          {
+            operationId: 'createWidget',
+            method: 'POST',
+            pathTemplate: '/widgets',
+            expect: { status: 200 },
+            extract: [{ fieldPath: 'id', bind: 'idVar' }],
+            eventualWaitsAfter: [
+              {
+                state: 'WidgetReady',
+                witness: {
+                  operationId: 'getWidget',
+                  method: 'GET',
+                  pathTemplate: '/widgets/{id}',
+                  predicate: { path: 'state', equals: 'READY' },
+                },
+              },
+            ],
+          },
+          {
+            operationId: 'deleteWidget',
+            method: 'POST',
+            pathTemplate: '/widgets/{id}/deletion',
+            expect: { status: 204 },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('emitter: eventual-state wait injection (#159 PR B)', () => {
+  test('renders an awaitEventually block immediately after the producer step', () => {
+    const src = renderPlaywrightSuite(buildCollectionWithWait(), {
+      suiteName: 'deleteWidget',
+      mode: 'feature',
+    });
+    // The wait must appear in the source AND sit between Step 1 (producer)
+    // and Step 2 (consumer). Position is part of the contract — a wait
+    // emitted before the producer (or after the consumer) doesn't fix the
+    // motivating case.
+    const producerIdx = src.indexOf('Step 1: createWidget');
+    const consumerIdx = src.indexOf('Step 2: deleteWidget');
+    const waitIdx = src.indexOf('await awaitEventually(');
+    expect(producerIdx).toBeGreaterThan(0);
+    expect(consumerIdx).toBeGreaterThan(producerIdx);
+    expect(waitIdx).toBeGreaterThan(producerIdx);
+    expect(waitIdx).toBeLessThan(consumerIdx);
+  });
+
+  test('imports await-eventually even when no step is itself an EC read', () => {
+    // Pre-PR-B the import was gated only on stepNeedsAwait() (read-shape EC
+    // ops). A wait-after-producer must lift the import on its own — otherwise
+    // the emitted suite references awaitEventually without an import.
+    const src = renderPlaywrightSuite(buildCollectionWithWait(), {
+      suiteName: 'deleteWidget',
+      mode: 'feature',
+    });
+    expect(src).toContain("import { awaitEventually } from './support/await-eventually';");
+  });
+
+  test('emits the witness URL using the ctx-binding rewrite (path param resolves to ctx.<name>Var)', () => {
+    // The witness URL must thread through buildUrlExpression so the
+    // `{id}` path-param picks up `ctx.idVar` extracted by the producer
+    // step (binds the wait to the producer's response).
+    const src = renderPlaywrightSuite(buildCollectionWithWait(), {
+      suiteName: 'deleteWidget',
+      mode: 'feature',
+    });
+    expect(src).toContain('const witnessUrl = baseUrl +');
+    expect(src).toContain('ctx.idVar');
+  });
+
+  test('renders a structured predicate that compares the configured path against the configured scalar', () => {
+    // The predicate is generated from the structured WitnessPredicate
+    // shape, NOT interpolated from a user-supplied string. The emitted
+    // function narrows `unknown` to a record, reads the configured
+    // top-level field via bracket-access (biome rewrites this to dot
+    // access in the regenerated suite, but the emitter outputs the
+    // bracket form), and compares with `===`.
+    const src = renderPlaywrightSuite(buildCollectionWithWait(), {
+      suiteName: 'deleteWidget',
+      mode: 'feature',
+    });
+    // Predicate body shape — `state` and `'READY'` come from the spec above.
+    expect(src).toContain("const v = (body as Record<string, unknown>)['state'];");
+    // Pre-biome quoting: JSON.stringify produces double quotes; biome
+    // rewrites them to single quotes in the regenerated suite. The
+    // assertion targets the emitter's raw output.
+    expect(src).toContain('return v === "READY";');
+  });
+
+  test('omits the wait block (and the await-eventually import gate) when no step has eventualWaitsAfter', () => {
+    // Sanity guard: a collection without any wait annotation must NOT
+    // emit the wait scaffolding. Catches a regression where the gate
+    // accidentally fires for every step.
+    const collection: EndpointScenarioCollection = {
+      endpoint: { operationId: 'createWidget', method: 'POST', path: '/widgets' },
+      requiredSemanticTypes: [],
+      optionalSemanticTypes: [],
+      scenarios: [
+        {
+          id: 'sc1',
+          name: 'simple',
+          operations: [{ operationId: 'createWidget', method: 'POST', path: '/widgets' }],
+          producedSemanticTypes: [],
+          satisfiedSemanticTypes: [],
+          requestPlan: [
+            {
+              operationId: 'createWidget',
+              method: 'POST',
+              pathTemplate: '/widgets',
+              expect: { status: 200 },
+            },
+          ],
+        },
+      ],
+    };
+    const src = renderPlaywrightSuite(collection, { suiteName: 'createWidget', mode: 'feature' });
+    expect(src).not.toContain('awaitEventually');
+    expect(src).not.toContain("from './support/await-eventually'");
+  });
+});

--- a/tests/codegen/playwright-eventual-wait.test.ts
+++ b/tests/codegen/playwright-eventual-wait.test.ts
@@ -118,6 +118,24 @@ describe('emitter: eventual-state wait injection (#159 PR B)', () => {
     expect(src).toContain('return v === "READY";');
   });
 
+  test('captures the awaitEventually response and asserts its status (#159 PR B review)', () => {
+    // awaitEventually returns early (without throwing) on hard-fail
+    // statuses (401/403/422/5xx etc.) so callers can produce a useful
+    // expect-vs-actual diff. Pre-review the emitter ignored the return
+    // value — a 401 against the witness would silently let the scenario
+    // proceed and the failure would be misattributed to the consumer
+    // step. The new shape captures the response, logs the body on
+    // mismatch (mirroring the request-step pattern), and asserts 200.
+    const src = renderPlaywrightSuite(buildCollectionWithWait(), {
+      suiteName: 'deleteWidget',
+      mode: 'feature',
+    });
+    expect(src).toContain('const witnessResp1 = await awaitEventually(');
+    expect(src).toContain('if (witnessResp1.status() !== 200)');
+    expect(src).toContain("console.error('Witness response body:'");
+    expect(src).toContain('expect(witnessResp1.status()).toBe(200);');
+  });
+
   test('omits the wait block (and the await-eventually import gate) when no step has eventualWaitsAfter', () => {
     // Sanity guard: a collection without any wait annotation must NOT
     // emit the wait scaffolding. Catches a regression where the gate

--- a/tests/regression/domain-semantics-validator.test.ts
+++ b/tests/regression/domain-semantics-validator.test.ts
@@ -234,6 +234,79 @@ describe('validateDomainSemantics', () => {
     // cross-ref invariant fires.
     expect(errs.length).toBeGreaterThan(0);
   });
+
+  // #159 PR B: eventual + witness coherence.
+  it('rejects runtimeStates entries with eventual: true but no witness', () => {
+    const errs = validateDomainSemantics({
+      runtimeStates: {
+        SomeEventualState: {
+          kind: 'state',
+          producedBy: ['x'],
+          eventual: true,
+          // witness intentionally omitted
+        },
+      },
+    });
+    expect(errs.find((e) => e.invariant === 'eventualStateWitnessShape')?.message).toContain(
+      'eventual: true but has no witness',
+    );
+  });
+
+  it('rejects runtimeStates entries with a witness but eventual omitted (witness is dead config)', () => {
+    const errs = validateDomainSemantics({
+      runtimeStates: {
+        SomeState: {
+          kind: 'state',
+          producedBy: ['x'],
+          witness: {
+            operationId: 'get',
+            predicate: { path: 'state', equals: 'READY' },
+          },
+        },
+      },
+    });
+    expect(errs.find((e) => e.invariant === 'eventualStateWitnessShape')?.message).toContain(
+      'declares a witness but eventual is not true',
+    );
+  });
+
+  it('accepts a coherent eventual + witness entry', () => {
+    const errs = validateDomainSemantics({
+      runtimeStates: {
+        SomeEventualState: {
+          kind: 'state',
+          producedBy: ['x'],
+          eventual: true,
+          witness: {
+            operationId: 'getX',
+            predicate: { path: 'state', equals: 'READY' },
+          },
+        },
+      },
+    });
+    // No eventualStateWitnessShape issue for this entry.
+    expect(errs.find((e) => e.invariant === 'eventualStateWitnessShape')).toBeUndefined();
+  });
+
+  it('rejects witness.predicate.path that is not a safe identifier', () => {
+    const errs = validateDomainSemantics({
+      runtimeStates: {
+        S: {
+          kind: 'state',
+          producedBy: ['x'],
+          eventual: true,
+          witness: {
+            operationId: 'getX',
+            predicate: { path: 'state; drop table users', equals: 'READY' },
+          },
+        },
+      },
+    });
+    // Structural zod issue from WitnessPredicateSchema (regex mismatch),
+    // surfaces as `shape` rather than a named cross-ref invariant.
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs.some((e) => e.message.includes('predicate.path must match'))).toBe(true);
+  });
 });
 
 // Boundary chokepoint used by the emitter (renderPlaywrightSuite /

--- a/tests/regression/domain-semantics-validator.test.ts
+++ b/tests/regression/domain-semantics-validator.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   assertSafeGlobalContextSeeds,
   validateDomainSemantics,
+  validateRuntimeStateWitnessGraphRefs,
 } from '../../path-analyser/src/domainSemanticsValidator.ts';
+import type { OperationGraph } from '../../path-analyser/src/types.ts';
 
 // ---------------------------------------------------------------------------
 // Class-scoped guards for path-analyser/src/domainSemanticsValidator.ts.
@@ -341,5 +343,137 @@ describe('assertSafeGlobalContextSeeds (boundary)', () => {
     expect(() => assertSafeGlobalContextSeeds([{ binding: 'tenant-id' }])).toThrow(
       /structural validation/,
     );
+  });
+});
+
+// #159 PR B (review): structural validation can't see the operation
+// graph, so a witness operationId that doesn't resolve, or whose method
+// isn't GET, slips through validateDomainSemantics and the planner
+// silently skips the wait. validateRuntimeStateWitnessGraphRefs runs at
+// load time AFTER the graph is assembled and rejects both shapes by name.
+describe('validateRuntimeStateWitnessGraphRefs (graph cross-references)', () => {
+  function buildGraph(
+    operations: Record<string, { operationId: string; method: string; path: string }>,
+    runtimeStates: Record<string, unknown>,
+  ): OperationGraph {
+    // Minimal stub: only the fields the validator reads. Casts to
+    // OperationNode are intentional — the test only exercises the
+    // validator's narrow read surface (operationId + method), not the
+    // full graph contract.
+    return {
+      // biome-ignore lint/plugin: test stub mirrors the narrow read surface of validateRuntimeStateWitnessGraphRefs
+      operations: operations as unknown as OperationGraph['operations'],
+      producersByType: {},
+      // biome-ignore lint/plugin: test stub mirrors the narrow read surface of validateRuntimeStateWitnessGraphRefs
+      domain: { version: 1, runtimeStates } as unknown as OperationGraph['domain'],
+    };
+  }
+
+  it('returns no issues when every eventual witness resolves to a GET op', () => {
+    const graph = buildGraph(
+      { getThing: { operationId: 'getThing', method: 'GET', path: '/things/{id}' } },
+      {
+        SomeEventualState: {
+          kind: 'state',
+          producedBy: ['x'],
+          eventual: true,
+          witness: {
+            operationId: 'getThing',
+            predicate: { path: 'state', equals: 'READY' },
+          },
+        },
+      },
+    );
+    expect(validateRuntimeStateWitnessGraphRefs(graph)).toEqual([]);
+  });
+
+  it('rejects witness.operationId that does not resolve in the bundled spec', () => {
+    const graph = buildGraph(
+      {},
+      {
+        S: {
+          kind: 'state',
+          producedBy: ['x'],
+          eventual: true,
+          witness: {
+            operationId: 'getMissing',
+            predicate: { path: 'state', equals: 'READY' },
+          },
+        },
+      },
+    );
+    const issues = validateRuntimeStateWitnessGraphRefs(graph);
+    expect(issues.find((i) => i.invariant === 'witnessOperationResolves')?.message).toContain(
+      'getMissing',
+    );
+  });
+
+  it('rejects witness.operationId whose method is not GET (PR B constraint)', () => {
+    const graph = buildGraph(
+      { searchThings: { operationId: 'searchThings', method: 'POST', path: '/things/search' } },
+      {
+        S: {
+          kind: 'state',
+          producedBy: ['x'],
+          eventual: true,
+          witness: {
+            operationId: 'searchThings',
+            predicate: { path: 'state', equals: 'READY' },
+          },
+        },
+      },
+    );
+    const issues = validateRuntimeStateWitnessGraphRefs(graph);
+    expect(issues.find((i) => i.invariant === 'witnessOperationIsGet')?.message).toContain('POST');
+  });
+
+  it('ignores non-eventual states even if they declare a witness shape', () => {
+    // Cross-check: validateDomainSemantics already flags this as
+    // `eventualStateWitnessShape`. validateRuntimeStateWitnessGraphRefs
+    // is concerned with graph resolution, not with eventual/witness
+    // coherence — so it must not also fire here.
+    const graph = buildGraph(
+      { getThing: { operationId: 'getThing', method: 'GET', path: '/things/{id}' } },
+      {
+        S: {
+          kind: 'state',
+          producedBy: ['x'],
+          // eventual omitted on purpose
+          witness: {
+            operationId: 'getThing',
+            predicate: { path: 'state', equals: 'READY' },
+          },
+        },
+      },
+    );
+    expect(validateRuntimeStateWitnessGraphRefs(graph)).toEqual([]);
+  });
+});
+
+// #159 PR B (review): WitnessPredicateSchema is now `.strict()` so extra
+// keys (typos like `equal` for `equals`) are rejected at load time rather
+// than silently dropped.
+describe('WitnessPredicateSchema strictness', () => {
+  it('rejects extra keys under witness.predicate (e.g. typo "equal" for "equals")', () => {
+    // validateDomainSemantics takes `unknown` and builds the parse tree
+    // via Zod, so the input is intentionally typed loosely here. The
+    // typo "equal" must trip Zod's strict() rejection at load time
+    // rather than silently dropping through and leaving the planner
+    // with a broken predicate at runtime.
+    const input: unknown = {
+      runtimeStates: {
+        S: {
+          kind: 'state',
+          producedBy: ['x'],
+          eventual: true,
+          witness: {
+            operationId: 'getThing',
+            predicate: { path: 'state', equals: 'READY', equal: 'OOPS' },
+          },
+        },
+      },
+    };
+    const errs = validateDomainSemantics(input);
+    expect(errs.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

PR B of #159 — closes the motivating case. PR A (#160, merged) picked the right BPMN fixture (`simple.bpmn`, instance completes without external coordination). PR B injects the wait so the `deleteProcessInstance` step doesn't race the engine's state projection lag.

Closes #159 together with #160.

## What lands

### Domain-semantics extension (`runtimeStates.<state>`)

```jsonc
"ProcessInstanceCompleted": {
  "kind": "state",
  "producedBy": ["createProcessInstance"],
  "eventual": true,
  "witness": {
    "operationId": "getProcessInstance",
    "predicate": { "path": "state", "equals": "COMPLETED" }
  }
}
```

`witness.waitUpToMs` and `pollIntervalMs` are optional (fall back to the helper's built-in defaults).

### Planner annotation

`buildRequestPlan` gains a final `annotateEventualWaits(steps, graph)` pass: for each consumer step whose `requires` names an eventual state, find the most recent earlier producer in the chain and stamp `eventualWaitsAfter` on it. The annotation carries the witness's resolved HTTP method + pathTemplate from the graph so the emitter doesn't need to look it up again. Dedup is per `(producer step, state)` — multiple downstream consumers of the same eventual state collapse to one wait.

### Emitter rendering

The wait is a sibling block to the producer step (not nested), emitted immediately after the producer's request/expect/extract block:

```ts
// Wait for ProcessInstanceCompleted (eventual; witness: getProcessInstance)
{
  const witnessUrl = baseUrl + `/process-instances/${ctx.processInstanceKeyVar || ...}`;
  await awaitEventually(
    async () => request.get(witnessUrl, { headers: await authHeaders() }),
    {
      method: 'GET', operationId: 'getProcessInstance',
      predicate: (body) => {
        if (body === null || typeof body !== 'object') return false;
        const v = (body as Record<string, unknown>).state;
        return v === 'COMPLETED';
      },
    },
  );
}
```

The `awaitEventually` import gate is widened to include the `eventualWaitsAfter` trigger, so a chain whose only EC pattern is a wait-after-producer still imports the helper.

### Safety

The predicate is generated from a **structured** shape — `{ path, equals }` — not interpolated from a user-supplied string. The validator enforces:

- `path` matches `/^[A-Za-z_$][A-Za-z0-9_$]*$/` (identifier-safe ASCII, same regex as the existing `globalContextSeeds` safety).
- `equals` is `string | number | boolean` (round-tripped through `JSON.stringify`).

The on-disk config cannot smuggle arbitrary code into the emitted suite.

### Cross-reference invariants (validator)

- `eventualStateWitnessShape`: `eventual: true` without a `witness` is a load-time error (would silently inject no wait); `witness` without `eventual: true` is also an error (the witness is dead config).
- Structural schema for `WitnessPredicate` rejects unsafe `path` values at load time.

### Regenerated output (the user-visible delta)

`generated/camunda-oca/playwright/deleteProcessInstance.feature.spec.ts` now has the `awaitEventually(...)` block between Step 2 (`createProcessInstance`) and Step 3 (`deleteProcessInstance`). No other spec is affected — no other state is marked eventual.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` for all three workspace tsconfigs — clean
- [x] `TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation` — clean
- [x] `npm test` — 38 files / 290 passed / 6 skipped (was 280 on PR A; +5 Layer-2 emitter tests, +4 validator tests, +1 Layer-3 invariant)
- [x] Spot-check: regenerated `deleteProcessInstance.feature.spec.ts` has the wait block exactly between Steps 2 and 3
- [x] Class-scoped sweep: no other emitted spec has spurious `awaitEventually(` calls (no other state marked eventual)

## Out of scope

The design issue called these out — not addressed here:

- POST `.../search`-shape witnesses (PR B constrains to GET).
- Nested-path predicates (PR B supports single top-level field only).
- Escape-hatch `eventualWait: { ms: N }` for states without a natural witness. Not needed for camunda-oca's current spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)