### PR TITLE
feat: modelDerived value-source classification + fixture providesValues (#162 PR 1)

### DIFF
--- a/configs/camunda-oca/domain-semantics.json
+++ b/configs/camunda-oca/domain-semantics.json
@@ -156,7 +156,15 @@
     "DecisionDefinitionKey": { "witnesses": "DecisionDefinitionDeployed" },
     "DecisionRequirementsKey": { "witnesses": "DecisionRequirementsDeployed" },
     "FormKey": { "witnesses": "FormDeployed" },
-    "JobKey": { "witnesses": "JobAvailableForActivation" }
+    "JobKey": { "witnesses": "JobAvailableForActivation" },
+    "ElementId": {
+      "kind": "modelDerived",
+      "$comment": "Element IDs are defined inside the deployed BPMN model. The planner reads them out-of-band from the chosen fixture's providesValues at plan time — no Camunda API round-trip required. See #162 PR 1."
+    },
+    "JobType": {
+      "kind": "modelDerived",
+      "$comment": "zeebe:taskDefinition type is encoded in the BPMN model on each service-task element. Read out-of-band from the chosen fixture's providesValues. Subsumes the pre-#162 ad-hoc `parameters.jobType` handling in the registry."
+    }
   },
   "operationArtifactRules": {
     "createDeployment": {

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -2736,7 +2736,7 @@ describeForThisConfig(
         ).toBeDefined();
         expect(
           binding,
-          `${t.endpoint}: ${t.varName} binding must NOT be the pre-PR-1 synthetic 'elementid_...' placeholder`,
+          `${t.endpoint}: ${t.varName} binding must NOT be the pre-PR-1 synthetic 'elementId_...' placeholder`,
         ).not.toMatch(SYNTHETIC_RE);
       });
 

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -2777,3 +2777,71 @@ describeForThisConfig(
   },
 );
 
+describeForThisConfig(
+  'bundled-spec invariants: jobType binds from chosen fixture (#163 review)',
+  () => {
+    // #163 review-comment guard: when the registry switched from
+    // `parameters.jobType` to `providesValues.JobType`, the planner code
+    // path that binds `jobTypeVar` (separate from
+    // `bindModelDerivedFromFixture`) almost regressed — it still read
+    // `regHit.params.jobType` and would have fallen through to
+    // `seedBinding('jobTypeVar')` at runtime once `parameters` was
+    // removed. The bridge in PR 1 now consults
+    // `providesValues.JobType[0]` first. This class-scoped invariant
+    // asserts every job-related endpoint's feature-1 (base) scenario
+    // binds `jobTypeVar = 'sampleJobType'` — the value `service-task.bpmn`
+    // declares — and not a synthetic, runtime-seeded, or absent binding.
+    //
+    // The invariant covers the class, not a single instance: any job-
+    // related endpoint whose chain deploys `service-task.bpmn` and whose
+    // request body / path needs JobType is in scope.
+
+    interface ScenarioWithBindings {
+      id?: string;
+      strategy?: string;
+      bindings?: Record<string, string>;
+    }
+    interface FeatureCollection {
+      endpoint: { operationId: string };
+      scenarios: ScenarioWithBindings[];
+    }
+
+    function loadCollection(filename: string): FeatureCollection {
+      const raw = readFileSync(join(FEATURE_SCENARIOS_DIR, filename), 'utf8');
+      // biome-ignore lint/plugin: parsed JSON is a runtime contract boundary
+      return JSON.parse(raw) as FeatureCollection;
+    }
+
+    const targets: { endpoint: string; featureFile: string }[] = [
+      { endpoint: 'activateJobs', featureFile: 'post--jobs--activation-scenarios.json' },
+      { endpoint: 'completeJob', featureFile: 'post--jobs--{jobKey}--completion-scenarios.json' },
+      { endpoint: 'failJob', featureFile: 'post--jobs--{jobKey}--failure-scenarios.json' },
+      { endpoint: 'throwJobError', featureFile: 'post--jobs--{jobKey}--error-scenarios.json' },
+    ];
+
+    for (const t of targets) {
+      it(`${t.endpoint} :: feature scenarios bind jobTypeVar to the fixture's JobType (#163)`, () => {
+        const path = join(FEATURE_SCENARIOS_DIR, t.featureFile);
+        if (!existsSync(path)) {
+          throw new Error(
+            `expected feature-output JSON not found: ${t.featureFile} — run 'npm run testsuite:generate'`,
+          );
+        }
+        const collection = loadCollection(t.featureFile);
+        // Pick the base (feature-1) scenario as the witness — any chain
+        // that needs jobTypeVar will have it set; the base scenario is
+        // the most representative.
+        const base = collection.scenarios.find(
+          (s) => s.strategy === 'featureCoverage' && s.id === 'feature-1',
+        );
+        expect(base, `${t.endpoint}: feature-1 base scenario not found`).toBeDefined();
+        const jt = base?.bindings?.jobTypeVar;
+        expect(
+          jt,
+          `${t.endpoint}: feature-1 must bind jobTypeVar (chain deploys service-task.bpmn, which declares JobType in providesValues)`,
+        ).toBe('sampleJobType');
+      });
+    }
+  },
+);
+

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -2617,3 +2617,163 @@ describeForThisConfig(
   },
 );
 
