### PR TITLE
fix: auto-derive request body variable bindings from requestBodySemanticTypes

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -3379,8 +3379,8 @@ describeForThisConfig(
         // `requestBodySemanticTypes` instead of emitting a seeded placeholder
         // named after the raw field leaf (e.g. `targetProcessDefinitionKeyVar`).
         //
-        // Class-scoped: for every edge in the graph that wires a *provider:true*
-        // response producer into a request body consumer (non-filter path), the
+        // Class-scoped: for every request-body consumer edge in the graph that
+        // wires a *provider:true* response producer (non-filter path), the
         // emitted feature spec for that consumer operation must NOT contain a
         // `seedBinding` call for the field-leaf-name-derived var.  Presence of
         // such a seeded call means the auto-derivation regressed and the field
@@ -3388,6 +3388,9 @@ describeForThisConfig(
         //
         // Edges from client-minted (establisher) or provider:false response
         // fields are excluded because those semantics are intentionally seeded.
+        //
+        // Parameter edges (path.*, query.*, header.*, cookie.*) are excluded —
+        // they are not request body fields and are wired via path/query helpers.
         //
         // Filter-prefixed paths (filter.* / filter[) are excluded because they
         // are deferred to #168 (clientMintedAttribute setter-chain reuse).
@@ -3406,9 +3409,18 @@ describeForThisConfig(
 
         // Index edges by consumer: targetOperationId → set of field leaf names
         // that should NOT appear as seeded vars in the feature spec.
+        // Only request-body consumer edges are relevant; skip parameter edges
+        // (path.*, query.*, header.*, cookie.*) which are not request body fields.
         const shouldNotSeedByOp = new Map<string, { fieldLeaf: string; semanticType: string }[]>();
         for (const edge of graph.edges) {
           const fp = edge.targetFieldPath;
+          if (
+            fp.startsWith('path.') ||
+            fp.startsWith('query.') ||
+            fp.startsWith('header.') ||
+            fp.startsWith('cookie.')
+          )
+            continue;
           if (fp.startsWith('filter.') || fp.startsWith('filter[')) continue;
           if (!providerTrueSemantics.has(edge.semanticType)) continue;
           const leaf = fp

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -68,8 +68,16 @@ interface OperationNode {
   requestBodySemanticTypes?: SemanticTypeEntry[];
   responseSemanticTypes?: Record<string, SemanticTypeEntry[]>;
 }
+interface GraphEdge {
+  sourceOperationId: string;
+  targetOperationId: string;
+  semanticType: string;
+  sourceFieldPath: string;
+  targetFieldPath: string;
+}
 interface DependencyGraph {
   operations: OperationNode[];
+  edges: GraphEdge[];
 }
 interface ScenarioFile {
   endpoint: { operationId: string };
@@ -3358,6 +3366,85 @@ describeForThisConfig(
         'Variant suite is missing scenarios for flat top-level optionals. Per #162 PR 4, the variant planner must absorb every populated-optional scenario the feature suite previously emitted as `opt=*`.',
       ).toEqual([]);
     });
+  },
+);
+
+describeForThisConfig(
+  'bundled-spec invariants: semantic body binding auto-derivation (#174)',
+  () => {
+    it(
+      'feature specs do not seed field-name vars for request body fields whose semantic type has a graph-level provider:true producer (#174)',
+      () => {
+        // Guard for the fix that auto-derives `ctx.${semanticType}Var` from
+        // `requestBodySemanticTypes` instead of emitting a seeded placeholder
+        // named after the raw field leaf (e.g. `targetProcessDefinitionKeyVar`).
+        //
+        // Class-scoped: for every edge in the graph that wires a *provider:true*
+        // response producer into a request body consumer (non-filter path), the
+        // emitted feature spec for that consumer operation must NOT contain a
+        // `seedBinding` call for the field-leaf-name-derived var.  Presence of
+        // such a seeded call means the auto-derivation regressed and the field
+        // is no longer wired to the semantic producer.
+        //
+        // Edges from client-minted (establisher) or provider:false response
+        // fields are excluded because those semantics are intentionally seeded.
+        //
+        // Filter-prefixed paths (filter.* / filter[) are excluded because they
+        // are deferred to #168 (clientMintedAttribute setter-chain reuse).
+        const graph = loadGraph();
+
+        // Build the set of semantic types with at least one provider:true response producer.
+        // Only response fields with `provider: true` flow into producersByType (graphLoader #97/#98).
+        const providerTrueSemantics = new Set<string>();
+        for (const op of graph.operations) {
+          for (const arr of Object.values(op.responseSemanticTypes ?? {})) {
+            for (const e of arr) {
+              if (e.provider) providerTrueSemantics.add(e.semanticType);
+            }
+          }
+        }
+
+        // Index edges by consumer: targetOperationId → set of field leaf names
+        // that should NOT appear as seeded vars in the feature spec.
+        const shouldNotSeedByOp = new Map<string, { fieldLeaf: string; semanticType: string }[]>();
+        for (const edge of graph.edges) {
+          const fp = edge.targetFieldPath;
+          if (fp.startsWith('filter.') || fp.startsWith('filter[')) continue;
+          if (!providerTrueSemantics.has(edge.semanticType)) continue;
+          const leaf = fp
+            .split('.')
+            .pop()
+            ?.replace(/\[\]$/, '')
+            ?.replace(/\[.*\]$/, '');
+          if (!leaf) continue;
+          const leafVar = `${leaf[0].toLowerCase()}${leaf.slice(1)}Var`;
+          const semanticVar = `${edge.semanticType[0].toLowerCase()}${edge.semanticType.slice(1)}Var`;
+          // Only flag cases where the field-leaf var name differs from the semantic var name;
+          // if they happen to be the same the seeded call is ambiguous either way.
+          if (leafVar === semanticVar) continue;
+          const entries = shouldNotSeedByOp.get(edge.targetOperationId) ?? [];
+          entries.push({ fieldLeaf: leafVar, semanticType: semanticVar });
+          shouldNotSeedByOp.set(edge.targetOperationId, entries);
+        }
+
+        const offenders: { spec: string; seededVar: string; expectedVar: string }[] = [];
+        for (const [opId, fields] of shouldNotSeedByOp.entries()) {
+          const specPath = join(GENERATED_TESTS_DIR, `${opId}.feature.spec.ts`);
+          if (!existsSync(specPath)) continue;
+          const src = readFileSync(specPath, 'utf8');
+          for (const { fieldLeaf, semanticType } of fields) {
+            if (src.includes(`seedBinding('${fieldLeaf}')`)) {
+              offenders.push({ spec: `${opId}.feature.spec.ts`, seededVar: fieldLeaf, expectedVar: semanticType });
+            }
+          }
+        }
+
+        expect(
+          offenders,
+          'Feature spec seeds a field-name var for a request body field whose semantic type has a provider:true graph-level producer. The auto-derivation from requestBodySemanticTypes must wire these to the semantic var (ctx.${semanticType}Var) instead of seeding a placeholder.',
+        ).toEqual([]);
+      },
+    );
   },
 );
 

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1191,7 +1191,7 @@ function buildRequestBodyFromCanonical(
     }
   }
   // Auto-derive semantic-type bindings from requestBodySemantics for consumer fields whose
