### PR TITLE
fix: mix per-spec-file salt into PRNG seed to prevent cross-worker id collisions

### DIFF
--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -240,7 +240,7 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
     lines.push("import { awaitEventually } from './support/await-eventually';");
   }
   lines.push('');
-  lines.push(`initSpecSalt('${suiteName}');`);
+  lines.push(`initSpecSalt(${JSON.stringify(suiteName)});`);
   if (needsValidation) {
     // Resolve responses.json relative to this spec file so the suite is
     // portable regardless of the working directory the test runner uses.

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -186,9 +186,9 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
     (s.requestPlan ?? []).some((step) => (step.extract?.length ?? 0) > 0),
   );
   if (hasAnyExtract) {
-    lines.push("import { extractInto, seedBinding } from './support/seeding';");
+    lines.push("import { extractInto, seedBinding, initSpecSalt } from './support/seeding';");
   } else {
-    lines.push("import { seedBinding } from './support/seeding';");
+    lines.push("import { seedBinding, initSpecSalt } from './support/seeding';");
   }
   // deploy() is emitted for 200-expected createDeployment multipart steps; resolveFixture
   // is emitted for any step that falls through to the inline multipart path — this includes
@@ -240,14 +240,16 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
     lines.push("import { awaitEventually } from './support/await-eventually';");
   }
   lines.push('');
+  lines.push(`initSpecSalt('${suiteName}');`);
   if (needsValidation) {
     // Resolve responses.json relative to this spec file so the suite is
     // portable regardless of the working directory the test runner uses.
+    lines.push('');
     lines.push(
       "const __responsesFile = import.meta.dirname + '/json-body-assertions/responses.json';",
     );
-    lines.push('');
   }