+describeForThisConfig(
+  'bundled-spec invariants: modelDerived value source (#162 PR 1)',
+  () => {
+    // PR 1 of #162: ElementId and JobType are declared `kind: modelDerived`
+    // in domain-semantics, and the fixture registry's `providesValues`
+    // entry on each bpmn fixture declares which concrete values that
+    // fixture deploys. When the feature planner emits a scenario whose
+    // endpoint has ElementId or JobType as an optional input, it must
+    // bind the var from the chain's deployment fixture's providesValues
+    // — not from the synthetic `fc:pos:<endpoint>:<semantic>` placeholder
+    // the pre-PR-1 planner used.
+    //
+    // The 4 single-deploy ElementId consumer sites covered here:
+    //   - createProcessInstance        :: startInstructions[].elementId
+    //   - activateAdHocSubProcessActivities :: elements[].elementId
+    //   - completeJob                  :: result.activateElements[].elementId
+    //   - modifyProcessInstance        :: activateInstructions[].elementId
+    //
+    // Other ElementId consumer sites that remain uncovered by PR 1:
+    //   - modifyProcessInstancesBatchOperation :: moveInstructions[].sourceElementId
+    //     (single-endpoint chain — the planner doesn't insert a
+    //      createDeployment prerequisite for batch operations even though
+    //      sourceElementId needs a model. Separate chain-construction issue.)
+    //   - migrateProcessInstance / migrateProcessInstancesBatchOperation
+    //     (multi-deploy: source-model + target-model — needs per-deploy-step
+    //      fixture selection. PR 1's helper takes the FIRST deploy step.)
+
+    // The deterministic-synthetic value pattern emitted by
+    // featureCoverageGenerator pre-PR-1:
+    // `<camelLower(semantic)>_<deterministicSuffix(...)>`,
+    // e.g. `elementId_e1wc`. The suffix is base36 alphanumeric. The
+    // assertions below check this leading-pattern is absent from the
+    // corresponding feature scenario's binding — proving the binding
+    // comes from providesValues instead. A real BPMN element id starts
+    // with the model's element name (e.g. `StartEvent_1`,
+    // `Activity_06kuv4r`) and so cannot start with the lower-cased
+    // semantic name.
+    const SYNTHETIC_RE = /^elementId_[A-Za-z0-9]+$/;
+
+    interface FeatureScenarioBody {
+      bindings?: Record<string, string>;
+      strategy?: string;
+      variantKey?: string;
+    }
+    interface FeatureScenarioFile {
+      endpoint: { operationId: string };
+      scenarios: FeatureScenarioBody[];
+    }
+
+    function loadFeatureCollection(file: string): FeatureScenarioFile {
+      const raw = readFileSync(file, 'utf8');
+      // biome-ignore lint/plugin: parsed JSON is a runtime contract boundary
+      return JSON.parse(raw) as FeatureScenarioFile;
+    }
+
+    function findScenarioBinding(
+      collection: FeatureScenarioFile,
+      variantKey: string,
+      varName: string,
+    ): string | undefined {
+      const scenario = collection.scenarios.find((s) => s.variantKey === variantKey);
+      return scenario?.bindings?.[varName];
+    }
+
+    interface Target {
+      endpoint: string;
+      featureFile: string;
+      variantKey: string;
+      varName: string;
+      consumerPathInBody: string;
+    }
+    const TARGETS: Target[] = [
+      {
+        endpoint: 'createProcessInstance',
+        featureFile: 'post--process-instances-scenarios.json',
+        variantKey: 'opt=ElementId',
+        varName: 'elementIdVar',
+        consumerPathInBody: 'startInstructions',
+      },
+      {
+        endpoint: 'activateAdHocSubProcessActivities',
+        featureFile:
+          'post--element-instances--ad-hoc-activities--{adHocSubProcessInstanceKey}--activation-scenarios.json',
+        variantKey: 'opt=ElementId',
+        varName: 'elementIdVar',
+        consumerPathInBody: 'elements',
+      },
+      {
+        endpoint: 'completeJob',
+        featureFile: 'post--jobs--{jobKey}--completion-scenarios.json',
+        variantKey: 'opt=ElementId',
+        varName: 'elementIdVar',
+        consumerPathInBody: 'result',
+      },
+      {
+        endpoint: 'modifyProcessInstance',
+        featureFile: 'post--process-instances--{processInstanceKey}--modification-scenarios.json',
+        variantKey: 'opt=ElementId',
+        varName: 'elementIdVar',
+        consumerPathInBody: 'activateInstructions',
+      },
+    ];
+
+    for (const t of TARGETS) {
+      it(`${t.endpoint} :: feature 'with ElementId' binds elementIdVar from fixture providesValues (#162)`, () => {
+        const path = join(FEATURE_SCENARIOS_DIR, t.featureFile);
+        if (!existsSync(path)) {
+          throw new Error(
+            `expected feature-output JSON not found: ${t.featureFile} — run 'npm run testsuite:generate'`,
+          );
+        }
+        const collection = loadFeatureCollection(path);
+        const binding = findScenarioBinding(collection, t.variantKey, t.varName);
+        expect(
+          binding,
+          `${t.endpoint}: scenario with variantKey '${t.variantKey}' must have a binding for ${t.varName}`,
+        ).toBeDefined();
+        expect(
+          binding,
+          `${t.endpoint}: ${t.varName} binding must NOT be the pre-PR-1 synthetic 'elementid_...' placeholder`,
+        ).not.toMatch(SYNTHETIC_RE);
+      });
+
+      it(`${t.endpoint} :: emitted feature spec references ctx.${t.varName} in the request body (#162)`, () => {
+        const specName = `${t.endpoint}.feature.spec.ts`;
+        const spec = join(GENERATED_TESTS_DIR, specName);
+        if (!existsSync(spec)) {
+          throw new Error(`expected emitted spec not found: ${specName}`);
+        }
+        const src = readFileSync(spec, 'utf8');
+        // The body for the 'opt=ElementId' scenario must reference the
+        // ElementId binding inside its consumer-path key (e.g. `elements`,
+        // `startInstructions`, …). Use the scenario title to scope the
+        // search to the right test block.
+        const scenarioMarker = `with ElementId`;
+        const scenarioIdx = src.indexOf(scenarioMarker);
+        expect(
+          scenarioIdx,
+          `${t.endpoint}: expected a scenario block titled 'with ElementId'`,
+        ).toBeGreaterThan(0);
+        // Find the end of the test block by scanning forward to the next
+        // `test(` opener (or end of file).
+        const nextTestIdx = src.indexOf("\n  test('", scenarioIdx + scenarioMarker.length);
+        const scenarioBlock = src.slice(
+          scenarioIdx,
+          nextTestIdx > 0 ? nextTestIdx : src.length,
+        );
+        expect(
+          scenarioBlock.includes(t.consumerPathInBody),
+          `${t.endpoint} 'with ElementId': body must populate '${t.consumerPathInBody}'`,
+        ).toBe(true);
+        expect(
+          scenarioBlock.includes(`ctx.${t.varName}`),
+          `${t.endpoint} 'with ElementId': body must reference ctx.${t.varName}`,
+        ).toBe(true);
+      });
+    }
+  },
+);
+

