### PR TITLE
feat: add deploy() helper to DRY out createDeployment multipart boilerplate

### DIFF
--- a/path-analyser/scripts/copy-support-templates.js
+++ b/path-analyser/scripts/copy-support-templates.js
@@ -15,6 +15,8 @@
 //     seeding.ts
 //     fixtures.ts
 //     seed-rules.json
+//     await-eventually.ts
+//     deployment.ts
 // ---------------------------------------------------------------------------
 import { promises as fs } from 'node:fs';
 import path from 'node:path';

--- a/path-analyser/scripts/copy-support-templates.js
+++ b/path-analyser/scripts/copy-support-templates.js
@@ -26,6 +26,7 @@ const SUPPORT_FILES = [
   'fixtures.ts',
   'seed-rules.json',
   'await-eventually.ts',
+  'deployment.ts',
 ];
 
 async function main() {

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -181,27 +181,46 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
     lines.push("import { recordResponse, sanitizeBody } from './support/recorder';");
   }
   lines.push("import { extractInto, seedBinding } from './support/seeding';");
-  // deploy() is emitted for createDeployment multipart steps; resolveFixture
-  // is emitted for any other multipart steps (non-createDeployment). In the
-  // current spec, createDeployment is the only multipart operation, so both
-  // flags are mutually exclusive in practice — but future multipart operations
-  // would use the resolveFixture-based inline machinery.
+  // deploy() is emitted for 200-expected createDeployment multipart steps; resolveFixture
+  // is emitted for any step that falls through to the inline multipart path — this includes
+  // non-createDeployment multipart steps AND createDeployment steps with a non-200 expected
+  // status (which are not routed through deploy()). Mirror the isDeploymentStep condition
+  // exactly so the two flags stay in sync.
   const hasDeploymentMultipart = collection.scenarios.some((s) =>
     (s.requestPlan ?? []).some(
       (step) =>
         step.operationId === 'createDeployment' &&
         step.bodyKind === 'multipart' &&
-        !!step.multipartTemplate,
+        !!step.multipartTemplate &&
+        step.expect.status === 200,
     ),
   );
   const hasOtherMultipart = collection.scenarios.some((s) =>
     (s.requestPlan ?? []).some(
       (step) =>
-        step.operationId !== 'createDeployment' &&
         step.bodyKind === 'multipart' &&
-        !!step.multipartTemplate,
+        !!step.multipartTemplate &&
+        !(step.operationId === 'createDeployment' && step.expect.status === 200),
     ),
   );
+  // authHeaders is used in inline request steps and awaitEventually witness blocks.
+  // deploy() calls authHeaders internally, so deploy()-only suites don't need this import.
+  const hasInlineRequestStep = collection.scenarios.some((s) =>
+    (s.requestPlan ?? []).some(
+      (step) =>
+        !(
+          step.operationId === 'createDeployment' &&
+          step.bodyKind === 'multipart' &&
+          !!step.multipartTemplate &&
+          step.expect.status === 200
+        ),
+    ),
+  );
+  if (hasInlineRequestStep || needsAwaitEventually) {
+    lines.push("import { buildBaseUrl, authHeaders } from './support/env';");
+  } else {
+    lines.push("import { buildBaseUrl } from './support/env';");
+  }
   if (hasDeploymentMultipart) {
     lines.push("import { deploy } from './support/deployment';");
   }

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -179,7 +179,25 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   if (recordResponses) {
     lines.push("import { recordResponse, sanitizeBody } from './support/recorder';");
   }
-  lines.push("import { extractInto, seedBinding } from './support/seeding';");
+  // extractInto is only used in non-deployment extract steps; deploy() handles extraction
+  // internally for deployment steps. Gate extractInto to avoid an unused-import error in
+  // suites whose request plan consists entirely of createDeployment multipart steps.
+  const hasNonDeployExtract = collection.scenarios.some((s) =>
+    (s.requestPlan ?? []).some(
+      (step) =>
+        !(
+          step.operationId === 'createDeployment' &&
+          step.bodyKind === 'multipart' &&
+          !!step.multipartTemplate &&
+          step.expect.status === 200
+        ) && (step.extract?.length ?? 0) > 0,
+    ),
+  );
+  if (hasNonDeployExtract) {
+    lines.push("import { extractInto, seedBinding } from './support/seeding';");
+  } else {
+    lines.push("import { seedBinding } from './support/seeding';");
+  }
   // deploy() is emitted for 200-expected createDeployment multipart steps; resolveFixture
   // is emitted for any step that falls through to the inline multipart path — this includes
   // non-createDeployment multipart steps AND createDeployment steps with a non-200 expected
@@ -423,6 +441,11 @@ function renderScenarioTest(
         .map((line: string, i: number) => (i === 0 ? line : `    ${line}`))
         .join('\n');
       body.push(`    const ${varName} = await deploy(ctx, request, ${tplIndented}, baseUrl);`);
+      // Explicit status assertion mirrors the normal request path so the
+      // generated suite's assertion pattern is consistent and expect is not unused.
+      // deploy() also throws on non-200 with the response body, but the
+      // expect() call keeps the declared expectation visible in the test.
+      body.push(`    expect(${varName}.status()).toBe(${step.expect.status});`);
     } else {
       body.push(`    const url = baseUrl + ${urlExpr};`);
       const bodyVar = `body${idx + 1}`;

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -181,7 +181,33 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
     lines.push("import { recordResponse, sanitizeBody } from './support/recorder';");
   }
   lines.push("import { extractInto, seedBinding } from './support/seeding';");