+  lines.push('');
   lines.push(`test.describe('${suiteName}', () => {`);
   const seeds = opts.globalContextSeeds ?? [];
   for (const scenario of collection.scenarios) {

--- a/path-analyser/src/codegen/support/seeding.ts
+++ b/path-analyser/src/codegen/support/seeding.ts
@@ -69,16 +69,16 @@ function resolveSeed(): { seed: string; random: boolean } {
   return { seed: raw && raw.length > 0 ? raw : DEFAULT_SEED, random: false };
 }
 
-// Per-spec-file salt injected by the generated spec file via initSpecSalt().
-// Mixing the spec filename into the seed prevents cross-worker id collisions
+// Per-suite salt injected by the generated spec file via initSpecSalt().
+// Mixing the suite name (operationId) into the seed prevents cross-worker id collisions
 // when Playwright runs multiple spec files in parallel: each worker re-seeds
-// from the same TEST_SEED, so without a per-file discriminator the first
+// from the same TEST_SEED, so without a per-suite discriminator the first
 // seedBinding() call in every worker returns the same value (#175).
 let _specSalt = '';
 let _globalEnv: SeedEnv | undefined;
 
 /**
- * Set the per-spec-file salt before the first seedBinding() call.
+ * Set the per-suite salt before the first seedBinding() call.
  *
  * Generated spec files call this at module level (before test.describe) so
  * each Playwright worker process draws from a distinct PRNG sequence even
@@ -109,11 +109,7 @@ function buildGlobalEnv(): SeedEnv {
   }
   const rand = random ? Math.random : mulberry32(seedNum >>> 0);
   const counters = new Map<string, number>();
-  const runId = random
-    ? `rt-${Date.now().toString(36)}`
-    : _specSalt
-      ? `det-${seedStr}-${_specSalt}`
-      : `det-${seedStr}`;
+  const runId = random ? `rt-${Date.now().toString(36)}` : `det-${seedStr}`;
   return {
     random: () => rand().toString(36).slice(2),
     counter: (bucket = 'default') => {

--- a/path-analyser/src/codegen/support/seeding.ts
+++ b/path-analyser/src/codegen/support/seeding.ts
@@ -69,30 +69,67 @@ function resolveSeed(): { seed: string; random: boolean } {
   return { seed: raw && raw.length > 0 ? raw : DEFAULT_SEED, random: false };
 }
 
-const globalEnv: SeedEnv = (() => {
+// Per-spec-file salt injected by the generated spec file via initSpecSalt().
+// Mixing the spec filename into the seed prevents cross-worker id collisions
+// when Playwright runs multiple spec files in parallel: each worker re-seeds
+// from the same TEST_SEED, so without a per-file discriminator the first
+// seedBinding() call in every worker returns the same value (#175).
+let _specSalt = '';
+let _globalEnv: SeedEnv | undefined;
+
+/**
+ * Set the per-spec-file salt before the first seedBinding() call.
+ *
+ * Generated spec files call this at module level (before test.describe) so
+ * each Playwright worker process draws from a distinct PRNG sequence even
+ * though all workers share the same TEST_SEED. The salt is the suite name
+ * (operationId), which is stable across regenerations.
+ *
+ * Calling this function resets the PRNG state so the new salt takes effect
+ * from the next seedBinding() call onward. It must not be called after
+ * seedBinding() has already been called in the same process.
+ */
+export function initSpecSalt(salt: string): void {
+  _specSalt = salt;
+  _globalEnv = undefined; // reset so next seedBinding() picks up the new salt
+}
+
+function buildGlobalEnv(): SeedEnv {
   const { seed: seedStr, random } = resolveSeed();
   let seedNum = 0;
   if (random) {
     seedNum = Date.now() ^ (Math.random() * 0xffffffff);
   } else {
-    // hash string to 32-bit int
+    // Hash TEST_SEED string to 32-bit int.
     for (let i = 0; i < seedStr.length; i++)
       seedNum = (Math.imul(31, seedNum) + seedStr.charCodeAt(i)) | 0;
+    // Mix in the per-spec-file salt so parallel workers draw different sequences.
+    for (let i = 0; i < _specSalt.length; i++)
+      seedNum = (Math.imul(31, seedNum) + _specSalt.charCodeAt(i)) | 0;
   }
   const rand = random ? Math.random : mulberry32(seedNum >>> 0);
   const counters = new Map<string, number>();
-  const env: SeedEnv = {
+  const runId = random
+    ? `rt-${Date.now().toString(36)}`
+    : _specSalt
+      ? `det-${seedStr}-${_specSalt}`
+      : `det-${seedStr}`;
+  return {
     random: () => rand().toString(36).slice(2),
     counter: (bucket = 'default') => {
       const v = (counters.get(bucket) || 0) + 1;
       counters.set(bucket, v);
       return v;
     },
-    runId: random ? `rt-${Date.now().toString(36)}` : `det-${seedStr}`,
+    runId,
     deterministic: !random,
   };
-  return env;
-})();
+}
+
+function getGlobalEnv(): SeedEnv {
+  if (!_globalEnv) _globalEnv = buildGlobalEnv();
+  return _globalEnv;
+}
 
 /**
  * Short suffix for test fixture identifiers (e.g. `tenantId_5l5k`).
@@ -205,12 +242,13 @@ function expandTemplate(tpl: string, varName: string, env: SeedEnv): string {
 
 export function seedBinding(varName: string, _opts?: SeedOptions): string {
   loadRules();
+  const env = getGlobalEnv();
   for (const r of rules) {
     const m = r.match instanceof RegExp ? r.match.test(varName) : r.match(varName);
-    if (m) return r.gen(varName, globalEnv);
+    if (m) return r.gen(varName, env);
   }
   // Should never reach here due to fallback rule
-  return `${varName}-${globalEnv.random().slice(0, 6)}`;
+  return `${varName}-${env.random().slice(0, 6)}`;
 }
 
 export function debugSeed(varName: string): string {

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -1182,7 +1182,7 @@ describe('emitter: initSpecSalt emission (#175)', () => {
       mode: 'feature',
       recordResponses: false,
     });
-    expect(src).toContain("initSpecSalt('createWidget');");
+    expect(src).toContain('initSpecSalt("createWidget");');
   });
 
   test('different suite names produce different initSpecSalt calls', () => {
@@ -1196,10 +1196,10 @@ describe('emitter: initSpecSalt emission (#175)', () => {
       mode: 'feature',
       recordResponses: false,
     });
-    expect(src1).toContain("initSpecSalt('createRole');");
-    expect(src2).toContain("initSpecSalt('assignRoleToClient');");
-    expect(src1).not.toContain("initSpecSalt('assignRoleToClient');");
-    expect(src2).not.toContain("initSpecSalt('createRole');");
+    expect(src1).toContain('initSpecSalt("createRole");');
+    expect(src2).toContain('initSpecSalt("assignRoleToClient");');
+    expect(src1).not.toContain('initSpecSalt("assignRoleToClient");');
+    expect(src2).not.toContain('initSpecSalt("createRole");');
   });
 
   test('initSpecSalt call appears before test.describe', () => {
@@ -1208,7 +1208,7 @@ describe('emitter: initSpecSalt emission (#175)', () => {
       mode: 'feature',
       recordResponses: false,
     });
-    const saltPos = src.indexOf("initSpecSalt('createWidget');");
+    const saltPos = src.indexOf('initSpecSalt("createWidget");');
     const describePos = src.indexOf("test.describe('createWidget'");
     expect(saltPos).toBeGreaterThan(-1);
     expect(describePos).toBeGreaterThan(-1);

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -321,7 +321,9 @@ describe('emitter: extractInto helper for response extraction (#84)', () => {
     const content = await renderFirst(
       buildCollectionWithExtracts([{ fieldPath: 'widgetKey', bind: 'widgetKeyVar' }]),
     );
-    expect(content).toContain("import { extractInto, seedBinding } from './support/seeding';");
+    expect(content).toContain(
+      "import { extractInto, seedBinding, initSpecSalt } from './support/seeding';",
+    );
   });
 
   test('emits exactly one extractInto(ctx, ...) call per extract entry', async () => {
@@ -1043,7 +1045,7 @@ describe('emitter: conditional import gating for deploy() and resolveFixture', (
     expect(src).toContain("import { buildBaseUrl } from './support/env';");
     // Minimal fixture has no step.extract entries; extractInto is not needed
     expect(src).not.toContain('extractInto');
-    expect(src).toContain("import { seedBinding } from './support/seeding';");
+    expect(src).toContain("import { seedBinding, initSpecSalt } from './support/seeding';");
   });
 
   test('deploy-only suite: emits explicit expect(status).toBe(200) for each deploy step', () => {
@@ -1100,7 +1102,9 @@ describe('emitter: conditional import gating for deploy() and resolveFixture', (
     // The placeholder alias must be emitted even though the step goes through deploy()
     expect(src).toContain("extractInto(ctx, 'processDefinitionIdVar'");
     // extractInto must be imported
-    expect(src).toContain("import { extractInto, seedBinding } from './support/seeding';");
+    expect(src).toContain(
+      "import { extractInto, seedBinding, initSpecSalt } from './support/seeding';",
+    );
   });
 
   test('non-200 createDeployment multipart: imports resolveFixture, not deploy', () => {
@@ -1158,5 +1162,56 @@ describe('emitter: conditional import gating for deploy() and resolveFixture', (
     expect(src).toContain("import { resolveFixture } from './support/fixtures';");
     // authHeaders is needed for the inline uploadDocument step
     expect(src).toContain('authHeaders');
+  });
+});
+
+// #175 — per-spec-file initSpecSalt emission
+describe('emitter: initSpecSalt emission (#175)', () => {
+  test('emitted suite imports initSpecSalt from the seeding module', () => {
+    const src = renderPlaywrightSuite(COLLECTION, {
+      suiteName: 'createWidget',
+      mode: 'feature',
+      recordResponses: false,
+    });
+    expect(src).toContain("import { seedBinding, initSpecSalt } from './support/seeding';");
+  });
+
+  test('emitted suite calls initSpecSalt with the suite name', () => {
+    const src = renderPlaywrightSuite(COLLECTION, {
+      suiteName: 'createWidget',
+      mode: 'feature',
+      recordResponses: false,
+    });
+    expect(src).toContain("initSpecSalt('createWidget');");
+  });
+
+  test('different suite names produce different initSpecSalt calls', () => {
+    const src1 = renderPlaywrightSuite(COLLECTION, {
+      suiteName: 'createRole',
+      mode: 'feature',
+      recordResponses: false,
+    });
+    const src2 = renderPlaywrightSuite(COLLECTION, {
+      suiteName: 'assignRoleToClient',
+      mode: 'feature',
+      recordResponses: false,
+    });
+    expect(src1).toContain("initSpecSalt('createRole');");
+    expect(src2).toContain("initSpecSalt('assignRoleToClient');");
+    expect(src1).not.toContain("initSpecSalt('assignRoleToClient');");
+    expect(src2).not.toContain("initSpecSalt('createRole');");
+  });
+
+  test('initSpecSalt call appears before test.describe', () => {
+    const src = renderPlaywrightSuite(COLLECTION, {
+      suiteName: 'createWidget',
+      mode: 'feature',
+      recordResponses: false,
+    });
+    const saltPos = src.indexOf("initSpecSalt('createWidget');");
+    const describePos = src.indexOf("test.describe('createWidget'");
+    expect(saltPos).toBeGreaterThan(-1);
+    expect(describePos).toBeGreaterThan(-1);
+    expect(saltPos).toBeLessThan(describePos);
   });
 });

--- a/tests/codegen/seeding.test.ts
+++ b/tests/codegen/seeding.test.ts
@@ -1,0 +1,45 @@
+// Tests for path-analyser/src/codegen/support/seeding.ts
+// Focus: per-spec-file salt (#175) — cross-worker id collision prevention.
+import { afterEach, describe, expect, test } from 'vitest';
+import { initSpecSalt, seedBinding } from '../../path-analyser/src/codegen/support/seeding.ts';
+
+describe('seeding: per-spec-file salt (#175)', () => {
+  afterEach(() => {
+    // Reset to no salt so other tests in this file start from a clean state.
+    initSpecSalt('');
+  });
+
+  test('same seedBinding key with different spec salts produces different values', () => {
+    initSpecSalt('specA');
+    const valA = seedBinding('roleIdVar');
+    initSpecSalt('specB');
+    const valB = seedBinding('roleIdVar');
+    expect(valA).not.toBe(valB);
+  });
+
+  test('same spec salt produces the same first value (deterministic)', () => {
+    initSpecSalt('createRole');
+    const val1 = seedBinding('roleIdVar');
+    initSpecSalt('createRole');
+    const val2 = seedBinding('roleIdVar');
+    expect(val1).toBe(val2);
+  });
+
+  test('all parallel-spec collisions avoided: N distinct salts produce N distinct first values', () => {
+    const specs = [
+      'createRole',
+      'assignRoleToClient',
+      'searchMappingRulesForRole',
+      'createGroup',
+      'createTenant',
+      'createUser',
+      'createClusterVariable',
+    ];
+    const values = specs.map((salt) => {
+      initSpecSalt(salt);
+      return seedBinding('roleIdVar');
+    });
+    const unique = new Set(values);
+    expect(unique.size).toBe(specs.length);
+  });
+});


### PR DESCRIPTION
## Problem (#175)

When Playwright runs multiple spec files in parallel, each file executes in its own worker process. `seeding.ts` initialises its PRNG (`mulberry32`) from `TEST_SEED` at **module load time**. As a result, the first `seedBinding('roleIdVar')` call in every worker returns the same value (e.g. `roleIdVar-n5oy8s` under `snapshot-baseline`). This caused **81–141 `ALREADY_EXISTS` (409)** errors when running the suite against a live broker:

```
Expected to create role with ID 'roleIdVar-n5oy8s', but a role with this ID already exists
Expected to create group with ID 'groupIdVar-...', but a group with this ID already exists
...
```

Verified with:
```bash
TEST_SEED=snapshot-baseline npx tsx -e "import { seedBinding } from './path-analyser/src/codegen/support/seeding'; console.log(seedBinding('roleIdVar'))"
# → roleIdVar-n5oy8s (same in every fresh process)
```

## Fix

Add `initSpecSalt(salt: string)` to `seeding.ts` and call it at module level in each generated spec file (before `test.describe`) with the **suite name (operationId)** as the salt.

The salt is mixed into the PRNG seed so each worker draws from a distinct sequence:

```ts
// createRole.feature.spec.ts
import { seedBinding, initSpecSalt } from './support/seeding';
initSpecSalt('createRole');
// → first seedBinding('roleIdVar') → unique value

// assignRoleToClient.feature.spec.ts
import { seedBinding, initSpecSalt } from './support/seeding';
initSpecSalt('assignRoleToClient');
// → first seedBinding('roleIdVar') → different unique value
```

Callers that don't call `initSpecSalt` (test harness, non-generated code) fall back to the original behaviour (salt = `''`), maintaining full backward compatibility with snapshot tests.

## Changes

- **`seeding.ts`**: replace module-level `globalEnv` IIFE with a lazy `buildGlobalEnv()` / `getGlobalEnv()` pair; add exported `initSpecSalt()` and module-level `_specSalt` state; mix `_specSalt` into `seedNum` and `runId`
- **`emitter.ts`**: import `initSpecSalt` in generated spec files; emit `initSpecSalt('<suiteName>');` before `test.describe`
- **`tests/codegen/seeding.test.ts`** (new): verifies distinct first values per spec salt, determinism per salt, and N-spec all-distinct coverage
- **`tests/codegen/playwright-emitter.test.ts`**: update import string assertions; add 4 `initSpecSalt` emission tests (import present, call present, per-suite variation, call precedes `test.describe`)

Closes #175