### PR TITLE
feat: clientMintedAttribute classification + requestSettersByType index (#162 PR 2)

### DIFF
--- a/configs/camunda-oca/domain-semantics.json
+++ b/configs/camunda-oca/domain-semantics.json
@@ -168,7 +168,7 @@
     "Tag": {
       "kind": "attribute",
       "clientMinted": true,
-      "$comment": "Free-form label attached to an entity (createProcessInstance.tags[], searchProcessInstances.filter.tags[], etc.). No producer endpoint and no first-order entity retrievable by tag — the planner mints a deterministic value and threads it through setter and consumer sites in the chain. See #162 PR 2."
+      "$comment": "Free-form label attached to an entity (createProcessInstance.tags[], searchProcessInstances.filter.tags[], etc.). No producer endpoint and no first-order entity retrievable by tag — the planner mints a deterministic value at setter sites (createProcessInstance.tags[]). Filter-consumer reuse — threading the same minted value into searchProcessInstances.filter.tags[] and similar — is deferred (see #168). See #162 PR 2."
     },
     "BusinessId": {
       "kind": "attribute",

--- a/configs/camunda-oca/domain-semantics.json
+++ b/configs/camunda-oca/domain-semantics.json
@@ -164,6 +164,16 @@
     "JobType": {
       "kind": "modelDerived",
       "$comment": "zeebe:taskDefinition type is encoded in the BPMN model on each service-task element. Read out-of-band from the chosen fixture's providesValues. Subsumes the pre-#162 ad-hoc `parameters.jobType` handling in the registry."
+    },
+    "Tag": {
+      "kind": "attribute",
+      "clientMinted": true,
+      "$comment": "Free-form label attached to an entity (createProcessInstance.tags[], searchProcessInstances.filter.tags[], etc.). No producer endpoint and no first-order entity retrievable by tag — the planner mints a deterministic value and threads it through setter and consumer sites in the chain. See #162 PR 2."
+    },
+    "BusinessId": {
+      "kind": "attribute",
+      "clientMinted": true,
+      "$comment": "Free-form correlation identifier attached to a process instance (createProcessInstance.businessId, searchProcessInstances.filter.businessId, etc.). Like Tag: client-minted, no producer endpoint, no first-order entity retrievable by it. The planner mints a deterministic value at the setter site; filter-consumer reuse is deferred (see #168)."
     }
   },
   "operationArtifactRules": {

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -2845,3 +2845,158 @@ describeForThisConfig(
   },
 );
 
+describeForThisConfig(
+  'bundled-spec invariants: clientMintedAttribute setter sites (#162 PR 2)',
+  () => {
+    // PR 2 of #162: every semantic declared `kind: 'attribute',
+    // clientMinted: true` in domain-semantics is bound by the planner
+    // (deterministic minted value with the `fc:cma:<sem>:` prefix) at
+    // setter sites — operations whose request body accepts the
+    // semantic at a top-level path. The body materializer fills the
+    // setter field with `ctx.<sem>Var`.
+    //
+    // Class-scoped: derive the (semantic, setter-op) pairs from
+    // domain-semantics + the dependency graph, then assert the
+    // bindings + emitted body for every pair. Adding a new attribute
+    // semantic to domain-semantics (or upstream introducing a new
+    // setter operation for an existing attribute semantic) lights up
+    // the same assertions automatically.
+    //
+    // Filter-consumer sites (path begins with `filter.` / `filter[`)
+    // are intentionally excluded — they need setter-chain reuse to be
+    // meaningful (a setter step inserted before the filter step that
+    // tags an entity, with the same minted value threaded through).
+    // Tracked in #168 (the deferred follow-up to #162 PR 2).
+
+    interface SemanticTypeDecl {
+      kind?: string;
+      clientMinted?: boolean;
+    }
+    interface DomainSemantics {
+      semanticTypes?: Record<string, SemanticTypeDecl>;
+    }
+
+    function loadAttributeClientMintedSemantics(): string[] {
+      const path = join(REPO_ROOT, 'configs', CONFIG_NAME, 'domain-semantics.json');
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const domain = JSON.parse(readFileSync(path, 'utf8')) as DomainSemantics;
+      return Object.entries(domain.semanticTypes ?? {})
+        .filter(([, spec]) => spec?.kind === 'attribute' && spec?.clientMinted === true)
+        .map(([name]) => name)
+        .sort();
+    }
+
+    function camelCase(s: string): string {
+      return s.charAt(0).toLowerCase() + s.slice(1);
+    }
+
+    // Mirror the planner's setter-site predicate: top-level path or any
+    // non-`filter.*` parent. Filter paths are deferred (see comment
+    // above and `bindClientMintedAttribute` in path-analyser/src/index.ts).
+    function isSetterPath(fieldPath: string): boolean {
+      return !fieldPath.startsWith('filter.') && !fieldPath.startsWith('filter[');
+    }
+
+    function setterOpsFor(semantic: string): OperationNode[] {
+      const graph = loadGraph();
+      const ops: OperationNode[] = [];
+      for (const op of graph.operations) {
+        const leaves = op.requestBodySemanticTypes ?? [];
+        if (leaves.some((l) => l.semanticType === semantic && isSetterPath(l.fieldPath))) {
+          ops.push(op);
+        }
+      }
+      return ops;
+    }
+
+    // OpenAPI op → feature-output JSON file name. Mirrors the
+    // generator's normalizeEndpointFileName: lowercased method, path
+    // with `/` replaced by `--`, leading `--`, trailing `-scenarios.json`.
+    function featureFileFor(op: OperationNode): string {
+      const method = op.method.toLowerCase();
+      const pathPart = op.path.replace(/\//g, '--');
+      return `${method}${pathPart}-scenarios.json`;
+    }
+
+    const ATTRIBUTE_SEMANTICS = loadAttributeClientMintedSemantics();
+
+    it('domain-semantics declares at least one clientMintedAttribute semantic (PR 2 must not regress to zero)', () => {
+      expect(
+        ATTRIBUTE_SEMANTICS.length,
+        `expected at least one kind:'attribute' + clientMinted:true semantic in configs/${CONFIG_NAME}/domain-semantics.json`,
+      ).toBeGreaterThan(0);
+    });
+
+    for (const semantic of ATTRIBUTE_SEMANTICS) {
+      const setterOps = setterOpsFor(semantic);
+
+      it(`${semantic}: at least one setter operation declares the semantic at a top-level body path`, () => {
+        expect(
+          setterOps.length,
+          `expected at least one operation accepting ${semantic} at a non-filter body path`,
+        ).toBeGreaterThan(0);
+      });
+
+      for (const op of setterOps) {
+        const varName = `${camelCase(semantic)}Var`;
+        const expectedPrefix = `fc:cma:${camelCase(semantic)}:`;
+        const variantKey = `opt=${semantic}`;
+
+        it(`${semantic} :: ${op.operationId}: opt=${semantic} feature scenario binds ${varName} with the clientMintedAttribute prefix (#162 PR 2)`, () => {
+          const featureFile = join(FEATURE_SCENARIOS_DIR, featureFileFor(op));
+          if (!existsSync(featureFile)) {
+            throw new Error(
+              `expected feature-output JSON not found: ${featureFileFor(op)} — run 'npm run testsuite:generate'`,
+            );
+          }
+          const raw = readFileSync(featureFile, 'utf8');
+          // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+          const parsed = JSON.parse(raw) as {
+            scenarios: Array<{ variantKey?: string; bindings?: Record<string, string> }>;
+          };
+          const scenario = parsed.scenarios.find((s) => s.variantKey === variantKey);
+          expect(
+            scenario,
+            `${op.operationId}: expected an ${variantKey} feature scenario`,
+          ).toBeDefined();
+          const binding = scenario?.bindings?.[varName];
+          expect(
+            binding,
+            `${op.operationId} ${variantKey}: must bind ${varName}`,
+          ).toBeDefined();
+          expect(
+            binding?.startsWith(expectedPrefix),
+            `${op.operationId} ${variantKey}: ${varName} binding must use the clientMintedAttribute prefix (${expectedPrefix}…); got '${binding}'`,
+          ).toBe(true);
+        });
+
+        it(`${semantic} :: ${op.operationId}: emitted with-${semantic} feature spec references ctx.${varName} (#162 PR 2)`, () => {
+          // Map operationId → emitted Playwright spec path. The
+          // generator names files by operationId (not method+path) for
+          // playwright suites, so this lookup is direct.
+          const spec = join(GENERATED_TESTS_DIR, `${op.operationId}.feature.spec.ts`);
+          if (!existsSync(spec)) {
+            throw new Error(
+              `expected emitted spec not found: ${op.operationId}.feature.spec.ts — run 'npm run testsuite:generate'`,
+            );
+          }
+          const src = readFileSync(spec, 'utf8');
+          // The variant title fragment the emitter writes for `opt=<X>`
+          // is `with <X>` (see featureCoverageGenerator title formatter).
+          const scenarioMarker = `with ${semantic}`;
+          const scenarioIdx = src.indexOf(scenarioMarker);
+          expect(
+            scenarioIdx,
+            `${op.operationId}: expected a scenario block titled '${scenarioMarker}'`,
+          ).toBeGreaterThan(0);
+          const nextTestIdx = src.indexOf("\n  test('", scenarioIdx + scenarioMarker.length);
+          const block = src.slice(scenarioIdx, nextTestIdx > 0 ? nextTestIdx : src.length);
+          expect(
+            block.includes(`ctx.${varName}`),
+            `${op.operationId} '${scenarioMarker}': body must reference ctx.${varName}`,
+          ).toBe(true);
+        });
+      }
+    }
+  },
+);

--- a/path-analyser/domain-semantics.schema.json
+++ b/path-analyser/domain-semantics.schema.json
@@ -98,8 +98,12 @@
           "witnesses": {"type": "string", "minLength": 1},
           "kind": {
             "type": "string",
-            "enum": ["modelDerived"],
-            "description": "Value-source classification (#162 PR 1). When `modelDerived`, the planner reads values from the chain's createDeployment fixture's providesValues entry — no API round-trip required. Future PRs will add `attribute` for client-minted free-form labels."
+            "enum": ["modelDerived", "attribute"],
+            "description": "Value-source classification (#162). When `modelDerived` the planner reads values from the chain's createDeployment fixture's providesValues entry (PR 1). When `attribute` the value is a free-form label minted by the planner / client; requires `clientMinted: true` (PR 2)."
+          },
+          "clientMinted": {
+            "type": "boolean",
+            "description": "Whether values of this semantic are minted by the planner / client rather than returned by a producer endpoint (#162 PR 2). Currently only meaningful with `kind: 'attribute'` — the validator enforces the pairing."
           },
           "$comment": {"type": "string"}
         }

