### PR TITLE
feat: default recordResponses=false (#117)

### DIFF
--- a/configs.json
+++ b/configs.json
@@ -9,7 +9,7 @@
         "$comment": "Pinned ref + expected hash live in configs/camunda-oca/spec-pin.json (kept as a separate file to preserve the spec-pin bump procedure documented in tests/regression/spec-pin.setup.ts)."
       },
       "codegen": {
-        "$comment": "Per-emitter codegen options. Resolved by getPlaywrightCodegenOptions() in path-analyser/src/configResolver.ts. Each subkey is the emitter id (see codegen/registry.ts). Missing keys default to behaviour that matches the pre-config baseline (recordResponses=true). camunda-oca opts out: the SDK example workflows that consume the emitted suite do not run observe:aggregate, so the recorder boilerplate is pure dead weight here. The aggregator workflow can be re-enabled by flipping this back to true.",
+        "$comment": "Per-emitter codegen options. Resolved by getPlaywrightCodegenOptions() in path-analyser/src/configResolver.ts. Each subkey is the emitter id (see codegen/registry.ts). Missing keys default to recordResponses=false (#117 — recorder is opt-in tooling for downstream response-shape diffing). camunda-oca pins it explicitly to false for self-documentation; the SDK example workflows that consume the emitted suite do not run observe:aggregate, so the recorder boilerplate is pure dead weight here. The aggregator workflow can be re-enabled by flipping this to true.",
         "playwright": {
           "recordResponses": false
         }

--- a/configs.json
+++ b/configs.json
@@ -9,7 +9,7 @@
         "$comment": "Pinned ref + expected hash live in configs/camunda-oca/spec-pin.json (kept as a separate file to preserve the spec-pin bump procedure documented in tests/regression/spec-pin.setup.ts)."
       },
       "codegen": {
-        "$comment": "Per-emitter codegen options. Resolved by getPlaywrightCodegenOptions() in path-analyser/src/configResolver.ts. Each subkey is the emitter id (see codegen/registry.ts). Missing keys default to recordResponses=false (#117 — recorder is opt-in tooling for downstream response-shape diffing). camunda-oca pins it explicitly to false for self-documentation; the SDK example workflows that consume the emitted suite do not run observe:aggregate, so the recorder boilerplate is pure dead weight here. The aggregator workflow can be re-enabled by flipping this to true.",
+        "$comment": "Per-emitter codegen options. Resolved by getPlaywrightCodegenOptions() in path-analyser/src/configResolver.ts. Each subkey is the emitter id (see codegen/registry.ts). Missing keys default to recordResponses=false (recorder is opt-in tooling for downstream response-shape diffing). camunda-oca pins it explicitly to false for self-documentation; the SDK example workflows that consume the emitted suite do not run observe:aggregate, so the recorder boilerplate is pure dead weight here. The aggregator workflow can be re-enabled by flipping this to true.",
         "playwright": {
           "recordResponses": false
         }

--- a/path-analyser/src/configResolver.ts
+++ b/path-analyser/src/configResolver.ts
@@ -108,8 +108,10 @@ export interface PlaywrightCodegenOptions {
    * emitted, and `recorder.ts` is not vendored into the suite's `support/`
    * directory.
    *
-   * Default: true (preserves the behaviour that existed before this option
-   * was introduced).
+   * Default: false (#117 — the recorder is opt-in tooling for downstream
+   * response-shape diffing; suites that don't consume
+   * `dist/runtime-observations/responses.jsonl` get cleaner output and
+   * skip the per-step `fs.appendFile`).
    */
   recordResponses: boolean;
 }
@@ -128,10 +130,10 @@ export function getPlaywrightCodegenOptions(repoRoot: string): PlaywrightCodegen
   const name = resolveActiveConfigName(index);
   const entry = index.configs[name];
   if (!isRecord(entry)) {
-    return { recordResponses: true };
+    return { recordResponses: false };
   }
   if (!('codegen' in entry)) {
-    return { recordResponses: true };
+    return { recordResponses: false };
   }
   const codegen = entry.codegen;
   if (!isRecord(codegen)) {
@@ -140,7 +142,7 @@ export function getPlaywrightCodegenOptions(repoRoot: string): PlaywrightCodegen
     );
   }
   if (!('playwright' in codegen)) {
-    return { recordResponses: true };
+    return { recordResponses: false };
   }
   const playwright = codegen.playwright;
   if (!isRecord(playwright)) {
@@ -148,7 +150,7 @@ export function getPlaywrightCodegenOptions(repoRoot: string): PlaywrightCodegen
       `Malformed configs.json: configs.${name}.codegen.playwright must be an object, got ${typeof playwright}.`,
     );
   }
