### PR TITLE
feat: fail-fast at graph load on unclassified requestBodySemantics (#162 PR 5)

### DIFF
--- a/configs/camunda-oca/domain-semantics.json
+++ b/configs/camunda-oca/domain-semantics.json
@@ -174,6 +174,42 @@
       "kind": "attribute",
       "clientMinted": true,
       "$comment": "Free-form correlation identifier attached to a process instance (createProcessInstance.businessId, searchProcessInstances.filter.businessId, etc.). Like Tag: client-minted, no producer endpoint, no first-order entity retrievable by it. The planner mints a deterministic value at the setter site; filter-consumer reuse is deferred (see #168)."
+    },
+    "AgentInstanceKey": {
+      "kind": "serverEmergent",
+      "$comment": "Server-minted lifecycle key for AI agent instances. No client API directly creates an AgentInstance with a returned key — instances emerge from agent runtime activity and are discoverable only via search/get. Used as a search-filter input; the planner mints a deterministic placeholder so the request validates and an empty result set is acceptable. See #162 PR 5."
+    },
+    "AuditLogKey": {
+      "kind": "serverEmergent",
+      "$comment": "Server-minted lifecycle key for audit-log entries. Audit logs are produced as a side-effect of audited writes — no direct create API. Search-filter input only; planner mints a deterministic placeholder. See #162 PR 5."
+    },
+    "AuditLogEntityKey": {
+      "kind": "serverEmergent",
+      "$comment": "Server-minted reference to the entity an audit-log entry was emitted for. Same lifecycle as AuditLogKey — emerges from audited writes, never directly minted via a client API. See #162 PR 5."
+    },
+    "DeploymentKey": {
+      "kind": "serverEmergent",
+      "$comment": "Temporary classification pending an upstream spec fix. createDeployment returns deploymentKey in its 200 response but the response field is currently flagged provider:false in the bundled spec, so the planner cannot bind it as a producerBound semantic. Once upstream marks deploymentKey as provider:true (tracked separately — see PR description), this entry should be removed and DeploymentKey will classify as producerBound automatically. See #162 PR 5."
+    },
+    "MessageSubscriptionKey": {
+      "kind": "serverEmergent",
+      "$comment": "Server-minted lifecycle key for a message subscription. Subscriptions emerge when a deployed process reaches a message catch event — no direct create API. Search-filter input only; planner mints a deterministic placeholder. See #162 PR 5."
+    },
+    "IncidentKey": {
+      "kind": "serverEmergent",
+      "$comment": "Server-minted lifecycle key for an incident. Incidents emerge from runtime failures during process execution — no direct create API. Search-filter input only; planner mints a deterministic placeholder. See #162 PR 5."
+    },
+    "UserTaskKey": {
+      "kind": "serverEmergent",
+      "$comment": "Server-minted lifecycle key for a user task instance. User tasks emerge when a deployed process reaches a user-task element — no direct create API. Search-filter input only; planner mints a deterministic placeholder. See #162 PR 5."
+    },
+    "VariableKey": {
+      "kind": "serverEmergent",
+      "$comment": "Server-minted key for a variable row. Variables are managed by process execution and via setVariables, but no client API mints a variable atomically with a returned key. Search-filter input only; planner mints a deterministic placeholder. See #162 PR 5."
+    },
+    "ScopeKey": {
+      "kind": "serverEmergent",
+      "$comment": "Server-minted key identifying the scope (process instance / element instance) a variable lives in. Same lifecycle as VariableKey — managed by process execution, never directly minted via a client API. Search-filter input only. See #162 PR 5."
     }
   },
   "operationArtifactRules": {

--- a/configs/camunda-oca/domain-semantics.json
+++ b/configs/camunda-oca/domain-semantics.json
@@ -189,7 +189,7 @@
     },
     "DeploymentKey": {
       "kind": "serverEmergent",
-      "$comment": "Temporary classification pending an upstream spec fix. createDeployment returns deploymentKey in its 200 response but the response field is currently flagged provider:false in the bundled spec, so the planner cannot bind it as a producerBound semantic. Once upstream marks deploymentKey as provider:true (tracked separately — see PR description), this entry should be removed and DeploymentKey will classify as producerBound automatically. See #162 PR 5."
+      "$comment": "Temporary classification pending upstream spec fix camunda/camunda#52926. createDeployment returns deploymentKey in its 200 response but the response field is currently flagged provider:false in the bundled spec, so the planner cannot bind it as a producerBound semantic. Once upstream marks deploymentKey as provider:true, this entry should be removed and DeploymentKey will classify as producerBound automatically. See #162 PR 5."
     },
     "MessageSubscriptionKey": {
       "kind": "serverEmergent",

--- a/path-analyser/src/bindSemanticInput.ts
+++ b/path-analyser/src/bindSemanticInput.ts
@@ -34,6 +34,7 @@ import type { ArtifactRegistryEntry, OperationGraph } from './types.js';
 export type SemanticClassification =
   | 'modelDerived'
   | 'clientMintedAttribute'
+  | 'serverEmergent'
   | 'producerBound'
   | 'clientMintedIdentifier'
   | 'externalBoundary'
@@ -42,6 +43,7 @@ export type SemanticClassification =
 export type BoundInput =
   | { classification: 'modelDerived'; varName: string; value?: string }
   | { classification: 'clientMintedAttribute'; varName: string; value: string }
+  | { classification: 'serverEmergent'; varName: string; value: string }
   | { classification: 'producerBound'; varName: string }
   | { classification: 'clientMintedIdentifier'; varName: string }
   | { classification: 'externalBoundary'; varName: string }
@@ -55,6 +57,16 @@ export type BoundInput =
  *
  *   - `kind: 'modelDerived'`                   → modelDerived
  *   - `kind: 'attribute' && clientMinted: true` → clientMintedAttribute
+ *   - `kind: 'serverEmergent'`                 → serverEmergent
+ *
+ * Tier 1c — `serverEmergent` (#162 PR 5): server-minted lifecycle
+ * identifiers that no client API call directly mints with a returned
+ * key. Examples: `IncidentKey` (emerges from runtime failures),
+ * `AuditLogKey` (side-effect of audited writes), `MessageSubscriptionKey`
+ * (emerges from process deployment with message catch). The planner
+ * binds a deterministic placeholder so search-filter request shapes
+ * validate; the search returning empty is acceptable because the value
+ * is a fabricated placeholder for a key the client could not have known.
  *
  * Tier 2 — graph-index classifications, in order:
  *
@@ -80,6 +92,7 @@ export function classifySemantic(semantic: string, graph: OperationGraph): Seman
   if (decl?.kind === 'attribute' && decl.clientMinted === true) {
     return 'clientMintedAttribute';
   }
+  if (decl?.kind === 'serverEmergent') return 'serverEmergent';
   if (graph.producersByType?.[semantic]?.length) return 'producerBound';
   if (graph.establishersByType?.[semantic]?.length) return 'clientMintedIdentifier';
   if (graph.externalEntityIdentifiers?.has(semantic)) return 'externalBoundary';
@@ -136,6 +149,15 @@ export function bindSemanticInput(args: {
         `fc:cma:${operationId}:${semantic}`,
       )}`;
       return { classification: 'clientMintedAttribute', varName, value };
+    }
+    case 'serverEmergent': {
+      // #162 PR 5: deterministic placeholder for server-minted lifecycle
+      // keys. Distinct prefix (`fc:sem`) so a grep over emitted suites
+      // can tell the two synthesised-value classes apart.
+      const value = `fc:sem:${camelCaseSemantic(semantic)}:${deterministicSuffix(
+        `fc:sem:${operationId}:${semantic}`,
+      )}`;
+      return { classification: 'serverEmergent', varName, value };
     }
     case 'producerBound':
     case 'clientMintedIdentifier':

--- a/path-analyser/src/domainSemanticsValidator.ts
+++ b/path-analyser/src/domainSemanticsValidator.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { classifySemantic } from './bindSemanticInput.js';
 import type { OperationGraph } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -37,10 +38,13 @@ import type { OperationGraph } from './types.js';
 const SemanticTypeSpecSchema = z
   .object({
     witnesses: z.string().min(1).optional(),
-    // #162 PR 1 added `modelDerived`; PR 2 adds `attribute`. Strict enum
-    // so a typo (e.g. `attributes`) is rejected at load time rather than
-    // silently falling through to the default classification chain.
-    kind: z.enum(['modelDerived', 'attribute']).optional(),
+    // #162 PR 1 added `modelDerived`; PR 2 added `attribute`; PR 5 adds
+    // `serverEmergent` for server-minted lifecycle keys (e.g. IncidentKey,
+    // AuditLogKey) that no client API directly mints with a returned value.
+    // Strict enum so a typo (e.g. `attributes`) is rejected at load time
+    // rather than silently falling through to the default classification
+    // chain.
+    kind: z.enum(['modelDerived', 'attribute', 'serverEmergent']).optional(),
     // #162 PR 2: only meaningful with `kind: 'attribute'`. Validator
     // enforces the pairing in `checkAttributeKindClientMintedPairing`
     // below.
@@ -554,6 +558,60 @@ export function validateRuntimeStateWitnessGraphRefs(
         message: `runtimeStates.${stateName}.witness.operationId "${spec.witness.operationId}" is ${method || 'an unknown method'}; PR B (#159) supports GET-shape witnesses only.`,
       });
     }