--- a/path-analyser/src/domainSemanticsValidator.ts
+++ b/path-analyser/src/domainSemanticsValidator.ts
@@ -37,11 +37,13 @@ import type { OperationGraph } from './types.js';
 const SemanticTypeSpecSchema = z
   .object({
     witnesses: z.string().min(1).optional(),
-    // #162 PR 1: value-source classification. Only `modelDerived` lands
-    // in PR 1; future PRs add `attribute` (client-minted free-form
-    // labels). Anything else is rejected at the schema layer so a typo
-    // doesn't silently fall through to the default classification chain.
-    kind: z.enum(['modelDerived']).optional(),
+    // #162 PR 1 added `modelDerived`; PR 2 adds `attribute`. Strict enum
+    // so a typo (e.g. `attributes`) is rejected at load time rather than
+    // silently falling through to the default classification chain.
+    kind: z.enum(['modelDerived', 'attribute']).optional(),
+    // #162 PR 2: only meaningful with `kind: 'attribute'`. Validator
+    // enforces the pairing in `checkSemanticTypeKindCoherent` below.
+    clientMinted: z.boolean().optional(),
   })
   .passthrough();
 
@@ -381,6 +383,35 @@ function checkEventualStateWitnessShape(d: DomainSemanticsShape): CrossRefIssue[
   return issues;
 }
 