--- a/path-analyser/domain-semantics.schema.json
+++ b/path-analyser/domain-semantics.schema.json
@@ -89,13 +89,19 @@
       }
     },
     "semanticTypes": {
-      "description": "Declarations of semantic identifier types (e.g. ProcessDefinitionKey). Each entry's `witnesses` names the runtimeStates/capabilities entry whose presence proves the semantic value exists. Cross-section resolution of `witnesses` is enforced at load time by domainSemanticsValidator.ts.",
+      "description": "Declarations of semantic identifier types (e.g. ProcessDefinitionKey). Each entry's `witnesses` names the runtimeStates/capabilities entry whose presence proves the semantic value exists. `kind` optionally classifies how the planner sources values of this type at plan time (#162). Cross-section resolution of `witnesses` is enforced at load time by domainSemanticsValidator.ts.",
       "type": "object",
       "additionalProperties": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "witnesses": {"type": "string", "minLength": 1}
+          "witnesses": {"type": "string", "minLength": 1},
+          "kind": {
+            "type": "string",
+            "enum": ["modelDerived"],
+            "description": "Value-source classification (#162 PR 1). When `modelDerived`, the planner reads values from the chain's createDeployment fixture's providesValues entry — no API round-trip required. Future PRs will add `attribute` for client-minted free-form labels."
+          },
+          "$comment": {"type": "string"}
         }
       }
     },

