### PR TITLE
refactor: extract bindSemanticInput dispatch chokepoint (#162 PR 3)

### DIFF
--- a/path-analyser/src/bindSemanticInput.ts
+++ b/path-analyser/src/bindSemanticInput.ts
@@ -104,7 +104,8 @@ export function classifySemantic(semantic: string, graph: OperationGraph): Seman
  *     missing fixture data.
  *
  *   - `clientMintedAttribute`: produces a deterministic
- *     `fc:cma:<sem>:<suffix>` token using `deterministicSuffix(opId, semantic)`,
+ *     `fc:cma:<sem>:<suffix>` token using
+ *     ``deterministicSuffix(`fc:cma:${operationId}:${semantic}`)``,
  *     matching the byte-stable mint formula from
  *     `bindClientMintedAttribute` PR 2.
  *

--- a/path-analyser/src/bindSemanticInput.ts
+++ b/path-analyser/src/bindSemanticInput.ts
@@ -40,7 +40,7 @@ export type SemanticClassification =
   | 'unclassified';
 
 export type BoundInput =
-  | { classification: 'modelDerived'; varName: string; value: string }
+  | { classification: 'modelDerived'; varName: string; value?: string }
   | { classification: 'clientMintedAttribute'; varName: string; value: string }
   | { classification: 'producerBound'; varName: string }
   | { classification: 'clientMintedIdentifier'; varName: string }
@@ -92,11 +92,16 @@ export function classifySemantic(semantic: string, graph: OperationGraph): Seman
  *
  * Behaviour-preserving with the pre-PR3 inline helpers:
  *
- *   - `modelDerived`: uses the FIRST entry of `fixture.providesValues[semantic]`
- *     (matches `bindModelDerivedFromFixture` PR 1 scope). Returns
- *     `unclassified` if the fixture is missing or has no value entry
- *     for this semantic — the caller (helper) is expected to bail out
- *     without mutating the scenario, mirroring the pre-PR3 `if (!values?.length) continue`.
+ *   - `modelDerived`: classification is reported regardless of whether a
+ *     value can be resolved. The returned `value` is the FIRST entry of
+ *     `fixture.providesValues[semantic]` when present, or `undefined`
+ *     when the fixture is missing or has no entry for this semantic.
+ *     Callers that mutate scenario state must guard on `value !== undefined`
+ *     before binding, mirroring the pre-PR3 `if (!values?.length) continue`.
+ *     Keeping the classification stable (rather than collapsing the
+ *     missing-value case to `unclassified`) lets PR 5 distinguish a
+ *     genuinely-unclassified semantic from a modelDerived semantic with
+ *     missing fixture data.
  *
  *   - `clientMintedAttribute`: produces a deterministic
  *     `fc:cma:<sem>:<suffix>` token using `deterministicSuffix(opId, semantic)`,
@@ -122,7 +127,7 @@ export function bindSemanticInput(args: {
   switch (classification) {
     case 'modelDerived': {
       const values = fixture?.providesValues?.[semantic];
-      if (!values?.length) return { classification: 'unclassified' };
+      if (!values?.length) return { classification: 'modelDerived', varName };
       return { classification: 'modelDerived', varName, value: values[0] };
     }
     case 'clientMintedAttribute': {

--- a/path-analyser/src/bindSemanticInput.ts
+++ b/path-analyser/src/bindSemanticInput.ts
@@ -1,0 +1,149 @@
+import { deterministicSuffix } from './codegen/support/seeding.js';
+import type { ArtifactRegistryEntry, OperationGraph } from './types.js';
+
+/**
+ * Unified classification + value-resolution dispatch (#162 PR 3).
+ *
+ * Single chokepoint for "where does the value of this semantic come
+ * from?" reasoning. Both `bindModelDerivedFromFixture` and
+ * `bindClientMintedAttribute` route through this module so the
+ * classification rules and per-classification value derivation live in
+ * one place rather than being scattered across helper-specific
+ * filters in `path-analyser/src/index.ts`.
+ *
+ * Scope of PR 3 (refactor only, no behaviour change):
+ *
+ *   - Classifications 3 (`clientMintedAttribute`) and 5 (`modelDerived`)
+ *     return a concrete `value` ready to bind into `scenario.bindings`.
+ *     These were the two cases the existing helpers handled inline.
+ *
+ *   - Classifications 1 (`producerBound`), 2 (`clientMintedIdentifier`)
+ *     and 4 (`externalBoundary`) are recognised but have no value
+ *     payload — they are bound by BFS in `scenarioGenerator.ts`. Calls
+ *     for these classifications return only the `varName` so callers
+ *     can verify "this is owned by another path" and bail out without
+ *     overwriting the BFS-driven binding.
+ *
+ *   - PR 4 will extend the variant planner to call this module so
+ *     populated optional sub-shapes flow through the same dispatch as
+ *     feature-coverage scenarios.
+ *
+ *   - PR 5 will turn `'unclassified'` into a load-time diagnostic.
+ */
+
+export type SemanticClassification =
+  | 'modelDerived'
+  | 'clientMintedAttribute'
+  | 'producerBound'
+  | 'clientMintedIdentifier'
+  | 'externalBoundary'
+  | 'unclassified';
+
+export type BoundInput =
+  | { classification: 'modelDerived'; varName: string; value: string }
+  | { classification: 'clientMintedAttribute'; varName: string; value: string }
+  | { classification: 'producerBound'; varName: string }
+  | { classification: 'clientMintedIdentifier'; varName: string }
+  | { classification: 'externalBoundary'; varName: string }
+  | { classification: 'unclassified' };
+
+/**
+ * Classification precedence rules (#162).
+ *
+ * Tier 1 — explicit `domain.semanticTypes[T].kind` declarations win
+ * regardless of graph indices:
+ *
+ *   - `kind: 'modelDerived'`                   → modelDerived
+ *   - `kind: 'attribute' && clientMinted: true` → clientMintedAttribute
+ *
+ * Tier 2 — graph-index classifications, in order:
+ *
+ *   - `graph.producersByType[T]`              → producerBound
+ *   - `graph.establishersByType[T]`           → clientMintedIdentifier
+ *   - `graph.externalEntityIdentifiers.has(T)` → externalBoundary
+ *
+ * Tier 3 — `unclassified` (PR 5 will fail the graph load on this).
+ *
+ * Why declarations win over indices: the domain-semantics file is the
+ * authoritative source of truth for value origin. A semantic declared
+ * `modelDerived` is intentionally sourced from a deployment artifact
+ * even if some search op happens to surface it incidentally; treating
+ * the incidental producer as authoritative would re-introduce the
+ * coverage-gap class #162 was opened to fix.
+ *
+ * Pure function — no side effects, no IO, no caching. Safe to call any
+ * number of times per (semantic, graph).
+ */
+export function classifySemantic(semantic: string, graph: OperationGraph): SemanticClassification {
+  const decl = graph.domain?.semanticTypes?.[semantic];
+  if (decl?.kind === 'modelDerived') return 'modelDerived';
+  if (decl?.kind === 'attribute' && decl.clientMinted === true) {
+    return 'clientMintedAttribute';
+  }
+  if (graph.producersByType?.[semantic]?.length) return 'producerBound';
+  if (graph.establishersByType?.[semantic]?.length) return 'clientMintedIdentifier';
+  if (graph.externalEntityIdentifiers?.has(semantic)) return 'externalBoundary';
+  return 'unclassified';
+}
+
+/**
+ * Resolve a `BoundInput` for a single (operationId, semantic) pair
+ * through the classification dispatch.
+ *
+ * Behaviour-preserving with the pre-PR3 inline helpers:
+ *
+ *   - `modelDerived`: uses the FIRST entry of `fixture.providesValues[semantic]`
+ *     (matches `bindModelDerivedFromFixture` PR 1 scope). Returns
+ *     `unclassified` if the fixture is missing or has no value entry
+ *     for this semantic — the caller (helper) is expected to bail out
+ *     without mutating the scenario, mirroring the pre-PR3 `if (!values?.length) continue`.
+ *
+ *   - `clientMintedAttribute`: produces a deterministic
+ *     `fc:cma:<sem>:<suffix>` token using `deterministicSuffix(opId, semantic)`,
+ *     matching the byte-stable mint formula from
+ *     `bindClientMintedAttribute` PR 2.
+ *
+ *   - producerBound / clientMintedIdentifier / externalBoundary: returned
+ *     with `varName` only. Callers should treat these as "owned by BFS"
+ *     and not overwrite the existing binding.
+ *
+ * The `varName` is `<camelCase(semantic)>Var` — the same convention every
+ * downstream emitter and L3 invariant relies on.
+ */
+export function bindSemanticInput(args: {
+  semantic: string;
+  operationId: string;
+  graph: OperationGraph;
+  fixture?: ArtifactRegistryEntry;
+}): BoundInput {
+  const { semantic, operationId, graph, fixture } = args;
+  const classification = classifySemantic(semantic, graph);
+  const varName = `${camelCaseSemantic(semantic)}Var`;
+  switch (classification) {
+    case 'modelDerived': {
+      const values = fixture?.providesValues?.[semantic];
+      if (!values?.length) return { classification: 'unclassified' };
+      return { classification: 'modelDerived', varName, value: values[0] };
+    }
+    case 'clientMintedAttribute': {
+      const value = `fc:cma:${camelCaseSemantic(semantic)}:${deterministicSuffix(
+        `fc:cma:${operationId}:${semantic}`,
+      )}`;
+      return { classification: 'clientMintedAttribute', varName, value };
+    }
+    case 'producerBound':
+    case 'clientMintedIdentifier':
+    case 'externalBoundary':
+      return { classification, varName };
+    default:
+      return { classification: 'unclassified' };
+  }
+}
+
+// Local copy so this module has no dependency on path-analyser/src/index.ts
+// (which would create an import cycle once index.ts re-imports the helpers
+// that route through this module). Identical to the camelCase function in
+// index.ts: lowercase the first character and leave the rest alone.
+function camelCaseSemantic(semantic: string): string {
+  return semantic.charAt(0).toLowerCase() + semantic.slice(1);
+}

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -765,6 +765,12 @@ export function bindModelDerivedFromFixture(
         fixture,
       });
       if (result.classification !== 'modelDerived') continue;
+      // Per #162 PR 3 reviewer note: the chokepoint reports modelDerived
+      // even when no fixture value is resolvable, so PR 5 can tell
+      // "unclassified semantic" apart from "modelDerived semantic with
+      // missing fixture data". The caller is responsible for skipping
+      // the unresolved case here — mirrors the pre-PR3 `if (!values?.length) continue`.
+      if (result.value === undefined) continue;
 
       scenario.bindings ||= {};
       // Authoritative override: a featureCoverageGenerator synthetic

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -2,8 +2,8 @@ import fsSync from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { bindSemanticInput } from './bindSemanticInput.js';
 import { buildCanonicalShapes } from './canonicalSchemas.js';
-import { deterministicSuffix } from './codegen/support/seeding.js';
 import {
   getActiveConfigDir,
   getFeatureOutputDir,
@@ -19,6 +19,7 @@ import {
 } from './scenarioGenerator.js';
 import { computeSeedBindings } from './seedBindings.js';
 import type {
+  ArtifactRegistryEntry,
   DomainSemantics,
   EndpointScenario,
   GenerationSummary,
@@ -732,8 +733,6 @@ export function bindModelDerivedFromFixture(
   graph: OperationGraph,
 ): void {
   if (scenario.strategy !== 'featureCoverage') return;
-  const domain = graph.domain;
-  if (!domain?.semanticTypes) return;
   if (!steps.length) return;
   const finalStep = steps[steps.length - 1];
   const endpoint = graph.operations[finalStep.operationId];
@@ -754,15 +753,23 @@ export function bindModelDerivedFromFixture(
 
   for (const subShape of subShapes) {
     for (const leaf of subShape.leaves) {
-      const semKind = domain.semanticTypes[leaf.semantic]?.kind;
-      if (semKind !== 'modelDerived') continue;
-      const values = fixture.providesValues[leaf.semantic];
-      if (!values?.length) continue;
-      const varName = `${camelCase(leaf.semantic)}Var`;
+      // #162 PR 3: route classification + value derivation through the
+      // unified chokepoint. The helper still owns its scope filter
+      // (subShape leaves only) and its mutation (binding + populatesSubShape
+      // entry); the chokepoint owns "is this a modelDerived semantic and
+      // what value does it resolve to?".
+      const result = bindSemanticInput({
+        semantic: leaf.semantic,
+        operationId: finalStep.operationId,
+        graph,
+        fixture,
+      });
+      if (result.classification !== 'modelDerived') continue;
+
       scenario.bindings ||= {};
       // Authoritative override: a featureCoverageGenerator synthetic
       // would otherwise shadow the real fixture value.
-      scenario.bindings[varName] = values[0];
+      scenario.bindings[result.varName] = result.value;
 
       const sub = scenario.populatesSubShape ?? {
         rootPath: subShape.rootPath,
@@ -855,8 +862,6 @@ export function bindClientMintedAttribute(
   graph: OperationGraph,
 ): void {
   if (scenario.strategy !== 'featureCoverage') return;
-  const domain = graph.domain;
-  if (!domain?.semanticTypes) return;
   if (!steps.length) return;
   const finalStep = steps[steps.length - 1];
   const endpoint = graph.operations[finalStep.operationId];
@@ -864,8 +869,6 @@ export function bindClientMintedAttribute(
   if (!bodySems.length) return;
 
   for (const bodySem of bodySems) {
-    const spec = domain.semanticTypes[bodySem.semantic];
-    if (spec?.kind !== 'attribute' || spec.clientMinted !== true) continue;
     // PR 2 narrowed scope: only fill at the endpoint that IS the setter
     // (the final-step body accepts the semantic). Filter-consumer sites
     // also have the semantic in their bodySemantics but need a separate
@@ -883,10 +886,20 @@ export function bindClientMintedAttribute(
       continue;
     }
 
-    const varName = `${camelCase(bodySem.semantic)}Var`;
-    const mintedValue = `fc:cma:${camelCase(bodySem.semantic)}:${deterministicSuffix(`fc:cma:${finalStep.operationId}:${bodySem.semantic}`)}`;
+    // #162 PR 3: route classification + mint through the unified
+    // chokepoint. The helper still owns its scope filter (setter-site
+    // bodySemantics only) and its mutation (binding + populatesSubShape
+    // entry); the chokepoint owns "is this a clientMintedAttribute and
+    // what deterministic value does it mint?".
+    const result = bindSemanticInput({
+      semantic: bodySem.semantic,
+      operationId: finalStep.operationId,
+      graph,
+    });
+    if (result.classification !== 'clientMintedAttribute') continue;
+
     scenario.bindings ||= {};
-    scenario.bindings[varName] = mintedValue;
+    scenario.bindings[result.varName] = result.value;
 
     // Always plant a populatesSubShape entry so the body is filled by
     // the existing materializer. setLeafPlaceholder handles all three
@@ -1464,35 +1477,6 @@ function normaliseProvidesValues(input: unknown): Record<string, string[]> | und
 }
 
 // -------- Artifact Registry support ---------
-type ArtifactRegistryEntry = {
-  kind: string;
-  path: string;
-  description?: string;
-  /**
-   * Runtime characteristics this specific fixture provides BEYOND what
-   * `artifactKinds.<kind>.producesStates` declares for the kind. The
-   * selector picks the entry whose effective providesStates (entry ∪
-   * kind) covers the chain's required states (#159).
-   */
-  providesStates?: string[];
-  /**
-   * Concrete values this fixture supplies for semantic types whose
-   * `semanticTypes.<X>.kind === 'modelDerived'` (#162 PR 1). The planner
-   * reads these out-of-band at plan time — no Camunda API round-trip is
-   * needed to learn the values, because the BPMN/DMN/Form file already
-   * encodes them (element IDs, job types, form IDs, …).
-   *
-   * Per-semantic the value is an array so a future per-consumer-site
-   * preference vocabulary can pick a specific entry; PR 1's planner
-   * takes index 0 unconditionally.
-   *
-   * After #164: this is the SOLE source of fixture-derived values. The
-   * pre-#162 ad-hoc `parameters: { jobType: ... }` field was the
-   * embryonic form of this idea and has been retired; any new
-   * fixture-derived value must be declared here.
-   */
-  providesValues?: Record<string, string[]>;
-};
 let artifactsRegistryCache: ArtifactRegistryEntry[] | undefined;
 function getArtifactsRegistry(): ArtifactRegistryEntry[] {
   if (artifactsRegistryCache) return artifactsRegistryCache;

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1,7 +1,7 @@
 import fsSync from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { buildCanonicalShapes } from './canonicalSchemas.js';
 import { deterministicSuffix } from './codegen/support/seeding.js';
 import {
@@ -431,10 +431,20 @@ async function main() {
   console.log(`Generated scenario files for ${processed} endpoints.`);
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+// Only auto-invoke main() when this module is executed directly as a
+// CLI (e.g. `node path-analyser/dist/src/index.js`), not when imported
+// by another module. Tests in tests/fixtures/planner/ import the
+// exported `bindModelDerivedFromFixture` / `bindClientMintedAttribute`
+// helpers from this file under Vitest; without the guard, importing
+// would kick off the generator pipeline (filesystem writes against
+// `generated/`) inside the test process. Standard ESM CLI idiom: the
+// module's own URL matches the file URL of `process.argv[1]`.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
 
 function buildRequestPlan(
   scenario: EndpointScenario,

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -716,7 +716,7 @@ function annotateEventualWaits(steps: RequestStep[], graph: OperationGraph): voi
  *     `buildRequestBodyFromCanonical` and do not need a populatesSubShape
  *     annotation.
  */
-function bindModelDerivedFromFixture(
+export function bindModelDerivedFromFixture(
   scenario: EndpointScenario,
   steps: RequestStep[],
   graph: OperationGraph,
@@ -839,7 +839,7 @@ function fixtureFromDeployStep(step: RequestStep): ArtifactRegistryEntry | undef
  *     `tags[]` and `filter.tags: ['${tagVar}']` for nested
  *     `filter.tags[]`.
  */
-function bindClientMintedAttribute(
+export function bindClientMintedAttribute(
   scenario: EndpointScenario,
   steps: RequestStep[],
   graph: OperationGraph,

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -608,6 +608,49 @@ export interface ArtifactKindSpec {
   deploymentSlices?: string[]; // e.g., ["processDefinition"] or ["decisionDefinition","decisionRequirements"]
 }
 
+/**
+ * Single entry in the deployment artifact registry
+ * (`path-analyser/fixtures/deployment-artifacts.json`). One entry per
+ * checked-in BPMN/DMN/Form file the planner can deploy via
+ * `createDeployment`. Loaded lazily and cached at module scope by
+ * `getArtifactsRegistry()` in `path-analyser/src/index.ts`.
+ *
+ * Exported from `types.ts` (rather than kept private to `index.ts`) so
+ * the unified classification dispatch in `bindSemanticInput.ts` can
+ * accept a fixture parameter without having to import from `index.ts`
+ * (which would create a circular dependency once `index.ts` re-imports
+ * the chokepoint helper).
+ */
+export interface ArtifactRegistryEntry {
+  kind: string;
+  path: string;
+  description?: string;
+  /**
+   * Runtime characteristics this specific fixture provides BEYOND what
+   * `artifactKinds.<kind>.producesStates` declares for the kind. The
+   * selector picks the entry whose effective providesStates (entry ∪
+   * kind) covers the chain's required states (#159).
+   */
+  providesStates?: string[];
+  /**
+   * Concrete values this fixture supplies for semantic types whose
+   * `semanticTypes.<X>.kind === 'modelDerived'` (#162 PR 1). The planner
+   * reads these out-of-band at plan time — no Camunda API round-trip is
+   * needed to learn the values, because the BPMN/DMN/Form file already
+   * encodes them (element IDs, job types, form IDs, …).
+   *
+   * Per-semantic the value is an array so a future per-consumer-site
+   * preference vocabulary can pick a specific entry; PR 1's planner
+   * takes index 0 unconditionally.
+   *
+   * After #164: this is the SOLE source of fixture-derived values. The
+   * pre-#162 ad-hoc `parameters: { jobType: ... }` field was the
+   * embryonic form of this idea and has been retired; any new
+   * fixture-derived value must be declared here.
+   */
+  providesValues?: Record<string, string[]>;
+}
+
 export interface OperationArtifactRuleSpec {
   rules?: ArtifactRule[]; // optional when composable
   composable?: boolean; // if true, generator composes artifacts via set cover

--- a/tests/fixtures/planner/classification-dispatch.test.ts
+++ b/tests/fixtures/planner/classification-dispatch.test.ts
@@ -1,0 +1,438 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bindClientMintedAttribute,
+  bindModelDerivedFromFixture,
+} from '../../../path-analyser/src/index.ts';
+import type {
+  DomainSemantics,
+  EndpointScenario,
+  OperationGraph,
+  OperationNode,
+  RequestStep,
+} from '../../../path-analyser/src/types.ts';
+
+/**
+ * Classification-dispatch fixtures — Layer 2 of the layered test
+ * strategy, for issue #162 PR 3 (unified `bindSemanticInput` chokepoint).
+ *
+ * Today the 5 value-source classifications described in #162 are
+ * dispatched by separate code paths:
+ *
+ *   1. producer-bound          → BFS in scenarioGenerator.ts
+ *   2. client-minted identifier → BFS via `establishersByType`
+ *   3. client-minted attribute  → bindClientMintedAttribute (#162 PR 2)
+ *   4. external boundary        → BFS via `externalEntityIdentifiers`
+ *   5. model-derived            → bindModelDerivedFromFixture (#162 PR 1)
+ *
+ * PR 3 will route all five through a single `bindSemanticInput` helper
+ * with NO behaviour change. This file is the green/green guard step
+ * (per AGENTS.md "Coverage analysis before a behaviour-preserving
+ * refactor") — synthetic-graph-driven assertions on the dispatch output
+ * that pass against current `main` and must continue passing after the
+ * refactor.
+ *
+ * Coverage map for the five classifications:
+ *
+ *   1. producer-bound          → planner-contracts.test.ts (fixtures
+ *                                A, F, G, H) covers chain-shape selection;
+ *                                see also planner-establishes.test.ts
+ *                                for binding-name discipline.
+ *   2. client-minted identifier → planner-establishes.test.ts (fixtures
+ *                                for `x-semantic-establishes`).
+ *   3. client-minted attribute  → THIS FILE.
+ *   4. external boundary        → planner-establishes.test.ts (ClientId
+ *                                fixture asserting `externalEntitySites`
+ *                                tagging).
+ *   5. model-derived            → THIS FILE.
+ *
+ * (3) and (5) had no L2 guard before this file because their helpers
+ * live in index.ts post-BFS, outside the scenarioGenerator entry point
+ * the rest of the planner suite calls. Exposing them and pinning their
+ * observable behaviour with synthetic inputs lets the PR 3 refactor land
+ * with a single, readable diff at the chokepoint instead of having to
+ * read the L3 bundled-spec invariants to know what each helper did.
+ */
+
+interface NodeOpts {
+  required?: string[];
+  optional?: string[];
+  produces?: string[];
+  optionalSubShapes?: OperationNode['optionalSubShapes'];
+  requestBodySemantics?: OperationNode['requestBodySemantics'];
+}
+
+function makeOp(operationId: string, opts: NodeOpts = {}): OperationNode {
+  return {
+    operationId,
+    method: 'POST',
+    path: `/${operationId}`,
+    requires: {
+      required: opts.required ?? [],
+      optional: opts.optional ?? [],
+    },
+    produces: opts.produces ?? [],
+    optionalSubShapes: opts.optionalSubShapes,
+    requestBodySemantics: opts.requestBodySemantics,
+  };
+}
+
+function makeGraph(opts: {
+  operations: OperationNode[];
+  domain?: DomainSemantics;
+}): OperationGraph {
+  const operations: Record<string, OperationNode> = {};
+  for (const node of opts.operations) operations[node.operationId] = node;
+  return {
+    operations,
+    producersByType: {},
+    domain: opts.domain,
+  };
+}
+
+function makeDeployStep(fixturePath: string): RequestStep {
+  return {
+    operationId: 'createDeployment',
+    method: 'POST',
+    pathTemplate: '/deployments',
+    bodyKind: 'multipart',
+    multipartTemplate: {
+      files: { resources: `@@FILE:${fixturePath}` },
+    },
+    expect: { status: 200 },
+  };
+}
+
+function makeEndpointStep(operationId: string): RequestStep {
+  return {
+    operationId,
+    method: 'POST',
+    pathTemplate: `/${operationId}`,
+    expect: { status: 200 },
+  };
+}
+
+function makeFeatureScenario(overrides: Partial<EndpointScenario> = {}): EndpointScenario {
+  return {
+    id: 'feature-1',
+    operations: [],
+    producedSemanticTypes: [],
+    satisfiedSemanticTypes: [],
+    strategy: 'featureCoverage',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Classification 5 — model-derived (bindModelDerivedFromFixture, #162 PR 1)
+// ---------------------------------------------------------------------------
+//
+// The helper binds a semantic value out-of-band from a deployment
+// artifact's `providesValues` map when:
+//
+//   - scenario.strategy === 'featureCoverage'
+//   - domain.semanticTypes[<sem>].kind === 'modelDerived'
+//   - the endpoint declares an optional sub-shape whose leaf semantic
+//     is <sem>
+//   - the chain includes a createDeployment step whose multipart
+//     template references a registry entry with providesValues[<sem>]
+//
+// These tests use `bpmn/service-task.bpmn`, which is a real entry in
+// path-analyser/fixtures/deployment-artifacts.json with both ElementId
+// and JobType providesValues. The registry contents are themselves
+// guarded by the L3 invariants in regression-invariants.test.ts; this
+// L2 layer locks in the dispatch behaviour given a known-good registry.
+
+const modelDerivedDomain: DomainSemantics = {
+  version: 1,
+  semanticTypes: {
+    ElementId: { kind: 'modelDerived' },
+  },
+};
+
+const endpointWithElementIdSubShape: OperationNode = makeOp('createProcessInstance', {
+  required: ['ProcessDefinitionKey'],
+  optionalSubShapes: [
+    {
+      rootPath: 'startInstructions[]',
+      leaves: [{ fieldPath: 'startInstructions[].elementId', semantic: 'ElementId' }],
+    },
+  ],
+});
+
+describe('classification 5: model-derived dispatch (#162 PR 1)', () => {
+  it('binds <sem>Var from fixture.providesValues[0] when leaf is modelDerived', () => {
+    const scenario = makeFeatureScenario();
+    const steps: RequestStep[] = [
+      makeDeployStep('bpmn/service-task.bpmn'),
+      makeEndpointStep('createProcessInstance'),
+    ];
+    const graph = makeGraph({
+      operations: [endpointWithElementIdSubShape],
+      domain: modelDerivedDomain,
+    });
+
+    bindModelDerivedFromFixture(scenario, steps, graph);
+
+    // service-task.bpmn declares providesValues.ElementId =
+    // ['StartEvent_1', 'Activity_06kuv4r', 'Event_0tll3bk']. The helper
+    // takes the first entry unconditionally.
+    expect(scenario.bindings?.elementIdVar).toBe('StartEvent_1');
+    expect(scenario.populatesSubShape?.rootPath).toBe('startInstructions[]');
+    expect(scenario.populatesSubShape?.leafPaths).toEqual(['startInstructions[].elementId']);
+    expect(scenario.populatesSubShape?.leafSemantics).toEqual(['ElementId']);
+  });
+
+  it('is a no-op for non-featureCoverage scenarios (variant suite untouched)', () => {
+    // Locks in the suite-scoping contract that #162 PR 4 will lift; PR 3
+    // must preserve it.
+    const scenario = makeFeatureScenario({ strategy: 'optionalSubShapeVariant' });
+    const steps: RequestStep[] = [
+      makeDeployStep('bpmn/service-task.bpmn'),
+      makeEndpointStep('createProcessInstance'),
+    ];
+    const graph = makeGraph({
+      operations: [endpointWithElementIdSubShape],
+      domain: modelDerivedDomain,
+    });
+
+    bindModelDerivedFromFixture(scenario, steps, graph);
+
+    expect(scenario.bindings).toBeUndefined();
+    expect(scenario.populatesSubShape).toBeUndefined();
+  });
+
+  it('is a no-op when the chain has no createDeployment step', () => {
+    const scenario = makeFeatureScenario();
+    const steps: RequestStep[] = [makeEndpointStep('createProcessInstance')];
+    const graph = makeGraph({
+      operations: [endpointWithElementIdSubShape],
+      domain: modelDerivedDomain,
+    });
+
+    bindModelDerivedFromFixture(scenario, steps, graph);
+
+    expect(scenario.bindings).toBeUndefined();
+  });
+
+  it('is a no-op when the deployment fixture has no providesValues for the semantic', () => {
+    const scenario = makeFeatureScenario();
+    const steps: RequestStep[] = [
+      // forms/simple.form is a real registry entry with no providesValues
+      makeDeployStep('forms/simple.form'),
+      makeEndpointStep('createProcessInstance'),
+    ];
+    const graph = makeGraph({
+      operations: [endpointWithElementIdSubShape],
+      domain: modelDerivedDomain,
+    });
+
+    bindModelDerivedFromFixture(scenario, steps, graph);
+
+    expect(scenario.bindings).toBeUndefined();
+  });
+
+  it('is a no-op when the deploy step references an unknown registry path', () => {
+    const scenario = makeFeatureScenario();
+    const steps: RequestStep[] = [
+      makeDeployStep('bpmn/does-not-exist.bpmn'),
+      makeEndpointStep('createProcessInstance'),
+    ];
+    const graph = makeGraph({
+      operations: [endpointWithElementIdSubShape],
+      domain: modelDerivedDomain,
+    });
+
+    bindModelDerivedFromFixture(scenario, steps, graph);
+
+    expect(scenario.bindings).toBeUndefined();
+  });
+
+  it('overrides any pre-existing synthetic binding (authoritative)', () => {
+    // The featureCoverageGenerator may have stamped a synthetic
+    // `fc:pos:elementId:...` placeholder before this helper runs.
+    // The modelDerived value wins.
+    const scenario = makeFeatureScenario({
+      bindings: { elementIdVar: 'fc:pos:elementId:SYNTHETIC' },
+    });
+    const steps: RequestStep[] = [
+      makeDeployStep('bpmn/service-task.bpmn'),
+      makeEndpointStep('createProcessInstance'),
+    ];
+    const graph = makeGraph({
+      operations: [endpointWithElementIdSubShape],
+      domain: modelDerivedDomain,
+    });
+
+    bindModelDerivedFromFixture(scenario, steps, graph);
+
+    expect(scenario.bindings?.elementIdVar).toBe('StartEvent_1');
+  });
+
+  it('is a no-op when domain.semanticTypes does not declare the leaf as modelDerived', () => {
+    // Class-scoped: leaves declared with other `kind` values (e.g.
+    // 'attribute') OR with no kind at all must not be touched. The
+    // helper is exclusive to classification 5.
+    const scenario = makeFeatureScenario();
+    const steps: RequestStep[] = [
+      makeDeployStep('bpmn/service-task.bpmn'),
+      makeEndpointStep('createProcessInstance'),
+    ];
+    const graph = makeGraph({
+      operations: [endpointWithElementIdSubShape],
+      // No kind on ElementId — falls back to producer/establisher chain.
+      domain: { version: 1, semanticTypes: { ElementId: {} } },
+    });
+
+    bindModelDerivedFromFixture(scenario, steps, graph);
+
+    expect(scenario.bindings).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Classification 3 — client-minted attribute (bindClientMintedAttribute,
+// #162 PR 2)
+// ---------------------------------------------------------------------------
+//
+// The helper mints a deterministic `fc:cma:<sem>:<suffix>` value and
+// stamps a populatesSubShape entry when:
+//
+//   - scenario.strategy === 'featureCoverage'
+//   - domain.semanticTypes[<sem>].kind === 'attribute'
+//     && clientMinted === true
+//   - the endpoint declares the semantic in requestBodySemantics with a
+//     setter-site path (NOT starting with `filter.` / `filter[`)
+//
+// Setter-site is a pragmatic PR 2 narrowing — filter consumers are
+// deferred to #168. PR 3 must preserve that narrowing.
+
+const attributeDomain: DomainSemantics = {
+  version: 1,
+  semanticTypes: {
+    Tag: { kind: 'attribute', clientMinted: true },
+  },
+};
+
+const setterEndpoint: OperationNode = makeOp('createProcessInstance', {
+  requestBodySemantics: [{ semantic: 'Tag', fieldPath: 'tags[]', required: false }],
+});
+
+const filterConsumerEndpoint: OperationNode = makeOp('searchProcessInstances', {
+  requestBodySemantics: [{ semantic: 'Tag', fieldPath: 'filter.tags[]', required: false }],
+});
+
+describe('classification 3: client-minted attribute dispatch (#162 PR 2)', () => {
+  it('mints fc:cma:<sem>:<suffix> and populates the sub-shape at a setter site', () => {
+    const scenario = makeFeatureScenario();
+    const steps: RequestStep[] = [makeEndpointStep('createProcessInstance')];
+    const graph = makeGraph({
+      operations: [setterEndpoint],
+      domain: attributeDomain,
+    });
+
+    bindClientMintedAttribute(scenario, steps, graph);
+
+    const tagVar = scenario.bindings?.tagVar;
+    expect(tagVar, 'tagVar must be minted').toBeDefined();
+    // The prefix is the load-bearing classification marker. The suffix
+    // is a deterministicSuffix() of (opId, semantic) — content tested
+    // by the L3 invariants; here we only assert the contract shape.
+    expect(tagVar).toMatch(/^fc:cma:tag:/);
+    expect(scenario.populatesSubShape?.leafPaths).toEqual(['tags[]']);
+    expect(scenario.populatesSubShape?.leafSemantics).toEqual(['Tag']);
+  });
+
+  it('is deterministic across runs for the same (opId, semantic)', () => {
+    // The minted value uses deterministicSuffix to keep snapshot output
+    // byte-stable. Two calls with identical inputs must produce
+    // identical bindings.
+    const sa = makeFeatureScenario();
+    const sb = makeFeatureScenario();
+    const steps: RequestStep[] = [makeEndpointStep('createProcessInstance')];
+    const graph = makeGraph({
+      operations: [setterEndpoint],
+      domain: attributeDomain,
+    });
+
+    bindClientMintedAttribute(sa, steps, graph);
+    bindClientMintedAttribute(sb, steps, graph);
+
+    expect(sa.bindings?.tagVar).toBe(sb.bindings?.tagVar);
+  });
+
+  it('is a no-op at filter-consumer sites (setter-only scope of PR 2)', () => {
+    // Class-scoped: every fieldPath beginning with `filter.` or
+    // `filter[` must be skipped. PR 3 must preserve this narrowing
+    // because #168's setter-chain-reuse pass has not landed.
+    const scenario = makeFeatureScenario();
+    const steps: RequestStep[] = [makeEndpointStep('searchProcessInstances')];
+    const graph = makeGraph({
+      operations: [filterConsumerEndpoint],
+      domain: attributeDomain,
+    });
+
+    bindClientMintedAttribute(scenario, steps, graph);
+
+    expect(scenario.bindings).toBeUndefined();
+    expect(scenario.populatesSubShape).toBeUndefined();
+  });
+
+  it('is a no-op for non-featureCoverage scenarios (variant suite untouched)', () => {
+    const scenario = makeFeatureScenario({ strategy: 'optionalSubShapeVariant' });
+    const steps: RequestStep[] = [makeEndpointStep('createProcessInstance')];
+    const graph = makeGraph({
+      operations: [setterEndpoint],
+      domain: attributeDomain,
+    });
+
+    bindClientMintedAttribute(scenario, steps, graph);
+
+    expect(scenario.bindings).toBeUndefined();
+  });
+
+  it('is a no-op when kind:attribute but clientMinted is not true', () => {
+    // Class-scoped: `kind: 'attribute'` is necessary but not sufficient
+    // — clientMinted must be explicitly true. A future server-derived
+    // attribute type must not get minted.
+    const scenario = makeFeatureScenario();
+    const steps: RequestStep[] = [makeEndpointStep('createProcessInstance')];
+    const graph = makeGraph({
+      operations: [setterEndpoint],
+      domain: {
+        version: 1,
+        semanticTypes: { Tag: { kind: 'attribute' } },
+      },
+    });
+
+    bindClientMintedAttribute(scenario, steps, graph);
+
+    expect(scenario.bindings).toBeUndefined();
+  });
+
+  it('is a no-op when the endpoint has no requestBodySemantics for the type', () => {
+    const scenario = makeFeatureScenario();
+    const steps: RequestStep[] = [makeEndpointStep('createProcessInstance')];
+    const graph = makeGraph({
+      // setter endpoint with NO requestBodySemantics array.
+      operations: [makeOp('createProcessInstance')],
+      domain: attributeDomain,
+    });
+
+    bindClientMintedAttribute(scenario, steps, graph);
+
+    expect(scenario.bindings).toBeUndefined();
+  });
+
+  it('is a no-op when domain.semanticTypes is undefined', () => {
+    const scenario = makeFeatureScenario();
+    const steps: RequestStep[] = [makeEndpointStep('createProcessInstance')];
+    const graph = makeGraph({
+      operations: [setterEndpoint],
+      domain: { version: 1 },
+    });
+
+    bindClientMintedAttribute(scenario, steps, graph);
+
+    expect(scenario.bindings).toBeUndefined();
+  });
+});

--- a/tests/fixtures/planner/classification-dispatch.test.ts
+++ b/tests/fixtures/planner/classification-dispatch.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { classifySemantic } from '../../../path-analyser/src/bindSemanticInput.ts';
+import {
+  bindSemanticInput,
+  classifySemantic,
+} from '../../../path-analyser/src/bindSemanticInput.ts';
 import {
   bindClientMintedAttribute,
   bindModelDerivedFromFixture,
@@ -540,5 +543,116 @@ describe('classifySemantic precedence (#162 PR 3)', () => {
     };
 
     expect(classifySemantic('SomeAttr', graph)).toBe('producerBound');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bindSemanticInput modelDerived value-resolution contract (#162 PR 3)
+// ---------------------------------------------------------------------------
+//
+// Reviewer note on PR 179 (copilot-pull-request-reviewer): the chokepoint
+// must NOT collapse "modelDerived semantic with missing fixture data" to
+// `unclassified`, because PR 5 needs to tell the two cases apart in
+// load-time diagnostics. The classification is a property of the
+// semantic + graph; the value is a separate question of whether the
+// active fixture happens to provide it.
+
+describe('bindSemanticInput modelDerived value-resolution (#162 PR 3)', () => {
+  const modelDerivedGraph: OperationGraph = {
+    operations: {},
+    producersByType: {},
+    domain: {
+      version: 1,
+      semanticTypes: { ElementId: { kind: 'modelDerived' } },
+    },
+  };
+
+  it('returns modelDerived with the fixture value when providesValues is populated', () => {
+    const fixture = {
+      kind: 'bpmnProcess',
+      path: 'bpmn/service-task.bpmn',
+      providesValues: { ElementId: ['service_task_1', 'service_task_2'] },
+    };
+
+    const result = bindSemanticInput({
+      semantic: 'ElementId',
+      operationId: 'createProcessInstance',
+      graph: modelDerivedGraph,
+      fixture,
+    });
+
+    expect(result).toEqual({
+      classification: 'modelDerived',
+      varName: 'elementIdVar',
+      value: 'service_task_1',
+    });
+  });
+
+  it('returns modelDerived (NOT unclassified) when the fixture lacks providesValues', () => {
+    // Defect-class guard for the reviewer note: stable classification
+    // even when the value can't be resolved. PR 5 will use this to
+    // distinguish "semantic not declared anywhere" from "semantic
+    // declared modelDerived but the selected fixture is the wrong file".
+    const fixture = {
+      kind: 'form',
+      path: 'forms/simple.form',
+    };
+
+    const result = bindSemanticInput({
+      semantic: 'ElementId',
+      operationId: 'createProcessInstance',
+      graph: modelDerivedGraph,
+      fixture,
+    });
+
+    expect(result.classification).toBe('modelDerived');
+    if (result.classification === 'modelDerived') {
+      expect(result.varName).toBe('elementIdVar');
+      expect(result.value).toBeUndefined();
+    }
+  });
+
+  it('returns modelDerived with no value when no fixture is supplied at all', () => {
+    const result = bindSemanticInput({
+      semantic: 'ElementId',
+      operationId: 'createProcessInstance',
+      graph: modelDerivedGraph,
+      // fixture intentionally omitted
+    });
+
+    expect(result.classification).toBe('modelDerived');
+    if (result.classification === 'modelDerived') {
+      expect(result.value).toBeUndefined();
+    }
+  });
+
+  it('returns modelDerived with no value when providesValues[<sem>] is an empty array', () => {
+    const fixture = {
+      kind: 'bpmnProcess',
+      path: 'bpmn/service-task.bpmn',
+      providesValues: { ElementId: [] },
+    };
+
+    const result = bindSemanticInput({
+      semantic: 'ElementId',
+      operationId: 'createProcessInstance',
+      graph: modelDerivedGraph,
+      fixture,
+    });
+
+    expect(result.classification).toBe('modelDerived');
+    if (result.classification === 'modelDerived') {
+      expect(result.value).toBeUndefined();
+    }
+  });
+
+  it('still returns unclassified when the semantic is neither declared nor indexed', () => {
+    const result = bindSemanticInput({
+      semantic: 'UnknownSemantic',
+      operationId: 'createProcessInstance',
+      graph: { operations: {}, producersByType: {} },
+    });
+
+    expect(result.classification).toBe('unclassified');
   });
 });

--- a/tests/fixtures/planner/classification-dispatch.test.ts
+++ b/tests/fixtures/planner/classification-dispatch.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { classifySemantic } from '../../../path-analyser/src/bindSemanticInput.ts';
 import {
   bindClientMintedAttribute,
   bindModelDerivedFromFixture,
@@ -434,5 +435,110 @@ describe('classification 3: client-minted attribute dispatch (#162 PR 2)', () =>
     bindClientMintedAttribute(scenario, steps, graph);
 
     expect(scenario.bindings).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifySemantic precedence (#162 PR 3)
+// ---------------------------------------------------------------------------
+//
+// The unified chokepoint resolves a semantic to ONE classification using
+// a documented precedence: explicit `domain.semanticTypes[T].kind`
+// declarations win over graph-index inferences. This block locks the
+// precedence in directly so PR 5 (load-time diagnostic on `unclassified`)
+// can build on a contract instead of an accident of code order.
+//
+// Today the bundled spec has no real collisions — every modelDerived /
+// clientMintedAttribute semantic is also absent from the producer /
+// establisher / external-entity indices. These synthetic tests assert
+// the precedence anyway, because the contract matters even if it is
+// today unobservable.
+
+describe('classifySemantic precedence (#162 PR 3)', () => {
+  function graphWithProducer(semantic: string): OperationGraph {
+    return {
+      operations: {},
+      producersByType: { [semantic]: ['someOp'] },
+    };
+  }
+
+  it('modelDerived declaration wins over a producersByType entry', () => {
+    const graph: OperationGraph = {
+      ...graphWithProducer('ElementId'),
+      domain: {
+        version: 1,
+        semanticTypes: { ElementId: { kind: 'modelDerived' } },
+      },
+    };
+
+    expect(classifySemantic('ElementId', graph)).toBe('modelDerived');
+  });
+
+  it('clientMintedAttribute declaration wins over a producersByType entry', () => {
+    const graph: OperationGraph = {
+      ...graphWithProducer('Tag'),
+      domain: {
+        version: 1,
+        semanticTypes: { Tag: { kind: 'attribute', clientMinted: true } },
+      },
+    };
+
+    expect(classifySemantic('Tag', graph)).toBe('clientMintedAttribute');
+  });
+
+  it('producerBound wins over clientMintedIdentifier when no domain.kind applies', () => {
+    const graph: OperationGraph = {
+      operations: {},
+      producersByType: { ProcessInstanceKey: ['createProcessInstance'] },
+      establishersByType: { ProcessInstanceKey: ['someOp'] },
+    };
+
+    expect(classifySemantic('ProcessInstanceKey', graph)).toBe('producerBound');
+  });
+
+  it('clientMintedIdentifier wins over externalBoundary when no producer applies', () => {
+    const graph: OperationGraph = {
+      operations: {},
+      producersByType: {},
+      establishersByType: { TenantId: ['createTenant'] },
+      externalEntityIdentifiers: new Set(['TenantId']),
+    };
+
+    expect(classifySemantic('TenantId', graph)).toBe('clientMintedIdentifier');
+  });
+
+  it('externalBoundary applies when only the external-entities set matches', () => {
+    const graph: OperationGraph = {
+      operations: {},
+      producersByType: {},
+      externalEntityIdentifiers: new Set(['ClientId']),
+    };
+
+    expect(classifySemantic('ClientId', graph)).toBe('externalBoundary');
+  });
+
+  it('returns unclassified when no declaration and no index entry matches', () => {
+    const graph: OperationGraph = {
+      operations: {},
+      producersByType: {},
+    };
+
+    expect(classifySemantic('UnknownSemantic', graph)).toBe('unclassified');
+  });
+
+  it('attribute declaration without clientMinted does NOT short-circuit producerBound', () => {
+    // A declaration of `kind: 'attribute'` without `clientMinted: true`
+    // must NOT be treated as clientMintedAttribute — only the explicit
+    // `clientMinted === true` flag promotes the semantic into PR 2's
+    // chokepoint scope.
+    const graph: OperationGraph = {
+      ...graphWithProducer('SomeAttr'),
+      domain: {
+        version: 1,
+        semanticTypes: { SomeAttr: { kind: 'attribute' } },
+      },
+    };
+
+    expect(classifySemantic('SomeAttr', graph)).toBe('producerBound');
   });
 });


### PR DESCRIPTION
PR 3 of issue #162 — unifies the 5-classification value-source dispatch into a single `bindSemanticInput` chokepoint. **Behaviour-preserving refactor: regenerated camunda-oca pipeline output is byte-identical** to `main` (`git diff --stat generated/` reports 0 files).

Closes step 3 of #162.

## Why

Today the 5 value-source classifications described in #162 are dispatched by separate, scattered code paths:

| # | Classification | Today's dispatch site |
|---|---|---|
| 1 | producer-bound | BFS in `scenarioGenerator.ts` |
| 2 | client-minted identifier | BFS via `establishersByType` |
| 3 | client-minted attribute | `bindClientMintedAttribute` (PR 2, #) |
| 4 | external boundary | BFS via `externalEntityIdentifiers` |
| 5 | model-derived | `bindModelDerivedFromFixture` (PR 1, #) |

The classification rules (which graph index / domain declaration determines which classification) are duplicated across these helpers, and there is no documented precedence when a semantic could match multiple. PR 5 will turn `unclassified` into a hard load-time diagnostic — that needs a single source of truth for the rules, not five inline filters.

## What

Two commits on this branch:

1. **`da62ca2` — `test: add L2 dispatch fixtures for the 5 value-source classifications`** (Step 0 / green guard)
   14 L2 fixtures in [tests/fixtures/planner/classification-dispatch.test.ts](tests/fixtures/planner/classification-dispatch.test.ts) that lock in the observable contracts of `bindModelDerivedFromFixture` (classification 5) and `bindClientMintedAttribute` (classification 3) before any production code moves. Per AGENTS.md "Coverage analysis before a behaviour-preserving refactor", these landed first and proved green against `main` so the refactor commit can prove green against the same assertions.

2. **`fe7f0d3` — `refactor: extract bindSemanticInput dispatch chokepoint (#162 PR 3)`**
   - New module path-analyser/src/bindSemanticInput.ts:
     - `classifySemantic(semantic, graph)` — single source of truth for the precedence rules.
     - `bindSemanticInput({ semantic, operationId, graph, fixture? })` — single chokepoint that classifies and (for `modelDerived` / `clientMintedAttribute`) derives the value too. Producer-bound / client-minted-identifier / external-boundary continue to be owned by the BFS engine; the chokepoint just returns the `varName` for them.
   - path-analyser/src/index.ts: `bindModelDerivedFromFixture` and `bindClientMintedAttribute` route their inner loops through `bindSemanticInput`. The setter-only narrowing for CMA stays in the caller (it's a request-shape filter, not a classification rule).
   - path-analyser/src/types.ts: `ArtifactRegistryEntry` moved here from `index.ts` to avoid a circular dep once `index.ts` re-imports the chokepoint helper.
   - +7 precedence-collision tests in classification-dispatch.test.ts — `describe('classifySemantic precedence (#162 PR 3)')`. Today the bundled spec has no real collisions; the synthetic tests assert the contract anyway because PR 5 will rely on it.

## Precedence

Documented in `classifySemantic` and pinned by tests:

```
modelDerived            (declaration: kind = 'modelDerived')
  > clientMintedAttribute (declaration: kind = 'attribute' && clientMinted = true)
  > producerBound         (graph index: producersByType[T])
  > clientMintedIdentifier (graph index: establishersByType[T])
  > externalBoundary       (graph index: externalEntityIdentifiers has T)
  > unclassified           (none of the above)
```

Declarations win over graph indices. Within a tier, the first matching rule wins.

## Verification

| Gate | Result |
|---|---|
| `npx tsc --noEmit` (all 3 workspaces) | clean |
| `npm run lint` (Biome) | clean |
| `npm test` | 357 passed, 6 skipped (was 350 before the +7 precedence tests) |
| `TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation` | succeeds |
| `git diff --stat generated/` after regen | **0 files** — byte-identical to `main` |

The byte-identical regen is the load-bearing guard for "no behaviour change". Layer-3 invariants in configs/camunda-oca/regression-invariants.test.ts pass against the regenerated output unchanged.

## Out of scope (deferred to PR 4 / PR 5 of #162)

- Routing the BFS-owned classifications (1, 2, 4) through `bindSemanticInput` for value derivation as well as classification. The chokepoint already classifies them; the value still comes from the BFS step output. Doing this in the same PR would no longer be byte-identical.
- Turning `unclassified` into a load-time error (PR 5).

Refs #162