### PR TITLE
refactor: suite-partition cut — feature required-only, variant owns optionals (#162 PR 4)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -2657,126 +2657,114 @@ describeForThisConfig(
     // assertions below check this leading-pattern is absent from the
     // corresponding feature scenario's binding — proving the binding
     // comes from providesValues instead. A real BPMN element id starts
-    // with the model's element name (e.g. `StartEvent_1`,
-    // `Activity_06kuv4r`) and so cannot start with the lower-cased
-    // semantic name.
-    const SYNTHETIC_RE = /^elementId_[A-Za-z0-9]+$/;
+    // #162 PR 4: the suite partition cut moved per-leaf optional
+    // coverage from feature (was `opt=ElementId`) to variant (one
+    // scenario per `<rootPath>::<fieldPath>`). The original assertion
+    // that `elementIdVar` resolves from a deploy fixture and must NOT
+    // match the synthetic `elementId_<suffix>` placeholder no longer
+    // applies in the variant suite: variant-suite fallback minting
+    // (path-analyser/src/scenarioGenerator.ts → `resolveFallbackValue`)
+    // legitimately produces synthetic placeholders for `modelDerived`
+    // semantics when the producer-chain BFS cannot satisfy the leaf,
+    // because the variant generator does not have deploy-fixture
+    // context at that stage. The cut's structural guards live in
+    // `'bundled-spec invariants: suite-partition cut (#162 PR 4)'`
+    // above. Here we keep a class-scoped existence + body-reference
+    // invariant only: every endpoint that declares ElementId as an
+    // optional body leaf must have at least one variant scenario that
+    // populates ElementId, binds `elementIdVar`, and the emitted
+    // variant spec must reference `ctx.elementIdVar`.
 
-    interface FeatureScenarioBody {
+    interface VariantScenarioBody {
       bindings?: Record<string, string>;
       strategy?: string;
       variantKey?: string;
+      populatesSubShape?: { leafSemantics?: string[] };
     }
-    interface FeatureScenarioFile {
+    interface VariantScenarioFile {
       endpoint: { operationId: string };
-      scenarios: FeatureScenarioBody[];
+      scenarios: VariantScenarioBody[];
     }
 
-    function loadFeatureCollection(file: string): FeatureScenarioFile {
+    function loadVariantCollection(file: string): VariantScenarioFile {
       const raw = readFileSync(file, 'utf8');
       // biome-ignore lint/plugin: parsed JSON is a runtime contract boundary
-      return JSON.parse(raw) as FeatureScenarioFile;
+      return JSON.parse(raw) as VariantScenarioFile;
     }
 
-    function findScenarioBinding(
-      collection: FeatureScenarioFile,
-      variantKey: string,
-      varName: string,
-    ): string | undefined {
-      const scenario = collection.scenarios.find((s) => s.variantKey === variantKey);
-      return scenario?.bindings?.[varName];
+    function findElementIdVariant(
+      collection: VariantScenarioFile,
+    ): VariantScenarioBody | undefined {
+      return collection.scenarios.find((s) =>
+        s.populatesSubShape?.leafSemantics?.includes('ElementId'),
+      );
     }
 
     interface Target {
       endpoint: string;
-      featureFile: string;
-      variantKey: string;
+      variantFile: string;
       varName: string;
-      consumerPathInBody: string;
     }
     const TARGETS: Target[] = [
       {
         endpoint: 'createProcessInstance',
-        featureFile: 'post--process-instances-scenarios.json',
-        variantKey: 'opt=ElementId',
+        variantFile: 'post--process-instances-scenarios.json',
         varName: 'elementIdVar',
-        consumerPathInBody: 'startInstructions',
       },
       {
         endpoint: 'activateAdHocSubProcessActivities',
-        featureFile:
+        variantFile:
           'post--element-instances--ad-hoc-activities--{adHocSubProcessInstanceKey}--activation-scenarios.json',
-        variantKey: 'opt=ElementId',
         varName: 'elementIdVar',
-        consumerPathInBody: 'elements',
       },
       {
         endpoint: 'completeJob',
-        featureFile: 'post--jobs--{jobKey}--completion-scenarios.json',
-        variantKey: 'opt=ElementId',
+        variantFile: 'post--jobs--{jobKey}--completion-scenarios.json',
         varName: 'elementIdVar',
-        consumerPathInBody: 'result',
       },
       {
         endpoint: 'modifyProcessInstance',
-        featureFile: 'post--process-instances--{processInstanceKey}--modification-scenarios.json',
-        variantKey: 'opt=ElementId',
+        variantFile: 'post--process-instances--{processInstanceKey}--modification-scenarios.json',
         varName: 'elementIdVar',
-        consumerPathInBody: 'activateInstructions',
       },
     ];
 
     for (const t of TARGETS) {
-      it(`${t.endpoint} :: feature 'with ElementId' binds elementIdVar from fixture providesValues (#162)`, () => {
-        const path = join(FEATURE_SCENARIOS_DIR, t.featureFile);
+      it(`${t.endpoint} :: variant suite emits an ElementId-populating scenario binding ${t.varName} (#162 PR 4)`, () => {
+        const path = join(VARIANT_SCENARIOS_DIR, t.variantFile);
         if (!existsSync(path)) {
           throw new Error(
-            `expected feature-output JSON not found: ${t.featureFile} — run 'npm run testsuite:generate'`,
+            `expected variant-output JSON not found: ${t.variantFile} — run 'npm run testsuite:generate'`,
           );
         }
-        const collection = loadFeatureCollection(path);
-        const binding = findScenarioBinding(collection, t.variantKey, t.varName);
+        const collection = loadVariantCollection(path);
+        const scenario = findElementIdVariant(collection);
         expect(
-          binding,
-          `${t.endpoint}: scenario with variantKey '${t.variantKey}' must have a binding for ${t.varName}`,
+          scenario,
+          `${t.endpoint}: expected a variant scenario whose populatesSubShape.leafSemantics includes 'ElementId'`,
         ).toBeDefined();
+        const binding = scenario?.bindings?.[t.varName];
         expect(
           binding,
-          `${t.endpoint}: ${t.varName} binding must NOT be the pre-PR-1 synthetic 'elementId_...' placeholder`,
-        ).not.toMatch(SYNTHETIC_RE);
+          `${t.endpoint}: ElementId variant must bind ${t.varName}`,
+        ).toBeDefined();
       });
 
-      it(`${t.endpoint} :: emitted feature spec references ctx.${t.varName} in the request body (#162)`, () => {
-        const specName = `${t.endpoint}.feature.spec.ts`;
+      it(`${t.endpoint} :: emitted variant spec references ctx.${t.varName} (#162 PR 4)`, () => {
+        const specName = `${t.endpoint}.variant.spec.ts`;
         const spec = join(GENERATED_TESTS_DIR, specName);
         if (!existsSync(spec)) {
           throw new Error(`expected emitted spec not found: ${specName}`);
         }
         const src = readFileSync(spec, 'utf8');
-        // The body for the 'opt=ElementId' scenario must reference the
-        // ElementId binding inside its consumer-path key (e.g. `elements`,
-        // `startInstructions`, …). Use the scenario title to scope the
-        // search to the right test block.
-        const scenarioMarker = `with ElementId`;
-        const scenarioIdx = src.indexOf(scenarioMarker);
+        // Variant specs use `variant-N` titles (no semantic-named
+        // marker), and an endpoint's variant file contains only its
+        // variant scenarios — so a file-wide `ctx.elementIdVar`
+        // reference is sufficient and unambiguous evidence that the
+        // ElementId variant body wires the binding.
         expect(
-          scenarioIdx,
-          `${t.endpoint}: expected a scenario block titled 'with ElementId'`,
-        ).toBeGreaterThan(0);
-        // Find the end of the test block by scanning forward to the next
-        // `test(` opener (or end of file).
-        const nextTestIdx = src.indexOf("\n  test('", scenarioIdx + scenarioMarker.length);
-        const scenarioBlock = src.slice(
-          scenarioIdx,
-          nextTestIdx > 0 ? nextTestIdx : src.length,
-        );
-        expect(
-          scenarioBlock.includes(t.consumerPathInBody),
-          `${t.endpoint} 'with ElementId': body must populate '${t.consumerPathInBody}'`,
-        ).toBe(true);
-        expect(
-          scenarioBlock.includes(`ctx.${t.varName}`),
-          `${t.endpoint} 'with ElementId': body must reference ctx.${t.varName}`,
+          src.includes(`ctx.${t.varName}`),
+          `${t.endpoint} variant spec: body must reference ctx.${t.varName}`,
         ).toBe(true);
       });
     }
@@ -2945,61 +2933,68 @@ describeForThisConfig(
 
       for (const op of setterOps) {
         const varName = `${camelCase(semantic)}Var`;
-        const expectedPrefix = `fc:cma:${camelCase(semantic)}:`;
-        const variantKey = `opt=${semantic}`;
 
-        it(`${semantic} :: ${op.operationId}: opt=${semantic} feature scenario binds ${varName} with the clientMintedAttribute prefix (#162 PR 2)`, () => {
-          const featureFile = join(FEATURE_SCENARIOS_DIR, featureFileFor(op));
-          if (!existsSync(featureFile)) {
+        it(`${semantic} :: ${op.operationId}: variant suite emits a ${semantic}-populating scenario binding ${varName} (#162 PR 4)`, () => {
+          const variantFile = join(VARIANT_SCENARIOS_DIR, featureFileFor(op));
+          if (!existsSync(variantFile)) {
             throw new Error(
-              `expected feature-output JSON not found: ${featureFileFor(op)} — run 'npm run testsuite:generate'`,
+              `expected variant-output JSON not found: ${featureFileFor(op)} — run 'npm run testsuite:generate'`,
             );
           }
-          const raw = readFileSync(featureFile, 'utf8');
+          const raw = readFileSync(variantFile, 'utf8');
           // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
           const parsed = JSON.parse(raw) as {
-            scenarios: Array<{ variantKey?: string; bindings?: Record<string, string> }>;
+            scenarios: Array<{
+              variantKey?: string;
+              bindings?: Record<string, string>;
+              populatesSubShape?: { leafSemantics?: string[] };
+            }>;
           };
-          const scenario = parsed.scenarios.find((s) => s.variantKey === variantKey);
+          const scenario = parsed.scenarios.find((s) =>
+            s.populatesSubShape?.leafSemantics?.includes(semantic),
+          );
           expect(
             scenario,
-            `${op.operationId}: expected an ${variantKey} feature scenario`,
+            `${op.operationId}: expected a variant scenario whose populatesSubShape.leafSemantics includes '${semantic}'`,
           ).toBeDefined();
           const binding = scenario?.bindings?.[varName];
           expect(
             binding,
-            `${op.operationId} ${variantKey}: must bind ${varName}`,
+            `${op.operationId}: ${semantic} variant must bind ${varName}`,
           ).toBeDefined();
-          expect(
-            binding?.startsWith(expectedPrefix),
-            `${op.operationId} ${variantKey}: ${varName} binding must use the clientMintedAttribute prefix (${expectedPrefix}…); got '${binding}'`,
-          ).toBe(true);
+          // PR 4 note: the binding may be either
+          //   - `fc:cma:<sem>:<suffix>` — variant fallback path
+          //     (`bindSemanticInput` for clientMintedAttribute), used
+          //     when the producer-chain BFS could not satisfy the leaf;
+          //   - `__PENDING__` — variant producer-chain path, where the
+          //     value is extracted at runtime from a search step in the
+          //     chain;
+          //   - `<sem>_<suffix>` — variant fallback path for
+          //     non-clientMintedAttribute classifications (only
+          //     reached when the semantic is not clientMinted; included
+          //     here for completeness even though clientMintedAttribute
+          //     semantics never take this branch).
+          // Asserting any of these specifically would couple this
+          // invariant to the BFS outcome rather than to the suite-
+          // partition contract.
         });
 
-        it(`${semantic} :: ${op.operationId}: emitted with-${semantic} feature spec references ctx.${varName} (#162 PR 2)`, () => {
-          // Map operationId → emitted Playwright spec path. The
-          // generator names files by operationId (not method+path) for
-          // playwright suites, so this lookup is direct.
-          const spec = join(GENERATED_TESTS_DIR, `${op.operationId}.feature.spec.ts`);
+        it(`${semantic} :: ${op.operationId}: emitted variant spec references ctx.${varName} (#162 PR 4)`, () => {
+          const spec = join(GENERATED_TESTS_DIR, `${op.operationId}.variant.spec.ts`);
           if (!existsSync(spec)) {
             throw new Error(
-              `expected emitted spec not found: ${op.operationId}.feature.spec.ts — run 'npm run testsuite:generate'`,
+              `expected emitted spec not found: ${op.operationId}.variant.spec.ts — run 'npm run testsuite:generate'`,
             );
           }
           const src = readFileSync(spec, 'utf8');
-          // The variant title fragment the emitter writes for `opt=<X>`
-          // is `with <X>` (see featureCoverageGenerator title formatter).
-          const scenarioMarker = `with ${semantic}`;
-          const scenarioIdx = src.indexOf(scenarioMarker);
+          // Variant specs use `variant-N` titles (no semantic-named
+          // marker), and an endpoint's variant file contains only its
+          // variant scenarios — so a file-wide `ctx.<sem>Var` reference
+          // is sufficient and unambiguous evidence that the scenario
+          // body wires the binding.
           expect(
-            scenarioIdx,
-            `${op.operationId}: expected a scenario block titled '${scenarioMarker}'`,
-          ).toBeGreaterThan(0);
-          const nextTestIdx = src.indexOf("\n  test('", scenarioIdx + scenarioMarker.length);
-          const block = src.slice(scenarioIdx, nextTestIdx > 0 ? nextTestIdx : src.length);
-          expect(
-            block.includes(`ctx.${varName}`),
-            `${op.operationId} '${scenarioMarker}': body must reference ctx.${varName}`,
+            src.includes(`ctx.${varName}`),
+            `${op.operationId} variant spec: body must reference ctx.${varName}`,
           ).toBe(true);
         });
       }

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -3257,13 +3257,20 @@ describeForThisConfig(
       const offenders: { file: string; id: string; variantKey: string }[] = [];
       for (const { file, parsed } of loadAllFeatureFiles()) {
         for (const s of readFeatureScenarios(parsed)) {
-          const key = s.variantKey;
-          if (typeof key !== 'string') continue;
           // Carve-out: behavioural-matrix scenarios (`duplicateTest`)
           // are allowed regardless of variantKey shape — the
           // distinguishing metadata is on the scenario object, not in
           // the key.
           if (s.duplicateTest) continue;
+          const key = s.variantKey;
+          // A missing/non-string variantKey is itself a regression:
+          // post-PR-4 every feature scenario must carry a suite-
+          // convention key. Treat as an offender so an accidentally
+          // omitted key cannot slip past this guard.
+          if (typeof key !== 'string') {
+            offenders.push({ file, id: s.id, variantKey: String(key) });
+            continue;
+          }
           if (!ALLOW_PATTERNS.some((p) => p.test(key))) {
             offenders.push({ file, id: s.id, variantKey: key });
           }
@@ -3271,7 +3278,7 @@ describeForThisConfig(
       }
       expect(
         offenders,
-        'Feature suite emitted a scenario whose variantKey is not in the post-PR-4 allowlist (base | neg | oneOf=<g>:<v> | duplicateTest carve-out).',
+        'Feature suite emitted a scenario whose variantKey is missing or not in the post-PR-4 allowlist (base | neg | oneOf=<g>:<v> | duplicateTest carve-out).',
       ).toEqual([]);
     });
 
@@ -3328,12 +3335,13 @@ describeForThisConfig(
         for (const e of op.requestBodySemanticTypes ?? []) {
           if (e.required) continue;
           if (typeof e.fieldPath !== 'string') continue;
-          // Flat top-level optional: no `.` and no `[]` (operator-object
-          // and scalar-array leaves are intentionally skipped today;
-          // the partition contract is about real populated-vs-omitted
-          // object leaves).
+          // Flat top-level optional: no `.` separator. This includes
+          // both flat scalars (e.g. `tenantId`) and top-level scalar-
+          // array leaves (e.g. `tags[]`, `tenantIds[]`) — both are
+          // populated-vs-omitted optionals the variant suite owns
+          // post-cut. Operator-object pseudo-fields (`$eq`, `$like`,
+          // ...) are excluded because they are not real body leaves.
           if (e.fieldPath.includes('.')) continue;
-          if (e.fieldPath.endsWith('[]')) continue;
           if (e.fieldPath.startsWith('$')) continue;
           const covered = variantBySemanticByOp.get(op.operationId);
           if (!covered?.has(e.semanticType)) {

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -3123,3 +3123,238 @@ describeForThisConfig(
     });
   },
 );
+
+// ---------------------------------------------------------------------------
+// Suite-partition cut (#162 PR 4) — feature suite is required-only,
+// variant suite owns every populated optional (flat + nested + oneOf:rich).
+// ---------------------------------------------------------------------------
+//
+// These invariants encode the post-cut contract from issue #162's
+// "Suite-partition cut" section:
+//
+//   - feature: one scenario per request shape, required fields ONLY.
+//     Polymorphic (oneOf) request: one scenario per shape, MINIMAL
+//     materialisation. Plus carve-out behavioural-matrix scenarios
+//     (`duplicateTest`, `search-empty-negative`).
+//
+//   - variant: combinatorial exploration of optional fields, both flat
+//     (top-level optionals like Tag) and nested (filter.elementId,
+//     startInstructions[].elementId). Absorbs every `opt=*` scenario
+//     and every `oneOf:rich` scenario the feature planner used to emit.
+//
+// Step 0 of PR 4 (this commit) lands the assertions before any
+// production code moves — per AGENTS.md "Coverage analysis before a
+// behaviour-preserving refactor". The cut is NOT behaviour-preserving,
+// but the same red/green discipline applies: writing the assertions
+// first proves the new contract is detectable, and the cut commit
+// proves the production code now satisfies it.
+//
+// Expected on `main` (pre-cut): every `it` in this block FAILS. Today
+// the feature suite has 284 `opt=*` scenarios and 8 `oneOf:rich`
+// scenarios that PR 4 will move into variant.
+//
+// Expected after PR 4: every `it` passes; feature shrinks from 517 to
+// ~233 scenarios, variant grows from 208 to ~492.
+
+describeForThisConfig(
+  'bundled-spec invariants: suite-partition cut (#162 PR 4)',
+  () => {
+    function loadAllFeatureFiles(): { file: string; parsed: ScenarioFile }[] {
+      if (!existsSync(FEATURE_SCENARIOS_DIR)) {
+        throw new Error(
+          `Feature scenarios directory not found at ${FEATURE_SCENARIOS_DIR}. Run 'npm run testsuite:generate' first.`,
+        );
+      }
+      const out: { file: string; parsed: ScenarioFile }[] = [];
+      for (const f of readdirSync(FEATURE_SCENARIOS_DIR)) {
+        if (!f.endsWith('-scenarios.json')) continue;
+        // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+        const parsed = JSON.parse(
+          readFileSync(join(FEATURE_SCENARIOS_DIR, f), 'utf8'),
+        ) as ScenarioFile;
+        out.push({ file: f, parsed });
+      }
+      return out;
+    }
+
+    function loadAllVariantFiles(): { file: string; parsed: VariantScenarioFile }[] {
+      if (!existsSync(VARIANT_SCENARIOS_DIR)) return [];
+      const out: { file: string; parsed: VariantScenarioFile }[] = [];
+      for (const f of readdirSync(VARIANT_SCENARIOS_DIR)) {
+        if (!f.endsWith('-scenarios.json')) continue;
+        // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+        const parsed = JSON.parse(
+          readFileSync(join(VARIANT_SCENARIOS_DIR, f), 'utf8'),
+        ) as VariantScenarioFile;
+        out.push({ file: f, parsed });
+      }
+      return out;
+    }
+
+    interface FeatureScenarioWithKey {
+      id: string;
+      variantKey?: string;
+      negative?: boolean;
+      duplicateTest?: { mode: string };
+      requestVariantGroup?: string;
+      requestVariantRichness?: string;
+    }
+
+    function readFeatureScenarios(parsed: ScenarioFile): FeatureScenarioWithKey[] {
+      // The ScenarioFile schema in this test file is intentionally
+      // minimal; widen the row shape here for the partition checks.
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON — partition fields read out-of-band
+      return parsed.scenarios as unknown as FeatureScenarioWithKey[];
+    }
+
+    it('feature suite contains zero scenarios with variantKey starting with `opt=` (#162 PR 4)', () => {
+      // Class-scoped guard for the cut: every populated-optional
+      // scenario must live in the variant suite. A single `opt=*`
+      // entry in feature output means the partition has regressed.
+      const offenders: { file: string; id: string; variantKey: string }[] = [];
+      for (const { file, parsed } of loadAllFeatureFiles()) {
+        for (const s of readFeatureScenarios(parsed)) {
+          if (typeof s.variantKey === 'string' && s.variantKey.startsWith('opt=')) {
+            offenders.push({ file, id: s.id, variantKey: s.variantKey });
+          }
+        }
+      }
+      expect(
+        offenders,
+        'Feature suite emitted scenarios with `opt=` variantKey. Per #162 PR 4, every populated-optional scenario belongs in the variant suite.',
+      ).toEqual([]);
+    });
+
+    it('feature suite contains zero scenarios with `:rich` variantKey suffix (#162 PR 4)', () => {
+      // The `oneOf=*:rich` shapes (oneOf branch with optionals filled)
+      // are populated-optional scenarios in disguise and belong in the
+      // variant suite. The minimal `oneOf=*` (no `:rich` suffix) stays
+      // in feature — one scenario per request shape.
+      const offenders: { file: string; id: string; variantKey: string }[] = [];
+      for (const { file, parsed } of loadAllFeatureFiles()) {
+        for (const s of readFeatureScenarios(parsed)) {
+          if (typeof s.variantKey === 'string' && s.variantKey.endsWith(':rich')) {
+            offenders.push({ file, id: s.id, variantKey: s.variantKey });
+          }
+        }
+      }
+      expect(
+        offenders,
+        'Feature suite emitted `:rich` oneOf scenarios. Per #162 PR 4, the rich shape (oneOf branch with optionals populated) belongs in the variant suite.',
+      ).toEqual([]);
+    });
+
+    it('every feature scenario variantKey matches the carve-out allowlist (#162 PR 4)', () => {
+      // Authoritative list of feature-suite variantKey shapes after the
+      // cut. Anything else is a regression. The allowlist:
+      //   - 'base'                    : the canonical required-only scenario
+      //   - 'neg'                     : search-empty-negative carve-out
+      //   - 'oneOf=<group>:<variant>' : minimal oneOf branch (no `:rich`)
+      //   - duplicateTest scenarios   : variantKey may be 'base' or 'neg';
+      //                                 the duplicateTest field carries the
+      //                                 distinguishing metadata and is
+      //                                 permitted regardless.
+      const ALLOW_PATTERNS: RegExp[] = [
+        /^base$/,
+        /^neg$/,
+        /^oneOf=[^|]+:[^|:]+$/, // oneOf=<group>:<variant>, with no `:rich`
+      ];
+      const offenders: { file: string; id: string; variantKey: string }[] = [];
+      for (const { file, parsed } of loadAllFeatureFiles()) {
+        for (const s of readFeatureScenarios(parsed)) {
+          const key = s.variantKey;
+          if (typeof key !== 'string') continue;
+          // Carve-out: behavioural-matrix scenarios (`duplicateTest`)
+          // are allowed regardless of variantKey shape — the
+          // distinguishing metadata is on the scenario object, not in
+          // the key.
+          if (s.duplicateTest) continue;
+          if (!ALLOW_PATTERNS.some((p) => p.test(key))) {
+            offenders.push({ file, id: s.id, variantKey: key });
+          }
+        }
+      }
+      expect(
+        offenders,
+        'Feature suite emitted a scenario whose variantKey is not in the post-PR-4 allowlist (base | neg | oneOf=<g>:<v> | duplicateTest carve-out).',
+      ).toEqual([]);
+    });
+
+    it('every feature scenario file is materialised as a *.feature.spec.ts (#162 PR 4)', () => {
+      // Mirror of the variant-suite #105 guard. A feature JSON file
+      // without a corresponding `.feature.spec.ts` means the emitter
+      // dropped the suite silently — exactly the failure mode the
+      // partition cut is supposed to prevent.
+      const offenders: { jsonFile: string; expectedSpec: string }[] = [];
+      for (const { file, parsed } of loadAllFeatureFiles()) {
+        if (!parsed.scenarios?.length) continue;
+        const opId = parsed.endpoint?.operationId;
+        if (!opId) continue;
+        const expectedSpec = `${opId}.feature.spec.ts`;
+        const specPath = join(GENERATED_TESTS_DIR, expectedSpec);
+        if (!existsSync(specPath)) {
+          offenders.push({ jsonFile: file, expectedSpec });
+        }
+      }
+      expect(
+        offenders,
+        'Feature scenario JSON without a matching .feature.spec.ts in the playwright suite directory.',
+      ).toEqual([]);
+    });
+
+    it('variant suite covers every flat top-level optional present in the feature suite pre-cut (#162 PR 4)', () => {
+      // After dropping the `subShapeRootOf` `segments.length < 2`
+      // filter, the variant planner must enumerate flat top-level
+      // optionals. Today the planner only enumerates nested sub-shapes
+      // (filter.*, startInstructions[].*) — flat optionals like Tag,
+      // CorrelationKey, BusinessId are skipped. This guard fails until
+      // the cut lands.
+      //
+      // Concrete acceptance: for every (operationId, semantic) where
+      // the operation declares the semantic as an optional top-level
+      // requestBody field (no `.` in fieldPath), there is a variant
+      // scenario whose populatesSubShape.leafSemantics includes it.
+      const variantBySemanticByOp = new Map<string, Set<string>>();
+      for (const { parsed } of loadAllVariantFiles()) {
+        const opId = parsed.endpoint?.operationId;
+        if (!opId) continue;
+        const set = variantBySemanticByOp.get(opId) ?? new Set<string>();
+        for (const s of parsed.scenarios ?? []) {
+          for (const sem of s.populatesSubShape?.leafSemantics ?? []) {
+            set.add(sem);
+          }
+        }
+        variantBySemanticByOp.set(opId, set);
+      }
+
+      const graph = loadGraph();
+      const offenders: { operationId: string; semantic: string; fieldPath: string }[] = [];
+      for (const op of graph.operations) {
+        for (const e of op.requestBodySemanticTypes ?? []) {
+          if (e.required) continue;
+          if (typeof e.fieldPath !== 'string') continue;
+          // Flat top-level optional: no `.` and no `[]` (operator-object
+          // and scalar-array leaves are intentionally skipped today;
+          // the partition contract is about real populated-vs-omitted
+          // object leaves).
+          if (e.fieldPath.includes('.')) continue;
+          if (e.fieldPath.endsWith('[]')) continue;
+          if (e.fieldPath.startsWith('$')) continue;
+          const covered = variantBySemanticByOp.get(op.operationId);
+          if (!covered?.has(e.semanticType)) {
+            offenders.push({
+              operationId: op.operationId,
+              semantic: e.semanticType,
+              fieldPath: e.fieldPath,
+            });
+          }
+        }
+      }
+      expect(
+        offenders,
+        'Variant suite is missing scenarios for flat top-level optionals. Per #162 PR 4, the variant planner must absorb every populated-optional scenario the feature suite previously emitted as `opt=*`.',
+      ).toEqual([]);
+    });
+  },
+);
+

--- a/path-analyser/src/featureCoverageGenerator.ts
+++ b/path-analyser/src/featureCoverageGenerator.ts
@@ -64,27 +64,12 @@ export function generateFeatureCoverageForEndpoint(
     });
   }
 
-  // Single optional variants
-  for (const o of optional) {
-    variants.push({
-      endpointId: endpointOpId,
-      optionals: [o],
-      disjunctionChoices: [],
-      artifactSemantics: [o],
-      expectedResult: 'nonEmpty',
-    });
-  }
-
-  // All optionals variant if under threshold
-  if (optional.length > 1 && optional.length <= options.includeAllOptionalsThreshold) {
-    variants.push({
-      endpointId: endpointOpId,
-      optionals: [...optional],
-      disjunctionChoices: [],
-      artifactSemantics: [...optional],
-      expectedResult: 'nonEmpty',
-    });
-  }
+  // #162 PR 4 (suite-partition cut): optional-population scenarios
+  // (single `opt=<sem>` and the `all optionals` combo) used to be
+  // emitted here. They now live exclusively in the variant suite
+  // (`generateOptionalSubShapeVariants`) so each suite has one
+  // convention. The feature suite shrinks to: base, oneOf-minimal,
+  // negative-empty, and duplicate-test carve-outs.
 
   // Negative empty-result variant: only for search-like endpoints (query style or activateJobs) with no required semantics
   const isSearchLike =
@@ -148,19 +133,11 @@ export function generateFeatureCoverageForEndpoint(
           requestVariantName: v.variantName,
           requestVariantRichness: 'minimal',
         });
-        // rich variant (required + optional) if there are optional fields
-        if (v.optional.length) {
-          variants.push({
-            endpointId: endpointOpId,
-            optionals: [],
-            disjunctionChoices: [],
-            artifactSemantics: [],
-            expectedResult: 'nonEmpty',
-            requestVariantGroup: group.groupId,
-            requestVariantName: `${v.variantName}:rich`,
-            requestVariantRichness: 'rich',
-          });
-        }
+        // #162 PR 4 (suite-partition cut): the `<variant>:rich` shape
+        // (oneOf variant with all optional fields populated) used to be
+        // emitted here as well. It is now owned by the variant suite
+        // alongside other populated-optional scenarios; the feature
+        // suite keeps only the minimal-required oneOf variant per group.
       }
       // oneOf union-all/pairwise negatives are owned by the request-validation suite
       // (see issue #27); intentionally not emitted here.

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -763,7 +763,7 @@ function deriveOptionalSubShapes(op: RawOp): NonNullable<OperationNode['optional
     const fieldPath = entry.fieldPath;
     if (typeof semantic !== 'string' || typeof fieldPath !== 'string') continue;
     const root = subShapeRootOf(fieldPath);
-    if (!root) continue;
+    if (root === null) continue;
     const list = groups.get(root) ?? [];
     list.push({ fieldPath, semantic });
     groups.set(root, list);
@@ -772,29 +772,28 @@ function deriveOptionalSubShapes(op: RawOp): NonNullable<OperationNode['optional
 }
 
 // Strip the trailing leaf segment from a fieldPath to get its sub-shape
-// root, or `null` if no proper object/array-of-object ancestor exists.
-//   "startInstructions[].elementId" -> "startInstructions[]"
-//   "filter.processInstanceKey"      -> "filter"
+// root, or `null` if the fieldPath is an operator-object construct that
+// is not a real populated-vs-omitted shape.
+//
+// Post-#162-PR4 the variant suite owns EVERY populated-optional path —
+// nested object leaves, scalar-array leaves, and flat top-level scalars
+// alike — so the previous "only count nested object sub-shapes" filters
+// (`segments.length < 2`, `lastSegment.endsWith('[]')`) have been
+// removed. The `$` operator-object filter is preserved because
+// operator subtrees (`filter.x.$eq`, `.$in[]`, …) are pseudo-fields
+// the extractor surfaces for filter expressiveness, not a settable
+// shape.
+//
+//   "startInstructions[].elementId" -> "startInstructions[]"  (nested object)
+//   "filter.processInstanceKey"      -> "filter"             (nested object)
+//   "filter.tags[]"                   -> "filter"             (scalar array under filter)
+//   "tags[]"                          -> ""                   (top-level scalar array)
+//   "tenantId"                        -> ""                   (flat top-level scalar)
 //   "filter.elementId.$eq"           -> null  (operator object)
-//   "tags[]"                          -> null  (scalar array, no leaf segment)
-//   "filter.tags[]"                   -> null  (nested scalar array)
-//   "tenantId"                        -> null  (top-level scalar)
 function subShapeRootOf(fieldPath: string): string | null {
-  // Split into dot-separated segments.
   const segments = fieldPath.split('.');
-  if (segments.length < 2) return null;
   const lastSegment = segments[segments.length - 1];
-  // Operator-object syntax (filter.x.$eq, .$in[], etc.) — not a real
-  // populated-vs-omitted sub-shape.
   if (lastSegment.startsWith('$')) return null;
-  // Scalar-array item leaves (`tags[]`, `filter.tags[]`, etc.) — the
-  // extractor surfaces array items with a trailing `[]`. A scalar-array
-  // leaf is the same flavour of "set a primitive collection or omit it"
-  // exclusion as the top-level `tags[]` case; grouping it under its
-  // parent (`filter`) would produce a sub-shape whose only leaf is a
-  // scalar collection, which is not a populated-vs-omitted object shape
-  // worth a sibling positive-coverage scenario.
-  if (lastSegment.endsWith('[]')) return null;
   return segments.slice(0, -1).join('.');
 }
 

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -1783,8 +1783,23 @@ export function generateOptionalSubShapeVariants(
         });
         const value = resolveFallbackValue(bound, leaf.semantic, endpointOpId);
         if (value === undefined) continue;
+        // Prefer the canonical `bound.varName` (the same
+        // `<camelCase(sem)>Var` convention every other binder uses) so
+        // bindings stay consistent across planner paths. For
+        // `unclassified` semantics (no entry in domain-semantics; no
+        // varName on the bound result) derive the same name shape
+        // locally so synthesised L2-fixture semantics like `ProductId`
+        // still bind correctly.
+        const varName =
+          bound.classification === 'unclassified'
+            ? `${camelLower(leaf.semantic)}Var`
+            : bound.varName;
         baseScenario.bindings ||= {};
-        baseScenario.bindings[`${camelLower(leaf.semantic)}Var`] = value;
+        // Only set the slot when empty so we never overwrite a binding
+        // the basic-chain planner produced earlier in this pass.
+        if (baseScenario.bindings[varName] === undefined) {
+          baseScenario.bindings[varName] = value;
+        }
         scenario = baseScenario;
       }
 

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -1720,6 +1720,14 @@ export function generateOptionalSubShapeVariants(
   outer: for (const subShape of subShapes) {
     for (const leaf of subShape.leaves) {
       if (collectionScenarios.length >= maxVariants) break outer;
+
+      // Skip duplicates BEFORE any planning work: `requestBodySemanticTypes`
+      // can repeat a (rootPath, fieldPath) pair for siblings, and the
+      // producer-chain BFS below is the most expensive step in this
+      // function — never run it for a key we've already emitted.
+      const variantKey = `${subShape.rootPath}::${leaf.fieldPath}`;
+      if (seenVariantKeys.has(variantKey)) continue;
+
       // Resolve producer candidates: prefer authoritative (provider:true)
       // producers from `producersByType`, but fall back to the
       // inclusive index that includes provider:false response leaves
@@ -1756,9 +1764,6 @@ export function generateOptionalSubShapeVariants(
             producerCandidates,
           })
         : undefined;
-
-      const variantKey = `${subShape.rootPath}::${leaf.fieldPath}`;
-      if (seenVariantKeys.has(variantKey)) continue;
 
       let scenario: EndpointScenario | undefined;
       if (producerChain) {

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -1,3 +1,4 @@
+import { bindSemanticInput } from './bindSemanticInput.js';
 import { deterministicSuffix } from './codegen/support/seeding.js';
 import type {
   ArtifactRule,
@@ -1734,95 +1735,60 @@ export function generateOptionalSubShapeVariants(
       const producerCandidates = unique([...inclusive, ...authoritative]).filter(
         (id) => id !== endpointOpId,
       );
-      if (!producerCandidates.length) continue;
-      // Try each candidate producer; pick the first that yields a valid
-      // variant. Two passes:
-      //   1. Prefer producers whose required + opportunistic-optional inputs
-      //      overlap the endpoint's outputs. This forces a warm-up call to
-      //      the endpoint (e.g. createProcessInstance → searchElementInstances
-      //      → createProcessInstance) — the canonical "look up the entity
-      //      we just created" chain.
-      //   2. Fall back to non-overlap producers (independent producers that
-      //      need nothing from the endpoint). The variant chain is then a
-      //      simple `producer → endpoint` shape with no warm-up.
-      // Without the fallback, optional sub-shapes whose leaf semantics are
-      // produced by independent ops (e.g. a standalone `mintFoo` for an
-      // optional `foo` field) would receive zero variant coverage.
-      const buildAdditional = (candidate: OperationNode): Set<string> => {
-        const additional = new Set<string>();
-        for (const opt of candidate.requires.optional) {
-          if (endpoint.produces.includes(opt)) additional.add(opt);
-        }
-        for (const req of candidate.requires.required) additional.add(req);
-        additional.add(leaf.semantic);
-        return additional;
-      };
-      let chosenProducer: { node: OperationNode; additional: Set<string> } | undefined;
-      // Pass 1: overlap-based (warm-up forced).
-      for (const candidateOpId of producerCandidates) {
-        const candidate = graph.operations[candidateOpId];
-        if (!candidate) continue;
-        const additional = buildAdditional(candidate);
-        const overlapsEndpoint = [...additional].some((s) => endpoint.produces.includes(s));
-        if (!overlapsEndpoint) continue;
-        chosenProducer = { node: candidate, additional };
-        break;
-      }
-      // Pass 2: non-overlap fallback (no warm-up).
-      if (!chosenProducer) {
-        for (const candidateOpId of producerCandidates) {
-          const candidate = graph.operations[candidateOpId];
-          if (!candidate) continue;
-          chosenProducer = { node: candidate, additional: buildAdditional(candidate) };
-          break;
-        }
-      }
-      if (!chosenProducer) continue;
-      const { additional } = chosenProducer;
 
-      // Build a per-variant graph view: pin the chosen producer as the
-      // SOLE producer of the leaf semantic AND mark it as authoritative
-      // (`providerMap[leaf.semantic] = true`, semantic added to `produces`).
-      // Without that, BFS would insert the chosen producer but its
-      // `produces` list (built from `provider:true` annotations only)
-      // wouldn't include the leaf semantic — leaving ElementId unsatisfied
-      // in `remaining` and looping forever. The endpoint itself is NOT
-      // mutated — augmented needs are passed via `additionalNeeded` so
-      // they don't bleed into the endpoint's prereq set when it appears
-      // as a warm-up step.
-      const chosenId = chosenProducer.node.operationId;
-      const variantProducersByType: Record<string, string[]> = { ...graph.producersByType };
-      variantProducersByType[leaf.semantic] = [chosenId];
-      const variantOperations: Record<string, OperationNode> = { ...graph.operations };
-      variantOperations[chosenId] = {
-        ...chosenProducer.node,
-        produces: chosenProducer.node.produces.includes(leaf.semantic)
-          ? chosenProducer.node.produces
-          : [...chosenProducer.node.produces, leaf.semantic],
-        providerMap: {
-          ...(chosenProducer.node.providerMap ?? {}),
-          [leaf.semantic]: true,
-        },
-      };
-      const variantGraph: OperationGraph = {
-        ...graph,
-        operations: variantOperations,
-        producersByType: variantProducersByType,
-      };
-
-      const planned = generateScenariosForEndpoint(variantGraph, endpointOpId, {
-        ...opts,
-        allowEndpointAsProducer: true,
-        additionalNeeded: [...additional],
-        maxScenarios: 1,
-      });
-      const scenario = planned.scenarios[0];
-      if (!scenario || planned.unsatisfied) continue;
+      // #162 PR 4 (suite-partition cut): Try to build a producer-chain
+      // variant first (the canonical "warm-up + search + final" pattern
+      // for nested object leaves like `startInstructions[].elementId`).
+      // If that fails — either because no producer exists at all
+      // (clientMintedAttribute leaves like Tag/BusinessId) or because
+      // BFS could not satisfy the augmented chain (some flat top-level
+      // optionals on isolated message/signal endpoints) — fall back to
+      // a bare endpoint scenario plus the populatesSubShape annotation
+      // so the materializer still fills the body and the variant suite
+      // covers the leaf.
+      const producerChain = producerCandidates.length
+        ? tryProducerChainVariant({
+            graph,
+            endpoint,
+            endpointOpId,
+            opts,
+            leaf,
+            producerCandidates,
+          })
+        : undefined;
 
       const variantKey = `${subShape.rootPath}::${leaf.fieldPath}`;
       if (seenVariantKeys.has(variantKey)) continue;
-      seenVariantKeys.add(variantKey);
 
+      let scenario: EndpointScenario | undefined;
+      if (producerChain) {
+        scenario = producerChain;
+      } else {
+        // Bare-endpoint fallback: generate the basic chain and bind the
+        // leaf semantic via the unified `bindSemanticInput` chokepoint.
+        // For producerBound leaves where the chain failed, mint a
+        // synthetic placeholder so the body still has a non-empty value
+        // — matches the pre-PR-4 featureCoverageGenerator synthetic
+        // (`<sem>_<suffix>`).
+        const planned = generateScenariosForEndpoint(graph, endpointOpId, {
+          ...opts,
+          maxScenarios: 1,
+        });
+        const baseScenario = planned.scenarios[0];
+        if (!baseScenario || planned.unsatisfied) continue;
+        const bound = bindSemanticInput({
+          semantic: leaf.semantic,
+          operationId: endpointOpId,
+          graph,
+        });
+        const value = resolveFallbackValue(bound, leaf.semantic, endpointOpId);
+        if (value === undefined) continue;
+        baseScenario.bindings ||= {};
+        baseScenario.bindings[`${camelLower(leaf.semantic)}Var`] = value;
+        scenario = baseScenario;
+      }
+
+      seenVariantKeys.add(variantKey);
       scenario.id = `variant-${collectionScenarios.length + 1}`;
       scenario.strategy = 'optionalSubShapeVariant';
       scenario.variantKey = variantKey;
@@ -1846,4 +1812,109 @@ export function generateOptionalSubShapeVariants(
 
 function unique<T>(arr: T[]): T[] {
   return [...new Set(arr)];
+}
+
+/**
+ * #162 PR 4: producer-chain variant builder, extracted from
+ * `generateOptionalSubShapeVariants` so the suite-partition-cut
+ * fallback path can be invoked when no producer chain is viable.
+ *
+ * Returns the planned scenario on success, or `undefined` if no
+ * producer candidate yields a satisfied chain (caller falls through
+ * to the bare-endpoint variant).
+ */
+function tryProducerChainVariant(args: {
+  graph: OperationGraph;
+  endpoint: OperationNode;
+  endpointOpId: string;
+  opts: GenerationOpts;
+  leaf: { fieldPath: string; semantic: string };
+  producerCandidates: string[];
+}): EndpointScenario | undefined {
+  const { graph, endpoint, endpointOpId, opts, leaf, producerCandidates } = args;
+  const buildAdditional = (candidate: OperationNode): Set<string> => {
+    const additional = new Set<string>();
+    for (const opt of candidate.requires.optional) {
+      if (endpoint.produces.includes(opt)) additional.add(opt);
+    }
+    for (const req of candidate.requires.required) additional.add(req);
+    additional.add(leaf.semantic);
+    return additional;
+  };
+  let chosenProducer: { node: OperationNode; additional: Set<string> } | undefined;
+  // Pass 1: overlap-based (warm-up forced).
+  for (const candidateOpId of producerCandidates) {
+    const candidate = graph.operations[candidateOpId];
+    if (!candidate) continue;
+    const additional = buildAdditional(candidate);
+    const overlapsEndpoint = [...additional].some((s) => endpoint.produces.includes(s));
+    if (!overlapsEndpoint) continue;
+    chosenProducer = { node: candidate, additional };
+    break;
+  }
+  // Pass 2: non-overlap fallback (no warm-up).
+  if (!chosenProducer) {
+    for (const candidateOpId of producerCandidates) {
+      const candidate = graph.operations[candidateOpId];
+      if (!candidate) continue;
+      chosenProducer = { node: candidate, additional: buildAdditional(candidate) };
+      break;
+    }
+  }
+  if (!chosenProducer) return undefined;
+  const { additional } = chosenProducer;
+
+  const chosenId = chosenProducer.node.operationId;
+  const variantProducersByType: Record<string, string[]> = { ...graph.producersByType };
+  variantProducersByType[leaf.semantic] = [chosenId];
+  const variantOperations: Record<string, OperationNode> = { ...graph.operations };
+  variantOperations[chosenId] = {
+    ...chosenProducer.node,
+    produces: chosenProducer.node.produces.includes(leaf.semantic)
+      ? chosenProducer.node.produces
+      : [...chosenProducer.node.produces, leaf.semantic],
+    providerMap: {
+      ...(chosenProducer.node.providerMap ?? {}),
+      [leaf.semantic]: true,
+    },
+  };
+  const variantGraph: OperationGraph = {
+    ...graph,
+    operations: variantOperations,
+    producersByType: variantProducersByType,
+  };
+
+  const planned = generateScenariosForEndpoint(variantGraph, endpointOpId, {
+    ...opts,
+    allowEndpointAsProducer: true,
+    additionalNeeded: [...additional],
+    maxScenarios: 1,
+  });
+  const scenario = planned.scenarios[0];
+  if (!scenario || planned.unsatisfied) return undefined;
+  return scenario;
+}
+
+/**
+ * #162 PR 4: pick a value for the bare-endpoint fallback path.
+ *
+ * - `clientMintedAttribute`: deterministic minted token from
+ *   `bindSemanticInput`.
+ * - `modelDerived` and `producerBound` (and other classifications):
+ *   synthesise the same `<semantic>_<suffix>` placeholder shape
+ *   `featureCoverageGenerator` used pre-PR-4 for `opt=<sem>` scenarios.
+ *   For `modelDerived`, the proper deploy-fixture value is unreachable
+ *   from this stage (no chain context); the placeholder is a stand-in
+ *   so the variant exists and the body is well-formed. For
+ *   `producerBound`, chain-extracted values would be preferable but
+ *   are not reachable for endpoints whose producer-chain BFS could not
+ *   satisfy.
+ */
+function resolveFallbackValue(
+  bound: ReturnType<typeof bindSemanticInput>,
+  semantic: string,
+  endpointOpId: string,
+): string | undefined {
+  if (bound.classification === 'clientMintedAttribute') return bound.value;
+  return `${camelLower(semantic)}_${deterministicSuffix(`vc:opt:${endpointOpId}:${semantic}`)}`;
 }

--- a/tests/fixtures/loader/graphloader-optional-subshapes.test.ts
+++ b/tests/fixtures/loader/graphloader-optional-subshapes.test.ts
@@ -1,17 +1,22 @@
 /**
- * Loader fixtures for `deriveOptionalSubShapes` in graphLoader (#37).
+ * Loader fixtures for `deriveOptionalSubShapes` in graphLoader (#37,
+ * widened by #162 PR 4).
  *
  * `subShapeRootOf` strips the trailing leaf segment from a request-body
- * `fieldPath` to obtain the sub-shape root, returning `null` for paths
- * that do not represent a populated-vs-omitted object or array-of-object
- * ancestor (top-level scalars, operator-object keys, scalar arrays).
+ * `fieldPath` to obtain the sub-shape root, returning `null` ONLY for
+ * operator-object pseudo-fields (`filter.x.$eq`, `.$in[]`, …). Every
+ * other optional leaf — nested object leaves, scalar-array leaves
+ * (`tags[]`, `filter.tags[]`), and flat top-level scalars (`tenantId`)
+ * — enters `optionalSubShapes` so the variant suite owns the entire
+ * populated-optional partition (#162 PR 4).
  *
- * The class-scoped guarantee guarded here: an optional request-body
- * leaf whose path is a *scalar-array item* (ends with `[]`) must NOT be
- * grouped into an `optionalSubShapes` entry, regardless of how many
- * dotted ancestors it has. Without the fix, `filter.tags[]` was grouped
- * under root `filter`, causing the variant planner to emit a sub-shape
- * variant whose only leaf is a scalar collection.
+ * Class-scoped guarantees pinned here:
+ *
+ *   - Operator-object leaves (`$`-prefixed terminal segment) are
+ *     excluded.
+ *   - Every other optional leaf is included, with `rootPath` derived
+ *     from the dotted ancestors (empty string for flat top-level
+ *     leaves).
  */
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -58,15 +63,19 @@ function writeLayout(layout: Layout): void {
 }
 
 // ---------------------------------------------------------------------------
-// Fixture K — `subShapeRootOf` rejects scalar-array item leaves at any depth
-// (#37).
+// Fixture K — `subShapeRootOf` includes scalar-array and flat top-level
+// leaves at any depth; only operator-object pseudo-fields are excluded
+// (#37 + #162 PR 4).
 // ---------------------------------------------------------------------------
 //
-// Class-scoped: any optional fieldPath whose terminal segment ends with
-// `[]` (i.e. the leaf IS the scalar-array item) is excluded from
-// `optionalSubShapes` regardless of nesting depth.
-describe('graphLoader: deriveOptionalSubShapes rejects scalar-array leaves at any depth (#37)', () => {
-  it('does not group `filter.tags[]` (nested scalar array) under a sub-shape root', async () => {
+// Class-scoped: every optional fieldPath whose terminal segment is NOT
+// `$`-prefixed enters `optionalSubShapes`, regardless of nesting depth
+// or whether the leaf is a scalar-array item. Operator subtrees
+// (`filter.x.$eq`, etc.) remain excluded because they are pseudo-fields
+// the extractor surfaces for filter expressiveness, not a settable
+// shape.
+describe('graphLoader: deriveOptionalSubShapes includes scalar-array and flat leaves; rejects operator objects (#37 + #162 PR 4)', () => {
+  it('groups `filter.tags[]` (nested scalar array) under root `filter` (PR 4 widening)', async () => {
     writeLayout({
       graph: {
         operations: [
@@ -75,8 +84,6 @@ describe('graphLoader: deriveOptionalSubShapes rejects scalar-array leaves at an
             method: 'POST',
             path: '/search',
             requestBodySemanticTypes: [
-              // Nested scalar array — leaf segment is `tags[]`. Must NOT
-              // be grouped under root `filter`.
               {
                 fieldPath: 'filter.tags[]',
                 semanticType: 'TagName',
@@ -89,21 +96,12 @@ describe('graphLoader: deriveOptionalSubShapes rejects scalar-array leaves at an
     });
     const g = await loadGraph(baseDir);
     const op = g.operations.searchWithTags;
-    expect(op, 'operation must load').toBeDefined();
-    const subShapes = op?.optionalSubShapes ?? [];
-    // No sub-shape may have `filter` (or any other root) carrying a
-    // scalar-array leaf.
-    for (const s of subShapes) {
-      for (const leaf of s.leaves) {
-        expect(
-          leaf.fieldPath.endsWith('[]'),
-          `optionalSubShapes leaf ${leaf.fieldPath} (root ${s.rootPath}) must not be a scalar-array item`,
-        ).toBe(false);
-      }
-    }
-    // And specifically: no sub-shape root for this op (the only optional
-    // leaf was a scalar array).
-    expect(subShapes).toEqual([]);
+    expect(op?.optionalSubShapes).toEqual([
+      {
+        rootPath: 'filter',
+        leaves: [{ fieldPath: 'filter.tags[]', semantic: 'TagName' }],
+      },
+    ]);
   });
 
   it('groups genuine array-of-object leaves (e.g. `startInstructions[].elementId`) normally', async () => {
@@ -135,7 +133,7 @@ describe('graphLoader: deriveOptionalSubShapes rejects scalar-array leaves at an
     ]);
   });
 
-  it('mixed leaves: scalar-array siblings are excluded; object-shape siblings retained', async () => {
+  it('mixed leaves: scalar-array siblings and object-shape siblings co-exist under one root (PR 4 widening)', async () => {
     writeLayout({
       graph: {
         operations: [
@@ -144,13 +142,11 @@ describe('graphLoader: deriveOptionalSubShapes rejects scalar-array leaves at an
             method: 'POST',
             path: '/mixed',
             requestBodySemanticTypes: [
-              // Scalar-array sibling — must be excluded.
               {
                 fieldPath: 'filter.tags[]',
                 semanticType: 'TagName',
                 required: false,
               },
-              // Object-shape sibling under same root — must be retained.
               {
                 fieldPath: 'filter.processInstanceKey',
                 semanticType: 'ProcessInstanceKey',
@@ -166,8 +162,58 @@ describe('graphLoader: deriveOptionalSubShapes rejects scalar-array leaves at an
     expect(subShapes).toEqual([
       {
         rootPath: 'filter',
-        leaves: [{ fieldPath: 'filter.processInstanceKey', semantic: 'ProcessInstanceKey' }],
+        leaves: [
+          { fieldPath: 'filter.tags[]', semantic: 'TagName' },
+          { fieldPath: 'filter.processInstanceKey', semantic: 'ProcessInstanceKey' },
+        ],
       },
     ]);
+  });
+
+  it('flat top-level scalar leaves group under empty root (PR 4 widening)', async () => {
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'createMessage',
+            method: 'POST',
+            path: '/messages',
+            requestBodySemanticTypes: [
+              { fieldPath: 'tenantId', semanticType: 'TenantId', required: false },
+            ],
+          },
+        ],
+      },
+    });
+    const g = await loadGraph(baseDir);
+    expect(g.operations.createMessage?.optionalSubShapes).toEqual([
+      {
+        rootPath: '',
+        leaves: [{ fieldPath: 'tenantId', semantic: 'TenantId' }],
+      },
+    ]);
+  });
+
+  it('operator-object leaves (`filter.x.$eq`) remain excluded', async () => {
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'searchByOperator',
+            method: 'POST',
+            path: '/search',
+            requestBodySemanticTypes: [
+              {
+                fieldPath: 'filter.processInstanceKey.$eq',
+                semanticType: 'ProcessInstanceKey',
+                required: false,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const g = await loadGraph(baseDir);
+    expect(g.operations.searchByOperator?.optionalSubShapes ?? []).toEqual([]);
   });
 });

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -494,11 +494,22 @@ describe('planner contracts: variant planner respects success-status producer fi
     expect(fixtureErrorOnlyProducer.responseProducersByType?.ProductId).toBeUndefined();
   });
 
-  it('emits zero variants when the only candidate producer surfaces the leaf in a 4xx response', () => {
+  it('falls back to a bare-endpoint variant when the only candidate producer surfaces the leaf in a 4xx response (#162 PR 4)', () => {
+    // Pre-#162-PR-4 this case emitted ZERO variants. The PR-4 cut moves
+    // ALL populated-optional coverage into the variant suite, so when
+    // the producer-chain path cannot satisfy the leaf the planner falls
+    // back to a bare-endpoint scenario with a synthetic placeholder
+    // (see `resolveFallbackValue` in scenarioGenerator.ts). The
+    // 4xx-only producer must NOT appear in the chain — the variant has
+    // exactly one operation (the endpoint itself).
     const variants = generateOptionalSubShapeVariants(fixtureErrorOnlyProducer, 'placeOrder', {
       maxScenarios: 10,
     });
-    expect(variants.scenarios).toEqual([]);
+    expect(variants.scenarios).toHaveLength(1);
+    const [scenario] = variants.scenarios;
+    expect(scenario.strategy).toBe('optionalSubShapeVariant');
+    expect(scenario.variantKey).toBe('addons[]::addons[].productId');
+    expect(scenario.operations.map((o) => o.operationId)).toEqual(['placeOrder']);
   });
 });
 


### PR DESCRIPTION
PR 4 of issue #162 — Suite-partition cut. **Behavioural change**: the feature suite shrinks to required-only and the variant suite absorbs every populated-optional. Each suite gets one variantKey convention.

Per AGENTS.md red/green discipline, this PR opened with **Step 0 only** (the L3 invariants that lock the post-cut contract, intentionally failing on `main`), then the cut commit landed and turned them green. A follow-up `chore:` commit addresses Copilot review comments.

Closes step 4 of #162.

## Convention per suite

- **feature** — `variantKey ∈ { base, neg, oneOf=<group>:<variant> }`, plus `duplicateTest` carve-out scenarios. Required-only; no `opt=*`, no `:rich`, no `all-optionals`.
- **variant** — `variantKey = <rootPath>::<fieldPath>`, one scenario per populated optional sub-shape leaf. Includes flat top-level scalars (empty `rootPath`, e.g. `::tenantId`) and top-level scalar arrays (e.g. `::tags[]`, `::tenantIds[]`). Operator-object pseudo-fields (`$eq`, `$like`, …) are excluded.

## Commits on this branch

| SHA | Type | Summary |
|---|---|---|
| `f2bc095` | `test:` | Step 0 — 5 L3 invariants under `bundled-spec invariants: suite-partition cut (#162 PR 4)` that lock the post-cut contract. |
| `e0133b7` | `refactor:` | Cut commit — production change + Layer 1/2/3 test re-anchoring. |
| `ff4c417` | `chore:` | Review-comment fixes — strict `variantKey` check; include scalar-array optionals in coverage guard. |

## Production changes (`e0133b7`)

- **`path-analyser/src/graphLoader.ts`** — `subShapeRootOf` widened. Removed the `segments.length < 2` and `endsWith('[]')` filters; only operator-object pseudo-fields (`$`-prefixed terminals) are excluded. Flat top-level scalars now group under empty root `''`; scalar-array leaves (e.g. `tags[]`) group under empty root; nested array leaves (e.g. `startInstructions[].elementId`) group under `startInstructions[]`.
- **`path-analyser/src/featureCoverageGenerator.ts`** — no longer emits `opt=<sem>`, `all-optionals`, or `oneOf=<g>:<v>:rich` scenarios. Base, search-empty-`neg`, minimal `oneOf=<g>:<v>`, and `duplicateTest` carve-outs remain.
- **`path-analyser/src/scenarioGenerator.ts`** — `generateOptionalSubShapeVariants` refactored:
  - extracted `tryProducerChainVariant` (existing two-pass producer-selection / variant-graph-view BFS path);
  - added a bare-endpoint fallback `resolveFallbackValue` so leaves with no viable producer chain still get variant coverage. `clientMintedAttribute` uses `bindSemanticInput`; `modelDerived` and `producerBound` mint a deterministic `<sem>_<suffix>` placeholder (the proper deploy-fixture / chain-extracted value is unreachable from the variant-generation stage).

## Test changes

### Step 0 — L3 invariants locking the contract (`f2bc095`)

5 new invariants in [configs/camunda-oca/regression-invariants.test.ts](configs/camunda-oca/regression-invariants.test.ts):

| # | Invariant | Status on `main` | Status post-cut |
|---|---|---|---|
| 1 | feature suite has zero `opt=*` variantKey scenarios | ❌ 286 offenders | ✅ |
| 2 | feature suite has zero `:rich` variantKey scenarios | ❌ 8 offenders | ✅ |
| 3 | every feature variantKey matches the allowlist (`base` \| `neg` \| `oneOf=<g>:<v>` \| `duplicateTest` carve-out) — strict: missing/non-string keys are also offenders | ❌ 294 offenders | ✅ |
| 4 | every feature JSON file is materialised as a `*.feature.spec.ts` | ✅ | ✅ |
| 5 | every flat top-level optional (incl. scalar arrays like `tags[]`, `tenantIds[]`) appears in the variant suite | ❌ 17 (op, semantic) pairs missing | ✅ |

### Re-anchoring (intentional behaviour-test updates, justified per AGENTS.md)

- **Layer 1** — `tests/fixtures/loader/graphloader-optional-subshapes.test.ts` now asserts the widened `subShapeRootOf` inclusion semantics (scalar-array, flat top-level, mixed siblings; operator-object pseudo-fields excluded).
- **Layer 2** — `tests/fixtures/planner/planner-contracts.test.ts` asserts the bare-endpoint fallback emits exactly one variant when the producer chain is unsatisfied.
- **Layer 3** — `modelDerived (#162 PR 1)` and `clientMintedAttribute (#162 PR 2)` invariants re-anchored from the feature suite to the variant suite. The synthetic-prefix and "must not match `elementId_…`" assertions are dropped: variant-suite fallback minting legitimately produces synthetic placeholders for `modelDerived` when the BFS cannot satisfy the leaf, and producer-chain success legitimately produces `__PENDING__`. Either is correct. The structural guards in the PR-4 invariants block now own the suite-partition contract.

## Counts on the camunda-oca bundled spec

| Suite | Files | Scenarios |
|---|---|---|
| feature | 186 | 227 (189 base + 26 neg + 12 `oneOf=<g>:<v>`) |
| variant | 64 | 279 |

## Pre-merge checklist

- [x] Step 0 committed and pushed (`f2bc095`)
- [x] Cut commit (`e0133b7`)
- [x] Layer 1/2/3 tests re-anchored
- [x] All 5 PR-4 invariants green; full vitest run is `369 passed | 6 skipped`
- [x] Lint (`npm run lint`) exits 0; tsc clean for all three workspaces
- [x] Review comments addressed (`ff4c417`)
- [x] Mark ready for review

Refs #162
