### PR TITLE
chore: lift tenantId/tenantIdVar literals into globalContextSeeds-driven loop (#200)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -3609,3 +3609,132 @@ describeForThisConfig(
   },
 );
 
+// ---------------------------------------------------------------------------
+// globalContextSeeds substitution into multipart templates (#200 — Lift 0)
+// ---------------------------------------------------------------------------
+//
+// Lift 0 of the ontology migration retired the literal `'tenantId'` /
+// `'tenantIdVar'` / `'__PENDING__'` triple that the multipart branch of
+// `buildRequestBodyFromCanonical()` previously hard-coded, replacing it
+// with a loop over `graph.domain.globalContextSeeds`. The behaviour is
+// supposed to be byte-identical: every multipart scenario whose request
+// body declares a `globalContextSeeds[i].fieldName` field must still
+// emit `template.fields[fieldName] = "${binding}"`, AND the scenario's
+// `bindings[binding]` must equal `__PENDING__` so the emitter's
+// universal-seed prologue (codegen/playwright/emitter.ts) can rewrite
+// it to the runtime sentinel (`<default>`). This invariant locks both
+// directions and is class-scoped (every multipart scenario across the
+// bundled output, not just createDeployment) so the same regression
+// can't recur in a sibling op.
+describeForThisConfig(
+  'bundled-spec invariants: globalContextSeeds substitution survives Lift 0 (#200)',
+  () => {
+    it('every multipart scenario binds and substitutes each globalContextSeeds entry whose fieldName appears in the multipart template', () => {
+      if (!existsSync(SCENARIOS_DIR)) {
+        throw new Error(
+          `Scenarios directory not found at ${SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+        );
+      }
+
+      // Read the active config's globalContextSeeds directly from the
+      // sidecar so this invariant fails loudly if the sidecar shape
+      // changes (it's the canonical source post-Lift 0).
+      const domainSemanticsPath = join(
+        REPO_ROOT,
+        'configs',
+        CONFIG_NAME,
+        'domain-semantics.json',
+      );
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const domainSemantics = JSON.parse(readFileSync(domainSemanticsPath, 'utf8')) as {
+        globalContextSeeds?: { fieldName: string; binding: string }[];
+      };
+      const seeds = domainSemantics.globalContextSeeds ?? [];
+      expect(
+        seeds.length,
+        'Lift 0 assumes the active config declares at least one globalContextSeeds entry; ' +
+          'without it the multipart substitution loop has nothing to do and this invariant ' +
+          'becomes vacuous.',
+      ).toBeGreaterThan(0);
+
+      interface MultipartStep {
+        multipartTemplate?: { fields?: Record<string, string> };
+      }
+      interface ScenarioWithMultipart {
+        id: string;
+        bindings?: Record<string, string>;
+        requestPlan?: MultipartStep[];
+      }
+      interface ScenarioFileWithMultipart {
+        endpoint: { operationId: string };
+        scenarios: ScenarioWithMultipart[];
+      }
+
+      const offenders: {
+        file: string;
+        scenarioId: string;
+        operationId: string;
+        seed: string;
+        reason: string;
+      }[] = [];
+      let multipartFieldHits = 0;
+
+      for (const f of readdirSync(SCENARIOS_DIR)) {
+        if (!f.endsWith('-scenarios.json')) continue;
+        // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+        const file = JSON.parse(
+          readFileSync(join(SCENARIOS_DIR, f), 'utf8'),
+        ) as ScenarioFileWithMultipart;
+        for (const scenario of file.scenarios ?? []) {
+          for (const step of scenario.requestPlan ?? []) {
+            const fields = step.multipartTemplate?.fields;
+            if (!fields) continue;
+            for (const seed of seeds) {
+              if (!(seed.fieldName in fields)) continue;
+              multipartFieldHits++;
+              const expected = `\${${seed.binding}}`;
+              if (fields[seed.fieldName] !== expected) {
+                offenders.push({
+                  file: f,
+                  scenarioId: scenario.id,
+                  operationId: file.endpoint.operationId,
+                  seed: seed.fieldName,
+                  reason: `multipart field '${seed.fieldName}' = ${JSON.stringify(
+                    fields[seed.fieldName],
+                  )}, expected ${JSON.stringify(expected)}`,
+                });
+              }
+              if (scenario.bindings?.[seed.binding] !== '__PENDING__') {
+                offenders.push({
+                  file: f,
+                  scenarioId: scenario.id,
+                  operationId: file.endpoint.operationId,
+                  seed: seed.fieldName,
+                  reason: `binding '${seed.binding}' = ${JSON.stringify(
+                    scenario.bindings?.[seed.binding],
+                  )}, expected "__PENDING__"`,
+                });
+              }
+            }
+          }
+        }
+      }
+
+      // Floor: at least one bundled-spec multipart scenario must have
+      // exercised at least one globalContextSeeds substitution. If
+      // multipartFieldHits is zero, the lift's only branch was never
+      // entered, the multipart op vanished from the spec, or the
+      // sidecar's fieldName drifted from the spec. Any of those is
+      // worth a hard fail so we don't ship a vacuously-passing guard.
+      expect(
+        multipartFieldHits,
+        'expected ≥1 multipart scenario across the bundled output to substitute a ' +
+          'globalContextSeeds field (e.g. createDeployment.tenantId). Zero matches ' +
+          'means the lift code path was never exercised.',
+      ).toBeGreaterThan(0);
+
+      expect(offenders).toEqual([]);
+    });
+  },
+);
+

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1484,10 +1484,9 @@ function buildRequestBodyFromCanonical(
     // emission time by the universal-seed prologue derived from the same
     // `globalContextSeeds` entry — see codegen/playwright/emitter.ts) and
     // substitutes a `${binding}` reference into the multipart fields. Driven
-    // entirely from the per-config sidecar so configs without the
-    // default-tenant concept (or any other globalContextSeeds entry) get no
-    // field substitution. Lifts the previously hard-coded
-    // `'tenantId'`/`'tenantIdVar'` literals out of generic planner code (#200).
+    // entirely from the per-config sidecar so configs without relevant
+    // globalContextSeeds entries get no field substitution. Lifts previously
+    // hard-coded field/binding name literals out of generic planner code (#200).
     for (const seed of graph.domain?.globalContextSeeds ?? []) {
       const node = nodes.find((n) => n.path === seed.fieldName);
       if (!node) continue;

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1478,13 +1478,22 @@ function buildRequestBodyFromCanonical(
       }
       template.files.resources = fileRef;
     }
-    const tenant = nodes.find((n) => n.path === 'tenantId');
-    if (tenant) {
-      const varName = 'tenantIdVar';
+    // Wire global context seeds (e.g. tenantIdVar) into multipart fields by
+    // matching the seed's `fieldName` against the canonical schema nodes.
+    // Each match seeds the planner binding with `__PENDING__` (resolved at
+    // emission time by the universal-seed prologue derived from the same
+    // `globalContextSeeds` entry — see codegen/playwright/emitter.ts) and
+    // substitutes a `${binding}` reference into the multipart fields. Driven
+    // entirely from the per-config sidecar so configs without the
+    // default-tenant concept (or any other globalContextSeeds entry) get no
+    // field substitution. Lifts the previously hard-coded
+    // `'tenantId'`/`'tenantIdVar'` literals out of generic planner code (#200).
+    for (const seed of graph.domain?.globalContextSeeds ?? []) {
+      const node = nodes.find((n) => n.path === seed.fieldName);
+      if (!node) continue;
       scenario.bindings ||= {};
-      if (!scenario.bindings[varName]) scenario.bindings[varName] = '__PENDING__';
-      template.fields.tenantId = `\
-${'${'}${varName}}`;
+      if (!scenario.bindings[seed.binding]) scenario.bindings[seed.binding] = '__PENDING__';
+      template.fields[seed.fieldName] = `\${${seed.binding}}`;
     }
     // Derive expected deployment slices using domain sidecar mapping (explicit). Fallback to heuristic later in emitter.
     const expectedSlicesSet = new Set<string>();


### PR DESCRIPTION
Lift 0 of the ontology migration (#199). The multipart branch of `buildRequestBodyFromCanonical()` previously hard-coded the literal triple `'tenantId'` (field name) / `'tenantIdVar'` (binding) / `'__PENDING__'` (sentinel), even though the same facts already live in `configs/camunda-oca/domain-semantics.json` under `globalContextSeeds[0]` and are consumed by the emitter via `graph.domain.globalContextSeeds`. That duplication is exactly the "single fact, multiple sites" pattern the audit flagged.

## Change

Replace the OCA-specific block with a loop over `graph.domain?.globalContextSeeds`. Each seed whose `fieldName` matches a canonical schema node is bound (`__PENDING__`) and substituted (`${binding}`) into the multipart template. Configs without a default-tenant concept simply contribute no entries and the loop is a no-op.

## On `__PENDING__`

The original #200 acceptance criteria asked to retire this literal too. That was overly strict — `__PENDING__` is the planner's **universal** "needs runtime resolution" sentinel (~13 sites in `index.ts`, plus `scenarioGenerator.ts` and the Playwright emitter at `codegen/playwright/emitter.ts:328`). It is API-agnostic and stays. The OCA-specific facts retired here are the **field name**, the **binding name**, and the **field→binding mapping** — all three now sourced from the sidecar.

## Behaviour-preservation guard

A new L3 invariant in `configs/camunda-oca/regression-invariants.test.ts` locks both directions class-scoped across every multipart scenario in the bundled output:
- `template.fields[fieldName] === "${binding}"`
- `bindings[binding] === "__PENDING__"`

Plus a floor that fails loudly if the lift code path is never exercised (e.g. the multipart op disappeared from the spec or the sidecar's `fieldName` drifted). Class-scoped: any new sibling multipart op that introduces a `globalContextSeeds` field is automatically covered.

## Verification

- Pre-push checklist: lint, all four `tsc --noEmit`, `npm run testsuite:generate` + `npm run generate:request-validation`, `npm test` (393 passed | 6 skipped).
- Post-regen `git diff` shows no change to tracked generator output → byte-identical.

Closes #200
