### PR TITLE
fix: skip inline extractInto for deploy() step non-alias extracts

### DIFF
--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -179,11 +179,24 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   if (recordResponses) {
     lines.push("import { recordResponse, sanitizeBody } from './support/recorder';");
   }
-  // extractInto is used in the per-step extract loop which runs for ALL steps (including
-  // deployment steps — see comment at the extract loop below). Gate the import on whether
-  // any step in the collection has extracts, regardless of step type.
+  // extractInto is used in the per-step extract loop. For deploy() steps only
+  // placeholderAlias extracts are emitted (all others are handled internally by
+  // deploy()). Mirror that filter here so the import is not emitted when all
+  // extracts for a deployment step are non-alias entries — those generate no
+  // extractInto() calls in the suite, which would produce a Biome noUnusedImports
+  // error.
   const hasAnyExtract = collection.scenarios.some((s) =>
-    (s.requestPlan ?? []).some((step) => (step.extract?.length ?? 0) > 0),
+    (s.requestPlan ?? []).some((step) => {
+      const isDeployStep =
+        step.operationId === 'createDeployment' &&
+        step.bodyKind === 'multipart' &&
+        !!step.multipartTemplate &&
+        step.expect.status === 200;
+      const relevant = isDeployStep
+        ? (step.extract ?? []).filter((ex) => ex.note === 'placeholderAlias')
+        : (step.extract ?? []);
+      return relevant.length > 0;
+    }),
   );
   if (hasAnyExtract) {
     lines.push("import { extractInto, seedBinding, initSpecSalt } from './support/seeding';");
@@ -583,6 +596,7 @@ function renderScenarioTest(
     // it skips the assignment when the value is `undefined` so seeded bindings
     // and earlier extracts in the same scenario aren't clobbered by a later step
     // whose response shape omits the field.
+    // deploy() steps: deploy() already extracts all known deployment response
     // fields internally (processDefinitionKeyVar, deploymentKeyVar, tenantIdVar,
     // etc.). Emitting those same extractInto() calls outside the helper would
     // call resp.json() a second time and duplicate every assignment.

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -583,16 +583,19 @@ function renderScenarioTest(
     // it skips the assignment when the value is `undefined` so seeded bindings
     // and earlier extracts in the same scenario aren't clobbered by a later step
     // whose response shape omits the field.
-    // Deployment steps are NOT skipped here: deploy() extracts the known semantic
-    // bindings internally, but the planner's aliasProducerExtractsToPlaceholders
-    // can attach extra extracts (e.g. placeholderAlias bindings for URL vars) to
-    // the same step. deploy() has no knowledge of these aliases, so the emitter
-    // must emit them. Re-emitting the hard-coded deploy() bindings is harmless
-    // because extractInto is a no-op when the response field is undefined, and
-    // overwrites with the same value when it is present.
-    if (step.extract?.length) {
+    // fields internally (processDefinitionKeyVar, deploymentKeyVar, tenantIdVar,
+    // etc.). Emitting those same extractInto() calls outside the helper would
+    // call resp.json() a second time and duplicate every assignment.
+    // Exception: placeholderAlias entries (note === 'placeholderAlias') bind to
+    // DIFFERENT ctx keys than deploy()'s hard-coded targets (e.g. an alias from
+    // processDefinitionKey → processDefinitionIdVar). deploy() has no knowledge
+    // of these aliases, so they must still be emitted here.
+    const effectiveExtracts = isDeploymentStep
+      ? (step.extract ?? []).filter((ex) => ex.note === 'placeholderAlias')
+      : (step.extract ?? []);
+    if (effectiveExtracts.length) {
       body.push(`    const json = await ${varName}.json();`);
-      for (const ex of step.extract) {
+      for (const ex of effectiveExtracts) {
         const optAcc = toOptionalAccessor(ex.fieldPath);
         body.push(`    extractInto(ctx, '${ex.bind}', json${optAcc});`);
       }

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -603,6 +603,9 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
     // No inline extractInto — all extraction delegated to deploy()
     const extractCalls = c.match(/extractInto\(ctx,/g) ?? [];
     expect(extractCalls, 'extractInto must not be emitted inline for deploy steps').toHaveLength(0);
+    expect(c, 'extractInto must not be imported when deploy-step extracts are fully suppressed').not.toContain(
+      'import { extractInto',
+    );
   });
 });
 

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -549,6 +549,61 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
     expect(c).not.toMatch(/__tenantIdIsDefault/);
     expect(c).not.toMatch(/&& __\w+IsDefault\) continue;/);
   });