+  }
+  return issues;
+}
+
+/**
+ * Validate that every semantic referenced by any operation's
+ * `requestBodySemanticTypes` resolves to a non-`'unclassified'`
+ * classification (#162 PR 5).
+ *
+ * The five terminal classifications are defined in
+ * `bindSemanticInput.ts#classifySemantic`:
+ *
+ *   - `modelDerived`            (domain-semantics: kind: 'modelDerived')
+ *   - `clientMintedAttribute`   (domain-semantics: kind: 'attribute' + clientMinted)
+ *   - `serverEmergent`          (domain-semantics: kind: 'serverEmergent')
+ *   - `producerBound`           (graph.producersByType[T])
+ *   - `clientMintedIdentifier`  (graph.establishersByType[T])
+ *   - `externalBoundary`        (graph.externalEntityIdentifiers)
+ *
+ * If a semantic falls through every tier, the planner has no rule for
+ * what value to bind into the request body. Pre-PR 5 this surfaced as
+ * a placeholder string in the emitted suite with no record of the gap;
+ * PR 5 turns it into a fail-fast at graph load so a future spec change
+ * that introduces a new semantic without an accompanying classification
+ * is caught immediately.
+ *
+ * The check is class-scoped: every (operationId, semantic) pair across
+ * the full graph is collected before throwing, so one load failure
+ * surfaces every gap rather than peeling them off one at a time.
+ *
+ * Returns the empty array on success.
+ */
+export function validateRequestBodySemanticsClassified(
+  graph: OperationGraph,
+): DomainSemanticsValidationError[] {
+  const issues: DomainSemanticsValidationError[] = [];
+  // Group offending sites by semantic so the error message stays
+  // readable when a missing classification fans out to many fields
+  // (e.g. AuditLogEntityKey appears at 10 sites in the live spec).
+  const offendersBySemantic = new Map<string, string[]>();
+  for (const op of Object.values(graph.operations)) {
+    for (const entry of op.requestBodySemantics ?? []) {
+      const classification = classifySemantic(entry.semantic, graph);
+      if (classification !== 'unclassified') continue;
+      const sites = offendersBySemantic.get(entry.semantic) ?? [];
+      sites.push(`${op.operationId}.${entry.fieldPath}`);
+      offendersBySemantic.set(entry.semantic, sites);
+    }
+  }
+  for (const [semantic, sites] of offendersBySemantic) {
+    issues.push({
+      invariant: 'requestBodySemanticUnclassified',
+      message: `semantic type "${semantic}" referenced by ${sites.length} requestBodySemanticTypes site(s) is unclassified — declare a domain-semantics.json entry (e.g. kind: 'serverEmergent' for server-minted lifecycle keys, kind: 'attribute' + clientMinted: true for client-supplied filter values), wire a producer/establisher in the spec, or add it to the kindRegistry as an external-entity identifier. Sites: ${sites.join(', ')}`,
+    });
   }
   return issues;
 }

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -496,7 +496,7 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
   if (classificationIssues.length > 0) {
     const detail = classificationIssues.map((i) => `  - [${i.invariant}] ${i.message}`).join('\n');
     throw new DomainSemanticsValidationFailure(
-      `domain-semantics.json failed cross-reference validation against the bundled spec:\n${detail}`,
+      `operation graph has unclassified requestBodySemanticTypes entries:\n${detail}`,
     );
   }
   return graph;

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -4,6 +4,7 @@ import { parse as parseYaml } from 'yaml';
 import { getActiveConfigDir, getGraphDir, getSpecBundleDir } from './configResolver.js';
 import {
   validateDomainSemantics,
+  validateRequestBodySemanticsClassified,
   validateRuntimeStateWitnessGraphRefs,
 } from './domainSemanticsValidator.js';
 import type { BootstrapSequence, DomainSemantics, OperationGraph, OperationNode } from './types.js';
