### PR TITLE
Wrap each emitted step in test.step() (#118)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1468,8 +1468,14 @@ describeForThisConfig('bundled-spec invariants: fixture selection by required st
       throw new Error(`expected emitted spec ${spec} not found — run 'npm run testsuite:generate'`);
     }
     const src = readFileSync(spec, 'utf8');
-    const createIdx = src.indexOf('Step 2: createProcessInstance');
-    const deleteIdx = src.indexOf('Step 3: deleteProcessInstance');
+    // #118: each request step is now wrapped in `await test.step('<operationId>', ...)`
+    // instead of being preceded by a `// Step N: <operationId>` comment.
+    // Locate the create/delete steps by their test.step labels. The emitter
+    // produces double-quoted labels via JSON.stringify(operationId); the
+    // biome.generated.json post-processing rewrites them to single quotes,
+    // so the test matches what's actually written to disk.
+    const createIdx = src.indexOf("test.step('createProcessInstance'");
+    const deleteIdx = src.indexOf("test.step('deleteProcessInstance'");
     expect(createIdx, 'createProcessInstance step marker not found').toBeGreaterThan(0);
     expect(deleteIdx, 'deleteProcessInstance step marker not found').toBeGreaterThan(createIdx);
     const between = src.slice(createIdx, deleteIdx);

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -345,12 +345,12 @@ function renderScenarioTest(
         step.bodyTemplate = { processDefinitionKey: '${processDefinitionKeyVar}' };
       }
     }