-  let recordResponses = true;
+  let recordResponses = false;
   if ('recordResponses' in playwright) {
     const v = playwright.recordResponses;
     if (typeof v !== 'boolean') {

--- a/path-analyser/src/configResolver.ts
+++ b/path-analyser/src/configResolver.ts
@@ -96,8 +96,8 @@ export function getActiveConfigDir(repoRoot: string): string {
  * Options that control the Playwright emitter, sourced from
  * `configs.json#configs.<active>.codegen.playwright`.
  *
- * Every field is optional in the on-disk schema and defaults to a value
- * that preserves pre-config behaviour. Missing `codegen` / `codegen.playwright`
+ * Every field is optional in the on-disk schema and has an explicit
+ * default documented on the field. Missing `codegen` / `codegen.playwright`
  * blocks yield an all-defaults result without throwing.
  */
 export interface PlaywrightCodegenOptions {

--- a/path-analyser/src/configResolver.ts
+++ b/path-analyser/src/configResolver.ts
@@ -108,10 +108,10 @@ export interface PlaywrightCodegenOptions {
    * emitted, and `recorder.ts` is not vendored into the suite's `support/`
    * directory.
    *
-   * Default: false (#117 — the recorder is opt-in tooling for downstream
+   * Default: false. The recorder is opt-in tooling for downstream
    * response-shape diffing; suites that don't consume
    * `dist/runtime-observations/responses.jsonl` get cleaner output and
-   * skip the per-step `fs.appendFile`).
+   * skip the per-step `fs.appendFile`.
    */
   recordResponses: boolean;
 }

--- a/tests/codegen/config-resolver-codegen-options.test.ts
+++ b/tests/codegen/config-resolver-codegen-options.test.ts
@@ -34,19 +34,21 @@ describe('getPlaywrightCodegenOptions', () => {
     await fs.writeFile(path.join(tmp, 'configs.json'), JSON.stringify(content), 'utf8');
   }
 
-  test('defaults to recordResponses=true when the config has no codegen block', async () => {
+  // #117: the recorder is opt-in tooling. Default is OFF so suites that
+  // don't consume responses.jsonl skip the boilerplate + per-step fs writes.
+  test('defaults to recordResponses=false when the config has no codegen block', async () => {
     await writeConfig({ description: 'test' });
-    expect(getPlaywrightCodegenOptions(tmp)).toEqual({ recordResponses: true });
+    expect(getPlaywrightCodegenOptions(tmp)).toEqual({ recordResponses: false });
   });
 
-  test('defaults to recordResponses=true when codegen has no playwright block', async () => {
+  test('defaults to recordResponses=false when codegen has no playwright block', async () => {
     await writeConfig({ codegen: {} });
-    expect(getPlaywrightCodegenOptions(tmp)).toEqual({ recordResponses: true });
+    expect(getPlaywrightCodegenOptions(tmp)).toEqual({ recordResponses: false });
   });
 
-  test('defaults to recordResponses=true when playwright omits recordResponses', async () => {
+  test('defaults to recordResponses=false when playwright omits recordResponses', async () => {
     await writeConfig({ codegen: { playwright: {} } });
-    expect(getPlaywrightCodegenOptions(tmp)).toEqual({ recordResponses: true });
+    expect(getPlaywrightCodegenOptions(tmp)).toEqual({ recordResponses: false });
   });
 
   test('returns recordResponses=true when explicitly set', async () => {

--- a/tests/codegen/config-resolver-codegen-options.test.ts
+++ b/tests/codegen/config-resolver-codegen-options.test.ts
@@ -34,7 +34,7 @@ describe('getPlaywrightCodegenOptions', () => {
     await fs.writeFile(path.join(tmp, 'configs.json'), JSON.stringify(content), 'utf8');
   }
 
-  // #117: the recorder is opt-in tooling. Default is OFF so suites that
+  // The recorder is opt-in tooling. Default is OFF so suites that
   // don't consume responses.jsonl skip the boilerplate + per-step fs writes.
   test('defaults to recordResponses=false when the config has no codegen block', async () => {
     await writeConfig({ description: 'test' });


### PR DESCRIPTION
Closes #117.

## What

Flip the in-code default of `codegen.playwright.recordResponses` from `true` to `false`.

## Why

Issue #117 asks the response-recorder block to be **off by default**. The gate itself already exists:

- `codegen.playwright.recordResponses` in `configs.json` is read by `getPlaywrightCodegenOptions()` in `path-analyser/src/configResolver.ts`.
- When `false`, the Playwright emitter omits the entire `try { … recordResponse({...}) … } catch {}` block, the `recordResponse`/`sanitizeBody` import, and the `recorder.ts` vendor step.
- `camunda-oca` already pins it explicitly to `false`.

The only remaining gap with #117's acceptance criteria was the *in-code default* — it still returned `true` to preserve pre-config behaviour. This PR flips that.

## Changes

- `path-analyser/src/configResolver.ts` — 4 default sites changed `true` → `false`; doc comment on `recordResponses` updated to describe the new default and rationale; block doc above `PlaywrightCodegenOptions` cleaned up (no longer says "preserves pre-config behaviour").
- `tests/codegen/config-resolver-codegen-options.test.ts` — the three "defaults to ..." tests updated to expect `false`.
- `configs.json` — `$comment` updated to reflect the new default; `camunda-oca`'s explicit `false` kept for self-documentation.

## Verification

- 102/102 `tests/codegen/` tests pass locally, including the L1/L2 coverage of the gate (`config-resolver-codegen-options.test.ts`, `playwright-record-responses.test.ts`, `materialize-support.test.ts`).
- Existing L3 invariant `no emitted feature spec records responses (camunda-oca config has recordResponses=false)` covers the bundled-spec output.
- Lint clean on touched files; tsc clean on `path-analyser/tsconfig.json`.
- Full regression suite runs in CI (lint → tsc all workspaces → fetch pinned spec → regen pipeline → `npm test`).

## Behaviour impact for existing configs

None for `camunda-oca` — it already pins `recordResponses: false` explicitly, so the resolved value is unchanged and the regenerated output is byte-identical.