### PR TITLE
fix: omit sentinel local for deploy-only scenarios

### DIFF
--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -363,18 +363,34 @@ function renderScenarioTest(
   // skip branch below — this is the only place the emitter knows about the
   // sentinel.
   //
+  // The local is only emitted when the scenario has at least one inline
+  // multipart step (i.e. a multipart step that is NOT routed through
+  // deploy()). deploy() steps pass strips as a JSON literal argument and
+  // never read the prologue local; omitting it for deploy-only scenarios
+  // prevents an unused-variable error in the generated suite.
+  //
   // Safety: `binding`, `fieldName`, `seedRule` are all required by the
   // domain-semantics validator (#87) to match `/^[A-Za-z_$][A-Za-z0-9_$]*$/`,
   // and `defaultSentinel` is required to contain no single quotes,
   // backslashes, or line terminators. That lets us interpolate them
   // directly into emitted single-quoted TS string literals without an
   // escape pass.
+  const hasInlineMultipartStep = (s.requestPlan ?? []).some(
+    (step) =>
+      step.bodyKind === 'multipart' &&
+      !!step.multipartTemplate &&
+      !(step.operationId === 'createDeployment' && step.expect.status === 200),
+  );
   const sentinelLocals = new Map<string, string>(); // fieldName -> local var name
   for (const seed of globalContextSeeds) {
     body.push(
       `  ctx['${seed.binding}'] = ctx['${seed.binding}'] ?? seedBinding('${seed.seedRule}');`,
     );
-    if (seed.stripFromMultipartWhenDefault && seed.defaultSentinel !== undefined) {
+    if (
+      hasInlineMultipartStep &&
+      seed.stripFromMultipartWhenDefault &&
+      seed.defaultSentinel !== undefined
+    ) {
       const local = `__${seed.fieldName}IsDefault`;
       sentinelLocals.set(seed.fieldName, local);
       body.push(`  const ${local} = ctx['${seed.binding}'] === '${seed.defaultSentinel}';`);

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -500,6 +500,53 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
     expect(c).not.toMatch(/__tenantIdIsDefault/);
     expect(c).not.toMatch(/&& __\w+IsDefault\) continue;/);
   });
+
+  test('deploy-only scenario: sentinel local not emitted (deploy() receives strips, local is unused)', async () => {
+    // Regression guard: when a scenario's only multipart step is a 200 createDeployment
+    // step (routed through deploy()), the sentinel __<fieldName>IsDefault local must NOT
+    // be emitted. deploy() receives strips as a JSON literal argument; it never reads the
+    // prologue local. Emitting it produces an unused-variable Biome error in the generated
+    // suite.
+    const deployOnlyCollection: EndpointScenarioCollection = {
+      endpoint: { operationId: 'createDeployment', method: 'POST', path: '/deployments' },
+      requiredSemanticTypes: [],
+      optionalSemanticTypes: [],
+      scenarios: [
+        {
+          id: 'sc1',
+          name: 'deploy case',
+          operations: [{ operationId: 'createDeployment', method: 'POST', path: '/deployments' }],
+          producedSemanticTypes: [],
+          satisfiedSemanticTypes: [],
+          requestPlan: [
+            {
+              operationId: 'createDeployment',
+              method: 'POST',
+              pathTemplate: '/deployments',
+              expect: { status: 200 },
+              bodyKind: 'multipart',
+              multipartTemplate: {
+                fields: { tenantId: '${' + 'tenantIdVar}' },
+                files: {},
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const [file] = await PlaywrightEmitter.emit(deployOnlyCollection, {
+      outDir: '/unused',
+      suiteName: 'createDeployment',
+      mode: 'feature',
+      globalContextSeeds: [TENANT_SEED],
+    });
+    const c = file.content;
+    // Seed assignment still emitted (always needed)
+    expect(c).toContain(`ctx['tenantIdVar'] = ctx['tenantIdVar'] ?? seedBinding('tenantIdVar');`);
+    // Sentinel local must NOT be emitted — no inline multipart step uses it
+    expect(c).not.toMatch(/__tenantIdIsDefault/);
+    expect(c).not.toMatch(/&& __\w+IsDefault\) continue;/);
+  });
 });
 
 // Boundary safety guards (#87 review): the public emitter entry points


### PR DESCRIPTION
## Problem

The `__<fieldName>IsDefault` sentinel local was unconditionally emitted in every scenario prologue that had a `globalContextSeed` with `stripFromMultipartWhenDefault: true`.

For example, `searchAuditLogs.variant.spec.ts` emitted:
```ts
const __tenantIdIsDefault = ctx.tenantIdVar === '<default>';
```

The local is only consumed in the inline multipart strip branch (non-deploy multipart steps). In deploy-only scenarios, all multipart steps are handled by `deploy()` which receives strips as a JSON literal argument — the prologue local is never read. This causes a Biome `noUnusedVariables` error in generated suites.

## Fix

Gate sentinel local emission on `hasInlineMultipartStep` — only emit when the scenario has at least one non-deploy multipart step in its request plan.

## Regression test

Added test: deploy-only scenario with `TENANT_SEED` must **not** emit `__tenantIdIsDefault` in the scenario prologue.

Closes #188