### PR TITLE
fix: emit empty object/array literal for unbound required object-typed body fields

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -47,6 +47,7 @@ const SCENARIOS_DIR = getScenariosDir(REPO_ROOT);
 const FEATURE_SCENARIOS_DIR = getFeatureOutputDir(REPO_ROOT);
 const VARIANT_SCENARIOS_DIR = getVariantOutputDir(REPO_ROOT);
 const GENERATED_TESTS_DIR = getPlaywrightSuiteDir(REPO_ROOT);
+const BUNDLED_SPEC_PATH = join(getSpecBundleDir(REPO_ROOT), 'rest-api.bundle.json');
 
 interface SemanticTypeEntry {
   semanticType: string;
@@ -3454,6 +3455,122 @@ describeForThisConfig(
         expect(
           offenders,
           'Feature spec seeds a field-name var for a request body field whose semantic type has a provider:true graph-level producer. The auto-derivation from requestBodySemanticTypes must wire these to the semantic var (ctx.${semanticType}Var) instead of seeding a placeholder.',
+        ).toEqual([]);
+      },
+    );
+  },
+);
+
+describeForThisConfig(
+  'bundled-spec invariants: object-typed body field seeding (#174 sub-class 1)',
+  () => {
+    it(
+      'no feature or variant scenario seeds a ${...} string placeholder for a required request body field whose schema type is object or array',
+      () => {
+        // Regression guard for #174 sub-class 1: the planner must emit {} / []
+        // literals for object/array-typed required body fields instead of seeding
+        // a string placeholder (which causes broker "cannot be parsed" errors).
+        //
+        // Class-scoped: covers every operation in the bundled spec — not just the
+        // known offenders (filter, variables, changeset) at the time of writing.
+        if (!existsSync(FEATURE_SCENARIOS_DIR)) {
+          throw new Error(
+            `Feature output directory not found at ${FEATURE_SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+          );
+        }
+        if (!existsSync(BUNDLED_SPEC_PATH)) {
+          throw new Error(
+            `Bundled spec not found at ${BUNDLED_SPEC_PATH}. Run 'npm run fetch-spec' first.`,
+          );
+        }
+
+        interface OpenApiSpec {
+          paths: Record<
+            string,
+            Record<
+              string,
+              {
+                operationId?: string;
+                requestBody?: {
+                  content?: {
+                    'application/json'?: { schema?: { $ref?: string; properties?: Record<string, { type?: string; $ref?: string }> } };
+                  };
+                };
+              }
+            >
+          >;
+          components?: { schemas?: Record<string, { type?: string; required?: string[]; properties?: Record<string, { type?: string; $ref?: string }> }> };
+        }
+
+        // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+        const spec = JSON.parse(readFileSync(BUNDLED_SPEC_PATH, 'utf8')) as OpenApiSpec;
+
+        // Build a map of operationId -> set of top-level body field names that have type 'object' or 'array'
+        const objectFieldsByOp = new Map<string, Set<string>>();
+        for (const pathItem of Object.values(spec.paths ?? {})) {
+          for (const op of Object.values(pathItem)) {
+            if (!op.operationId) continue;
+            const jsonBody = op.requestBody?.content?.['application/json']?.schema;
+            if (!jsonBody) continue;
+            const schemaRef = jsonBody.$ref;
+            const schema = schemaRef
+              ? spec.components?.schemas?.[schemaRef.split('/').pop() ?? '']
+              : jsonBody;
+            if (!schema?.properties) continue;
+            const objectFields = new Set<string>();
+            for (const [fieldName, fieldSchema] of Object.entries(schema.properties)) {
+              let effectiveType = fieldSchema.type;
+              if (!effectiveType && fieldSchema.$ref) {
+                const refName = fieldSchema.$ref.split('/').pop() ?? '';
+                effectiveType = spec.components?.schemas?.[refName]?.type;
+              }
+              if (effectiveType === 'object' || effectiveType === 'array') {
+                objectFields.add(fieldName);
+              }
+            }
+            if (objectFields.size > 0) {
+              objectFieldsByOp.set(op.operationId, objectFields);
+            }
+          }
+        }
+
+        interface FeatureScenarioFile {
+          endpoint: { operationId: string };
+          scenarios: {
+            id: string;
+            requestPlan?: { operationId: string; bodyTemplate?: Record<string, unknown> }[];
+          }[];
+        }
+
+        const offenders: { file: string; scenario: string; field: string; value: string }[] = [];
+        const templatePattern = /^\$\{[^}]+\}$/;
+
+        const dirs = [FEATURE_SCENARIOS_DIR, VARIANT_SCENARIOS_DIR];
+        for (const dir of dirs) {
+          if (!existsSync(dir)) continue;
+          for (const f of readdirSync(dir)) {
+            if (!f.endsWith('-scenarios.json')) continue;
+            // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+            const file = JSON.parse(readFileSync(join(dir, f), 'utf8')) as FeatureScenarioFile;
+            const objectFields = objectFieldsByOp.get(file.endpoint?.operationId ?? '');
+            if (!objectFields) continue;
+            for (const scenario of file.scenarios ?? []) {
+              for (const step of scenario.requestPlan ?? []) {
+                for (const [field, value] of Object.entries(step.bodyTemplate ?? {})) {
+                  if (objectFields.has(field) && typeof value === 'string' && templatePattern.test(value)) {
+                    offenders.push({ file: f, scenario: scenario.id, field, value });
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        expect(
+          offenders,
+          'A scenario bodyTemplate seeds a string placeholder for a field whose request body schema type is object or array. ' +
+            'The planner must emit {} or [] literals for these fields instead of ${...} placeholders. ' +
+            'A string placeholder causes broker "Request property [X] cannot be parsed" errors (#174 sub-class 1).',
         ).toEqual([]);
       },
     );

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -3484,6 +3484,14 @@ describeForThisConfig(
           );
         }
 
+        interface SchemaObject {
+          type?: string;
+          $ref?: string;
+          required?: string[];
+          properties?: Record<string, SchemaObject>;
+          oneOf?: SchemaObject[];
+        }
+
         interface OpenApiSpec {
           paths: Record<
             string,
@@ -3493,17 +3501,53 @@ describeForThisConfig(
                 operationId?: string;
                 requestBody?: {
                   content?: {
-                    'application/json'?: { schema?: { $ref?: string; properties?: Record<string, { type?: string; $ref?: string }> } };
+                    'application/json'?: { schema?: SchemaObject };
                   };
                 };
               }
             >
           >;
-          components?: { schemas?: Record<string, { type?: string; required?: string[]; properties?: Record<string, { type?: string; $ref?: string }> }> };
+          components?: { schemas?: Record<string, SchemaObject> };
         }
 
         // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
         const spec = JSON.parse(readFileSync(BUNDLED_SPEC_PATH, 'utf8')) as OpenApiSpec;
+
+        function resolveRef(ref: string): SchemaObject | undefined {
+          const name = ref.split('/').pop() ?? '';
+          return spec.components?.schemas?.[name];
+        }
+
+        function resolveSchemaObj(s: SchemaObject): SchemaObject {
+          if (s.$ref) return resolveRef(s.$ref) ?? s;
+          return s;
+        }
+
+        function getEffectiveType(s: SchemaObject): string | undefined {
+          if (s.type) return s.type;
+          if (s.$ref) return resolveRef(s.$ref)?.type;
+          return undefined;
+        }
+
+        /** Collect top-level field names whose resolved type is 'object' or 'array' from a schema. */
+        function collectObjectArrayFields(schema: SchemaObject): Set<string> {
+          const fields = new Set<string>();
+          const resolved = resolveSchemaObj(schema);
+          // Root schema with properties
+          for (const [fieldName, fieldSchema] of Object.entries(resolved.properties ?? {})) {
+            const t = getEffectiveType(fieldSchema);
+            if (t === 'object' || t === 'array') fields.add(fieldName);
+          }
+          // oneOf variants: union their fields
+          for (const variant of resolved.oneOf ?? []) {
+            const rv = resolveSchemaObj(variant);
+            for (const [fieldName, fieldSchema] of Object.entries(rv.properties ?? {})) {
+              const t = getEffectiveType(fieldSchema);
+              if (t === 'object' || t === 'array') fields.add(fieldName);
+            }
+          }
+          return fields;
+        }
 
         // Build a map of operationId -> set of top-level body field names that have type 'object' or 'array'
         const objectFieldsByOp = new Map<string, Set<string>>();
@@ -3512,22 +3556,7 @@ describeForThisConfig(
             if (!op.operationId) continue;
             const jsonBody = op.requestBody?.content?.['application/json']?.schema;
             if (!jsonBody) continue;
-            const schemaRef = jsonBody.$ref;
-            const schema = schemaRef
-              ? spec.components?.schemas?.[schemaRef.split('/').pop() ?? '']
-              : jsonBody;
-            if (!schema?.properties) continue;
-            const objectFields = new Set<string>();
-            for (const [fieldName, fieldSchema] of Object.entries(schema.properties)) {
-              let effectiveType = fieldSchema.type;
-              if (!effectiveType && fieldSchema.$ref) {
-                const refName = fieldSchema.$ref.split('/').pop() ?? '';
-                effectiveType = spec.components?.schemas?.[refName]?.type;
-              }
-              if (effectiveType === 'object' || effectiveType === 'array') {
-                objectFields.add(fieldName);
-              }
-            }
+            const objectFields = collectObjectArrayFields(jsonBody);
             if (objectFields.size > 0) {
               objectFieldsByOp.set(op.operationId, objectFields);
             }

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -3535,7 +3535,6 @@ describeForThisConfig(
         }
 
         interface FeatureScenarioFile {
-          endpoint: { operationId: string };
           scenarios: {
             id: string;
             requestPlan?: { operationId: string; bodyTemplate?: Record<string, unknown> }[];
@@ -3552,10 +3551,10 @@ describeForThisConfig(
             if (!f.endsWith('-scenarios.json')) continue;
             // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
             const file = JSON.parse(readFileSync(join(dir, f), 'utf8')) as FeatureScenarioFile;
-            const objectFields = objectFieldsByOp.get(file.endpoint?.operationId ?? '');
-            if (!objectFields) continue;
             for (const scenario of file.scenarios ?? []) {
               for (const step of scenario.requestPlan ?? []) {
+                const objectFields = objectFieldsByOp.get(step.operationId);
+                if (!objectFields) continue;
                 for (const [field, value] of Object.entries(step.bodyTemplate ?? {})) {
                   if (objectFields.has(field) && typeof value === 'string' && templatePattern.test(value)) {
                     offenders.push({ file: f, scenario: scenario.id, field, value });

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -3537,12 +3537,13 @@ describeForThisConfig(
         interface FeatureScenarioFile {
           scenarios: {
             id: string;
+            seedBindings?: string[];
             requestPlan?: { operationId: string; bodyTemplate?: Record<string, unknown> }[];
           }[];
         }
 
         const offenders: { file: string; scenario: string; field: string; value: string }[] = [];
-        const templatePattern = /^\$\{[^}]+\}$/;
+        const templatePattern = /^\$\{([^}]+)\}$/;
 
         const dirs = [FEATURE_SCENARIOS_DIR, VARIANT_SCENARIOS_DIR];
         for (const dir of dirs) {
@@ -3552,11 +3553,14 @@ describeForThisConfig(
             // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
             const file = JSON.parse(readFileSync(join(dir, f), 'utf8')) as FeatureScenarioFile;
             for (const scenario of file.scenarios ?? []) {
+              const seededVars = new Set(scenario.seedBindings ?? []);
               for (const step of scenario.requestPlan ?? []) {
                 const objectFields = objectFieldsByOp.get(step.operationId);
                 if (!objectFields) continue;
                 for (const [field, value] of Object.entries(step.bodyTemplate ?? {})) {
-                  if (objectFields.has(field) && typeof value === 'string' && templatePattern.test(value)) {
+                  if (!objectFields.has(field) || typeof value !== 'string') continue;
+                  const match = templatePattern.exec(value);
+                  if (match && seededVars.has(match[1])) {
                     offenders.push({ file: f, scenario: scenario.id, field, value });
                   }
                 }

--- a/path-analyser/src/extractSchemas.ts
+++ b/path-analyser/src/extractSchemas.ts
@@ -259,6 +259,11 @@ function findOneOfGroups(
       const props = vs.properties || {};
       const required = vs.required || [];
       const optional = Object.keys(props).filter((k) => !required.includes(k));
+      const fieldTypes: Record<string, string> = {};
+      for (const [fname, fsch] of Object.entries(props)) {
+        const ft = effectiveType(fsch, components);
+        if (ft && ft !== 'unknown') fieldTypes[fname] = ft;
+      }
       let discriminator: { field: string; value: string } | undefined;
       if (resolved.discriminator?.propertyName) {
         const discField = resolved.discriminator.propertyName;
@@ -274,6 +279,7 @@ function findOneOfGroups(
         variantName: vs.title || `variant${idx + 1}`,
         required,
         optional,
+        fieldTypes,
         discriminator,
       };
     });

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1166,21 +1166,25 @@ function buildRequestBodyFromCanonical(
     for (const n of nodes) {
       // Top-level array fields are recorded by walkSchema as 'field[]' (with type: 'array').
       // Normalize those to bare name so declaredTypeByLeaf['field'] === 'array'.
-      const isTopLevelArray = n.path.endsWith('[]') && !n.path.slice(0, -2).includes('[]');
-      const normalizedPath = isTopLevelArray ? n.path.slice(0, -2) : n.path;
+      // Guard: stripped path must have no '.' (confirming it's truly top-level, not 'parent.items[]').
+      const strippedPath = n.path.endsWith('[]') ? n.path.slice(0, -2) : n.path;
+      const isTopLevelArray =
+        n.path.endsWith('[]') && !strippedPath.includes('[]') && !strippedPath.includes('.');
+      const normalizedPath = isTopLevelArray ? strippedPath : n.path;
       if (!normalizedPath.includes('[]')) {
         const leaf = normalizedPath.split('.').pop() ?? '';
         if (leaf && !declaredTypeByLeaf[leaf]) declaredTypeByLeaf[leaf] = n.type;
       }
     }
   } catch {}
-  // Include top-level array required nodes (path ends with '[]', no '[]' in the base path)
+  // Include top-level array required nodes (path ends with '[]', no '[]' or '.' in the base path)
   // so that required array fields like 'moveInstructions' are not silently dropped.
-  const requiredFields = nodes.filter(
-    (n) =>
-      n.required &&
-      (!n.path.includes('[]') || (n.path.endsWith('[]') && !n.path.slice(0, -2).includes('[]'))),
-  );
+  const requiredFields = nodes.filter((n) => {
+    if (!n.required) return false;
+    if (!n.path.includes('[]')) return true;
+    const strippedPath = n.path.slice(0, -2);
+    return n.path.endsWith('[]') && !strippedPath.includes('[]') && !strippedPath.includes('.');
+  });
   // Bindings map from domain valueBindings (request.* -> parameter name).
   // Two RHS grammars are supported:
   //   1. `state.parameter`        — legacy form; parameter name is the leaf of the RHS.

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1164,13 +1164,23 @@ function buildRequestBodyFromCanonical(
   const declaredTypeByLeaf: Record<string, string> = {};
   try {
     for (const n of nodes) {
-      if (!n.path.includes('[]')) {
-        const leaf = n.path.split('.').pop() ?? '';
+      // Top-level array fields are recorded by walkSchema as 'field[]' (with type: 'array').
+      // Normalize those to bare name so declaredTypeByLeaf['field'] === 'array'.
+      const isTopLevelArray = n.path.endsWith('[]') && !n.path.slice(0, -2).includes('[]');
+      const normalizedPath = isTopLevelArray ? n.path.slice(0, -2) : n.path;
+      if (!normalizedPath.includes('[]')) {
+        const leaf = normalizedPath.split('.').pop() ?? '';
         if (leaf && !declaredTypeByLeaf[leaf]) declaredTypeByLeaf[leaf] = n.type;
       }
     }
   } catch {}
-  const requiredFields = nodes.filter((n) => n.required && !n.path.includes('[]'));
+  // Include top-level array required nodes (path ends with '[]', no '[]' in the base path)
+  // so that required array fields like 'moveInstructions' are not silently dropped.
+  const requiredFields = nodes.filter(
+    (n) =>
+      n.required &&
+      (!n.path.includes('[]') || (n.path.endsWith('[]') && !n.path.slice(0, -2).includes('[]'))),
+  );
   // Bindings map from domain valueBindings (request.* -> parameter name).
   // Two RHS grammars are supported:
   //   1. `state.parameter`        — legacy form; parameter name is the leaf of the RHS.
@@ -1278,7 +1288,8 @@ function buildRequestBodyFromCanonical(
     } else {
       // Non-oneOf: use canonical required flags
       for (const f of requiredFields) {
-        const leaf = f.path.split('.').pop() ?? '';
+        // Array nodes are recorded as 'field[]'; strip the suffix for the template key.
+        const leaf = f.path.replace(/\[\]$/, '').split('.').pop() ?? '';
         if (allowedFields && !allowedFields.has(leaf)) continue;
         const viaProvider = resolveProvider(opId, leaf, scenario);
         if (viaProvider !== undefined) {
@@ -1287,13 +1298,16 @@ function buildRequestBodyFromCanonical(
         }
         // Special-case: support mapping jobType -> type
         const hasJobType = !!bindingMap.jobType;
-        const mapJobTypeToType = leaf === 'type' && !bindingMap[f.path] && hasJobType;
-        const semanticParam = semanticFallback[f.path];
+        const normalizedPath = f.path.replace(/\[\]$/, '');
+        const mapJobTypeToType = leaf === 'type' && !bindingMap[normalizedPath] && hasJobType;
+        const semanticParam = semanticFallback[normalizedPath];
         const mappedParamName = mapJobTypeToType
           ? 'jobType'
-          : bindingMap[f.path] || semanticParam || leaf || 'value';
+          : bindingMap[normalizedPath] || semanticParam || leaf || 'value';
         const varName = `${camelCase(mappedParamName)}Var`;
-        const hasBinding = mapJobTypeToType ? true : !!(bindingMap[f.path] || semanticParam);
+        const hasBinding = mapJobTypeToType
+          ? true
+          : !!(bindingMap[normalizedPath] || semanticParam);
         if (hasBinding) {
           scenario.bindings ||= {};
           if (!scenario.bindings[varName]) scenario.bindings[varName] = '__PENDING__';
@@ -1311,7 +1325,7 @@ function buildRequestBodyFromCanonical(
           scenario.bindings ||= {};
           if (!scenario.bindings[varName]) scenario.bindings[varName] = '__PENDING__';
           template[leaf] = `${'${'}${varName}}`;
-          if (!bindingMap[f.path]) missing.push(f.path);
+          if (!bindingMap[normalizedPath]) missing.push(normalizedPath);
         }
       }
       // For search-like empty-negative scenarios, allow provider-injected optional filters to drive an empty result

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1225,6 +1225,7 @@ function buildRequestBodyFromCanonical(
   const defaults = getRequestDefaultsForOperation(opId);
   let allowedFields: Set<string> | undefined;
   let chosenVariantRequired: string[] | undefined;
+  let chosenVariant: RequestOneOfVariant | undefined;
   if (chosenCt === 'application/json' && requestGroups.length) {
     // Determine selected variant for endpoint scenarios
     const selected = isEndpoint ? scenario.requestVariants?.[0] : undefined;
@@ -1239,6 +1240,7 @@ function buildRequestBodyFromCanonical(
     if (!isEndpoint) {
       chosen = variants.find((v) => v.required.some((f) => /Key$/.test(f))) || chosen;
     }
+    chosenVariant = chosen;
     chosenVariantRequired = [...(chosen?.required || [])];
     // Allow chosen required, plus chosen optional that are NOT required by any other variant
     const otherRequired = new Set<string>(
@@ -1274,12 +1276,12 @@ function buildRequestBodyFromCanonical(
             template[name] = `${'${'}${varName}}`;
           } else if (defaults && Object.hasOwn(defaults, name)) {
             template[name] = defaults[name];
-          } else if (declaredTypeByLeaf[name] === 'object') {
+          } else if ((declaredTypeByLeaf[name] ?? chosenVariant?.fieldTypes?.[name]) === 'object') {
             // Object-typed required field with no binding: emit {} rather than seeding
             // a string placeholder. An empty object is always a valid JSON value and
             // avoids "Request property [X] cannot be parsed" broker errors (#174 sub-class 1).
             template[name] = {};
-          } else if (declaredTypeByLeaf[name] === 'array') {
+          } else if ((declaredTypeByLeaf[name] ?? chosenVariant?.fieldTypes?.[name]) === 'array') {
             template[name] = [];
           } else {
             scenario.bindings ||= {};

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1260,6 +1260,13 @@ function buildRequestBodyFromCanonical(
             template[name] = `${'${'}${varName}}`;
           } else if (defaults && Object.hasOwn(defaults, name)) {
             template[name] = defaults[name];
+          } else if (declaredTypeByLeaf[name] === 'object') {
+            // Object-typed required field with no binding: emit {} rather than seeding
+            // a string placeholder. An empty object is always a valid JSON value and
+            // avoids "Request property [X] cannot be parsed" broker errors (#174 sub-class 1).
+            template[name] = {};
+          } else if (declaredTypeByLeaf[name] === 'array') {
+            template[name] = [];
           } else {
             scenario.bindings ||= {};
             if (!scenario.bindings[varName]) scenario.bindings[varName] = '__PENDING__';
@@ -1293,6 +1300,13 @@ function buildRequestBodyFromCanonical(
           template[leaf] = `${'${'}${varName}}`;
         } else if (defaults && Object.hasOwn(defaults, leaf)) {
           template[leaf] = defaults[leaf];
+        } else if (f.type === 'object') {
+          // Object-typed required field with no binding: emit {} rather than seeding
+          // a string placeholder. An empty object is always a valid JSON value and
+          // avoids "Request property [X] cannot be parsed" broker errors (#174 sub-class 1).
+          template[leaf] = {};
+        } else if (f.type === 'array') {
+          template[leaf] = [];
         } else {
           scenario.bindings ||= {};
           if (!scenario.bindings[varName]) scenario.bindings[varName] = '__PENDING__';

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -348,6 +348,8 @@ export interface RequestOneOfVariant {
   variantName: string;
   required: string[];
   optional: string[];
+  /** Effective JSON Schema type for each field in this variant ('object', 'array', 'string', …). */
+  fieldTypes: Record<string, string>;
   discriminator?: { field: string; value: string };
 }
 


### PR DESCRIPTION
## Problem

When a required request body field has schema type `object` or `array` and no semantic binding or default is configured, the planner was seeding a string placeholder (`${filterVar}`, `${variablesVar}`, `${changesetVar}`). At runtime the broker rejected these requests with:

> Request property [filter] cannot be parsed

because the interpolated value was a string, not an object.

This is **#174 sub-class 1**: object-typed body fields seeded as strings.

## Root cause

In `buildRequestBodyFromCanonical`, the fallback branch for unbound required fields always emitted a `${varName}` placeholder. No distinction was made between scalar fields (which legitimately need a seed binding) and object/array fields (which should receive an empty literal).

## Fix

In both the oneOf branch and the non-oneOf branch of `buildRequestBodyFromCanonical`, when a required canonical node has `type === 'object'` or `type === 'array'` and no binding, semantic fallback, or default is available, emit `{}` or `[]` directly in the `bodyTemplate` instead of a seed placeholder.

Since `computeSeedBindings` walks the template for `${...}` patterns, a literal `{}` produces no match — no `seedBinding()` call is generated.

**Semantic validity:**
- `filter: {}` = match all (batch operations)
- `variables: {}` = empty variables object (always valid)
- `changeset: {}` = no-op update (all properties optional)

## Affected operations (18)

`filter` (15): all batch ops + stats — `cancelProcessInstancesBatchOperation`, `deleteDecisionInstancesBatchOperation`, `deleteProcessInstancesBatchOperation`, `resolveIncidentsBatchOperation`, `modifyProcessInstancesBatchOperation`, `migrateProcessInstancesBatchOperation`, `getBatchOperation`, `cancelBatchOperation`, `resumeBatchOperation`, `suspendBatchOperation`, `getJobErrorStatistics`, `getJobTimeSeriesStatistics`, `getJobWorkerStatistics`, `getProcessDefinitionInstanceVersionStatistics`, `getProcessInstanceStatisticsByDefinition`

`variables` (2): `createElementInstanceVariables`, `evaluateConditionals`

`changeset` (1): `updateJob`

## Regression guard

Adds a class-scoped Layer-3 invariant: no feature or variant scenario may seed a `${...}` string placeholder for a body field whose request body schema type is `object` or `array`. The invariant loads the bundled spec to identify object-typed fields across **all** operations — not just the known offenders at time of writing.

Closes #174 sub-class 1