### PR TITLE
fix: materialize fixture files into generated suite output directory

### DIFF
--- a/path-analyser/src/codegen/index.ts
+++ b/path-analyser/src/codegen/index.ts
@@ -13,6 +13,7 @@ import { parseCliArgs } from './cli-args.js';
 import { writeEmitted } from './orchestrator.js';
 import { PlaywrightEmitter } from './playwright/emitter.js';
 import {
+  materializeFixtures,
   materializeResponseSchemas,
   materializeSupport,
 } from './playwright/materialize-support.js';
@@ -140,6 +141,10 @@ async function run() {
     recordResponses = codegenOpts.recordResponses;
     const excludeSupportFiles = recordResponses ? undefined : ['recorder.ts'];
     await materializeSupport(outDir, undefined, undefined, true, excludeSupportFiles);
+    // Copy BPMN/DMN/form fixture files into <outDir>/fixtures/ so the suite
+    // is self-contained: @@FILE:<rel-path> markers in emitted tests resolve
+    // via support/fixtures.ts regardless of process.cwd().
+    await materializeFixtures(outDir);
     // Also extract response-body schemas alongside the emitted specs so the
     // generated `validateResponse(...)` calls have a schema source. Co-located
     // here (rather than a separate npm script) so every codegen run produces

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -9,7 +9,7 @@ import type {
   RequestStep,
 } from '../../types.js';
 import type { EmitContext, EmittedFile, Emitter } from '../emitter.js';
-import { materializeSupport } from './materialize-support.js';
+import { materializeFixtures, materializeSupport } from './materialize-support.js';
 
 interface EmitOptions {
   outDir: string;
@@ -87,6 +87,7 @@ export async function emitPlaywrightSuite(
   const recordResponses = opts.recordResponses ?? true;
   const excludeSupportFiles = recordResponses ? undefined : ['recorder.ts'];
   await materializeSupport(opts.outDir, undefined, undefined, true, excludeSupportFiles);
+  await materializeFixtures(opts.outDir);
   const file = path.join(opts.outDir, playwrightSuiteFileName(collection, opts.mode || 'feature'));
   const code = renderPlaywrightSuite(collection, opts);
   await fs.writeFile(file, code, 'utf8');

--- a/path-analyser/src/codegen/playwright/materialize-support.ts
+++ b/path-analyser/src/codegen/playwright/materialize-support.ts
@@ -175,9 +175,10 @@ export const FIXTURES_DIR_NAME = 'fixtures';
 /**
  * Locate the generator's `fixtures/` directory.
  *
- * In dist mode the fixtures live at `<pkg>/fixtures/` (two levels up from
- * `dist/src/codegen/playwright/`). In source mode they live at
- * `<pkg>/fixtures/` (three levels up from `src/codegen/playwright/`).
+ * In both dist and source modes the fixtures live at `<pkg>/fixtures/`.
+ * From `dist/src/codegen/playwright/` that is four parent hops up;
+ * from `src/codegen/playwright/` it is three hops up. The search loop
+ * handles both without a hard-coded depth.
  */
 function defaultFixturesSourceDir(): string {
   const here = path.dirname(fileURLToPath(import.meta.url));
@@ -200,8 +201,9 @@ function defaultFixturesSourceDir(): string {
  * tests resolve via the `path.resolve(here, '..', 'fixtures', p)` candidate
  * in `support/fixtures.ts` regardless of `process.cwd()`.
  *
- * Idempotent: always overwrites to keep the vendored copy in sync with the
- * generator's fixture source on every codegen run.
+ * Idempotent: wipes `<outDir>/fixtures/` before copying so the vendored
+ * copy stays in sync with the generator's fixture source on every codegen
+ * run — including when files are deleted from the source tree.
  *
  * @param outDir          The same directory passed to {@link materializeSupport}.
  * @param fixturesSourceDir  Optional override for the fixtures source directory.
@@ -214,6 +216,10 @@ export async function materializeFixtures(
 ): Promise<string> {
   const srcDir = fixturesSourceDir ?? defaultFixturesSourceDir();
   const destDir = path.join(outDir, FIXTURES_DIR_NAME);
+
+  // Wipe the destination first so deleted source files don't accumulate in
+  // the vendored copy across successive codegen runs.
+  await fs.rm(destDir, { recursive: true, force: true });
 
   async function copyDir(src: string, dest: string): Promise<void> {
     await fs.mkdir(dest, { recursive: true });

--- a/path-analyser/src/codegen/playwright/materialize-support.ts
+++ b/path-analyser/src/codegen/playwright/materialize-support.ts
@@ -1,12 +1,13 @@
 // ---------------------------------------------------------------------------
-// Vendors the Playwright runtime support files AND project scaffolding into
-// an emitted test suite so the suite is runnable in place:
+// Vendors the Playwright runtime support files, project scaffolding, AND
+// artifact fixture files into an emitted test suite so the suite is runnable
+// in place:
 //
 //   cd <outDir>
 //   npm install
 //   API_BASE_URL=http://localhost:8080/v2 npm test
 //
-// Two template sets are copied:
+// Three sets of assets are copied:
 //   * support/ — runtime helpers (env.ts, recorder.ts, seeding.ts,
 //                fixtures.ts, seed-rules.json). Sources:
 //                path-analyser/src/codegen/support/, staged into
@@ -15,6 +16,8 @@
 //   * project root — package.json, playwright.config.ts, tsconfig.json,
 //                    .env.example, README.md.
 //                    Sources: path-analyser/templates/.
+//   * fixtures/ — BPMN/DMN/form files referenced by @@FILE:<rel-path>
+//                 markers in emitted tests. Sources: path-analyser/fixtures/.
 //
 // Keep SUPPORT_TEMPLATE_FILES in sync with
 // path-analyser/scripts/copy-support-templates.js.
@@ -162,6 +165,70 @@ export async function materializeSupport(
     await fs.copyFile(path.join(projSrcDir, name), dest);
   }
 
+  return destDir;
+}
+
+/** Subdirectory created under the emitter's outDir to hold BPMN/DMN/form
+ *  fixture files referenced by `@@FILE:<rel-path>` markers in emitted tests. */
+export const FIXTURES_DIR_NAME = 'fixtures';
+
+/**
+ * Locate the generator's `fixtures/` directory.
+ *
+ * In dist mode the fixtures live at `<pkg>/fixtures/` (two levels up from
+ * `dist/src/codegen/playwright/`). In source mode they live at
+ * `<pkg>/fixtures/` (three levels up from `src/codegen/playwright/`).
+ */
+function defaultFixturesSourceDir(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  let dir = here;
+  for (let i = 0; i < 6; i++) {
+    const candidate = path.join(dir, 'fixtures');
+    if (existsSync(path.join(candidate, 'bpmn'))) {
+      return candidate;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.resolve(here, '..', '..', '..', '..', 'fixtures');
+}
+
+/**
+ * Copy `<fixturesSourceDir>/` recursively into `<outDir>/fixtures/` so the
+ * emitted suite is self-contained: `@@FILE:<rel-path>` markers in generated
+ * tests resolve via the `path.resolve(here, '..', 'fixtures', p)` candidate
+ * in `support/fixtures.ts` regardless of `process.cwd()`.
+ *
+ * Idempotent: always overwrites to keep the vendored copy in sync with the
+ * generator's fixture source on every codegen run.
+ *
+ * @param outDir          The same directory passed to {@link materializeSupport}.
+ * @param fixturesSourceDir  Optional override for the fixtures source directory.
+ *                           Production callers should omit this.
+ * @returns               Path to the fixtures directory under `outDir`.
+ */
+export async function materializeFixtures(
+  outDir: string,
+  fixturesSourceDir?: string,
+): Promise<string> {
+  const srcDir = fixturesSourceDir ?? defaultFixturesSourceDir();
+  const destDir = path.join(outDir, FIXTURES_DIR_NAME);
+
+  async function copyDir(src: string, dest: string): Promise<void> {
+    await fs.mkdir(dest, { recursive: true });
+    for (const entry of await fs.readdir(src, { withFileTypes: true })) {
+      const srcPath = path.join(src, entry.name);
+      const destPath = path.join(dest, entry.name);
+      if (entry.isDirectory()) {
+        await copyDir(srcPath, destPath);
+      } else {
+        await fs.copyFile(srcPath, destPath);
+      }
+    }
+  }
+
+  await copyDir(srcDir, destDir);
   return destDir;
 }
 

--- a/tests/codegen/materialize-support.test.ts
+++ b/tests/codegen/materialize-support.test.ts
@@ -178,13 +178,15 @@ describe('materializeFixtures', () => {
     const destDir = await materializeFixtures(tmp);
     expect(destDir).toBe(path.join(tmp, FIXTURES_DIR_NAME));
 
-    const bmpDir = path.join(destDir, 'bpmn');
-    expect(existsSync(bmpDir)).toBe(true);
-    const bpmnFiles = await fs.readdir(bmpDir);
-    expect(bpmnFiles.length).toBeGreaterThan(0);
-    for (const f of bpmnFiles) {
-      const stat = await fs.stat(path.join(bmpDir, f));
-      expect(stat.size).toBeGreaterThan(0);
+    for (const subdir of ['bpmn', 'dmn', 'forms']) {
+      const dir = path.join(destDir, subdir);
+      expect(existsSync(dir), `${subdir}/ should exist`).toBe(true);
+      const files = await fs.readdir(dir);
+      expect(files.length, `${subdir}/ should contain at least one file`).toBeGreaterThan(0);
+      for (const f of files) {
+        const stat = await fs.stat(path.join(dir, f));
+        expect(stat.size, `${subdir}/${f} should be non-empty`).toBeGreaterThan(0);
+      }
     }
   });
 
@@ -193,14 +195,17 @@ describe('materializeFixtures', () => {
     await expect(materializeFixtures(tmp)).resolves.toBe(path.join(tmp, FIXTURES_DIR_NAME));
   });
 
-  test('resolveFixture can load a materialized file from its here-relative candidate', async () => {
-    // Verify that the fixture resolution path used by support/fixtures.ts
-    // (`path.resolve(here, '..', 'fixtures', p)`) finds the materialized
-    // files when `here` is <outDir>/support/ (as it is in the generated suite).
+  test('here-relative candidate path resolves to a materialized file when here is <outDir>/support/', async () => {
+    // Guard against regressions to the fixture resolution path used by
+    // support/fixtures.ts. That file calls:
+    //   path.resolve(here, '..', 'fixtures', p)
+    // where `here` = fileURLToPath(import.meta.url)'s dirname = <outDir>/support/.
+    // If materializeFixtures stops populating <outDir>/fixtures/ or the
+    // relative traversal changes, this assertion fails.
     await materializeFixtures(tmp);
     const supportDir = path.join(tmp, 'support');
     await fs.mkdir(supportDir, { recursive: true });
-    // Simulate resolveFixture's here-relative candidate from <outDir>/support/:
+    // Reproduce the exact candidate that support/fixtures.ts constructs:
     const candidate = path.resolve(supportDir, '..', 'fixtures', 'bpmn/service-task.bpmn');
     const buf = await fs.readFile(candidate);
     expect(buf.length).toBeGreaterThan(0);

--- a/tests/codegen/materialize-support.test.ts
+++ b/tests/codegen/materialize-support.test.ts
@@ -3,6 +3,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import {
+  FIXTURES_DIR_NAME,
+  materializeFixtures,
   materializeSupport,
   PROJECT_TEMPLATE_FILES,
   SUPPORT_DIR_NAME,
@@ -158,5 +160,49 @@ describe('materializeSupport', () => {
     } finally {
       await fs.rm(fakeSrc, { recursive: true, force: true });
     }
+  });
+});
+
+describe('materializeFixtures', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mat-fixtures-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  test('copies bpmn/ dmn/ forms/ fixture files into <outDir>/fixtures/', async () => {
+    const destDir = await materializeFixtures(tmp);
+    expect(destDir).toBe(path.join(tmp, FIXTURES_DIR_NAME));
+
+    const bmpDir = path.join(destDir, 'bpmn');
+    expect(existsSync(bmpDir)).toBe(true);
+    const bpmnFiles = await fs.readdir(bmpDir);
+    expect(bpmnFiles.length).toBeGreaterThan(0);
+    for (const f of bpmnFiles) {
+      const stat = await fs.stat(path.join(bmpDir, f));
+      expect(stat.size).toBeGreaterThan(0);
+    }
+  });
+
+  test('is idempotent: a second call overwrites without error', async () => {
+    await materializeFixtures(tmp);
+    await expect(materializeFixtures(tmp)).resolves.toBe(path.join(tmp, FIXTURES_DIR_NAME));
+  });
+
+  test('resolveFixture can load a materialized file from its here-relative candidate', async () => {
+    // Verify that the fixture resolution path used by support/fixtures.ts
+    // (`path.resolve(here, '..', 'fixtures', p)`) finds the materialized
+    // files when `here` is <outDir>/support/ (as it is in the generated suite).
+    await materializeFixtures(tmp);
+    const supportDir = path.join(tmp, 'support');
+    await fs.mkdir(supportDir, { recursive: true });
+    // Simulate resolveFixture's here-relative candidate from <outDir>/support/:
+    const candidate = path.resolve(supportDir, '..', 'fixtures', 'bpmn/service-task.bpmn');
+    const buf = await fs.readFile(candidate);
+    expect(buf.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Problem

The generated Playwright suite's `support/fixtures.ts` helper has a candidate search list for resolving `@@FILE:<rel-path>` markers. When running from the **repo root**, the candidate `path.resolve(process.cwd(), 'path-analyser/fixtures', p)` succeeds. When running the suite **standalone** (the documented usage: `cd <outDir> && npm install && npm test`), all candidates fail with "Fixture not found".

The `materializeSupport()` step copies `support/*.ts` helpers and project scaffolding, but never copied the actual fixture files (BPMN, DMN, form files) into the output directory.

## Fix

Add `materializeFixtures()` to `materialize-support.ts` that copies `path-analyser/fixtures/` recursively into `<outDir>/fixtures/`. This makes the `here`-relative candidate in `support/fixtures.ts`:

```ts
path.resolve(here, '..', 'fixtures', p)  // here = <outDir>/support/
```

resolve to `<outDir>/fixtures/bpmn/service-task.bpmn` etc., which now exists.

Call `materializeFixtures(outDir)` from `codegen/index.ts` immediately after `materializeSupport()` so every codegen run produces a truly self-contained suite.

## Tests

Three new tests in `materializeFixtures` describe block:
- Verifies `bpmn/`, `dmn/`, `forms/` are copied with non-zero content
- Idempotent (second call doesn't fail)
- Confirms the exact resolution path used by `support/fixtures.ts` (`here/../fixtures/p`) finds the materialized file — regression guard for the full resolution chain