--- a/path-analyser/fixtures/deployment-artifacts.json
+++ b/path-analyser/fixtures/deployment-artifacts.json
@@ -1,18 +1,24 @@
 {
-  "$comment": "Fixture registry consumed by chooseFixtureFromRegistry() in path-analyser/src/index.ts. Each entry's `providesStates` lists the runtime characteristics this specific fixture provides BEYOND what its `kind` already guarantees in artifactKinds.<kind>.producesStates. The selector picks the entry whose effective providesStates (entry ∪ kind) covers the chain's required states; ties break by smallest providesStates set, then by array order here. See #159.",
+  "$comment": "Fixture registry consumed by chooseFixtureFromRegistry() in path-analyser/src/index.ts. Each entry's `providesStates` lists the runtime characteristics this specific fixture provides BEYOND what its `kind` already guarantees in artifactKinds.<kind>.producesStates. `providesValues` lists concrete values the fixture supplies for semantic types declared `kind: modelDerived` in domain-semantics (#162 PR 1 — element ids, job types, etc.; the planner reads these out-of-band at plan time, no API round-trip). The selector picks the entry whose effective providesStates (entry ∪ kind) covers the chain's required states; ties break by smallest providesStates set, then by array order here. See #159, #162.",
   "artifacts": [
     {
       "kind": "bpmnProcess",
       "path": "bpmn/service-task.bpmn",
       "description": "BPMN process with a service task and zeebe:taskDefinition type sampleJobType. Selected for chains whose consumer ops require ModelHasServiceTaskType (e.g. activateJobs, completeJob, failJob).",
       "providesStates": ["ModelHasServiceTaskType"],
-      "parameters": { "jobType": "sampleJobType" }
+      "providesValues": {
+        "ElementId": ["StartEvent_1", "Activity_06kuv4r", "Event_0tll3bk"],
+        "JobType": ["sampleJobType"]
+      }
     },
     {
       "kind": "bpmnProcess",
       "path": "bpmn/simple.bpmn",
       "description": "Start → end only. An instance created from this BPMN reaches COMPLETED without external coordination (no service tasks, no user tasks, no timer events). Selected for chains whose consumer ops require ProcessInstanceCompleted (e.g. deleteProcessInstance).",
-      "providesStates": ["ProcessInstanceCompleted"]
+      "providesStates": ["ProcessInstanceCompleted"],
+      "providesValues": {
+        "ElementId": ["Event_1qq1nf7", "Event_1ma9skw"]
+      }
     },
     {
       "kind": "form",

--- a/path-analyser/src/domainSemanticsValidator.ts
+++ b/path-analyser/src/domainSemanticsValidator.ts
@@ -37,6 +37,11 @@ import type { OperationGraph } from './types.js';
 const SemanticTypeSpecSchema = z
   .object({
     witnesses: z.string().min(1).optional(),
+    // #162 PR 1: value-source classification. Only `modelDerived` lands
+    // in PR 1; future PRs add `attribute` (client-minted free-form
+    // labels). Anything else is rejected at the schema layer so a typo
+    // doesn't silently fall through to the default classification chain.
+    kind: z.enum(['modelDerived']).optional(),
   })
   .passthrough();
 

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -568,6 +568,12 @@ function buildRequestPlan(
       steps.push(dup);
     }
   }
+  // #162 PR 1: bind modelDerived semantics from the chain's deploy fixture
+  // BEFORE merging populatesSubShape, so that the merge sees the
+  // populatesSubShape entry the helper plants for nested-path values
+  // (and so the binding has the fixture value rather than the
+  // synthetic placeholder featureCoverageGenerator stamped earlier).
+  bindModelDerivedFromFixture(scenario, steps, graph);
   // Issue #105 (Phase 3): for variant scenarios, deep-merge the populated
   // sub-shape into the FINAL step's bodyTemplate. The planner stamps
   // `populatesSubShape` on each variant scenario; the emitter expects the
@@ -660,6 +666,139 @@ function annotateEventualWaits(steps: RequestStep[], graph: OperationGraph): voi
       });
     }
   }