-  // semantic type has a chain producer in this scenario. This avoids the need to manually
+  // semantic type has a graph-level response producer. This avoids the need to manually
   // duplicate x-semantic-type information in domain-semantics.json valueBindings entries.
   // Filter paths are excluded — those are deferred to issue #168 (setter-chain reuse).
   const semanticFallback: Record<string, string> = {};

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1190,6 +1190,21 @@ function buildRequestBodyFromCanonical(
       }
     }
   }
+  // Auto-derive semantic-type bindings from requestBodySemantics for consumer fields whose
+  // semantic type has a chain producer in this scenario. This avoids the need to manually
+  // duplicate x-semantic-type information in domain-semantics.json valueBindings entries.
+  // Filter paths are excluded — those are deferred to issue #168 (setter-chain reuse).
+  const semanticFallback: Record<string, string> = {};
+  for (const entry of graph.operations[opId]?.requestBodySemantics ?? []) {
+    if (entry.fieldPath.startsWith('filter.') || entry.fieldPath.startsWith('filter[')) continue;
+    if (bindingMap[entry.fieldPath]) continue;
+    // Only auto-derive when the graph has a response-producer for this semantic type.
+    // This excludes clientMintedAttribute semantics (Tag, BusinessId) which have no
+    // graph-level response producer and are handled separately by bindClientMintedAttribute.
+    if (!graph.producersByType[entry.semantic]?.length) continue;
+    semanticFallback[entry.fieldPath] = camelCase(entry.semantic);
+  }
+
   // If JSON and oneOf groups exist, figure out which fields are allowed
   const requestGroups = requestGroupsIndex?.[opId] || [];
   // Load request defaults (operation-level overrides global)
