### PR TITLE
fix: producerBound semantics receive __PENDING__ not synthetic literals

### DIFF
--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -432,9 +432,17 @@ function renderScenarioTest(
         .split('\n')
         .map((line: string, i: number) => (i === 0 ? line : `    ${line}`))
         .join('\n');
-      body.push(`    const ${varName} = await deploy(ctx, request, ${tplIndented}, baseUrl);`);
+      // Derive strip rules from globalContextSeeds so deploy() has no
+      // hard-coded domain knowledge about sentinel values or field names.
+      const strips = globalContextSeeds
+        .filter((seed) => seed.stripFromMultipartWhenDefault && seed.defaultSentinel !== undefined)
+        .map((seed) => ({ fieldName: seed.fieldName, sentinel: seed.defaultSentinel }));
+      const stripsArg = strips.length > 0 ? `, ${JSON.stringify(strips)}` : '';
+      body.push(
+        `    const ${varName} = await deploy(ctx, request, ${tplIndented}, baseUrl${stripsArg});`,
+      );
       // Explicit status assertion mirrors the normal request path so the
-      // generated suite's assertion pattern is consistent and expect is not unused.
+      // generated suite's assertion pattern is consistent across all steps.
       // deploy() also throws on non-200 with the response body, but the
       // expect() call keeps the declared expectation visible in the test.
       body.push(`    expect(${varName}.status()).toBe(${step.expect.status});`);

--- a/path-analyser/src/codegen/support/deployment.ts
+++ b/path-analyser/src/codegen/support/deployment.ts
@@ -33,6 +33,9 @@ interface ApiResponseLike {
   statusText(): string;
   text(): Promise<string>;
   url(): string;
+  // Required for structural compatibility with Playwright's APIResponse (which includes
+  // [Symbol.asyncDispose] as a required member). ESNext.Disposable must be in
+  // path-analyser/tsconfig.json's lib array for this to compile.
   [Symbol.asyncDispose](): Promise<void>;
 }
 
@@ -57,7 +60,7 @@ export interface DeployBody {
  * Perform a createDeployment call and extract all known response fields into ctx.
  *
  * - Resolves `@@FILE:<path>` entries in `body.files` via resolveFixture().
- * - Strips the `tenantId` field when `ctx['tenantIdVar'] === '<default>'` so
+ * - Strips the `tenantId` field when `ctx.tenantIdVar === '<default>'` so
  *   single-tenant deployments work without an explicit tenantId param.
  * - Throws a descriptive Error on any non-200 response (includes the response body
  *   for diagnosis).

--- a/path-analyser/src/codegen/support/deployment.ts
+++ b/path-analyser/src/codegen/support/deployment.ts
@@ -34,8 +34,9 @@ interface ApiResponseLike {
   text(): Promise<string>;
   url(): string;
   // Required for structural compatibility with Playwright's APIResponse (which includes
-  // [Symbol.asyncDispose] as a required member). ESNext.Disposable must be in
-  // path-analyser/tsconfig.json's lib array for this to compile.
+  // [Symbol.asyncDispose] as a required member). Both path-analyser/tsconfig.json and
+  // the generated suite's tsconfig must include ESNext.Disposable in their lib array
+  // for this to compile.
   [Symbol.asyncDispose](): Promise<void>;
 }
 

--- a/path-analyser/src/codegen/support/deployment.ts
+++ b/path-analyser/src/codegen/support/deployment.ts
@@ -58,11 +58,24 @@ export interface DeployBody {
 }
 
 /**
+ * A strip rule: skip `fieldName` from the multipart body when the field's
+ * resolved value equals `sentinel`. Passed by the emitter via the `strips`
+ * parameter so deploy() has no hard-coded domain knowledge about tenant sentinels
+ * or any other config-specific defaults.
+ */
+export interface DeployStripRule {
+  fieldName: string;
+  sentinel: string;
+}
+
+/**
  * Perform a createDeployment call and extract all known response fields into ctx.
  *
  * - Resolves `@@FILE:<path>` entries in `body.files` via resolveFixture().
- * - Strips the `tenantId` field when `ctx.tenantIdVar === '<default>'` so
- *   single-tenant deployments work without an explicit tenantId param.
+ * - Strips fields whose resolved value equals the corresponding sentinel in `strips`
+ *   (e.g. `{ fieldName: 'tenantId', sentinel: '<default>' }` for single-tenant
+ *   deployments). Strips are derived by the emitter from `globalContextSeeds` so
+ *   no domain-specific knowledge is hard-coded here.
  * - Throws a descriptive Error on any non-200 response (includes the response body
  *   for diagnosis).
  * - Extracts all known deployment response fields into ctx; extractInto() is a
@@ -75,11 +88,12 @@ export async function deploy(
   request: ApiRequestContextLike,
   body: DeployBody,
   baseUrl: string,
+  strips?: DeployStripRule[],
 ): Promise<ApiResponseLike> {
   const multipart: Record<string, string | { name: string; mimeType: string; buffer: Buffer }> = {};
 
   for (const [k, v] of Object.entries(body.fields ?? {})) {
-    if (k === 'tenantId' && ctx.tenantIdVar === '<default>') continue;
+    if (strips?.some((s) => s.fieldName === k && String(v) === s.sentinel)) continue;
     if (v !== undefined && v !== null) multipart[k] = String(v);
   }
 

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -787,14 +787,20 @@ export function generateScenariosForEndpoint(
         bindingsDraft.processDefinitionIdVar1 = 'proc_${RANDOM}';
         modelsDraft = [{ kind: 'bpmn', processDefinitionIdVar: 'processDefinitionIdVar1' }];
       }
-      // Identifier heuristic: assign vars for newly added semantics ending with 'Key'
+      // Identifier heuristic: assign vars for newly added semantics ending with 'Key'.
+      // Only applies to semantics that have no authoritative producer — producerBound
+      // semantics (those with a producer in graph.producersByType) receive __PENDING__
+      // because their value is server-established at runtime via the response.
       const newlyAddedSemantics = [...newProduced].filter((s) => !state.produced.has(s));
       for (const s of newlyAddedSemantics) {
         if (/Key$/.test(s)) {
           const varName = semanticToVarName(s, bindingsDraft);
-          if (!bindingsDraft[varName])
-            bindingsDraft[varName] =
-              `${camelLower(s)}_${deterministicSuffix(`sg:key:${s}:${varName}`)}`;
+          if (!bindingsDraft[varName]) {
+            const isProducerBound = (graph.producersByType[s]?.length ?? 0) > 0;
+            bindingsDraft[varName] = isProducerBound
+              ? '__PENDING__'
+              : `${camelLower(s)}_${deterministicSuffix(`sg:key:${s}:${varName}`)}`;
+          }
         }
       }
       // Issue #104: when the producer is an establisher, mint a fresh
@@ -1554,7 +1560,7 @@ function coverageCount(rule: ArtifactRule, remaining: Set<string>, graph: Operat
 
 function ensureArtifactBindings(
   _rule: ArtifactRule,
-  _graph: OperationGraph,
+  graph: OperationGraph,
   state: State,
   semantics: string[],
   _states: string[],
@@ -1564,9 +1570,16 @@ function ensureArtifactBindings(
   // Semantic-driven bindings naming
   for (const s of semantics) {
     const varName = semanticToVarName(s, state.bindingsDraft);
-    if (!state.bindingsDraft[varName])
-      state.bindingsDraft[varName] =
-        `${camelLower(s)}_${deterministicSuffix(`sg:sem:${s}:${varName}`)}`;
+    if (!state.bindingsDraft[varName]) {
+      // producerBound semantics (those with an authoritative producer) get
+      // __PENDING__ — their value is server-established at runtime via the
+      // producer's response. All other artifact semantics (model-derived,
+      // client-minted) get a deterministic literal for pre-seeding.
+      const isProducerBound = (graph.producersByType[s]?.length ?? 0) > 0;
+      state.bindingsDraft[varName] = isProducerBound
+        ? '__PENDING__'
+        : `${camelLower(s)}_${deterministicSuffix(`sg:sem:${s}:${varName}`)}`;
+    }
     // If BPMN process definition -> ensure BPMN model spec exists
     if (s === 'ProcessDefinitionKey' && !state.modelsDraft.find((m) => m.kind === 'bpmn')) {
       state.modelsDraft.push({ kind: 'bpmn', processDefinitionIdVar: varName });

--- a/path-analyser/templates/tsconfig.json
+++ b/path-analyser/templates/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "lib": ["ES2022", "ESNext.Disposable"],
     "module": "ES2022",
     "moduleResolution": "Bundler",
     "esModuleInterop": true,

--- a/path-analyser/tsconfig.json
+++ b/path-analyser/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "lib": ["ES2022", "ESNext.Disposable"],
     "module": "nodenext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -669,7 +669,10 @@ describe('planner contracts: producerBound semantics must be __PENDING__ in bind
 
   it('class-scoped: no scenario for any endpoint has a synthetic literal for a producerBound Key semantic', () => {
     // Any semantic ending in 'Key' that has an authoritative producer must
-    // have its var set to __PENDING__, not a synthetic `<sem>_<suffix>`.
+    // have ALL its vars (including suffixed allocations like processDefinitionKeyVar2)
+    // set to __PENDING__, not a synthetic `<sem>_<suffix>`.
+    // The pattern ^<base>Var\d*$ catches the primary slot and any overflow
+    // slots that semanticToVarName allocates when the primary is already taken.
     const graph = fixtureProducerBoundBinding;
     const authoritative = Object.keys(graph.producersByType).filter(
       (s) => s.endsWith('Key') && (graph.producersByType[s]?.length ?? 0) > 0,
@@ -677,10 +680,17 @@ describe('planner contracts: producerBound semantics must be __PENDING__ in bind
     const collection = plan(graph, 'searchAuditLogs');
     for (const scenario of collection.scenarios) {
       for (const sem of authoritative) {
-        const varName = `${sem.charAt(0).toLowerCase()}${sem.slice(1)}Var`;
-        const value = scenario.bindings?.[varName];
-        if (value !== undefined) {
-          expect(value, `${varName} should be __PENDING__, not a synthetic literal`).toBe(
+        const baseVarName = `${sem.charAt(0).toLowerCase()}${sem.slice(1)}Var`;
+        const pattern = new RegExp(`^${baseVarName}\\d*$`);
+        const bindings = scenario.bindings ?? {};
+        const matchingKeys = Object.keys(bindings).filter((k) => pattern.test(k));
+        // The primary var must exist (the planner must allocate a slot for it)
+        expect(
+          matchingKeys.length,
+          `expected at least one binding matching ${pattern} for producerBound semantic ${sem}`,
+        ).toBeGreaterThan(0);
+        for (const key of matchingKeys) {
+          expect(bindings[key], `${key} should be __PENDING__, not a synthetic literal`).toBe(
             '__PENDING__',
           );
         }

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -627,6 +627,68 @@ const fixtureNonOverlapVariant: OperationGraph = makeGraph([
   }),
 ]);
 
+// ---------------------------------------------------------------------------
+// Fixture L: producerBound semantics must not receive synthetic literals
+// ---------------------------------------------------------------------------
+//
+// When `createDeployment` is selected as an authoritative producer for
+// `ProcessDefinitionKey`, the planner used to assign a synthetic literal
+// (`processDefinitionKey_<suffix>`) to `bindingsDraft.processDefinitionKeyVar`
+// via the Key heuristic and `ensureArtifactBindings`. This caused the emitter
+// to emit `ctx.processDefinitionKeyVar = 'processDefinitionKey_dadq'` on the
+// line *before* the deployment call that actually establishes the value —
+// the synthetic pre-seed was immediately overwritten at runtime.
+//
+// Class-scoped rule: any semantic that has an authoritative producer in
+// `graph.producersByType` is `producerBound` — its value is server-established
+// at runtime via the producer's response. Its binding must be `'__PENDING__'`
+// in the planned scenario, never a synthetic literal. `__PENDING__` causes
+// the emitter to skip the literal assignment; `deploy()` / `extractInto()`
+// then populate the binding at runtime with the real server-assigned value.
+const fixtureProducerBoundBinding: OperationGraph = makeGraph([
+  makeOp('createDeployment', {
+    produces: ['ProcessDefinitionKey'],
+    providerMap: { ProcessDefinitionKey: true },
+  }),
+  makeOp('searchAuditLogs', {
+    required: ['ProcessDefinitionKey'],
+  }),
+]);
+
+describe('planner contracts: producerBound semantics must be __PENDING__ in bindings', () => {
+  it('ProcessDefinitionKey binding is __PENDING__ when createDeployment is the authoritative producer', () => {
+    // Reproducer: prior to the fix the planner emitted
+    // `processDefinitionKeyVar: 'processDefinitionKey_<suffix>'`.
+    // The emitter then output a redundant literal assignment that was
+    // overwritten by the deployment helper at runtime.
+    const collection = plan(fixtureProducerBoundBinding, 'searchAuditLogs');
+    expect(collection.scenarios.length).toBeGreaterThan(0);
+    const scenario = collection.scenarios[0];
+    expect(scenario.bindings?.processDefinitionKeyVar).toBe('__PENDING__');
+  });
+
+  it('class-scoped: no scenario for any endpoint has a synthetic literal for a producerBound Key semantic', () => {
+    // Any semantic ending in 'Key' that has an authoritative producer must
+    // have its var set to __PENDING__, not a synthetic `<sem>_<suffix>`.
+    const graph = fixtureProducerBoundBinding;
+    const authoritative = Object.keys(graph.producersByType).filter(
+      (s) => s.endsWith('Key') && (graph.producersByType[s]?.length ?? 0) > 0,
+    );
+    const collection = plan(graph, 'searchAuditLogs');
+    for (const scenario of collection.scenarios) {
+      for (const sem of authoritative) {
+        const varName = `${sem.charAt(0).toLowerCase()}${sem.slice(1)}Var`;
+        const value = scenario.bindings?.[varName];
+        if (value !== undefined) {
+          expect(value, `${varName} should be __PENDING__, not a synthetic literal`).toBe(
+            '__PENDING__',
+          );
+        }
+      }
+    }
+  });
+});
+
 describe('planner contracts: variant planner non-overlap producer fallback (#37)', () => {
   it('emits a producer→endpoint variant with no warm-up when the producer needs nothing from the endpoint', () => {
     const variants = generateOptionalSubShapeVariants(fixtureNonOverlapVariant, 'createOrder', {


### PR DESCRIPTION
## Problem

`ensureArtifactBindings()` and the Key heuristic in `scenarioGenerator.ts` both assigned a synthetic literal (e.g. `processDefinitionKey_mn0q`) to `bindings` for semantics like `ProcessDefinitionKey` — even when an authoritative producer exists in `graph.producersByType`.

The concrete symptom: in `searchAuditLogs.variant.spec.ts` variant-2 (bpmn #1), the emitter output:

```ts
ctx.processDefinitionKeyVar = 'processDefinitionKey_dadq';   // ← spurious pre-seed
const deployment = await deploy(request, ctx, body);          // ← overwrites it at runtime
```

The literal was immediately overwritten by `deploy()`'s `extractInto()` call, but the emitter still emitted the redundant assignment — a lint `no-unused-vars`-style signal that something was wrong.

A second side-effect: `semanticToVarName` allocated a fresh `processDefinitionKeyVar2` slot because the first slot was already filled by the spurious literal when the Key heuristic ran.

## Root cause

Both `ensureArtifactBindings` and the Key heuristic lacked a `producerBound` guard. Any semantic that has a live entry in `graph.producersByType` is server-established at runtime — its binding must be `__PENDING__`, not a synthetic pre-seed.

## Fix

- **`ensureArtifactBindings()`** — `isProducerBound` guard: if `graph.producersByType[s]?.length > 0`, assign `'__PENDING__'`; otherwise assign the deterministic literal as before. Renamed `_graph` parameter to `graph`.
- **Key heuristic** (newly-added `*Key` semantics) — same `isProducerBound` guard.

`__PENDING__` causes the emitter (`emitter.ts:298`) to skip the literal assignment; `deploy()` / `extractInto()` then populates the binding at runtime with the real server-assigned value.

## Test

Added **Fixture L** in `tests/fixtures/planner/planner-contracts.test.ts`:

- **Instance-scoped**: `processDefinitionKeyVar` binding is `__PENDING__` when `createDeployment` is the authoritative producer (reproduces the exact defect).
- **Class-scoped**: no `*Key`-suffixed producerBound semantic in any planned scenario gets a synthetic literal value (guards the whole category).

Closes #185 (partial — the `deploy()` helper itself is in #186; this PR fixes the redundant pre-seed that helper revealed).