+}
+
+/**
+ * #162 PR 1: bind modelDerived semantic values from the chain's
+ * createDeployment fixture and annotate `populatesSubShape` so the final
+ * step's body materializes the value.
+ *
+ * "modelDerived" means the value comes from inside the deployment
+ * artifact itself (e.g. an ElementId encoded in the BPMN), not from a
+ * Camunda API response. The fixture registry's `providesValues` entry
+ * declares which concrete values each fixture supplies.
+ *
+ * Scope (PR 1):
+ *
+ *   - Runs ONLY for feature-coverage scenarios. Variant scenarios
+ *     continue using their producer-chain logic (see
+ *     `generateOptionalSubShapeVariants`); PR 4 of #162 unifies them.
+ *
+ *   - Single-deploy chains only — the helper picks the FIRST
+ *     `createDeployment` step's fixture as the value source. Multi-deploy
+ *     chains (source + target models, e.g. migrateProcessInstance) need
+ *     per-deploy-step fixture selection and are a follow-up.
+ *
+ *   - Index 0 of `providesValues[semantic]` is used unconditionally.
+ *     A future per-consumer-site preference vocabulary can pick a
+ *     specific entry; not load-bearing today.
+ *
+ * Side effects:
+ *
+ *   - For every modelDerived semantic listed in the endpoint's
+ *     `requestBodySemanticTypes`, overrides any pre-existing binding
+ *     (synthetic or otherwise) with the fixture value. The override is
+ *     intentional: modelDerived values are authoritative over the
+ *     `fc:pos:...` synthetic placeholder stamped by featureCoverageGenerator.
+ *
+ *   - For nested-array semantics (`fieldPath` containing `[]`), adds a
+ *     `populatesSubShape` entry so `mergePopulatesSubShapeIntoFinalBody`
+ *     materializes the nested structure. Top-level scalar semantics are
+ *     handled by the existing flat-optional fill loop in
+ *     `buildRequestBodyFromCanonical` and do not need a populatesSubShape
+ *     annotation.
+ */
+function bindModelDerivedFromFixture(
+  scenario: EndpointScenario,
+  steps: RequestStep[],
+  graph: OperationGraph,
+): void {
+  if (scenario.strategy !== 'featureCoverage') return;
+  const domain = graph.domain;
+  if (!domain?.semanticTypes) return;
+  if (!steps.length) return;
+  const finalStep = steps[steps.length - 1];
+  const endpoint = graph.operations[finalStep.operationId];
+  // optionalSubShapes already filters to nested optional semantic leaves
+  // (the graphLoader pre-computes this via `subShapeRootOf`). PR 1's
+  // scope is exactly that subset — nested ElementId at consumer sites
+  // like `startInstructions[].elementId`. Top-level scalar modelDerived
+  // semantics (e.g. JobType) go through a different binding path and
+  // are out of scope here.
+  const subShapes = endpoint?.optionalSubShapes ?? [];
+  if (!subShapes.length) return;
+  // Find the first createDeployment step in the chain — single-deploy
+  // only in PR 1; multi-deploy is a follow-up.
+  const deployStep = steps.find((s) => s.operationId === 'createDeployment');
+  if (!deployStep) return;
+  const fixture = fixtureFromDeployStep(deployStep);
+  if (!fixture?.providesValues) return;
+
+  for (const subShape of subShapes) {
+    for (const leaf of subShape.leaves) {
+      const semKind = domain.semanticTypes[leaf.semantic]?.kind;
+      if (semKind !== 'modelDerived') continue;
+      const values = fixture.providesValues[leaf.semantic];
+      if (!values?.length) continue;
+      const varName = `${camelCase(leaf.semantic)}Var`;
+      scenario.bindings ||= {};
+      // Authoritative override: a featureCoverageGenerator synthetic
+      // would otherwise shadow the real fixture value.
+      scenario.bindings[varName] = values[0];
+
+      const sub = scenario.populatesSubShape ?? {
+        rootPath: subShape.rootPath,
+        leafPaths: [],
+        leafSemantics: [],
+      };
+      if (!sub.leafPaths.includes(leaf.fieldPath)) {
+        sub.leafPaths.push(leaf.fieldPath);
+        sub.leafSemantics ||= [];
+        sub.leafSemantics.push(leaf.semantic);
+      }
+      if (!sub.rootPath) sub.rootPath = subShape.rootPath;
+      scenario.populatesSubShape = sub;
+    }
+  }
+}
+
+/**
+ * Find the fixture registry entry referenced by a `createDeployment`
+ * step's multipart `resources` template. Multi-deploy steps carry
+ * multiple file references; PR 1 returns the entry for the FIRST one
+ * (single-deploy scope).
+ */
+function fixtureFromDeployStep(step: RequestStep): ArtifactRegistryEntry | undefined {
+  const tpl = step.multipartTemplate;
+  if (!isPlainRecord(tpl)) return undefined;
+  const files = isPlainRecord(tpl.files) ? tpl.files : undefined;
+  if (!files) return undefined;
+  for (const v of Object.values(files)) {
+    if (typeof v === 'string' && v.startsWith('@@FILE:')) {
+      const path = v.slice('@@FILE:'.length);
+      return getArtifactsRegistry().find((e) => e.path === path);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Compute the sub-shape root segment for a given fieldPath. Mirrors the
+ * (simpler) cases of `subShapeRootOf` in graphLoader; here we only need
+ * the deepest object/array-of-object ancestor so the emitter's
+ * `populatesSubShape` annotation has a non-empty root.
+ *
+ *   "startInstructions[].elementId"     → "startInstructions[]"
+ *   "result.activateElements[].elementId" → "result.activateElements[]"
+ *   "moveInstructions[].sourceElementId"  → "moveInstructions[]"
+ *
+ * Top-level scalars never reach this function — they go through the
+ * existing flat-optional fill path in buildRequestBodyFromCanonical.
+ */
+function subShapeRootForFieldPath(fieldPath: string): string {
+  const segments = fieldPath.split('.');
+  if (segments.length < 2) return '';
+  return segments.slice(0, -1).join('.');
 }
 
 function mergePopulatesSubShapeIntoFinalBody(
@@ -1160,11 +1299,38 @@ ${'${'}${varName}}`;
   return undefined;
 }
 
+/**
+ * Validate and copy a registry entry's `providesValues` shape. Each value
+ * must be an array of strings; anything else is dropped silently so a
+ * malformed entry doesn't poison the cache (the L3 coherence invariant
+ * surfaces the issue separately). Returns `undefined` when the input
+ * isn't a usable record, so callers can early-out cheaply.
+ */
+function normaliseProvidesValues(input: unknown): Record<string, string[]> | undefined {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return undefined;
+  const out: Record<string, string[]> = {};
+  for (const [k, v] of Object.entries(input)) {
+    if (!Array.isArray(v)) continue;
+    const strings: string[] = [];
+    for (const x of v) {
+      if (typeof x === 'string') strings.push(x);
+    }
+    if (strings.length) out[k] = strings;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 // -------- Artifact Registry support ---------
 type ArtifactRegistryEntry = {
   kind: string;
   path: string;
   description?: string;
+  /**
+   * Pre-#162 ad-hoc bag of "characteristics this fixture has" — the
+   * planner only ever consulted `parameters.jobType`. Kept for back-compat
+   * during the transition to `providesValues` (#162 PR 1); new entries
+   * should declare values under `providesValues` instead.
+   */
   parameters?: Record<string, unknown>;
   /**
    * Runtime characteristics this specific fixture provides BEYOND what
@@ -1173,6 +1339,18 @@ type ArtifactRegistryEntry = {
    * kind) covers the chain's required states (#159).
    */
   providesStates?: string[];
+  /**
+   * Concrete values this fixture supplies for semantic types whose
+   * `semanticTypes.<X>.kind === 'modelDerived'` (#162 PR 1). The planner
+   * reads these out-of-band at plan time — no Camunda API round-trip is
+   * needed to learn the values, because the BPMN/DMN/Form file already
+   * encodes them (element IDs, job types, form IDs, …).
+   *
+   * Per-semantic the value is an array so a future per-consumer-site
+   * preference vocabulary can pick a specific entry; PR 1's planner
+   * takes index 0 unconditionally.
+   */
+  providesValues?: Record<string, string[]>;
 };
 let artifactsRegistryCache: ArtifactRegistryEntry[] | undefined;
 function getArtifactsRegistry(): ArtifactRegistryEntry[] {
@@ -1198,6 +1376,7 @@ function getArtifactsRegistry(): ArtifactRegistryEntry[] {
         description: e.description,
         parameters: e.parameters,
         providesStates: Array.isArray(e.providesStates) ? [...e.providesStates] : undefined,
+        providesValues: normaliseProvidesValues(e.providesValues),
       }));
       return artifactsRegistryCache || [];
     } catch {}

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -782,25 +782,6 @@ function fixtureFromDeployStep(step: RequestStep): ArtifactRegistryEntry | undef
   return undefined;
 }
 
-/**
- * Compute the sub-shape root segment for a given fieldPath. Mirrors the
- * (simpler) cases of `subShapeRootOf` in graphLoader; here we only need
- * the deepest object/array-of-object ancestor so the emitter's
- * `populatesSubShape` annotation has a non-empty root.
- *
- *   "startInstructions[].elementId"     → "startInstructions[]"
- *   "result.activateElements[].elementId" → "result.activateElements[]"
- *   "moveInstructions[].sourceElementId"  → "moveInstructions[]"
- *
- * Top-level scalars never reach this function — they go through the
- * existing flat-optional fill path in buildRequestBodyFromCanonical.
- */
-function subShapeRootForFieldPath(fieldPath: string): string {
-  const segments = fieldPath.split('.');
-  if (segments.length < 2) return '';
-  return segments.slice(0, -1).join('.');
-}
-
 function mergePopulatesSubShapeIntoFinalBody(
   scenario: EndpointScenario,
   steps: RequestStep[],
@@ -1257,11 +1238,25 @@ function buildRequestBodyFromCanonical(
       );
       const regHit = chooseFixtureFromRegistry(kind, requiredStates, kindLevelProvides);
       const fileRef = regHit?.ref || defaultFixtures[kind || ''] || '@@FILE:bpmn/simple.bpmn';
-      // If registry provides a jobType parameter, bind it for later request body use
-      if (regHit?.params && typeof regHit.params.jobType === 'string') {
+      // Bind jobType from the chosen fixture for later use in the request
+      // body (`activateJobs.type`, `completeJob`/`failJob`/`throwJobError`
+      // path params, etc.). #163 review: the canonical source is
+      // `providesValues.JobType[0]` (PR 1 of #162's data shape); the
+      // legacy `parameters.jobType` field on the registry entry is
+      // accepted as a fallback during the transition. #164 will retire
+      // the literal-field-name special-case in
+      // `buildRequestBodyFromCanonical` that pairs with this binding;
+      // until then both call sites must agree on the source of truth.
+      const jobTypeFromProvides = regHit?.providesValues?.JobType?.[0];
+      const jobTypeFromParams =
+        regHit?.params && typeof regHit.params.jobType === 'string'
+          ? regHit.params.jobType
+          : undefined;
+      const jobTypeValue = jobTypeFromProvides ?? jobTypeFromParams;
+      if (jobTypeValue !== undefined) {
         const varName = 'jobTypeVar';
         scenario.bindings ||= {};
-        if (!scenario.bindings[varName]) scenario.bindings[varName] = regHit.params.jobType;
+        if (!scenario.bindings[varName]) scenario.bindings[varName] = jobTypeValue;
       }
       template.files.resources = fileRef;
     }
@@ -1503,7 +1498,13 @@ function chooseFixtureFromRegistry(
   kind: string | undefined,
   requiredStates: ReadonlySet<string>,
   kindLevelProvides: ReadonlySet<string>,
-): { ref: string; params?: Record<string, unknown> } | undefined {
+):
+  | {
+      ref: string;
+      params?: Record<string, unknown>;
+      providesValues?: Record<string, string[]>;
+    }
+  | undefined {
   if (!kind) return undefined;
   const candidates = getArtifactsRegistry().filter((e) => e.kind === kind);
   if (candidates.length === 0) return undefined;
@@ -1524,14 +1525,22 @@ function chooseFixtureFromRegistry(
   // deterministic and matches the docstring.
   if (covers.length === 0) {
     const fallback = candidates[0];
-    return { ref: `@@FILE:${fallback.path}`, params: fallback.parameters };
+    return {
+      ref: `@@FILE:${fallback.path}`,
+      params: fallback.parameters,
+      providesValues: fallback.providesValues,
+    };
   }
   const best = covers.reduce((acc, e) => {
     const accSize = acc.providesStates?.length ?? 0;
     const eSize = e.providesStates?.length ?? 0;
     return eSize < accSize ? e : acc;
   });
-  return { ref: `@@FILE:${best.path}`, params: best.parameters };
+  return {
+    ref: `@@FILE:${best.path}`,
+    params: best.parameters,
+    providesValues: best.providesValues,
+  };
 }
 
 /**

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -695,11 +695,12 @@ function annotateEventualWaits(steps: RequestStep[], graph: OperationGraph): voi
  *
  * Side effects:
  *
- *   - For every modelDerived semantic listed in the endpoint's
- *     `requestBodySemanticTypes`, overrides any pre-existing binding
- *     (synthetic or otherwise) with the fixture value. The override is
- *     intentional: modelDerived values are authoritative over the
- *     `fc:pos:...` synthetic placeholder stamped by featureCoverageGenerator.
+ *   - For modelDerived semantics on nested optional sub-shape leaves from
+ *     `endpoint.optionalSubShapes` (i.e. the leaves computed via
+ *     `subShapeRootOf`), overrides any pre-existing binding (synthetic or
+ *     otherwise) with the fixture value. The override is intentional:
+ *     modelDerived values are authoritative over the `fc:pos:...`
+ *     synthetic placeholder stamped by featureCoverageGenerator.
  *
  *   - For nested-array semantics (`fieldPath` containing `[]`), adds a
  *     `populatesSubShape` entry so `mergePopulatesSubShapeIntoFinalBody`

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -444,6 +444,23 @@ export interface SemanticTypeSpec {
   // value implies the existence of. Required for key-shaped semantic types
   // (those listed in artifactKinds.*.producesSemantics).
   witnesses?: string;
+  /**
+   * How the planner obtains a value for this semantic type (#162). Five
+   * classifications are envisioned; PR 1 adds `modelDerived`.
+   *
+   *   - `modelDerived`: the value is read out-of-band from a deployment
+   *     artifact in the same chain. The planner looks the value up in the
+   *     `providesValues` entry of the fixture chosen for the chain's
+   *     `createDeployment` step. Examples: `ElementId`, `JobType` — these
+   *     values come from the BPMN model itself, not from a Camunda API
+   *     response.
+   *
+   * Future PRs will add `attribute` (free-form client-minted labels —
+   * `Tag`, `BusinessId`) under this same field. Absent `kind` means the
+   * planner falls back to its existing classification chain
+   * (producersByType / establishersByType / external-entity).
+   */
+  kind?: 'modelDerived';
 }
 
 export interface IdentifierSpec {


### PR DESCRIPTION
## Summary

PR 1 of #162. Adds the **`modelDerived`** value-source classification — the first of the five-way semantic-value classification described in the design issue. Closes the lying-`feature-N - with ElementId` scenarios on 4 of the 7 affected endpoints.

The feature suite's `feature-N - with ElementId` scenarios on `createProcessInstance`, `completeJob`, `activateAdHocSubProcessActivities`, and `modifyProcessInstance` now bind `elementIdVar` from the chain's deployment fixture (`providesValues.ElementId[0]`) instead of from a synthetic `elementId_<hex>` placeholder, and the emitted body populates `startInstructions[].elementId` / `result.activateElements[].elementId` / `elements[].elementId` / `activateInstructions[].elementId` with a reference to that binding.

## What this lands

### Data side

- **`semanticTypes.<X>.kind: 'modelDerived'`** in domain-semantics — declares that values of `X` come out-of-band from a deployment artifact, not from a Camunda API response. `ElementId` and `JobType` are so declared for camunda-oca (the latter as a placeholder for the follow-up that subsumes `parameters.jobType`).

- **`registry[i].providesValues: Record<string, string[]>`** in [path-analyser/fixtures/deployment-artifacts.json](path-analyser/fixtures/deployment-artifacts.json) — declares which concrete values each fixture supplies for modelDerived semantics. Hand-curated for now (the BPMN files are checked-in and change rarely):

  ```jsonc
  // bpmn/service-task.bpmn
  "providesValues": {
    "ElementId": ["StartEvent_1", "Activity_06kuv4r", "Event_0tll3bk"],
    "JobType": ["sampleJobType"]
  }

  // bpmn/simple.bpmn
  "providesValues": {
    "ElementId": ["Event_1qq1nf7", "Event_1ma9skw"]
  }
  ```

  Per-semantic the value is an array so a future per-consumer-site preference vocabulary can pick a specific entry; PR 1 takes index 0 unconditionally.

### Planner side

- **`bindModelDerivedFromFixture(scenario, steps, graph)`** — new post-pass in [path-analyser/src/index.ts](path-analyser/src/index.ts) that runs after the per-step body builders and before `mergePopulatesSubShapeIntoFinalBody`. For each `optionalSubShape` leaf whose semantic is modelDerived, the helper reads `providesValues` from the first `createDeployment` step's fixture in the chain, overrides the synthetic binding, and adds a `populatesSubShape` entry so the existing materializer fills the body.

- **Authoritative override**: a `featureCoverageGenerator`-stamped `elementId_<hex>` synthetic would otherwise shadow the real fixture value. The override is intentional — modelDerived values are authoritative over synthetic placeholders.

- **Gated** on `scenario.strategy === 'featureCoverage'`. Variant scenarios continue using their existing producer-chain logic (through `searchElementInstances`); the unification work is in PR 4 of #162.

### Validator

- `SemanticTypeSpecSchema` now recognises `kind: 'modelDerived'` (strict enum). A typo in domain-semantics JSON is rejected at load time.

## Class-scoped guards (Layer-3 invariants)

Two invariants per endpoint × 4 endpoints in [configs/camunda-oca/regression-invariants.test.ts](configs/camunda-oca/regression-invariants.test.ts):

1. **Binding source**: `bindings.elementIdVar` for the `opt=ElementId` feature scenario must NOT match the pre-PR-1 synthetic pattern `/^elementId_[A-Za-z0-9]+$/`. After PR 1 the binding is `'StartEvent_1'` (or whichever fixture entry the selector chose).
2. **Body shape**: the emitted scenario block for `feature-N - with ElementId` must reference both the consumer's nested path (e.g. `startInstructions`) AND `ctx.elementIdVar`.

Both halves catch partial-regression: dropping the override but keeping the body-shape (or vice versa).

## Out of scope (documented follow-ups)

These were called out in the issue and are intentionally NOT in this PR:

- **`parameters.jobType` subsumption** — `JobType` is not in any operation's `requestBodySemanticTypes` (the spec doesn't annotate it as a semantic type on `activateJobs.type`). It's bridged via `operationRequirements.valueBindings`, which is a different planner code path. `JobType` is declared `kind: modelDerived` here as a placeholder; the runtime consumption needs the valueBindings-bridge work to land. Existing `parameters.jobType` handling is unchanged.

- **`modifyProcessInstancesBatchOperation :: moveInstructions[].sourceElementId`** — the planner emits a single-step chain (no `createDeployment`), so there's no fixture to read `providesValues` from. Chain construction needs to recognise modelDerived semantics as a dependency on a deploy step. Documented as a follow-up in the L3 invariants block.

- **Multi-deploy chains** (`migrateProcessInstance`, `migrateProcessInstancesBatchOperation`) — both consumer sites need a source-model AND target-model fixture; PR 1's helper reads the first `createDeployment` step's fixture only.

- **Variant suite unification** — variant scenarios still bind ElementId via the producer chain through `searchElementInstances`. PR 4 of #162 widens variant to use `providesValues` directly and drops the `subShapeRootOf` filter, eliminating the duplicate-coverage that PR 1 introduces.

- **Layer-2 unit test of `bindModelDerivedFromFixture`** — skipped for PR 1 in favour of the class-scoped L3 invariants across 4 endpoints. Adding the L2 test requires exporting the helper or running the full pipeline against a synthetic graph; not load-bearing given the L3 coverage.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` for all three workspace tsconfigs — clean
- [x] `TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation` — clean
- [x] `npm test` — 38 files / 304 passed / 6 skipped (was 290; +8 new L3 invariants + 6 from other tests now exercising the modelDerived-bound bindings)
- [x] Spot-check across 4 endpoints: each `feature-N - with ElementId` now emits a body referencing `ctx.elementIdVar` inside its consumer's nested path
- [x] Class-scoped sweep: `bindings.elementIdVar` is no longer a `fc:pos:` synthetic on any of the 4 covered endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)