@@ -1236,8 +1251,9 @@ function buildRequestBodyFromCanonical(
             template[name] = viaProvider;
             continue;
           }
-          const varName = `${camelCase(bindingMap[mappedName] || name || 'value')}Var`;
-          const hasBinding = !!bindingMap[mappedName];
+          const semanticParam = semanticFallback[mappedName];
+          const varName = `${camelCase(bindingMap[mappedName] || semanticParam || name || 'value')}Var`;
+          const hasBinding = !!(bindingMap[mappedName] || semanticParam);
           if (hasBinding) {
             scenario.bindings ||= {};
             if (!scenario.bindings[varName]) scenario.bindings[varName] = '__PENDING__';
@@ -1265,11 +1281,12 @@ function buildRequestBodyFromCanonical(
         // Special-case: support mapping jobType -> type
         const hasJobType = !!bindingMap.jobType;
         const mapJobTypeToType = leaf === 'type' && !bindingMap[f.path] && hasJobType;
+        const semanticParam = semanticFallback[f.path];
         const mappedParamName = mapJobTypeToType
           ? 'jobType'
-          : bindingMap[f.path] || leaf || 'value';
+          : bindingMap[f.path] || semanticParam || leaf || 'value';
         const varName = `${camelCase(mappedParamName)}Var`;
-        const hasBinding = mapJobTypeToType ? true : !!bindingMap[f.path];
+        const hasBinding = mapJobTypeToType ? true : !!(bindingMap[f.path] || semanticParam);
         if (hasBinding) {
           scenario.bindings ||= {};
           if (!scenario.bindings[varName]) scenario.bindings[varName] = '__PENDING__';


### PR DESCRIPTION
## Problem

When building the request body template, the planner used only manual `valueBindings` entries from `domain-semantics.json`. If no manual entry was present, the field-leaf name was used verbatim:

```ts
// Before: targetProcessDefinitionKey emitted a seeded placeholder
ctx.targetProcessDefinitionKeyVar = seedBinding('targetProcessDefinitionKeyVar');
```

This affected any consumer field whose semantic type had a graph-level producer but no manual `valueBindings` entry — pagination cursors (`page.after` → `EndCursor`), element IDs (`sourceElementId`/`targetElementId`), migration targets, etc.

## Fix

Adds a `semanticFallback` map in `buildRequestBodyFromCanonical` derived from the operation's `requestBodySemantics` (already extracted by graphLoader). For each non-filter consumer field whose semantic type has at least one `provider:true` response producer in `graph.producersByType`, the fallback maps `fieldPath → camelCase(semanticType)`.

```ts
// After: targetProcessDefinitionKey wired to the chain-produced var
targetProcessDefinitionKey: ctx.processDefinitionKeyVar,
```

Manual `bindingMap` entries take precedence. Filter-prefixed paths are excluded (deferred to #168).

The guard uses `graph.producersByType[entry.semantic]?.length` rather than `scenario.productionMap?.[entry.semantic]` because feature scenarios (`.feature.spec.ts`) do not have `productionMap` set — it is `undefined` on `FeatureScenario` objects.

## Layer-3 Invariant

Adds a class-scoped regression guard: for every graph edge wiring a `provider:true` response producer to a non-filter request body consumer (where the leaf var name differs from the semantic var name), the emitted feature spec must not contain a `seedBinding` call for the field-name-derived var.

## Edge Case (tracked separately)

When the same semantic type fills two distinct roles in a single chain (e.g. `migrateProcessInstance` needs both source and target `ProcessDefinitionKey`), both resolve to the same `ctx.processDefinitionKeyVar`. Per-role disambiguation is tracked in #195 and is out of scope here.

## What's Not Fixed

- Object-typed body fields (`filter`, `variables`, `changeset`) — still seeded as strings (#174 sub-class 1)
- Filter-prefixed consumer fields (`filter.*`) — deferred to #168

Closes part of #174.