+// #162 PR 2: `kind: 'attribute'` and `clientMinted: true` are paired —
+// a `clientMinted: true` flag without `kind: 'attribute'` is dead config
+// (the planner only consults clientMinted on attribute-kind semantics),
+// and `kind: 'attribute'` without `clientMinted: true` is currently
+// undefined (PR 2's planner branch hard-requires clientMinted, since the
+// alternative interpretation — server-minted attributes — isn't part of
+// the classification vocabulary). Both directions get a load-time error
+// so a typo doesn't silently fall through.
+function checkAttributeKindClientMintedPairing(d: DomainSemanticsShape): CrossRefIssue[] {
+  const issues: CrossRefIssue[] = [];
+  for (const [name, spec] of Object.entries(d.semanticTypes ?? {})) {
+    const kind = spec.kind;
+    const clientMinted = spec.clientMinted === true;
+    if (kind === 'attribute' && !clientMinted) {
+      issues.push({
+        code: 'attributeKindClientMintedPairing',
+        message: `semanticTypes.${name} sets kind: 'attribute' but is missing clientMinted: true. PR 2 (#162) requires the pairing — declare clientMinted: true or change the kind.`,
+      });
+    }
+    if (clientMinted && kind !== 'attribute') {
+      issues.push({
+        code: 'attributeKindClientMintedPairing',
+        message: `semanticTypes.${name} sets clientMinted: true but kind is ${kind ? `'${kind}'` : 'absent'}. The planner only consults clientMinted on attribute-kind semantics.`,
+      });
+    }
+  }
+  return issues;
+}
+
 const CROSS_REF_CHECKS = [
   checkArtifactKindStateDeclared,
   checkArtifactKindWitnessDeclared,
@@ -390,6 +421,7 @@ const CROSS_REF_CHECKS = [
   checkDisjunctionMemberResolves,
   checkGlobalContextSeedsCoherent,
   checkEventualStateWitnessShape,
+  checkAttributeKindClientMintedPairing,
 ] as const;
 
 // Composed schema: structural shape + every cross-reference invariant.

--- a/path-analyser/src/domainSemanticsValidator.ts
+++ b/path-analyser/src/domainSemanticsValidator.ts
@@ -42,7 +42,8 @@ const SemanticTypeSpecSchema = z
     // silently falling through to the default classification chain.
     kind: z.enum(['modelDerived', 'attribute']).optional(),
     // #162 PR 2: only meaningful with `kind: 'attribute'`. Validator
-    // enforces the pairing in `checkSemanticTypeKindCoherent` below.
+    // enforces the pairing in `checkAttributeKindClientMintedPairing`
+    // below.
     clientMinted: z.boolean().optional(),
   })
   .passthrough();

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -186,6 +186,11 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
   const producersByType: Record<string, string[]> = {};
   const responseProducersByType: Record<string, string[]> = {};
   const establishersByType: Record<string, string[]> = {};