-  lines.push("import { resolveFixture } from './support/fixtures';");
+  // deploy() is emitted for createDeployment multipart steps; resolveFixture
+  // is emitted for any other multipart steps (non-createDeployment). In the
+  // current spec, createDeployment is the only multipart operation, so both
+  // flags are mutually exclusive in practice — but future multipart operations
+  // would use the resolveFixture-based inline machinery.
+  const hasDeploymentMultipart = collection.scenarios.some((s) =>
+    (s.requestPlan ?? []).some(
+      (step) =>
+        step.operationId === 'createDeployment' &&
+        step.bodyKind === 'multipart' &&
+        !!step.multipartTemplate,
+    ),
+  );
+  const hasOtherMultipart = collection.scenarios.some((s) =>
+    (s.requestPlan ?? []).some(
+      (step) =>
+        step.operationId !== 'createDeployment' &&
+        step.bodyKind === 'multipart' &&
+        !!step.multipartTemplate,
+    ),
+  );
+  if (hasDeploymentMultipart) {
+    lines.push("import { deploy } from './support/deployment';");
+  }
+  if (hasOtherMultipart) {
+    lines.push("import { resolveFixture } from './support/fixtures';");
+  }
   if (needsAwaitEventually) {
     lines.push("import { awaitEventually } from './support/await-eventually';");
   }