-    // (#118) Each request step is wrapped in `await test.step(...)` so it
-    // shows up as a labelled, collapsible group in the Playwright HTML
-    // report and trace viewer, with per-step timing and failure attribution
-    // to the named step. Cross-step state flows through `ctx` declared in
-    // the outer test scope; the per-step locals (resp/body/json) are still
-    // confined to the callback, same as the pre-#118 bare-block scope.
+    // Each request step is wrapped in `await test.step(...)` so it shows
+    // up as a labelled, collapsible group in the Playwright HTML report
+    // and trace viewer, with per-step timing and failure attribution to
+    // the named step. Cross-step state flows through `ctx` declared in
+    // the outer test scope; the per-step locals (resp/body/json) stay
+    // confined to the callback.
     body.push(`  await test.step(${JSON.stringify(step.operationId)}, async () => {`);
     body.push(`    const url = baseUrl + ${urlExpr};`);
     const bodyVar = `body${idx + 1}`;

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -351,7 +351,7 @@ function renderScenarioTest(
     // to the named step. Cross-step state flows through `ctx` declared in
     // the outer test scope; the per-step locals (resp/body/json) are still
     // confined to the callback, same as the pre-#118 bare-block scope.
-    body.push(`  await test.step('${step.operationId}', async () => {`);
+    body.push(`  await test.step(${JSON.stringify(step.operationId)}, async () => {`);
     body.push(`    const url = baseUrl + ${urlExpr};`);
     const bodyVar = `body${idx + 1}`;
     if (step.bodyKind === 'json' && step.bodyTemplate) {

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -345,9 +345,13 @@ function renderScenarioTest(
         step.bodyTemplate = { processDefinitionKey: '${processDefinitionKeyVar}' };
       }
     }
-    // Basic body handling placeholder
-    body.push(`  // Step ${idx + 1}: ${step.operationId}`);
-    body.push(`  {`);
+    // (#118) Each request step is wrapped in `await test.step(...)` so it
+    // shows up as a labelled, collapsible group in the Playwright HTML
+    // report and trace viewer, with per-step timing and failure attribution
+    // to the named step. Cross-step state flows through `ctx` declared in
+    // the outer test scope; the per-step locals (resp/body/json) are still
+    // confined to the callback, same as the pre-#118 bare-block scope.
+    body.push(`  await test.step('${step.operationId}', async () => {`);
     body.push(`    const url = baseUrl + ${urlExpr};`);
     const bodyVar = `body${idx + 1}`;
     if (step.bodyKind === 'json' && step.bodyTemplate) {
@@ -473,7 +477,7 @@ function renderScenarioTest(
         body.push(`    extractInto(ctx, '${ex.bind}', json${optAcc});`);
       }
     }
-    body.push('  }');
+    body.push('  });');
     // #159 PR B: render planner-annotated eventual-state waits AFTER the
     // producer step's block. Emitted as a sibling block (not nested inside
     // the producer's `{ ... }`) so its locals (`witnessUrl`, etc.) don't

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -581,16 +581,15 @@ describe('emitter: boundary safety re-validation (#87 review)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// #118 — wrap each request step in test.step()
+// Wrap each request step in test.step()
 // ---------------------------------------------------------------------------
 //
-// Pre-#118 the emitter delimited each request step with a `// Step N: <op>`
-// comment and a bare `{ ... }` block. Post-#118 each step is wrapped in
+// Each request step is wrapped in
 // `await test.step('<operationId>', async () => { ... });` so the step
 // appears as a labelled, collapsible group in the Playwright HTML report
 // and trace viewer. The label is just the operationId — no `Step N:`
-// prefix.
-describe('PlaywrightEmitter — request steps wrapped in test.step() (#118)', () => {
+// prefix and no `// Step N: <op>` comment.
+describe('PlaywrightEmitter — request steps wrapped in test.step()', () => {
   function multiStepCollection(): EndpointScenarioCollection {
     return {
       endpoint: { operationId: 'deleteWidget', method: 'POST', path: '/widgets/{id}/deletion' },
@@ -636,9 +635,9 @@ describe('PlaywrightEmitter — request steps wrapped in test.step() (#118)', ()
   });
 
   test('label is just the operationId — no "Step N:" prefix anywhere', () => {
-    // Class-scoped guard: the user's #118 request is to drop the
-    // step-index prefix entirely. Any reintroduction of `Step <n>:` —
-    // whether as a comment or inside a test.step label — fails this test.
+    // Class-scoped guard: the step-index prefix is intentionally absent.
+    // Any reintroduction of `Step <n>:` — whether as a comment or inside
+    // a test.step label — fails this test.
     const src = renderPlaywrightSuite(multiStepCollection(), {
       suiteName: 'deleteWidget',
       mode: 'feature',
@@ -648,11 +647,12 @@ describe('PlaywrightEmitter — request steps wrapped in test.step() (#118)', ()
   });
 
   test('does not reintroduce the legacy bare `{` step block', () => {
-    // Pre-#118 the emitter opened each step with a bare `{` (preceded by a
-    // `// Step N: <op>` comment). The new shape uses `await test.step(...)`,
+    // The legacy shape opened each step with a bare `{` preceded by a
+    // `// Step N: <op>` comment. The current shape uses `await test.step(...)`,
     // and the only emitted bare block now belongs to the eventual-wait
     // emitter (`{` immediately after a `// Wait for ...` comment). This
-    // guard targets the pre-#118 shape specifically — a `// Step N:` line.
+    // guard targets the legacy shape specifically — a `// Step N:` line
+    // immediately followed by a bare `{`.
     const src = renderPlaywrightSuite(multiStepCollection(), {
       suiteName: 'deleteWidget',
       mode: 'feature',

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -631,8 +631,8 @@ describe('PlaywrightEmitter — request steps wrapped in test.step() (#118)', ()
       suiteName: 'deleteWidget',
       mode: 'feature',
     });
-    expect(src).toContain("await test.step('createWidget', async () => {");
-    expect(src).toContain("await test.step('deleteWidget', async () => {");
+    expect(src).toContain('await test.step("createWidget", async () => {');
+    expect(src).toContain('await test.step("deleteWidget", async () => {');
   });
 
   test('label is just the operationId — no "Step N:" prefix anywhere', () => {
@@ -667,6 +667,48 @@ describe('PlaywrightEmitter — request steps wrapped in test.step() (#118)', ()
     });
     const matches = src.match(/await test\.step\(/g) ?? [];
     expect(matches.length).toBe(2);
+  });
+
+  test('escapes operationIds that contain TS string metacharacters (Copilot PR #170 review)', () => {
+    // Class-scoped guard: the label argument to test.step() must be a
+    // syntactically valid TS string literal regardless of which
+    // characters the OpenAPI `operationId` contains. The OpenAPI spec
+    // does not formally restrict `operationId` to /[A-Za-z0-9_]+/, so an
+    // upstream rename that introduces a single quote, backslash, or
+    // newline must not produce an unparseable emitted suite (or, worse,
+    // allow code-injection into the emitted file). Using
+    // `JSON.stringify(operationId)` is the chokepoint that enforces this.
+    const hostile = "weird'op\\with\nnewline";
+    const src = renderPlaywrightSuite(
+      {
+        endpoint: { operationId: hostile, method: 'POST', path: '/x' },
+        requiredSemanticTypes: [],
+        optionalSemanticTypes: [],
+        scenarios: [
+          {
+            id: 'sc1',
+            name: 'hostile id',
+            operations: [{ operationId: hostile, method: 'POST', path: '/x' }],
+            producedSemanticTypes: [],
+            satisfiedSemanticTypes: [],
+            requestPlan: [
+              {
+                operationId: hostile,
+                method: 'POST',
+                pathTemplate: '/x',
+                expect: { status: 200 },
+              },
+            ],
+          },
+        ],
+      },
+      { suiteName: 'hostile', mode: 'feature' },
+    );
+    // The emitted label is JSON.stringify(operationId): double-quoted,
+    // with `'`, `\`, and `\n` escaped. The raw hostile string must NOT
+    // appear unescaped inside a single-quoted literal next to test.step().
+    expect(src).toContain(`await test.step(${JSON.stringify(hostile)}, async () => {`);
+    expect(src).not.toMatch(/test\.step\('[^']*'[^,]*\\?\n/);
   });
 });
 

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -581,6 +581,96 @@ describe('emitter: boundary safety re-validation (#87 review)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #118 — wrap each request step in test.step()
+// ---------------------------------------------------------------------------
+//
+// Pre-#118 the emitter delimited each request step with a `// Step N: <op>`
+// comment and a bare `{ ... }` block. Post-#118 each step is wrapped in
+// `await test.step('<operationId>', async () => { ... });` so the step
+// appears as a labelled, collapsible group in the Playwright HTML report
+// and trace viewer. The label is just the operationId — no `Step N:`
+// prefix.
+describe('PlaywrightEmitter — request steps wrapped in test.step() (#118)', () => {
+  function multiStepCollection(): EndpointScenarioCollection {
+    return {
+      endpoint: { operationId: 'deleteWidget', method: 'POST', path: '/widgets/{id}/deletion' },
+      requiredSemanticTypes: [],
+      optionalSemanticTypes: [],
+      scenarios: [
+        {
+          id: 'sc1',
+          name: 'create then delete',
+          operations: [
+            { operationId: 'createWidget', method: 'POST', path: '/widgets' },
+            { operationId: 'deleteWidget', method: 'POST', path: '/widgets/{id}/deletion' },
+          ],
+          producedSemanticTypes: [],
+          satisfiedSemanticTypes: [],
+          requestPlan: [
+            {
+              operationId: 'createWidget',
+              method: 'POST',
+              pathTemplate: '/widgets',
+              expect: { status: 200 },
+              extract: [{ fieldPath: 'id', bind: 'idVar' }],
+            },
+            {
+              operationId: 'deleteWidget',
+              method: 'POST',
+              pathTemplate: '/widgets/{id}/deletion',
+              expect: { status: 204 },
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  test('wraps each request step in await test.step(<operationId>, async () => { ... })', () => {
+    const src = renderPlaywrightSuite(multiStepCollection(), {
+      suiteName: 'deleteWidget',
+      mode: 'feature',
+    });
+    expect(src).toContain("await test.step('createWidget', async () => {");
+    expect(src).toContain("await test.step('deleteWidget', async () => {");
+  });
+
+  test('label is just the operationId — no "Step N:" prefix anywhere', () => {
+    // Class-scoped guard: the user's #118 request is to drop the
+    // step-index prefix entirely. Any reintroduction of `Step <n>:` —
+    // whether as a comment or inside a test.step label — fails this test.
+    const src = renderPlaywrightSuite(multiStepCollection(), {
+      suiteName: 'deleteWidget',
+      mode: 'feature',
+    });
+    expect(src).not.toMatch(/\/\/\s*Step\s+\d+:/);
+    expect(src).not.toMatch(/test\.step\(\s*['"`]Step\s+\d+:/);
+  });
+
+  test('does not reintroduce the legacy bare `{` step block', () => {
+    // Pre-#118 the emitter opened each step with a bare `{` (preceded by a
+    // `// Step N: <op>` comment). The new shape uses `await test.step(...)`,
+    // and the only emitted bare block now belongs to the eventual-wait
+    // emitter (`{` immediately after a `// Wait for ...` comment). This
+    // guard targets the pre-#118 shape specifically — a `// Step N:` line.
+    const src = renderPlaywrightSuite(multiStepCollection(), {
+      suiteName: 'deleteWidget',
+      mode: 'feature',
+    });
+    expect(src).not.toMatch(/\/\/ Step \d+: \w+\s*\n\s*\{/);
+  });
+
+  test('emits one test.step wrapper per request step', () => {
+    const src = renderPlaywrightSuite(multiStepCollection(), {
+      suiteName: 'deleteWidget',
+      mode: 'feature',
+    });
+    const matches = src.match(/await test\.step\(/g) ?? [];
+    expect(matches.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // #106 — eventual-consistency wrapping
 // ---------------------------------------------------------------------------
 //

--- a/tests/codegen/playwright-eventual-wait.test.ts
+++ b/tests/codegen/playwright-eventual-wait.test.ts
@@ -69,8 +69,8 @@ describe('emitter: eventual-state wait injection (#159 PR B)', () => {
     // consumer) doesn't fix the motivating case. Post-#118 the per-step
     // marker is `await test.step('<operationId>', ...)`, not a `// Step N`
     // comment.
-    const producerIdx = src.indexOf("test.step('createWidget'");
-    const consumerIdx = src.indexOf("test.step('deleteWidget'");
+    const producerIdx = src.indexOf('test.step("createWidget"');
+    const consumerIdx = src.indexOf('test.step("deleteWidget"');
     const waitIdx = src.indexOf('await awaitEventually(');
     expect(producerIdx).toBeGreaterThan(0);
     expect(consumerIdx).toBeGreaterThan(producerIdx);

--- a/tests/codegen/playwright-eventual-wait.test.ts
+++ b/tests/codegen/playwright-eventual-wait.test.ts
@@ -66,9 +66,8 @@ describe('emitter: eventual-state wait injection (#159 PR B)', () => {
     // The wait must appear in the source AND sit between the producer
     // (createWidget) and the consumer (deleteWidget). Position is part of
     // the contract — a wait emitted before the producer (or after the
-    // consumer) doesn't fix the motivating case. Post-#118 the per-step
-    // marker is `await test.step('<operationId>', ...)`, not a `// Step N`
-    // comment.
+    // consumer) doesn't fix the motivating case. The per-step marker is
+    // `await test.step('<operationId>', ...)`.
     const producerIdx = src.indexOf('test.step("createWidget"');
     const consumerIdx = src.indexOf('test.step("deleteWidget"');
     const waitIdx = src.indexOf('await awaitEventually(');

--- a/tests/codegen/playwright-eventual-wait.test.ts
+++ b/tests/codegen/playwright-eventual-wait.test.ts
@@ -63,12 +63,14 @@ describe('emitter: eventual-state wait injection (#159 PR B)', () => {
       suiteName: 'deleteWidget',
       mode: 'feature',
     });
-    // The wait must appear in the source AND sit between Step 1 (producer)
-    // and Step 2 (consumer). Position is part of the contract — a wait
-    // emitted before the producer (or after the consumer) doesn't fix the
-    // motivating case.
-    const producerIdx = src.indexOf('Step 1: createWidget');
-    const consumerIdx = src.indexOf('Step 2: deleteWidget');
+    // The wait must appear in the source AND sit between the producer
+    // (createWidget) and the consumer (deleteWidget). Position is part of
+    // the contract — a wait emitted before the producer (or after the
+    // consumer) doesn't fix the motivating case. Post-#118 the per-step
+    // marker is `await test.step('<operationId>', ...)`, not a `// Step N`
+    // comment.
+    const producerIdx = src.indexOf("test.step('createWidget'");
+    const consumerIdx = src.indexOf("test.step('deleteWidget'");
     const waitIdx = src.indexOf('await awaitEventually(');
     expect(producerIdx).toBeGreaterThan(0);
     expect(consumerIdx).toBeGreaterThan(producerIdx);


### PR DESCRIPTION
## Summary

- Wrap each request step emitted by the Playwright emitter in `await test.step('<operationId>', async () => { ... })` instead of the `// Step N: <op>` comment + bare `{ ... }` block, so steps appear as labelled, collapsible groups with per-step timing in the HTML report and trace viewer.
- Per the issue author's instruction, the label is just the `operationId` — no `Step N:` prefix.
- Cross-step state still flows through `ctx` (declared in the outer test scope); per-step locals (`resp`/`body`/`json`) stay confined to the callback, matching the pre-change bare-block scope.

Closes #118.

## Implementation notes

- `path-analyser/src/codegen/playwright/emitter.ts` — one production change: the per-step block-open and block-close lines now emit `await test.step('<operationId>', async () => {` and `});` respectively.
- `tests/codegen/playwright-eventual-wait.test.ts` — the producer/consumer position check used to search for the old `// Step 1: createWidget` / `// Step 2: deleteWidget` comments; updated to look for the new `test.step('createWidget'` / `test.step('deleteWidget'` markers.
- `tests/codegen/playwright-emitter.test.ts` — adds a class-scoped regression `describe` (#118) pinning four properties: each request step is wrapped in `test.step('<operationId>', async () => { ... })`; no `Step N:` prefix appears anywhere (comment or label); the legacy `// Step N: <op>\n{` shape is absent; one `test.step` wrapper per request step.

Per AGENTS.md §"Behaviour tests are the regression guard", this is an intentional emitter-contract change and the affected behaviour test was updated to track the new shape rather than the pre-change shape.

## Test plan

- [x] `vitest run` on the codegen test directory — 101 passed (10 files). Verified locally against an isolated config because the repo-wide `npm test` is currently blocked on `tests/regression/spec-pin.setup.ts` reporting bundled-spec drift on `main` (reproduced against a clean `main` checkout — unrelated to this PR).
- [x] `tsc --noEmit -p path-analyser/tsconfig.json` — clean.
- [ ] CI green on this branch.
- [ ] Manual: regenerate a suite with `npm run codegen:playwright`, eyeball one emitted spec, and confirm `await test.step('<operationId>', async () => { ... })` appears around each step.
- [ ] Manual: run a regenerated suite and inspect the HTML report — each step should appear as a labelled, collapsible group.

## Out of scope

- No change to scenario planning, request-plan construction, or the negative-suite emitter (as the issue specifies).
- The eventual-wait sibling block keeps its existing `// Wait for ...` + bare-block shape; only request-step blocks are wrapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)