+  // #162 PR 2: per-semantic index of ops that ACCEPT this semantic in
+  // their request body. Parallel to producersByType (response side) and
+  // establishersByType (request side, identifier-shaped). Used by the
+  // planner to find setter sites for clientMintedAttribute semantics.
+  const requestSettersByType: Record<string, string[]> = {};
   for (const op of Object.values(operations)) {
     // `producersByType` is the authoritative-producer index after #98:
     // membership means "this op returns or witnesses an authoritative
@@ -234,6 +239,16 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
       const list = responseProducersByType[leaf.semantic] ?? [];
       if (!list.includes(op.operationId)) list.push(op.operationId);
       responseProducersByType[leaf.semantic] = list;
+    }
+    // #162 PR 2: index every semantic-typed request-body leaf so the
+    // planner can ask "which ops accept this semantic in their body?"
+    // Dedup at the writer — an op with multiple leaves of the same
+    // semantic (e.g. `filter.tags[]` AND `filter.$or[].tags[]`) still
+    // appears once.
+    for (const leaf of op.requestBodySemantics ?? []) {
+      const list = requestSettersByType[leaf.semantic] ?? [];
+      if (!list.includes(op.operationId)) list.push(op.operationId);
+      requestSettersByType[leaf.semantic] = list;
     }
   }
 
@@ -449,6 +464,9 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     producersByState,
     establishersByType: Object.keys(establishersByType).length ? establishersByType : undefined,
     externalEntityIdentifiers,
+    requestSettersByType: Object.keys(requestSettersByType).length
+      ? requestSettersByType
+      : undefined,
   };
   // #159 PR B (review): the structural domain-semantics validator can't
   // see the graph, so a witness operationId that doesn't resolve (typo,
@@ -621,8 +639,33 @@ function normalizeOp(opId: string, op: RawOp): OperationNode {
     pathParameters: extractPathParameters(op),
     optionalSubShapes: optionalSubShapes.length ? optionalSubShapes : undefined,
     responseSemanticLeaves: responseLeaves.length ? responseLeaves : undefined,
+    requestBodySemantics: extractRequestBodySemantics(op),
     establishes,
   };