@@ -353,46 +379,69 @@ function renderScenarioTest(
     // the outer test scope; the per-step locals (resp/body/json) stay
     // confined to the callback.
     body.push(`  await test.step(${JSON.stringify(step.operationId)}, async () => {`);
-    body.push(`    const url = baseUrl + ${urlExpr};`);
-    const bodyVar = `body${idx + 1}`;
-    if (step.bodyKind === 'json' && step.bodyTemplate) {
-      const json = JSON.stringify(step.bodyTemplate, null, 4).replace(
+
+    // createDeployment multipart steps use the deploy() helper which encapsulates
+    // multipart body building, @@FILE: resolution, auth, HTTP POST, status
+    // assertion (throws on non-200), and extraction of all known deployment
+    // response fields into ctx. This keeps each deployment step as a single
+    // declarative call instead of ~35 lines of boilerplate.
+    const isDeploymentStep =
+      step.operationId === 'createDeployment' &&
+      step.bodyKind === 'multipart' &&
+      !!step.multipartTemplate;
+    if (isDeploymentStep && step.multipartTemplate) {
+      const tpl = JSON.stringify(step.multipartTemplate, null, 2).replace(
         /"\\?\$\{([^}]+)\}"/g,
         (_, v) => `ctx["${v}"]`,
       );
-      body.push(`    const ${bodyVar} = ${json};`);
-    } else if (step.bodyKind === 'multipart' && step.multipartTemplate) {
-      // multipart template format: { fields: Record<string,string>, files: Record<string,string> }
-      const tpl = JSON.stringify(step.multipartTemplate, null, 4).replace(
-        /"\\?\$\{([^}]+)\}"/g,
-        (_, v) => `ctx["${v}"]`,
-      );
-      body.push(`    const ${bodyVar} = ${tpl};`);
-    }
-    const opts: string[] = [];
-    opts.push('headers: await authHeaders()');
-    if (step.bodyKind === 'json' && step.bodyTemplate) opts.push(`data: ${bodyVar}`);
-    if (step.bodyKind === 'multipart' && step.multipartTemplate) {
-      // Convert template to Playwright's expected multipart shape: a keyed object map.
-      // Field values are stringified (`String(v)`); file values are passed as
-      // `{ name, mimeType, buffer }`. The element type below mirrors the
-      // permissive subset of Playwright's `multipart` option that we actually
-      // emit, so the generated suite typechecks under `strict: true` when
-      // `request.post({ multipart })` is called.
-      body.push(
-        `    const multipart: Record<string, string | { name: string; mimeType: string; buffer: Buffer }> = {};`,
-      );
-      body.push(`    for (const [k,v] of Object.entries(${bodyVar}.fields||{})) {`);
-      // Emit a strip branch for every globalContextSeeds entry whose
-      // sentinel local was declared in the prologue. The emitter never
-      // hard-codes a field name here — the field name is the metadata key
-      // and the local was named after it.
-      for (const [fieldName, local] of sentinelLocals) {
-        body.push(`      if (k === '${fieldName}' && ${local}) continue;`);
+      // Indent all lines after the first so the object literal aligns under
+      // the opening `{` in the deploy() call.
+      const tplIndented = tpl
+        .split('\n')
+        .map((line: string, i: number) => (i === 0 ? line : `    ${line}`))
+        .join('\n');
+      body.push(`    const ${varName} = await deploy(ctx, request, ${tplIndented}, baseUrl);`);
+    } else {
+      body.push(`    const url = baseUrl + ${urlExpr};`);
+      const bodyVar = `body${idx + 1}`;
+      if (step.bodyKind === 'json' && step.bodyTemplate) {
+        const json = JSON.stringify(step.bodyTemplate, null, 4).replace(
+          /"\\?\$\{([^}]+)\}"/g,
+          (_, v) => `ctx["${v}"]`,
+        );
+        body.push(`    const ${bodyVar} = ${json};`);
+      } else if (step.bodyKind === 'multipart' && step.multipartTemplate) {
+        // Non-createDeployment multipart template
+        const tpl = JSON.stringify(step.multipartTemplate, null, 4).replace(
+          /"\\?\$\{([^}]+)\}"/g,
+          (_, v) => `ctx["${v}"]`,
+        );
+        body.push(`    const ${bodyVar} = ${tpl};`);
       }
-      body.push(`      if (v !== undefined && v !== null) multipart[k] = String(v);`);
-      body.push(`    }`);
-      body.push(`    for (const [k,v] of Object.entries(${bodyVar}.files||{})) {
+      const opts: string[] = [];
+      opts.push('headers: await authHeaders()');
+      if (step.bodyKind === 'json' && step.bodyTemplate) opts.push(`data: ${bodyVar}`);
+      if (step.bodyKind === 'multipart' && step.multipartTemplate) {
+        // Convert template to Playwright's expected multipart shape: a keyed object map.
+        // Field values are stringified (`String(v)`); file values are passed as
+        // `{ name, mimeType, buffer }`. The element type below mirrors the
+        // permissive subset of Playwright's `multipart` option that we actually
+        // emit, so the generated suite typechecks under `strict: true` when
+        // `request.post({ multipart })` is called.
+        body.push(
+          `    const multipart: Record<string, string | { name: string; mimeType: string; buffer: Buffer }> = {};`,
+        );
+        body.push(`    for (const [k,v] of Object.entries(${bodyVar}.fields||{})) {`);
+        // Emit a strip branch for every globalContextSeeds entry whose
+        // sentinel local was declared in the prologue. The emitter never
+        // hard-codes a field name here — the field name is the metadata key
+        // and the local was named after it.
+        for (const [fieldName, local] of sentinelLocals) {
+          body.push(`      if (k === '${fieldName}' && ${local}) continue;`);
+        }
+        body.push(`      if (v !== undefined && v !== null) multipart[k] = String(v);`);
+        body.push(`    }`);
+        body.push(`    for (const [k,v] of Object.entries(${bodyVar}.files||{})) {
         if (typeof v === 'string' && v.startsWith('@@FILE:')) {
           const p = v.slice('@@FILE:'.length);
           const buf = await resolveFixture(p);
@@ -402,28 +451,30 @@ function renderScenarioTest(
           multipart[k] = String(v);
         }
       }`);
-      opts.push('multipart: multipart');
+        opts.push('multipart: multipart');
+      }
+      // (#106) Eventually-consistent reads are wrapped with awaitEventually(),
+      // which retries the same request within a budget until the response is
+      // observably consistent (default predicate for POST .../search:
+      // `body.items.length > 0`; for GET: any 200) and returns the final
+      // APIResponse. Non-EC steps go straight through `request.${method}`.
+      if (awaitStepIndices.has(idx)) {
+        body.push(`    const ${varName} = await awaitEventually(`);
+        body.push(`      async () => request.${method}(url, { ${opts.join(', ')} }),`);
+        body.push(
+          `      { method: '${step.method.toUpperCase()}', operationId: '${step.operationId}' },`,
+        );
+        body.push(`    );`);
+      } else {
+        body.push(`    const ${varName} = await request.${method}(url, { ${opts.join(', ')} });`);
+      }
+      body.push(`    if (${varName}.status() !== ${step.expect.status}) {`);
+      body.push(`      try { console.error('Response body:', await ${varName}.text()); } catch {}`);
+      body.push(`    }`);
+      body.push(`    expect(${varName}.status()).toBe(${step.expect.status});`);
     }
-    // (#106) Eventually-consistent reads are wrapped with awaitEventually(),
-    // which retries the same request within a budget until the response is
-    // observably consistent (default predicate for POST .../search:
-    // `body.items.length > 0`; for GET: any 200) and returns the final
-    // APIResponse. Non-EC steps go straight through `request.${method}`.
-    if (awaitStepIndices.has(idx)) {
-      body.push(`    const ${varName} = await awaitEventually(`);
-      body.push(`      async () => request.${method}(url, { ${opts.join(', ')} }),`);
-      body.push(
-        `      { method: '${step.method.toUpperCase()}', operationId: '${step.operationId}' },`,
-      );
-      body.push(`    );`);
-    } else {
-      body.push(`    const ${varName} = await request.${method}(url, { ${opts.join(', ')} });`);
-    }
-    body.push(`    if (${varName}.status() !== ${step.expect.status}) {`);
-    body.push(`      try { console.error('Response body:', await ${varName}.text()); } catch {}`);
-    body.push(`    }`);
-    body.push(`    expect(${varName}.status()).toBe(${step.expect.status});`);
     // Record observation for this step (best-effort). Only capture response shapes for 200 responses.
+    // For deploy() steps the helper throws on non-200, so __status is always 200 when this block runs.
     if (recordResponses) {
       body.push(`    try {`);
       body.push(`      const __status = ${varName}.status();`);
@@ -465,13 +516,12 @@ function renderScenarioTest(
         `    await validateResponse(${routeSpec}, ${varName}, { responsesFilePath: __responsesFile });`,
       );
     }
-    // Extraction. `extractInto` is the vendored helper from
-    // support/seeding.ts; it skips the assignment when the value is
-    // `undefined` so seeded bindings (e.g. globalContextSeeds entries)
-    // and earlier extracts in the same scenario aren't clobbered by a
-    // later step whose response shape omits the field. See its JSDoc
-    // for the full preserve-on-undefined rationale.
-    if (step.extract?.length) {
+    // Extraction. `extractInto` is the vendored helper from support/seeding.ts;
+    // it skips the assignment when the value is `undefined` so seeded bindings
+    // and earlier extracts in the same scenario aren't clobbered by a later step
+    // whose response shape omits the field. deploy() steps are excluded here
+    // because the helper extracts all known deployment response fields internally.
+    if (!isDeploymentStep && step.extract?.length) {
       body.push(`    const json = await ${varName}.json();`);
       for (const ex of step.extract) {
         const optAcc = toOptionalAccessor(ex.fieldPath);

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -176,7 +176,6 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   // Import vendored helpers from the suite-local ./support/ directory.
   // materializeSupport() copies these files alongside the emitted specs so
   // the generated suite has no dependency on this generator project.
-  lines.push("import { buildBaseUrl, authHeaders } from './support/env';");
   if (recordResponses) {
     lines.push("import { recordResponse, sanitizeBody } from './support/recorder';");
   }

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -385,10 +385,14 @@ function renderScenarioTest(
     // assertion (throws on non-200), and extraction of all known deployment
     // response fields into ctx. This keeps each deployment step as a single
     // declarative call instead of ~35 lines of boilerplate.
+    // Only route 200-expected steps through deploy(): the helper hard-codes a
+    // 200 assertion, so a step with a declared non-200 expected status must
+    // fall through to the normal request path where step.expect.status is honoured.
     const isDeploymentStep =
       step.operationId === 'createDeployment' &&
       step.bodyKind === 'multipart' &&
-      !!step.multipartTemplate;
+      !!step.multipartTemplate &&
+      step.expect.status === 200;
     if (isDeploymentStep && step.multipartTemplate) {
       const tpl = JSON.stringify(step.multipartTemplate, null, 2).replace(
         /"\\?\$\{([^}]+)\}"/g,

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -179,21 +179,13 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   if (recordResponses) {
     lines.push("import { recordResponse, sanitizeBody } from './support/recorder';");
   }
-  // extractInto is only used in non-deployment extract steps; deploy() handles extraction
-  // internally for deployment steps. Gate extractInto to avoid an unused-import error in
-  // suites whose request plan consists entirely of createDeployment multipart steps.
-  const hasNonDeployExtract = collection.scenarios.some((s) =>
-    (s.requestPlan ?? []).some(
-      (step) =>
-        !(
-          step.operationId === 'createDeployment' &&
-          step.bodyKind === 'multipart' &&
-          !!step.multipartTemplate &&
-          step.expect.status === 200
-        ) && (step.extract?.length ?? 0) > 0,
-    ),
+  // extractInto is used in the per-step extract loop which runs for ALL steps (including
+  // deployment steps — see comment at the extract loop below). Gate the import on whether
+  // any step in the collection has extracts, regardless of step type.
+  const hasAnyExtract = collection.scenarios.some((s) =>
+    (s.requestPlan ?? []).some((step) => (step.extract?.length ?? 0) > 0),
   );
-  if (hasNonDeployExtract) {
+  if (hasAnyExtract) {
     lines.push("import { extractInto, seedBinding } from './support/seeding';");
   } else {
     lines.push("import { seedBinding } from './support/seeding';");
@@ -564,9 +556,15 @@ function renderScenarioTest(
     // Extraction. `extractInto` is the vendored helper from support/seeding.ts;
     // it skips the assignment when the value is `undefined` so seeded bindings
     // and earlier extracts in the same scenario aren't clobbered by a later step
-    // whose response shape omits the field. deploy() steps are excluded here
-    // because the helper extracts all known deployment response fields internally.
-    if (!isDeploymentStep && step.extract?.length) {
+    // whose response shape omits the field.
+    // Deployment steps are NOT skipped here: deploy() extracts the known semantic
+    // bindings internally, but the planner's aliasProducerExtractsToPlaceholders
+    // can attach extra extracts (e.g. placeholderAlias bindings for URL vars) to
+    // the same step. deploy() has no knowledge of these aliases, so the emitter
+    // must emit them. Re-emitting the hard-coded deploy() bindings is harmless
+    // because extractInto is a no-op when the response field is undefined, and
+    // overwrites with the same value when it is present.
+    if (step.extract?.length) {
       body.push(`    const json = await ${varName}.json();`);
       for (const ex of step.extract) {
         const optAcc = toOptionalAccessor(ex.fieldPath);

--- a/path-analyser/src/codegen/playwright/materialize-support.ts
+++ b/path-analyser/src/codegen/playwright/materialize-support.ts
@@ -35,6 +35,7 @@ export const SUPPORT_TEMPLATE_FILES = [
   'fixtures.ts',
   'seed-rules.json',
   'await-eventually.ts',
+  'deployment.ts',
 ] as const;
 
 /** Files copied directly into <outDir>/ (project root scaffolding). */

--- a/path-analyser/src/codegen/playwright/materialize-support.ts
+++ b/path-analyser/src/codegen/playwright/materialize-support.ts
@@ -9,7 +9,8 @@
 //
 // Three sets of assets are copied:
 //   * support/ — runtime helpers (env.ts, recorder.ts, seeding.ts,
-//                fixtures.ts, seed-rules.json). Sources:
+//                fixtures.ts, seed-rules.json, await-eventually.ts,
+//                deployment.ts). Sources:
 //                path-analyser/src/codegen/support/, staged into
 //                dist/src/codegen/playwright/support-templates/ at
 //                build time.

--- a/path-analyser/src/codegen/support/deployment.ts
+++ b/path-analyser/src/codegen/support/deployment.ts
@@ -72,8 +72,7 @@ export async function deploy(
   body: DeployBody,
   baseUrl: string,
 ): Promise<ApiResponseLike> {
-  const multipart: Record<string, string | { name: string; mimeType: string; buffer: Buffer }> =
-    {};
+  const multipart: Record<string, string | { name: string; mimeType: string; buffer: Buffer }> = {};
 
   for (const [k, v] of Object.entries(body.fields ?? {})) {
     if (k === 'tenantId' && ctx.tenantIdVar === '<default>') continue;

--- a/path-analyser/src/codegen/support/deployment.ts
+++ b/path-analyser/src/codegen/support/deployment.ts
@@ -131,7 +131,7 @@ export async function deploy(
   extractInto(
     ctx,
     'decisionRequirementsKeyVar',
-    json?.deployments?.[0]?.decisionDefinition?.decisionRequirementsKey,
+    json?.deployments?.[0]?.decisionRequirements?.decisionRequirementsKey,
   );
   extractInto(ctx, 'formIdVar', json?.deployments?.[0]?.form?.formId);
 

--- a/path-analyser/src/codegen/support/deployment.ts
+++ b/path-analyser/src/codegen/support/deployment.ts
@@ -130,8 +130,13 @@ export async function deploy(
   );
   extractInto(
     ctx,
+    'decisionRequirementsIdVar',
+    json?.deployments?.[0]?.decisionDefinition?.decisionRequirementsId,
+  );
+  extractInto(
+    ctx,
     'decisionRequirementsKeyVar',
-    json?.deployments?.[0]?.decisionRequirements?.decisionRequirementsKey,
+    json?.deployments?.[0]?.decisionDefinition?.decisionRequirementsKey,
   );
   extractInto(ctx, 'formIdVar', json?.deployments?.[0]?.form?.formId);
 

--- a/path-analyser/src/codegen/support/deployment.ts
+++ b/path-analyser/src/codegen/support/deployment.ts
@@ -1,0 +1,140 @@
+// Runtime helper for createDeployment multipart calls.
+//
+// Encapsulates the full deployment lifecycle in a single call:
+//   - resolve @@FILE: paths via resolveFixture()
+//   - build the multipart body, stripping tenantId when the default sentinel is active
+//   - POST /deployments with auth headers
+//   - throw a descriptive Error on any non-200 response
+//   - extract all known deployment response fields into ctx
+//   - return the APIResponse so callers can optionally call validateResponse()
+//
+// This file is vendored verbatim into every generated Playwright suite under
+// <outDir>/support/deployment.ts by materializeSupport(). Keep it free of npm
+// package imports — only the co-vendored ./env, ./fixtures, and ./seeding
+// helpers are permitted.
+
+import { authHeaders } from './env.js';
+import { resolveFixture } from './fixtures.js';
+import { extractInto } from './seeding.js';
+
+/**
+ * Structural mirror of Playwright's APIResponse — avoids a Playwright import while
+ * remaining assignable to assert-json-body's PlaywrightAPIResponse parameter.
+ */
+interface ApiResponseLike {
+  body(): Promise<Buffer>;
+  dispose(): Promise<void>;
+  headers(): Record<string, string>;
+  headersArray(): Array<{ name: string; value: string }>;
+  // biome-ignore lint/suspicious/noExplicitAny: mirrors Playwright's actual json() return type
+  json(): Promise<any>;
+  ok(): boolean;
+  status(): number;
+  statusText(): string;
+  text(): Promise<string>;
+  url(): string;
+  [Symbol.asyncDispose](): Promise<void>;
+}
+
+/** Structural subset of Playwright's APIRequestContext — avoids a Playwright import. */
+interface ApiRequestContextLike {
+  post(
+    url: string,
+    options?: {
+      headers?: Record<string, string>;
+      multipart?: Record<string, string | { name: string; mimeType: string; buffer: Buffer }>;
+    },
+  ): Promise<ApiResponseLike>;
+}
+
+/** Multipart body template accepted by deploy(). */
+export interface DeployBody {
+  fields?: Record<string, unknown>;
+  files?: Record<string, string>;
+}
+
+/**
+ * Perform a createDeployment call and extract all known response fields into ctx.
+ *
+ * - Resolves `@@FILE:<path>` entries in `body.files` via resolveFixture().
+ * - Strips the `tenantId` field when `ctx['tenantIdVar'] === '<default>'` so
+ *   single-tenant deployments work without an explicit tenantId param.
+ * - Throws a descriptive Error on any non-200 response (includes the response body
+ *   for diagnosis).
+ * - Extracts all known deployment response fields into ctx; extractInto() is a
+ *   no-op for fields absent from the response, so pre-seeded ctx bindings are
+ *   preserved.
+ * - Returns the APIResponse so callers can optionally call validateResponse().
+ */
+export async function deploy(
+  ctx: Record<string, unknown>,
+  request: ApiRequestContextLike,
+  body: DeployBody,
+  baseUrl: string,
+): Promise<ApiResponseLike> {
+  const multipart: Record<string, string | { name: string; mimeType: string; buffer: Buffer }> =
+    {};
+
+  for (const [k, v] of Object.entries(body.fields ?? {})) {
+    if (k === 'tenantId' && ctx.tenantIdVar === '<default>') continue;
+    if (v !== undefined && v !== null) multipart[k] = String(v);
+  }
+
+  for (const [k, v] of Object.entries(body.files ?? {})) {
+    if (typeof v === 'string' && v.startsWith('@@FILE:')) {
+      const p = v.slice('@@FILE:'.length);
+      const buf = await resolveFixture(p);
+      const name = p.split('/').pop() ?? 'file';
+      multipart[k] = { name, mimeType: 'application/octet-stream', buffer: buf };
+    } else {
+      multipart[k] = String(v);
+    }
+  }
+
+  const resp = await request.post(`${baseUrl}/deployments`, {
+    headers: await authHeaders(),
+    multipart,
+  });
+
+  if (resp.status() !== 200) {
+    const text = await resp.text().catch(() => '(unreadable)');
+    throw new Error(`[createDeployment] expected HTTP 200, got ${resp.status()}: ${text}`);
+  }
+
+  const json = await resp.json();
+
+  // Extract all known deployment response fields. extractInto() skips
+  // undefined values, so fields absent from this response shape leave any
+  // pre-seeded ctx binding untouched.
+  extractInto(
+    ctx,
+    'processDefinitionIdVar',
+    json?.deployments?.[0]?.processDefinition?.processDefinitionId,
+  );
+  extractInto(
+    ctx,
+    'processDefinitionKeyVar',
+    json?.deployments?.[0]?.processDefinition?.processDefinitionKey,
+  );
+  extractInto(ctx, 'formKeyVar', json?.deployments?.[0]?.form?.formKey);
+  extractInto(ctx, 'deploymentKeyVar', json?.deploymentKey);
+  extractInto(ctx, 'tenantIdVar', json?.tenantId);
+  extractInto(
+    ctx,
+    'decisionDefinitionIdVar',
+    json?.deployments?.[0]?.decisionDefinition?.decisionDefinitionId,
+  );
+  extractInto(
+    ctx,
+    'decisionDefinitionKeyVar',
+    json?.deployments?.[0]?.decisionDefinition?.decisionDefinitionKey,
+  );
+  extractInto(
+    ctx,
+    'decisionRequirementsKeyVar',
+    json?.deployments?.[0]?.decisionDefinition?.decisionRequirementsKey,
+  );
+  extractInto(ctx, 'formIdVar', json?.deployments?.[0]?.form?.formId);
+
+  return resp;
+}

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -980,3 +980,123 @@ describe('PlaywrightEmitter — eventual-consistency wrapping (#106)', () => {
     expect(src).toContain("operationId: 'searchProcessInstances'");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Import gating: deploy() vs resolveFixture vs authHeaders
+// ---------------------------------------------------------------------------
+//
+// These tests guard the three conditional import decisions added for the
+// deploy() helper. Each decision has a class-scoped rule:
+//
+//   1. deploy-only suite (all createDeployment multipart steps are status 200)
+//      → imports `deploy` from deployment, NOT resolveFixture, NOT authHeaders
+//      (deploy() handles auth internally; no inline request uses authHeaders)
+//
+//   2. non-200 createDeployment multipart step (falls through to inline path)
+//      → imports resolveFixture (the inline multipart path calls it), NOT deploy
+//
+//   3. mixed suite (200-deployment + non-deployment multipart)
+//      → imports both deploy and resolveFixture
+//
+// Regression risk: a change to the isDeploymentStep condition or import
+// flags that shifts a step between the deploy() path and the inline path
+// can produce a missing import (compile error in the generated suite) or
+// an unused import (Biome noUnusedImports error in the generated suite).
+
+describe('emitter: conditional import gating for deploy() and resolveFixture', () => {
+  function deployOnlyCollection(expectedStatus = 200): EndpointScenarioCollection {
+    return {
+      endpoint: { operationId: 'createDeployment', method: 'POST', path: '/deployments' },
+      requiredSemanticTypes: [],
+      optionalSemanticTypes: [],
+      scenarios: [
+        {
+          id: 'sc1',
+          operations: [{ operationId: 'createDeployment', method: 'POST', path: '/deployments' }],
+          producedSemanticTypes: [],
+          satisfiedSemanticTypes: [],
+          requestPlan: [
+            {
+              operationId: 'createDeployment',
+              method: 'POST',
+              pathTemplate: '/deployments',
+              expect: { status: expectedStatus },
+              bodyKind: 'multipart',
+              multipartTemplate: { fields: {}, files: {} },
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  test('deploy-only suite: imports deploy, not resolveFixture, not authHeaders', () => {
+    const src = renderPlaywrightSuite(deployOnlyCollection(200), {
+      suiteName: 'createDeployment',
+      mode: 'feature',
+      recordResponses: false,
+    });
+    expect(src).toContain("import { deploy } from './support/deployment';");
+    expect(src).not.toContain('resolveFixture');
+    // authHeaders is handled internally by deploy(); suite must not import it
+    expect(src).not.toContain('authHeaders');
+    expect(src).toContain("import { buildBaseUrl } from './support/env';");
+  });
+
+  test('non-200 createDeployment multipart: imports resolveFixture, not deploy', () => {
+    // A non-200 createDeployment step (e.g. request-validation scenario) falls
+    // through to the inline multipart path which calls resolveFixture.
+    const src = renderPlaywrightSuite(deployOnlyCollection(400), {
+      suiteName: 'createDeployment',
+      mode: 'feature',
+      recordResponses: false,
+    });
+    expect(src).not.toContain('import { deploy }');
+    expect(src).toContain("import { resolveFixture } from './support/fixtures';");
+    // Inline path uses authHeaders
+    expect(src).toContain('authHeaders');
+  });
+
+  test('mixed suite (200-deployment + non-deployment multipart): imports both', () => {
+    const src = renderPlaywrightSuite(
+      {
+        endpoint: { operationId: 'createDeployment', method: 'POST', path: '/deployments' },
+        requiredSemanticTypes: [],
+        optionalSemanticTypes: [],
+        scenarios: [
+          {
+            id: 'sc1',
+            operations: [{ operationId: 'createDeployment', method: 'POST', path: '/deployments' }],
+            producedSemanticTypes: [],
+            satisfiedSemanticTypes: [],
+            requestPlan: [
+              // 200 deployment step → deploy()
+              {
+                operationId: 'createDeployment',
+                method: 'POST',
+                pathTemplate: '/deployments',
+                expect: { status: 200 },
+                bodyKind: 'multipart',
+                multipartTemplate: { fields: {}, files: {} },
+              },
+              // non-deployment multipart step → inline + resolveFixture
+              {
+                operationId: 'uploadDocument',
+                method: 'POST',
+                pathTemplate: '/documents',
+                expect: { status: 200 },
+                bodyKind: 'multipart',
+                multipartTemplate: { fields: {}, files: { file: '@@FILE:test.txt' } },
+              },
+            ],
+          },
+        ],
+      },
+      { suiteName: 'createDeployment', mode: 'feature', recordResponses: false },
+    );
+    expect(src).toContain("import { deploy } from './support/deployment';");
+    expect(src).toContain("import { resolveFixture } from './support/fixtures';");
+    // authHeaders is needed for the inline uploadDocument step
+    expect(src).toContain('authHeaders');
+  });
+});

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -1041,8 +1041,7 @@ describe('emitter: conditional import gating for deploy() and resolveFixture', (
     // authHeaders is handled internally by deploy(); suite must not import it
     expect(src).not.toContain('authHeaders');
     expect(src).toContain("import { buildBaseUrl } from './support/env';");
-    // extractInto is only used in non-deploy extract steps; deploy() handles
-    // extraction internally, so a deploy-only suite must not import extractInto
+    // Minimal fixture has no step.extract entries; extractInto is not needed
     expect(src).not.toContain('extractInto');
     expect(src).toContain("import { seedBinding } from './support/seeding';");
   });
@@ -1057,6 +1056,51 @@ describe('emitter: conditional import gating for deploy() and resolveFixture', (
       recordResponses: false,
     });
     expect(src).toContain('expect(resp1.status()).toBe(200)');
+  });
+
+  test('deploy step with placeholder-alias extract: emits extractInto and imports it', () => {
+    // aliasProducerExtractsToPlaceholders can attach a placeholderAlias extract to a
+    // createDeployment step (e.g. bind processDefinitionIdVar from the same fieldPath as
+    // processDefinitionKeyVar when the next step's path uses {processDefinitionId}).
+    // The emitter must emit this extractInto call even for deployment steps; skipping it
+    // leaves the URL placeholder var unset in the generated test.
+    const src = renderPlaywrightSuite(
+      {
+        endpoint: { operationId: 'createDeployment', method: 'POST', path: '/deployments' },
+        requiredSemanticTypes: [],
+        optionalSemanticTypes: [],
+        scenarios: [
+          {
+            id: 'sc1',
+            operations: [{ operationId: 'createDeployment', method: 'POST', path: '/deployments' }],
+            producedSemanticTypes: [],
+            satisfiedSemanticTypes: [],
+            requestPlan: [
+              {
+                operationId: 'createDeployment',
+                method: 'POST',
+                pathTemplate: '/deployments',
+                expect: { status: 200 },
+                bodyKind: 'multipart',
+                multipartTemplate: { fields: {}, files: {} },
+                extract: [
+                  {
+                    fieldPath: 'deployments[0].processDefinition.processDefinitionKey',
+                    bind: 'processDefinitionIdVar',
+                    note: 'placeholderAlias',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      { suiteName: 'createDeployment', mode: 'feature', recordResponses: false },
+    );
+    // The placeholder alias must be emitted even though the step goes through deploy()
+    expect(src).toContain("extractInto(ctx, 'processDefinitionIdVar'");
+    // extractInto must be imported
+    expect(src).toContain("import { extractInto, seedBinding } from './support/seeding';");
   });
 
   test('non-200 createDeployment multipart: imports resolveFixture, not deploy', () => {

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -1041,6 +1041,22 @@ describe('emitter: conditional import gating for deploy() and resolveFixture', (
     // authHeaders is handled internally by deploy(); suite must not import it
     expect(src).not.toContain('authHeaders');
     expect(src).toContain("import { buildBaseUrl } from './support/env';");
+    // extractInto is only used in non-deploy extract steps; deploy() handles
+    // extraction internally, so a deploy-only suite must not import extractInto
+    expect(src).not.toContain('extractInto');
+    expect(src).toContain("import { seedBinding } from './support/seeding';");
+  });
+
+  test('deploy-only suite: emits explicit expect(status).toBe(200) for each deploy step', () => {
+    // The explicit assertion keeps expect from @playwright/test from becoming
+    // unused in suites whose request plan consists entirely of deploy() steps,
+    // and mirrors the status-assertion pattern emitted for inline request steps.
+    const src = renderPlaywrightSuite(deployOnlyCollection(200), {
+      suiteName: 'createDeployment',
+      mode: 'feature',
+      recordResponses: false,
+    });
+    expect(src).toContain('expect(resp1.status()).toBe(200)');
   });
 
   test('non-200 createDeployment multipart: imports resolveFixture, not deploy', () => {

--- a/tests/fixtures/planner/planner-establishes.test.ts
+++ b/tests/fixtures/planner/planner-establishes.test.ts
@@ -737,9 +737,9 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
       // calls. The contract for `producersByType` is "authoritative
       // producers only" — establishers must stay in `establishersByType`.
       const graph = fixtureSimpleEstablisherChain;
-      const beforeUsername = [...(graph.producersByType['Username'] ?? [])];
+      const beforeUsername = [...(graph.producersByType.Username ?? [])];
       generateScenariosForEndpoint(graph, 'getUser', { maxScenarios: 10 });
-      const afterUsername = graph.producersByType['Username'] ?? [];
+      const afterUsername = graph.producersByType.Username ?? [];
       // The establisher (`createUser`) must NOT have leaked into the
       // global producer index for Username.
       expect(afterUsername).toEqual(beforeUsername);

--- a/tests/fixtures/planner/planner-seed-bindings.test.ts
+++ b/tests/fixtures/planner/planner-seed-bindings.test.ts
@@ -48,6 +48,7 @@ describe('computeSeedBindings (#136)', () => {
             pathTemplate: '/v2/users',
             expect: { status: 201 },
             bodyKind: 'json',
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional generator template placeholders, not JS interpolation
             bodyTemplate: { username: '${usernameVar}', password: '${passwordVar}' },
             extract: [{ fieldPath: 'username', bind: 'usernameVar', semantic: 'Username' }],
           },
@@ -80,6 +81,7 @@ describe('computeSeedBindings (#136)', () => {
             pathTemplate: '/v2/users',
             expect: { status: 201 },
             bodyKind: 'json',
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional generator template placeholder, not JS interpolation
             bodyTemplate: { username: '${usernameVar}' },
             extract: [{ fieldPath: 'username', bind: 'usernameVar' }],
           },
@@ -113,6 +115,7 @@ describe('computeSeedBindings (#136)', () => {
             pathTemplate: '/v2/users',
             expect: { status: 201 },
             bodyKind: 'json',
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional generator template placeholders, not JS interpolation
             bodyTemplate: { username: '${usernameVar}', tenantId: '${tenantIdVar}' },
           },
         ],
@@ -154,6 +157,7 @@ describe('computeSeedBindings (#136)', () => {
             pathTemplate: '/v2/documents',
             expect: { status: 201 },
             bodyKind: 'multipart',
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional generator template placeholder, not JS interpolation
             multipartTemplate: { fileName: '${fileNameVar}' },
           },
         ],
@@ -177,6 +181,7 @@ describe('computeSeedBindings (#136)', () => {
             pathTemplate: '/x',
             expect: { status: 201 },
             bodyKind: 'json',
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional generator template placeholders, not JS interpolation
             bodyTemplate: { b: '${bVar}', a: '${aVar}' },
           },
           {
@@ -185,6 +190,7 @@ describe('computeSeedBindings (#136)', () => {
             pathTemplate: '/y',
             expect: { status: 201 },
             bodyKind: 'json',
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional generator template placeholders, not JS interpolation
             bodyTemplate: { c: '${cVar}', a: '${aVar}' },
           },
         ],


### PR DESCRIPTION
Closes #185

## Problem

82 generated `createDeployment` test files each contained ~35 lines of identical multipart machinery:
- `resolveFixture()` calls per file entry
- multipart object construction with `tenantId` sentinel stripping
- `request.post()` call
- HTTP 200 status assertion
- `extractInto()` calls for all 9 known response fields

## Solution

Introduces a `deploy(ctx, request, body, baseUrl)` vendored support helper that encapsulates the full deployment lifecycle in a single call. Each generated test step reduces to:

```ts
const resp1 = await deploy(ctx, request, {
  fields: { name: 'deployment', tenantId: ctx.tenantIdVar },
  files: { resources: '@@FILE:bpmn/service-task.bpmn' },
}, baseUrl);
await validateResponse(/* … */, resp1, { responsesFilePath: __responsesFile });
```

The `deploy()` helper:
- Resolves `@@FILE:` paths via `resolveFixture()`
- Strips `tenantId` when `ctx.tenantIdVar === '<default>'`
- POSTs to `/deployments` with auth headers
- Throws a descriptive `Error` on non-200 (includes response body for diagnosis)
- Extracts all 9 known response fields into `ctx`
- Returns the response for optional `validateResponse()` chaining

`ApiResponseLike` is a full structural mirror of Playwright's `APIResponse` interface, so the return value satisfies `validateResponse()`'s parameter type without importing Playwright in the vendored helper.

## Emitter changes

The emitter now distinguishes `createDeployment` multipart steps (use `deploy()`) from all other multipart steps (keep existing inline machinery). Import guards ensure `resolveFixture` is only imported when a non-deployment multipart step is present, and `deploy` is only imported when a deployment step is present.