@@ -479,6 +480,21 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
   const witnessIssues = validateRuntimeStateWitnessGraphRefs(graph);
   if (witnessIssues.length > 0) {
     const detail = witnessIssues.map((i) => `  - [${i.invariant}] ${i.message}`).join('\n');
+    throw new DomainSemanticsValidationFailure(
+      `domain-semantics.json failed cross-reference validation against the bundled spec:\n${detail}`,
+    );
+  }
+  // #162 PR 5: every semantic referenced by an operation's
+  // requestBodySemanticTypes must classify into one of the five
+  // terminal classifications (see bindSemanticInput.ts). An
+  // unclassified semantic means the planner has no rule for what value
+  // to bind into the request body — fail-fast here so a future spec
+  // change that introduces a new semantic without an accompanying
+  // domain-semantics declaration is caught at load time rather than
+  // surfacing as an unexplained placeholder in the emitted suite.
+  const classificationIssues = validateRequestBodySemanticsClassified(graph);
+  if (classificationIssues.length > 0) {
+    const detail = classificationIssues.map((i) => `  - [${i.invariant}] ${i.message}`).join('\n');
     throw new DomainSemanticsValidationFailure(
       `domain-semantics.json failed cross-reference validation against the bundled spec:\n${detail}`,
     );

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -1918,8 +1918,12 @@ function tryProducerChainVariant(args: {
 /**
  * #162 PR 4: pick a value for the bare-endpoint fallback path.
  *
- * - `clientMintedAttribute`: deterministic minted token from
- *   `bindSemanticInput`.
+ * - `clientMintedAttribute` and `serverEmergent` (PR 5): deterministic
+ *   minted token from `bindSemanticInput`. Both classifications carry
+ *   their own value because the planner is the authoritative source
+ *   for what to put in the request body (no producer chain to extract
+ *   from); reusing `bound.value` keeps the byte-stable mint formula
+ *   centralised in `bindSemanticInput.ts`.
  * - `modelDerived` and `producerBound` (and other classifications):
  *   synthesise the same `<semantic>_<suffix>` placeholder shape
  *   `featureCoverageGenerator` used pre-PR-4 for `opt=<sem>` scenarios.
@@ -1936,5 +1940,6 @@ function resolveFallbackValue(
   endpointOpId: string,
 ): string | undefined {
   if (bound.classification === 'clientMintedAttribute') return bound.value;
+  if (bound.classification === 'serverEmergent') return bound.value;
   return `${camelLower(semantic)}_${deterministicSuffix(`vc:opt:${endpointOpId}:${semantic}`)}`;
 }

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -495,8 +495,15 @@ export interface SemanticTypeSpec {
    * Absent `kind` means the planner falls back to its existing
    * classification chain (producersByType / establishersByType /
    * external-entity / synthetic).
+   *
+   * `serverEmergent` (#162 PR 5): server-minted lifecycle identifiers
+   * that no client API directly mints with a returned value (e.g.
+   * `IncidentKey`, `AuditLogKey`, `MessageSubscriptionKey`). The planner
+   * binds a deterministic placeholder so search-filter request shapes
+   * validate; an empty search result is acceptable because the value is
+   * a fabricated placeholder for a key the client could not have known.
    */
-  kind?: 'modelDerived' | 'attribute';
+  kind?: 'modelDerived' | 'attribute' | 'serverEmergent';
   /**
    * Whether values of this semantic are minted by the planner / client
    * rather than returned by a producer endpoint (#162 PR 2). Only

--- a/tests/fixtures/loader/graphloader-optional-subshapes.test.ts
+++ b/tests/fixtures/loader/graphloader-optional-subshapes.test.ts
@@ -54,11 +54,32 @@ interface Layout {
   domain?: Record<string, unknown>;
 }
 
+// Default classifications for the synthetic semantics these fixtures
+// use in their `requestBodySemanticTypes` blocks. Without this, #162
+// PR 5's fail-fast load-time diagnostic rejects every fixture that
+// references a semantic with no producer/establisher in the synthetic
+// graph (which is most of them — these fixtures are scoped to the
+// sub-shape grouping behaviour, not to the classification chain).
+//
+// Any test exercising the unclassified-detection path itself must
+// override `domain` explicitly.
+const DEFAULT_DOMAIN = {
+  semanticTypes: {
+    Tag: { kind: 'attribute', clientMinted: true },
+    TagName: { kind: 'attribute', clientMinted: true },
+    BusinessId: { kind: 'attribute', clientMinted: true },
+    TenantId: { kind: 'attribute', clientMinted: true },
+    ElementId: { kind: 'modelDerived' },
+    ProcessInstanceKey: { kind: 'serverEmergent' },
+    ProcessDefinitionId: { kind: 'serverEmergent' },
+  },
+};
+
 function writeLayout(layout: Layout): void {
   writeFileSync(join(graphDir, 'operation-dependency-graph.json'), JSON.stringify(layout.graph));
   writeFileSync(
     join(configDir, 'domain-semantics.json'),
-    JSON.stringify(layout.domain ?? { operationRequirements: {} }),
+    JSON.stringify(layout.domain ?? DEFAULT_DOMAIN),
   );
 }
 

--- a/tests/fixtures/loader/graphloader-request-body-semantic-classification.test.ts
+++ b/tests/fixtures/loader/graphloader-request-body-semantic-classification.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Loader fixtures for #162 PR 5 — unclassified-semantic load-time
+ * diagnostic.
+ *
+ * Every semantic referenced by an operation's `requestBodySemanticTypes`
+ * must fit exactly one of the five classifications defined in
+ * `bindSemanticInput.ts`:
+ *
+ *   - `modelDerived`             (domain-semantics: kind: 'modelDerived')
+ *   - `clientMintedAttribute`    (domain-semantics: kind: 'attribute' + clientMinted)
+ *   - `serverEmergent`           (domain-semantics: kind: 'serverEmergent')
+ *   - `producerBound`            (graph.producersByType[T])
+ *   - `clientMintedIdentifier`   (graph.establishersByType[T])
+ *   - `externalBoundary`         (graph.externalEntityIdentifiers)
+ *
+ * If a semantic falls through all of those, `classifySemantic` returns
+ * `'unclassified'` and the planner has no rule for what value to bind.
+ * Pre-PR 5 this surfaced as a placeholder string in the emitted suite
+ * with no record of the gap; PR 5 turns it into a fail-fast at graph
+ * load so a future spec change that introduces a new semantic without
+ * an accompanying classification is caught immediately.
+ *
+ * The fixtures here exercise the validator in isolation against
+ * synthetic graphs — the real bundled-spec sweep is covered by the
+ * pipeline regen step (any unclassified semantic in the live graph
+ * fails `npm run testsuite:generate`).
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadGraph } from '../../../path-analyser/src/graphLoader.ts';
+
+interface Layout {
+  graph: Record<string, unknown>;
+  domain: Record<string, unknown>;
+}
+
+let workdir: string;
+let baseDir: string;
+let graphDir: string;
+let configDir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'graphloader-pr5-'));
+  baseDir = join(workdir, 'path-analyser');
+  graphDir = join(workdir, 'generated', 'camunda-oca', 'graph');
+  configDir = join(workdir, 'configs', 'camunda-oca');
+  mkdirSync(baseDir, { recursive: true });
+  mkdirSync(graphDir, { recursive: true });
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(
+    join(workdir, 'configs.json'),
+    JSON.stringify({ default: 'camunda-oca', configs: { 'camunda-oca': {} } }),
+  );
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+function writeLayout(layout: Layout): void {
+  writeFileSync(join(graphDir, 'operation-dependency-graph.json'), JSON.stringify(layout.graph));
+  writeFileSync(join(configDir, 'domain-semantics.json'), JSON.stringify(layout.domain));
+}
+
+describe('graphLoader: requestBodySemantics classification fail-fast (#162 PR 5)', () => {
+  it('throws when a single requestBodySemanticTypes entry references an unclassified semantic', async () => {
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'searchFoos',
+            method: 'POST',
+            path: '/foos/search',
+            requestBodySemanticTypes: [
+              { semanticType: 'FooKey', fieldPath: 'filter.fooKey', required: false },
+            ],
+          },
+        ],
+      },
+      // No semanticTypes declaration for FooKey, no producer, no establisher,
+      // no external-entity identifier — the classifier returns 'unclassified'.
+      domain: {},
+    });
+
+    await expect(loadGraph(baseDir)).rejects.toThrow(/requestBodySemanticUnclassified/);
+    await expect(loadGraph(baseDir)).rejects.toThrow(/FooKey/);
+    await expect(loadGraph(baseDir)).rejects.toThrow(/searchFoos/);
+  });
+
+  it('reports every offending (operationId, semantic) pair — class-scoped, not just the first', async () => {
+    // Two ops, two distinct unclassified semantics. The diagnostic must
+    // list both so a future spec change introducing N new semantics
+    // surfaces all of them in one load failure rather than turning into
+    // a peel-the-onion of N separate failures.
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'searchAlphas',
+            method: 'POST',
+            path: '/alphas/search',
+            requestBodySemanticTypes: [
+              { semanticType: 'AlphaKey', fieldPath: 'filter.alphaKey', required: false },
+            ],
+          },
+          {
+            operationId: 'searchBetas',
+            method: 'POST',
+            path: '/betas/search',
+            requestBodySemanticTypes: [
+              { semanticType: 'BetaKey', fieldPath: 'filter.betaKey', required: false },
+            ],
+          },
+        ],
+      },
+      domain: {},
+    });
+
+    let captured: unknown;
+    try {
+      await loadGraph(baseDir);
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured, 'expected loadGraph to throw').toBeInstanceOf(Error);
+    const message = captured instanceof Error ? captured.message : String(captured);
+    expect(message).toMatch(/AlphaKey/);
+    expect(message).toMatch(/searchAlphas/);
+    expect(message).toMatch(/BetaKey/);
+    expect(message).toMatch(/searchBetas/);
+  });
+
+  it('passes when every requestBodySemantics entry resolves to a known classification', async () => {
+    // One op declares a producerBound semantic (Tier 2a) and one
+    // serverEmergent semantic (Tier 1c — the new class PR 5 adds for
+    // server-minted lifecycle keys like IncidentKey/AuditLogKey that no
+    // client API call directly creates).
+    writeLayout({
+      graph: {
+        operations: [
+          {
+            operationId: 'createWidget',
+            method: 'POST',
+            path: '/widgets',
+            producesSemanticTypes: ['WidgetKey'],
+            // Mirror the response-shape that drives providerMap=true so
+            // the producer is authoritative (Tier 2a).
+            responseSemanticTypes: [
+              { semanticType: 'WidgetKey', fieldPath: 'widgetKey', provider: true },
+            ],
+          },
+          {
+            operationId: 'searchWidgetIncidents',
+            method: 'POST',
+            path: '/widgets/incidents/search',
+            requestBodySemanticTypes: [
+              { semanticType: 'WidgetKey', fieldPath: 'filter.widgetKey', required: false },
+              {
+                semanticType: 'WidgetIncidentKey',
+                fieldPath: 'filter.incidentKey',
+                required: false,
+              },
+            ],
+          },
+        ],
+      },
+      domain: {
+        semanticTypes: {
+          WidgetIncidentKey: { kind: 'serverEmergent' },
+        },
+      },
+    });
+
+    const g = await loadGraph(baseDir);
+    // Sanity: the load actually succeeded and produced the expected
+    // operations, otherwise this test is vacuously green.
+    expect(Object.keys(g.operations)).toEqual(
+      expect.arrayContaining(['createWidget', 'searchWidgetIncidents']),
+    );
+  });
+});

--- a/tests/fixtures/loader/graphloader-request-setters.test.ts
+++ b/tests/fixtures/loader/graphloader-request-setters.test.ts
@@ -49,11 +49,30 @@ interface Layout {
   domain?: Record<string, unknown>;
 }
 
+// Default classifications for the synthetic semantics these fixtures
+// reference in their `requestBodySemanticTypes` blocks. Without this,
+// #162 PR 5's load-time fail-fast diagnostic rejects every fixture
+// that names a semantic with no corresponding producer/establisher in
+// the synthetic graph (which is most of them — these fixtures are
+// scoped to the request-setter index, not to the classification chain).
+//
+// Any test exercising the unclassified-detection path itself must
+// override `domain` explicitly.
+const DEFAULT_DOMAIN = {
+  semanticTypes: {
+    Tag: { kind: 'attribute', clientMinted: true },
+    BusinessId: { kind: 'attribute', clientMinted: true },
+    NoPath: { kind: 'attribute', clientMinted: true },
+    ProcessInstanceKey: { kind: 'serverEmergent' },
+    ProcessDefinitionId: { kind: 'serverEmergent' },
+  },
+};
+
 function writeLayout(layout: Layout): void {
   writeFileSync(join(graphDir, 'operation-dependency-graph.json'), JSON.stringify(layout.graph));
   writeFileSync(
     join(configDir, 'domain-semantics.json'),
-    JSON.stringify(layout.domain ?? { operationRequirements: {} }),
+    JSON.stringify(layout.domain ?? DEFAULT_DOMAIN),
   );
 }
 


### PR DESCRIPTION
Closes the issue #162 series (PR 5/5).

## What

Turn `'unclassified'` from a silent fallback into a fail-fast diagnostic at graph load. Every semantic referenced by an operation's `requestBodySemanticTypes` must now resolve to one of:

| Tier | Source | Classification |
|---|---|---|
| 1a | `domain.semanticTypes[T].kind: 'modelDerived'` | `modelDerived` |
| 1b | `domain.semanticTypes[T].kind: 'attribute'` + `clientMinted: true` | `clientMintedAttribute` |
| **1c (new)** | **`domain.semanticTypes[T].kind: 'serverEmergent'`** | **`serverEmergent`** |
| 2a | `graph.producersByType[T]` | `producerBound` |
| 2b | `graph.establishersByType[T]` | `clientMintedIdentifier` |
| 2c | `graph.externalEntityIdentifiers.has(T)` | `externalBoundary` |

Anything that falls through every tier throws `DomainSemanticsValidationFailure` from `loadGraph`, with **every** offending `(operationId, semantic)` pair surfaced in one error rather than peeling them off one at a time.

## Why a new `serverEmergent` class

Pre-PR 5 the live spec had 9 semantics that classified as `'unclassified'`:

| Semantic | Sites | Pattern |
|---|---|---|
| `AgentInstanceKey` | 5 | Server-minted by agent runtime |
| `AuditLogKey` | 5 | Side-effect of audited writes |
| `AuditLogEntityKey` | 10 | Same lifecycle as AuditLogKey |
| `MessageSubscriptionKey` | 15 | Emerges from message-catch deployment |
| `IncidentKey` | 1 | Emerges from runtime failures |
| `UserTaskKey` | 1 | Emerges from process reaching user-task |
| `VariableKey` | 5 | Server-managed by process execution |
| `ScopeKey` | 5 | Same lifecycle as VariableKey |
| `DeploymentKey` | 10 | (see below — temporary) |

These don't fit any existing class:
- Not `producerBound` — no client API directly returns them.
- Not `clientMinted*` — the client never mints them.
- Not `externalBoundary` — they originate inside Camunda, not in an external system like an OIDC provider.

They are **server-minted lifecycle identifiers that emerge as side-effects of state changes**. The planner mints a deterministic `fc:sem:<sem>:<suffix>` placeholder (distinct prefix from `fc:cma:` so a grep can tell them apart), the search request validates, and an empty result set is acceptable because the value is fabricated for a key the client could not have known.

## DeploymentKey is a temporary classification

`createDeployment` returns `deploymentKey` in its 200 response, but the response field is currently flagged `provider:false` in the bundled spec. That prevents Tier-2a `producerBound` classification, so PR 5 declares it `serverEmergent` to keep the pipeline green. Once the upstream spec marks `deploymentKey` as `provider:true`, the entry should be removed and `DeploymentKey` will classify as `producerBound` automatically.

Tracked upstream: camunda/camunda#52926.

## Tests

- `tests/fixtures/loader/graphloader-request-body-semantic-classification.test.ts` — Layer-1 fixture for the validator. Three named assertions:
  - **single-instance fail** — one unclassified semantic → throws with the offending semantic name and operationId in the message.
  - **class-scoped fail** — two unclassified semantics across two ops → both surfaced in one error.
  - **happy path** — every entry classifies via Tier-1c `serverEmergent` declaration or Tier-2a producer → load succeeds.
- The bundled-spec sweep is implicitly covered by the pipeline regen step: any unclassified semantic in the live graph fails `npm run testsuite:generate` immediately.
- Two existing fixture suites (`graphloader-optional-subshapes`, `graphloader-request-setters`) gained a `DEFAULT_DOMAIN` block classifying the synthetic semantics they reference, so PR 5's fail-fast doesn't reject every test that doesn't supply its own sidecar. Tests exercising the unclassified-detection path explicitly override `domain`.

## Drift

**Zero generated-output drift.** The existing 9 semantics already routed through the bare-endpoint fallback in PR 4, which behaves identically for `serverEmergent` and `clientMintedAttribute` (both go through `bound.value`).

## Verification

```
npx tsc --noEmit -p path-analyser/tsconfig.json              # clean
npx tsc --noEmit -p semantic-graph-extractor/tsconfig.json   # clean
npx tsc --noEmit -p request-validation/tsconfig.json         # clean
TEST_SEED=snapshot-baseline npm run testsuite:generate       # ok, 186 endpoints + 67 variants
npm run generate:request-validation                          # ok
npm run lint                                                 # 0 errors (10 warnings + 2 infos pre-existing on main)
npx vitest run                                               # 372 passed | 6 skipped
```

Refs #162