+
+  test('deploy step: no inline extractInto block emitted outside deploy() (no duplicate extraction)', async () => {
+    // Regression guard: deploy() already extracts all known deployment response
+    // fields (processDefinitionKeyVar, deploymentKeyVar, tenantIdVar, etc.)
+    // internally. The emitter must NOT also emit a `const json = await resp.json()`
+    // + extractInto loop for the same step — that would call json() twice and
+    // duplicate every assignment. Class-scoped: asserts the emitted suite never
+    // contains either artefact of the old inline extraction block after a deploy()
+    // call, regardless of which extract entries the planner attached.
+    const deployWithExtracts: EndpointScenarioCollection = {
+      endpoint: { operationId: 'createDeployment', method: 'POST', path: '/deployments' },
+      requiredSemanticTypes: [],
+      optionalSemanticTypes: [],
+      scenarios: [
+        {
+          id: 'sc1',
+          name: 'deploy with extracts',
+          operations: [{ operationId: 'createDeployment', method: 'POST', path: '/deployments' }],
+          producedSemanticTypes: [],
+          satisfiedSemanticTypes: [],
+          requestPlan: [
+            {
+              operationId: 'createDeployment',
+              method: 'POST',
+              pathTemplate: '/deployments',
+              expect: { status: 200 },
+              bodyKind: 'multipart',
+              multipartTemplate: { fields: {}, files: {} },
+              extract: [
+                { fieldPath: 'deploymentKey', bind: 'deploymentKeyVar' },
+                {
+                  fieldPath: 'deployments[0].processDefinition.processDefinitionKey',
+                  bind: 'processDefinitionKeyVar',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const [file] = await PlaywrightEmitter.emit(deployWithExtracts, {
+      outDir: '/unused',
+      suiteName: 'createDeployment',
+      mode: 'feature',
+    });
+    const c = file.content;
+    // deploy() call must be present
+    expect(c).toContain('await deploy(ctx, request,');
+    // No second json() read — deploy() owns the response body
+    const jsonReads = c.match(/const json = await \w+\.json\(\);/g) ?? [];
+    expect(jsonReads, 'resp.json() must not be called outside deploy()').toHaveLength(0);
+    // No inline extractInto — all extraction delegated to deploy()
+    const extractCalls = c.match(/extractInto\(ctx,/g) ?? [];
+    expect(extractCalls, 'extractInto must not be emitted inline for deploy steps').toHaveLength(0);
+  });
 });
 
 // Boundary safety guards (#87 review): the public emitter entry points

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -603,7 +603,8 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
     // No inline extractInto — all extraction delegated to deploy()
     const extractCalls = c.match(/extractInto\(ctx,/g) ?? [];
     expect(extractCalls, 'extractInto must not be emitted inline for deploy steps').toHaveLength(0);
-    expect(c, 'extractInto must not be imported when deploy-step extracts are fully suppressed').not.toContain(
+    // extractInto must not be imported — suppressed calls must also suppress the import
+    expect(c, 'extractInto must not be imported when no calls are emitted').not.toContain(
       'import { extractInto',
     );
   });


### PR DESCRIPTION
## Summary

`deploy()` in `support/deployment.ts` already extracts all known deployment response fields internally (`processDefinitionKeyVar`, `deploymentKeyVar`, `tenantIdVar`, etc.). The emitter was still emitting a duplicate `const json = await resp.json()` + `extractInto` loop for the same step — calling `json()` twice and duplicating every assignment.

## What changed

**`path-analyser/src/codegen/playwright/emitter.ts`**

For `isDeploymentStep`, filter `step.extract` to only emit entries where `note === 'placeholderAlias'`. These entries bind to _different_ `ctx` keys than `deploy()`'s hard-coded targets (e.g. a URL-param alias `processDefinitionKey → processDefinitionIdVar`), so `deploy()` has no knowledge of them and they must still be emitted. Non-alias entries for deploy steps are suppressed because they duplicate `deploy()`'s own extraction.

The old comment that justified the duplication as "harmless" is replaced with an explanation of the split.

**`tests/codegen/playwright-emitter.test.ts`**

Adds a regression guard in the existing deploy-step describe block: when all `step.extract` entries are non-alias bindings, the emitted suite must contain no `const json = await …json()` call and no `extractInto(ctx, …)` call outside `deploy()`.

The existing test that asserts a `note: 'placeholderAlias'` extract IS still emitted continues to pass unchanged.