+}
+
+/**
+ * Surface every semantic-typed request-body leaf on the OperationNode
+ * so downstream consumers (the requestSettersByType index, the planner's
+ * clientMintedAttribute helper) can iterate without re-reading the raw
+ * graph JSON. Unlike `optionalSubShapes` this list is INCLUSIVE — it
+ * carries nested, top-level, scalar-array, and required leaves; the
+ * consumer filters as needed (#162 PR 2).
+ */
+function extractRequestBodySemantics(op: RawOp): OperationNode['requestBodySemantics'] {
+  if (!Array.isArray(op.requestBodySemanticTypes)) return undefined;
+  const out: NonNullable<OperationNode['requestBodySemantics']> = [];
+  for (const entry of op.requestBodySemanticTypes) {
+    if (!entry || typeof entry.semanticType !== 'string' || typeof entry.fieldPath !== 'string') {
+      continue;
+    }
+    out.push({
+      semantic: entry.semanticType,
+      fieldPath: entry.fieldPath,
+      required: entry.required === true,
+    });
+  }
+  return out.length ? out : undefined;
 }
 
 function normalizeEstablishes(raw: unknown): OperationNode['establishes'] {

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -3,6 +3,7 @@ import { mkdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildCanonicalShapes } from './canonicalSchemas.js';
+import { deterministicSuffix } from './codegen/support/seeding.js';
 import {
   getActiveConfigDir,
   getFeatureOutputDir,
@@ -574,6 +575,12 @@ function buildRequestPlan(
   // (and so the binding has the fixture value rather than the
   // synthetic placeholder featureCoverageGenerator stamped earlier).
   bindModelDerivedFromFixture(scenario, steps, graph);
+  // #162 PR 2: bind clientMintedAttribute semantics with a deterministic
+  // minted value at setter sites in the same window (before the
+  // populatesSubShape merge). Independent of bindModelDerivedFromFixture
+  // — different value source (planner, not fixture) — but co-located so
+  // both feed the same downstream materialization.
+  bindClientMintedAttribute(scenario, steps, graph);
   // Issue #105 (Phase 3): for variant scenarios, deep-merge the populated
   // sub-shape into the FINAL step's bodyTemplate. The planner stamps
   // `populatesSubShape` on each variant scenario; the emitter expects the
@@ -781,6 +788,138 @@ function fixtureFromDeployStep(step: RequestStep): ArtifactRegistryEntry | undef
     }
   }
   return undefined;
+}
+
+/**
+ * #162 PR 2: bind values for `kind: 'attribute'` + `clientMinted: true`
+ * semantic types at SETTER sites in the chain. A setter site is an
+ * operation whose request body declares the semantic — the value
+ * originates from the planner (a deterministic minted token), not from
+ * any producer endpoint, and gets stamped into the body via the
+ * standard `populatesSubShape` materializer.
+ *
+ * Scope (PR 2):
+ *
+ *   - Runs ONLY for feature-coverage scenarios. Variant scenarios are
+ *     handled by their own dedicated planner path; the unified-dispatch
+ *     refactor is #162 PR 3.
+ *
+ *   - Setter-site only. If the endpoint accepts the semantic in its
+ *     request body, we mint + populate here. Filter-consumer endpoints
+ *     (search/batch ops where a tag is matched against existing
+ *     entities) need setter-chain reuse — insert a setter step BEFORE
+ *     the consumer step and thread the same minted value through — and
+ *     are deferred to a follow-up issue. Without that work, filter
+ *     scenarios would search for a non-existent value and return empty
+ *     results, failing the non-empty assertion.
+ *
+ *   - Walks `endpoint.requestBodySemantics` (the inclusive index added
+ *     in PR 2 for exactly this purpose) so scalar-array paths (`tags[]`)
+ *     and top-level scalars (`businessId`) are visible alongside
+ *     nested-object leaves. `optionalSubShapes` would miss them.
+ *
+ *   - The `fc:cma:<sem>:` prefix on the minted value tags the source
+ *     (`fc` = feature coverage, `cma` = client-minted attribute) so
+ *     a grep of the emitted output can distinguish it from
+ *     `fc:pos:<sem>:` (the pre-#162 synthetic) and from
+ *     producer-bound values.
+ *
+ * Side effects:
+ *
+ *   - Overrides any pre-existing binding (synthetic from
+ *     featureCoverageGenerator) with the new minted value. Override is
+ *     intentional — clientMintedAttribute values are authoritative over
+ *     the pre-classification synthetic.
+ *
+ *   - Adds a `populatesSubShape` entry for the leaf (even when the path
+ *     is top-level scalar or scalar-array) so the existing
+ *     `mergePopulatesSubShapeIntoFinalBody` materializer fills the body.
+ *     `setLeafPlaceholder` already handles scalar-array `[]` leaves
+ *     correctly — building `tags: ['${tagVar}']` for top-level
+ *     `tags[]` and `filter.tags: ['${tagVar}']` for nested
+ *     `filter.tags[]`.
+ */
+function bindClientMintedAttribute(
+  scenario: EndpointScenario,
+  steps: RequestStep[],
+  graph: OperationGraph,
+): void {
+  if (scenario.strategy !== 'featureCoverage') return;
+  const domain = graph.domain;
+  if (!domain?.semanticTypes) return;
+  if (!steps.length) return;
+  const finalStep = steps[steps.length - 1];
+  const endpoint = graph.operations[finalStep.operationId];
+  const bodySems = endpoint?.requestBodySemantics ?? [];
+  if (!bodySems.length) return;
+
+  for (const bodySem of bodySems) {
+    const spec = domain.semanticTypes[bodySem.semantic];
+    if (spec?.kind !== 'attribute' || spec.clientMinted !== true) continue;
+    // PR 2 narrowed scope: only fill at the endpoint that IS the setter
+    // (the final-step body accepts the semantic). Filter-consumer sites
+    // also have the semantic in their bodySemantics but need a separate
+    // setter-chain pass to make the value meaningful — deferred.
+    //
+    // Heuristic for "this is a setter site" vs "this is a filter
+    // consumer": filter consumers have the semantic under a path
+    // beginning with `filter.` or `filter[` (the bundled spec uses
+    // `filter.tags[]` and `filter.$or[].tags[]`); setters have the
+    // semantic at top-level or under a non-filter parent. This is a
+    // pragmatic shortcut for PR 2; the follow-up issue (#168) will use
+    // the requestSettersByType index to discover setters generically
+    // and prepend a setter step before each filter consumer.
+    if (bodySem.fieldPath.startsWith('filter.') || bodySem.fieldPath.startsWith('filter[')) {
+      continue;
+    }
+
+    const varName = `${camelCase(bodySem.semantic)}Var`;
+    const mintedValue = `fc:cma:${camelCase(bodySem.semantic)}:${deterministicSuffix(`fc:cma:${finalStep.operationId}:${bodySem.semantic}`)}`;
+    scenario.bindings ||= {};
+    scenario.bindings[varName] = mintedValue;
+
+    // Always plant a populatesSubShape entry so the body is filled by
+    // the existing materializer. setLeafPlaceholder handles all three
+    // shapes the planner emits: top-level scalar (`businessId`),
+    // top-level scalar array (`tags[]`), and nested scalar array
+    // (`filter.tags[]`, when setter-chain support lands).
+    const sub = scenario.populatesSubShape ?? {
+      rootPath: subShapeRootForFieldPath(bodySem.fieldPath),
+      leafPaths: [],
+      leafSemantics: [],
+    };
+    if (!sub.leafPaths.includes(bodySem.fieldPath)) {
+      sub.leafPaths.push(bodySem.fieldPath);
+      sub.leafSemantics ||= [];
+      sub.leafSemantics.push(bodySem.semantic);
+    }
+    if (!sub.rootPath) sub.rootPath = subShapeRootForFieldPath(bodySem.fieldPath);
+    scenario.populatesSubShape = sub;
+  }
+}
+
+/**
+ * Compute the sub-shape root for a fieldPath. Used by the
+ * clientMintedAttribute helper to seed `populatesSubShape.rootPath` for
+ * top-level scalar / scalar-array leaves where the graphLoader's
+ * `subShapeRootOf` returns null. Mirrors the simpler cases:
+ *
+ *   "tags[]"           → "tags[]"
+ *   "businessId"       → "businessId"
+ *   "filter.tags[]"    → "filter"  (deepest object/array-of-object
+ *                                   ancestor — but PR 2 skips this
+ *                                   branch since filter sites are
+ *                                   deferred)
+ *
+ * Single-segment paths return the segment itself rather than the empty
+ * string the graphLoader's stricter rule would yield — the rootPath
+ * is informational metadata on populatesSubShape and the merge logic
+ * doesn't actually read it.
+ */
+function subShapeRootForFieldPath(fieldPath: string): string {
+  const segments = fieldPath.split('.');
+  if (segments.length === 1) return segments[0];
+  return segments.slice(0, -1).join('.');
 }
 
 function mergePopulatesSubShapeIntoFinalBody(

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -71,6 +71,18 @@ export interface OperationNode extends OperationRef {
     status: string;
     provider: boolean;
   }>;
+  // #162 PR 2: every semantic-typed request-body leaf, regardless of
+  // nesting or required flag. Surfaced separately from `optionalSubShapes`
+  // (which filters to nested-object-only) so the requestSettersByType
+  // index and the clientMintedAttribute planner helper can iterate
+  // scalar arrays (`tags[]`) and top-level scalars (`businessId`)
+  // alongside nested-object leaves. Empty/undefined when the operation
+  // has no semantic-typed request-body fields.
+  requestBodySemantics?: Array<{
+    semantic: string;
+    fieldPath: string;
+    required: boolean;
+  }>;
   // Issue #104: x-semantic-establishes annotation passthrough. When
   // present, the operation establishes an entity whose identifiers are
   // client-minted via the listed request inputs. The planner schedules
@@ -139,6 +151,22 @@ export interface OperationGraph {
   // the kind-scoped sibling of the per-tuple `acceptsExternal: true`
   // flag. Empty/undefined means no registry was loaded.
   externalEntityIdentifiers?: Set<string>;
+  /**
+   * Map of semantic type → operations that ACCEPT this semantic in their
+   * request body (#162 PR 2). Parallel to `producersByType` (response
+   * body) and `establishersByType` (request body, identifier-shaped).
+   * Used by the planner to find setter sites for client-minted attribute
+   * semantics — e.g. `createProcessInstance` is the only setter for
+   * `Tag` in the camunda-oca spec, accepting `tags[]` in its body.
+   *
+   * Includes every semantic-typed request-body leaf regardless of nesting
+   * or `required` flag, so the planner can discover both top-level
+   * (`tags[]`) and nested (`filter.tags[]`) setter locations. The
+   * setter-chain reuse pass (a follow-up to PR 2) will consume this
+   * to insert a setter step before a downstream consumer step that
+   * requires the same minted value.
+   */
+  requestSettersByType?: Record<string, string[]>;
 }
 
 export interface BootstrapSequence {
@@ -445,22 +473,37 @@ export interface SemanticTypeSpec {
   // (those listed in artifactKinds.*.producesSemantics).
   witnesses?: string;
   /**
-   * How the planner obtains a value for this semantic type (#162). Five
-   * classifications are envisioned; PR 1 adds `modelDerived`.
+   * How the planner obtains a value for this semantic type (#162). Two
+   * classifications land so far; the issue envisions five in total.
    *
-   *   - `modelDerived`: the value is read out-of-band from a deployment
-   *     artifact in the same chain. The planner looks the value up in the
-   *     `providesValues` entry of the fixture chosen for the chain's
-   *     `createDeployment` step. Examples: `ElementId`, `JobType` — these
-   *     values come from the BPMN model itself, not from a Camunda API
-   *     response.
+   *   - `modelDerived` (#162 PR 1): the value is read out-of-band from a
+   *     deployment artifact in the same chain. The planner looks the
+   *     value up in the `providesValues` entry of the fixture chosen for
+   *     the chain's `createDeployment` step. Examples: `ElementId`,
+   *     `JobType` — values come from the BPMN model itself, not from a
+   *     Camunda API response.
    *
-   * Future PRs will add `attribute` (free-form client-minted labels —
-   * `Tag`, `BusinessId`) under this same field. Absent `kind` means the
-   * planner falls back to its existing classification chain
-   * (producersByType / establishersByType / external-entity).
+   *   - `attribute` (#162 PR 2): the value is a free-form label attached
+   *     to another entity, with no first-order entity retrievable by it
+   *     and no producer in the API. The planner mints a deterministic
+   *     value and binds it; setter-chain reuse threads the same value
+   *     between a setter site and any downstream consumer in the same
+   *     scenario. Requires `clientMinted: true` on the same entry —
+   *     `attribute` is a structural shape, `clientMinted` says where the
+   *     value originates. Examples: `Tag`, `BusinessId`.
+   *
+   * Absent `kind` means the planner falls back to its existing
+   * classification chain (producersByType / establishersByType /
+   * external-entity / synthetic).
    */
-  kind?: 'modelDerived';
+  kind?: 'modelDerived' | 'attribute';
+  /**
+   * Whether values of this semantic are minted by the planner / client
+   * rather than returned by a producer endpoint (#162 PR 2). Only
+   * meaningful with `kind: 'attribute'`. Future PRs may extend
+   * client-minted semantics to identifier-shaped types as well.
+   */
+  clientMinted?: boolean;
 }
 
 export interface IdentifierSpec {

--- a/tests/fixtures/loader/graphloader-request-setters.test.ts
+++ b/tests/fixtures/loader/graphloader-request-setters.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Loader fixtures for `requestSettersByType` and the per-op
+ * `requestBodySemantics` index added in #162 PR 2.
+ *
+ * Class-scoped guarantee: every semantic-typed request-body leaf surfaces
+ * on `OperationNode.requestBodySemantics` regardless of nesting,
+ * required flag, or scalar/array shape; and the per-graph
+ * `requestSettersByType` index lists every operation that accepts each
+ * semantic in its body, dedup'd, with no entries when no operation
+ * declares a body semantic.
+ *
+ * These properties are what the planner's `bindClientMintedAttribute`
+ * helper and the future setter-chain reuse pass consume; if either
+ * regresses, attribute-classification scenarios silently revert to the
+ * pre-PR-2 synthetic placeholder. The fixture is the smallest spec
+ * that exercises each shape independently.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadGraph } from '../../../path-analyser/src/graphLoader.ts';
+
+let workdir: string;
+let baseDir: string;
+let graphDir: string;
+let configDir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'graphloader-request-setters-'));
+  baseDir = join(workdir, 'path-analyser');
+  graphDir = join(workdir, 'generated', 'camunda-oca', 'graph');
+  configDir = join(workdir, 'configs', 'camunda-oca');
+  mkdirSync(baseDir, { recursive: true });
+  mkdirSync(graphDir, { recursive: true });
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(
+    join(workdir, 'configs.json'),
+    JSON.stringify({ default: 'camunda-oca', configs: { 'camunda-oca': {} } }),
+  );
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+interface Layout {
+  graph: Record<string, unknown>;
+  domain?: Record<string, unknown>;
+}
+
+function writeLayout(layout: Layout): void {
+  writeFileSync(join(graphDir, 'operation-dependency-graph.json'), JSON.stringify(layout.graph));
+  writeFileSync(
+    join(configDir, 'domain-semantics.json'),
+    JSON.stringify(layout.domain ?? { operationRequirements: {} }),
+  );
+}
+
+describe('graphLoader: requestBodySemantics surfaces every body leaf shape (#162 PR 2)', () => {
+  it('top-level scalar, top-level scalar array, and nested-object leaves all surface', async () => {
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'createInstance',
+            method: 'POST',
+            path: '/instance',
+            requestBodySemanticTypes: [
+              { fieldPath: 'businessId', semanticType: 'BusinessId', required: false },
+              { fieldPath: 'tags[]', semanticType: 'Tag', required: false },
+              {
+                fieldPath: 'filter.processInstanceKey',
+                semanticType: 'ProcessInstanceKey',
+                required: false,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const g = await loadGraph(baseDir);
+    const op = g.operations.createInstance;
+    expect(op?.requestBodySemantics).toEqual([
+      { semantic: 'BusinessId', fieldPath: 'businessId', required: false },
+      { semantic: 'Tag', fieldPath: 'tags[]', required: false },
+      {
+        semantic: 'ProcessInstanceKey',
+        fieldPath: 'filter.processInstanceKey',
+        required: false,
+      },
+    ]);
+  });
+
+  it('preserves the `required: true` flag on body leaves', async () => {
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'createDeployment',
+            method: 'POST',
+            path: '/deployments',
+            requestBodySemanticTypes: [
+              {
+                fieldPath: 'processDefinitionId',
+                semanticType: 'ProcessDefinitionId',
+                required: true,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const g = await loadGraph(baseDir);
+    expect(g.operations.createDeployment?.requestBodySemantics).toEqual([
+      { semantic: 'ProcessDefinitionId', fieldPath: 'processDefinitionId', required: true },
+    ]);
+  });
+
+  it('omits `requestBodySemantics` when the operation has no body semantics', async () => {
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'getStatus',
+            method: 'GET',
+            path: '/status',
+          },
+        ],
+      },
+    });
+    const g = await loadGraph(baseDir);
+    expect(g.operations.getStatus?.requestBodySemantics).toBeUndefined();
+  });
+
+  it('skips malformed entries (missing semanticType or fieldPath) without throwing', async () => {
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'looseOp',
+            method: 'POST',
+            path: '/loose',
+            requestBodySemanticTypes: [
+              { fieldPath: 'businessId', semanticType: 'BusinessId', required: false },
+              // Missing semanticType — the loader must drop this entry,
+              // not surface a partial { fieldPath, undefined } in the
+              // index (which would produce a bogus `undefined` key in
+              // requestSettersByType).
+              { fieldPath: 'noType' },
+              // Missing fieldPath.
+              { semanticType: 'NoPath' },
+            ],
+          },
+        ],
+      },
+    });
+    const g = await loadGraph(baseDir);
+    expect(g.operations.looseOp?.requestBodySemantics).toEqual([
+      { semantic: 'BusinessId', fieldPath: 'businessId', required: false },
+    ]);
+  });
+});
+
+describe('graphLoader: requestSettersByType lists every body-acceptor per semantic (#162 PR 2)', () => {
+  it('builds a per-semantic list of operations that accept the semantic in their body', async () => {
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'createInstance',
+            method: 'POST',
+            path: '/instance',
+            requestBodySemanticTypes: [
+              { fieldPath: 'tags[]', semanticType: 'Tag', required: false },
+              { fieldPath: 'businessId', semanticType: 'BusinessId', required: false },
+            ],
+          },
+          {
+            operationId: 'searchInstances',
+            method: 'POST',
+            path: '/instance/search',
+            requestBodySemanticTypes: [
+              { fieldPath: 'filter.tags[]', semanticType: 'Tag', required: false },
+            ],
+          },
+        ],
+      },
+    });
+    const g = await loadGraph(baseDir);
+    expect(g.requestSettersByType).toBeDefined();
+    expect(g.requestSettersByType?.Tag).toEqual(['createInstance', 'searchInstances']);
+    expect(g.requestSettersByType?.BusinessId).toEqual(['createInstance']);
+  });
+
+  it('dedups when one operation declares the same semantic on multiple body leaves', async () => {
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'searchInstances',
+            method: 'POST',
+            path: '/instance/search',
+            requestBodySemanticTypes: [
+              { fieldPath: 'filter.tags[]', semanticType: 'Tag', required: false },
+              { fieldPath: 'filter.$or[].tags[]', semanticType: 'Tag', required: false },
+            ],
+          },
+        ],
+      },
+    });
+    const g = await loadGraph(baseDir);
+    expect(g.requestSettersByType?.Tag).toEqual(['searchInstances']);
+  });
+
+  it('omits `requestSettersByType` entirely when no operation has body semantics', async () => {
+    writeLayout({
+      graph: {
+        operations: [{ operationId: 'getStatus', method: 'GET', path: '/status' }],
+      },
+    });
+    const g = await loadGraph(baseDir);
+    expect(g.requestSettersByType).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

PR 2 of #162 — adds the `clientMintedAttribute` value-source classification and the `requestSettersByType` graph index. The planner now mints a deterministic value (`fc:cma:<sem>:<suffix>`) for `kind: 'attribute', clientMinted: true` semantics at setter sites and the existing `populatesSubShape` materializer fills the request body with it, in place of the pre-#162 synthetic placeholder.

Closes the PR-2 portion of #162. Filter-consumer setter-chain reuse is deferred to #168.

## Defect

`feature-N - createProcessInstance - with Tag` (and `with BusinessId`) emitted bodies that either omitted the field entirely (`tags[]`, a scalar-array path the variant body builder skipped) or filled it with a synthetic placeholder (`businessId_1xfw`) that didn't telegraph its source. The scenario name claimed coverage the body never delivered — one of the lying-scenario classes #162 enumerates.

## What changed

- **`configs/camunda-oca/domain-semantics.json`** — declare `Tag` and `BusinessId` as `kind: 'attribute', clientMinted: true`.
- **Schema + validator** (`path-analyser/domain-semantics.schema.json`, `path-analyser/src/domainSemanticsValidator.ts`) — extend `kind` enum with `'attribute'`, add `clientMinted` boolean, add `checkAttributeKindClientMintedPairing` cross-ref check that errors at load time if the two fields are unpaired in either direction.
- **Loader** (`path-analyser/src/graphLoader.ts`, `types.ts`) — surface every semantic-typed body leaf on `OperationNode.requestBodySemantics` regardless of nesting / required / scalar-array shape (the existing `optionalSubShapes` index filters too aggressively for this purpose). Build a per-graph `requestSettersByType` index parallel to `producersByType` / `establishersByType`.
- **Planner** (`path-analyser/src/index.ts`) — new `bindClientMintedAttribute` helper, called from `buildRequestPlan` for `featureCoverage` scenarios. Mints the value, overrides any pre-existing synthetic placeholder, and plants a `populatesSubShape` entry so the existing merge fills the body.

## Tests (per the layered strategy)

- **Layer 1 (loader)** — new `tests/fixtures/loader/graphloader-request-setters.test.ts` covers `requestBodySemantics` extraction (top-level scalar, scalar array, nested object leaf, required flag preserved, malformed entries skipped, absent when no body semantics) and `requestSettersByType` build (per-semantic op list, dedup across multiple leaves of the same semantic in one op, undefined when empty).
- **Layer 3 (bundled-spec invariants)** — `configs/camunda-oca/regression-invariants.test.ts` invariants are class-scoped: derive every `(attribute+clientMinted, setter-op)` pair from `domain-semantics.json` + the dependency graph and assert both the binding prefix (`fc:cma:<sem>:`) and the emitted spec body (`ctx.<sem>Var`). Adding a new attribute semantic or new setter op lights up the same checks automatically.

Layer-2 planner-helper tests are not added here because `bindClientMintedAttribute` is an internal function and its observable behaviour is covered end-to-end by the class-scoped Layer-3 invariants. The unified-dispatch refactor (#162 PR 3) will give these helpers a public seam worth a dedicated planner fixture.

## Scope

- **Setter sites only.** Filter-consumer paths (`filter.*`, `filter[…]`) are intentionally skipped — they need setter-chain reuse to be meaningful (a setter step inserted before the filter step that tags an entity, with the same minted value threaded through). Tracked in #168.
- **Variant scenarios** still go through their own planner path. Unifying both planners on a single `bindSemanticInput` dispatch is #162 PR 3.

## Verification

- `npm run lint` — clean.
- `npx tsc --noEmit -p {semantic-graph-extractor,path-analyser,request-validation,tests}/tsconfig.json` — all four typecheck.
- `TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation` — pipeline regenerates cleanly.
- `npm test` — **322 passed | 6 skipped (328)**.

Sample of the new emitted output for `createProcessInstance`:

```ts
ctx.tagVar = 'fc:cma:tag:1iom';
ctx.businessIdVar = 'fc:cma:businessId:yjwm';
// …
const body = {
  // …
  tags: [ctx.tagVar],
  businessId: ctx.businessIdVar,
};
```
