### PR TITLE
chore: retire the parameters field on ArtifactRegistryEntry (#164 Phase A)

### DIFF
--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1241,19 +1241,17 @@ function buildRequestBodyFromCanonical(
       const fileRef = regHit?.ref || defaultFixtures[kind || ''] || '@@FILE:bpmn/simple.bpmn';
       // Bind jobType from the chosen fixture for later use in the request
       // body (`activateJobs.type`, `completeJob`/`failJob`/`throwJobError`
-      // path params, etc.). #163 review: the canonical source is
-      // `providesValues.JobType[0]` (PR 1 of #162's data shape); the
-      // legacy `parameters.jobType` field on the registry entry is
-      // accepted as a fallback during the transition. #164 will retire
-      // the literal-field-name special-case in
-      // `buildRequestBodyFromCanonical` that pairs with this binding;
-      // until then both call sites must agree on the source of truth.
-      const jobTypeFromProvides = regHit?.providesValues?.JobType?.[0];
-      const jobTypeFromParams =
-        regHit?.params && typeof regHit.params.jobType === 'string'
-          ? regHit.params.jobType
-          : undefined;
-      const jobTypeValue = jobTypeFromProvides ?? jobTypeFromParams;
+      // path params, etc.). After #164 the SOLE source is
+      // `providesValues.JobType[0]` (declared on the bpmnProcess fixture
+      // alongside ElementId). The legacy `parameters.jobType` field and
+      // its `??`-fallback reader are gone.
+      //
+      // The literal-field-name special-case at line 944
+      // (`name === 'type' && bindingMap.jobType`) that pairs the
+      // semantically-named `jobType` binding with the spec-named `type`
+      // field is intentionally left in place — that's a separate
+      // architectural cleanup tracked by #162 PR 3 (unified dispatch).
+      const jobTypeValue = regHit?.providesValues?.JobType?.[0];
       if (jobTypeValue !== undefined) {
         const varName = 'jobTypeVar';
         scenario.bindings ||= {};
@@ -1322,13 +1320,6 @@ type ArtifactRegistryEntry = {
   path: string;
   description?: string;
   /**
-   * Pre-#162 ad-hoc bag of "characteristics this fixture has" — the
-   * planner only ever consulted `parameters.jobType`. Kept for back-compat
-   * during the transition to `providesValues` (#162 PR 1); new entries
-   * should declare values under `providesValues` instead.
-   */
-  parameters?: Record<string, unknown>;
-  /**
    * Runtime characteristics this specific fixture provides BEYOND what
    * `artifactKinds.<kind>.producesStates` declares for the kind. The
    * selector picks the entry whose effective providesStates (entry ∪
@@ -1345,6 +1336,11 @@ type ArtifactRegistryEntry = {
    * Per-semantic the value is an array so a future per-consumer-site
    * preference vocabulary can pick a specific entry; PR 1's planner
    * takes index 0 unconditionally.
+   *
+   * After #164: this is the SOLE source of fixture-derived values. The
+   * pre-#162 ad-hoc `parameters: { jobType: ... }` field was the
+   * embryonic form of this idea and has been retired; any new
+   * fixture-derived value must be declared here.
    */
   providesValues?: Record<string, string[]>;
 };
@@ -1370,7 +1366,6 @@ function getArtifactsRegistry(): ArtifactRegistryEntry[] {
         kind: e.kind,
         path: e.path,
         description: e.description,
-        parameters: e.parameters,
         providesStates: Array.isArray(e.providesStates) ? [...e.providesStates] : undefined,
         providesValues: normaliseProvidesValues(e.providesValues),
       }));
@@ -1499,13 +1494,7 @@ function chooseFixtureFromRegistry(
   kind: string | undefined,
   requiredStates: ReadonlySet<string>,
   kindLevelProvides: ReadonlySet<string>,
-):
-  | {
-      ref: string;
-      params?: Record<string, unknown>;
-      providesValues?: Record<string, string[]>;
-    }
-  | undefined {
+): { ref: string; providesValues?: Record<string, string[]> } | undefined {
   if (!kind) return undefined;
   const candidates = getArtifactsRegistry().filter((e) => e.kind === kind);
   if (candidates.length === 0) return undefined;
@@ -1528,7 +1517,6 @@ function chooseFixtureFromRegistry(
     const fallback = candidates[0];
     return {
       ref: `@@FILE:${fallback.path}`,
-      params: fallback.parameters,
       providesValues: fallback.providesValues,
     };
   }
@@ -1539,7 +1527,6 @@ function chooseFixtureFromRegistry(
   });
   return {
     ref: `@@FILE:${best.path}`,
-    params: best.parameters,
     providesValues: best.providesValues,
   };
 }

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1246,11 +1246,11 @@ function buildRequestBodyFromCanonical(
       // alongside ElementId). The legacy `parameters.jobType` field and
       // its `??`-fallback reader are gone.
       //
-      // The literal-field-name special-case at line 944
-      // (`name === 'type' && bindingMap.jobType`) that pairs the
-      // semantically-named `jobType` binding with the spec-named `type`
-      // field is intentionally left in place — that's a separate
-      // architectural cleanup tracked by #162 PR 3 (unified dispatch).
+      // The `jobType` → `type` mapping special-case elsewhere in
+      // `buildRequestBodyFromCanonical` (pairing the semantically-named
+      // `jobType` binding with the spec-named `type` field) is
+      // intentionally left in place — that's a separate architectural
+      // cleanup tracked by #162 PR 3 (unified dispatch).
       const jobTypeValue = regHit?.providesValues?.JobType?.[0];
       if (jobTypeValue !== undefined) {
         const varName = 'jobTypeVar';
@@ -1480,9 +1480,10 @@ function resolveProvider(opId: string, field: string, scenario: EndpointScenario
  *      fewer extra states the chain didn't ask for). Ties at that point
  *      break by array order in the registry.
  *
- * Returns the chosen entry's `@@FILE:<path>` ref plus its parameters, or
- * `undefined` when no entry of the right kind exists at all (the caller then
- * falls back to a hard-coded default).
+ * Returns the chosen entry's `@@FILE:<path>` ref plus its `providesValues`
+ * (the per-fixture modelDerived value source — #162 PR 1), or `undefined`
+ * when no entry of the right kind exists at all (the caller then falls
+ * back to a hard-coded default).
  *
  * When no entry of the right kind covers `requiredStates` (a real
  * misconfiguration — the chain asked for a state nothing provides), the


### PR DESCRIPTION
## Summary

Phase A of #164 (narrowed scope per the issue update). PR #163 + its review fixup made `providesValues.JobType[0]` the canonical source for the `jobTypeVar` binding and added a bridge that preferred providesValues over the legacy `parameters.jobType` field. This PR removes the now-dead `parameters` field entirely.

> **Stacked on [#163 (PR 1 of #162)](https://github.com/camunda/api-test-generator/pull/163).** Once #163 merges this branch will rebase onto main automatically.

## What this lands

Three small deletions:

1. **Type:** `parameters?: Record<string, unknown>` removed from `ArtifactRegistryEntry`. The loader stops propagating `e.parameters` into cached registry entries.
2. **Return shape:** `params` removed from `chooseFixtureFromRegistry`. Only `ref` and `providesValues` remain.
3. **Call site:** the `??`-fallback in the jobType-binding code collapses to a direct `regHit.providesValues?.JobType?.[0]` read.

After this PR, **`providesValues` is the sole source of fixture-derived values**.

## What's explicitly NOT in this PR

The literal-field-name special-case at [path-analyser/src/index.ts:944](path-analyser/src/index.ts#L944) (`name === 'type' && !bindingMap[name] && bindingMap.jobType ? 'jobType' : name`) stays. It bridges two naming conventions:

- Spec calls the field `type` (`activateJobs.type`, `completeJob.type`, etc.)
- Domain-semantics names the binding `jobType` (semantic-shaped, via `operationRequirements.valueBindings`).

Removing it cleanly requires routing the binding through `bindModelDerivedFromFixture` (the modelDerived helper from #163), which in turn needs a `requestSettersByType` index on `OperationNode`. That work is part of #162 PR 3 (unified dispatch) and #162 PR 2 (`clientMintedAttribute` introduces the same `requestSettersByType` index for Tag/BusinessId). Doing it standalone would duplicate the planner index for one consumer; better to wait.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation` — clean
- [x] `npm test` — 38 files / 308 passing / 6 skipped (byte-stable against #163)
- [x] Spot-check: `ctx.jobTypeVar = 'sampleJobType'` still emitted across `activateJobs`, `completeJob`, `failJob`, `throwJobError` specs
- [x] L3 invariant from #163 (every job-related endpoint's feature-1 binds `jobTypeVar === 'sampleJobType'`) continues to pass — locks the simplified code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)