### PR TITLE
chore: derive edge-establisher behaviour from ABox; ignore spec edge metadata (#208, Lift 3)

### DIFF
--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -773,7 +773,7 @@ function normalizeEstablishes(
   //     what the spec annotation says).
   //   - opId NOT in `edgeEstablishers` ⇒ `shape: undefined` (treat as
   //     non-edge even if the spec annotation says `shape: 'edge'`; the
-  //     drift is surfaced as a warning by validateEdgeAnnotationDrift).
+  //     drift is surfaced as a warning by detectEdgeAnnotationDrift).
   //
   // When the ABox is absent (`edgeEstablishers === null`), fall back to
   // the legacy spec-annotation behaviour for backward compat with

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -7,6 +7,7 @@ import {
   validateRequestBodySemanticsClassified,
   validateRuntimeStateWitnessGraphRefs,
 } from './domainSemanticsValidator.js';
+import { loadEdgeEstablishers } from './ontology/loader.js';
 import type { BootstrapSequence, DomainSemantics, OperationGraph, OperationNode } from './types.js';
 
 class DomainSemanticsValidationFailure extends Error {
@@ -134,6 +135,15 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     throw new Error(`Failed to parse graph JSON at ${graphPath}: ${msg}`);
   }
 
+  // Lift 3 / #208: load the per-config edges ABox up front. The set of
+  // edge-establisher opIds is the authoritative source for
+  // `op.establishes.shape === 'edge'` going forward; the spec
+  // annotation's `shape` field is consulted only for cross-validation
+  // (drift warning). When the active config has not shipped an edges
+  // ABox, `edgeEstablishers` is `null` and `normalizeEstablishes` falls
+  // back to the legacy spec-annotation behaviour for backward compat.
+  const edgeEstablishers = loadEdgeEstablishers(repoRoot);
+
   const operations: Record<string, OperationNode> = {};
 
   // Support multiple possible root shapes
@@ -176,11 +186,32 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
         console.warn('[graphLoader] Skipping node without operationId/id/name:', Object.keys(op));
         continue;
       }
-      operations[opId] = normalizeOp(opId, op);
+      operations[opId] = normalizeOp(opId, op, edgeEstablishers);
     }
   } else {
     for (const [opId, op] of Object.entries(candidateOps)) {
-      operations[opId] = normalizeOp(opId, op);
+      operations[opId] = normalizeOp(opId, op, edgeEstablishers);
+    }
+  }
+
+  // Lift 3 / #208: cross-validate the edges ABox against the spec
+  // annotations now that every op has been normalised. The ABox is
+  // authoritative for `shape: 'edge'` at runtime, but a disagreement
+  // with the spec annotation almost always signals a config error
+  // (typo in `establishedBy`, ABox missing a recently-added op,
+  // upstream rename) — surface it loudly so it doesn't rot.
+  //
+  // Strict mode (STRICT_EDGES_ABOX=1) escalates drift to a hard error;
+  // default is a warning so a partially-migrated config still loads.
+  if (edgeEstablishers !== null) {
+    const drift = detectEdgeAnnotationDrift(candidateOps, edgeEstablishers, operations);
+    if (drift.length > 0) {
+      const detail = drift.map((d) => `  - ${d}`).join('\n');
+      const message = `edges ABox / spec-annotation drift detected:\n${detail}`;
+      if (process.env.STRICT_EDGES_ABOX === '1') {
+        throw new Error(message);
+      }
+      console.warn(`WARNING: ${message}\n  (set STRICT_EDGES_ABOX=1 to fail-fast on drift.)`);
     }
   }
 
@@ -502,7 +533,7 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
   return graph;
 }
 
-function normalizeOp(opId: string, op: RawOp): OperationNode {
+function normalizeOp(opId: string, op: RawOp, edgeEstablishers: Set<string> | null): OperationNode {
   // Extract produced semantic types.
   // Priority:
   // 1. Explicit fields (producesSemanticTypes / producesSemanticType / produces / outputsSemanticTypes)
@@ -618,7 +649,7 @@ function normalizeOp(opId: string, op: RawOp): OperationNode {
   // *consumed* prerequisites, not values established by this op. The
   // edge itself has no semantic type the planner can chain on, so we
   // don't touch `produces` for edges.
-  const establishes = normalizeEstablishes(op.establishes);
+  const establishes = normalizeEstablishes(op.establishes, opId, edgeEstablishers);
   const establishedSemantics = new Set<string>();
   if (establishes && establishes.shape !== 'edge') {
     for (const id of establishes.identifiedBy) {
@@ -684,7 +715,11 @@ function extractRequestBodySemantics(op: RawOp): OperationNode['requestBodySeman
   return out.length ? out : undefined;
 }
 
-function normalizeEstablishes(raw: unknown): OperationNode['establishes'] {
+function normalizeEstablishes(
+  raw: unknown,
+  opId: string,
+  edgeEstablishers: Set<string> | null,
+): OperationNode['establishes'] {
   if (!raw || typeof raw !== 'object') return undefined;
   // biome-ignore lint/plugin: extractor JSON contract — fields validated below.
   const r = raw as { kind?: unknown; shape?: unknown; identifiedBy?: unknown };
@@ -727,19 +762,108 @@ function normalizeEstablishes(raw: unknown): OperationNode['establishes'] {
     if (e.acceptsExternal === true) entry.acceptsExternal = true;
     identifiedBy.push(entry);
   }
-  // Same `shape` restriction as the extractor: an unknown string would
-  // silently degrade to non-edge behaviour and `normalizeOp` would push
-  // the components into `produces` and strip them from `requires` —
-  // the exact opposite of the intended edge semantics. Reject unknown
-  // shapes wholesale.
+  // Lift 3 / #208: ABox is the authoritative source for `shape: 'edge'`
+  // when the active config has shipped an edges ABox. The spec
+  // annotation's `shape` field is consulted only as a fallback (for
+  // configs without an ABox) and as a drift signal (cross-validated by
+  // a separate check in loadGraph after all ops are normalised).
+  //
+  // When the ABox is present:
+  //   - opId in `edgeEstablishers` ⇒ `shape: 'edge'` (regardless of
+  //     what the spec annotation says).
+  //   - opId NOT in `edgeEstablishers` ⇒ `shape: undefined` (treat as
+  //     non-edge even if the spec annotation says `shape: 'edge'`; the
+  //     drift is surfaced as a warning by validateEdgeAnnotationDrift).
+  //
+  // When the ABox is absent (`edgeEstablishers === null`), fall back to
+  // the legacy spec-annotation behaviour for backward compat with
+  // configs that have not yet migrated.
   const rawShape = r.shape;
-  const shapeValid = rawShape === undefined || rawShape === 'edge';
-  if (!shapeValid) return undefined;
+  let resolvedShape: 'edge' | undefined;
+  if (edgeEstablishers !== null) {
+    resolvedShape = edgeEstablishers.has(opId) ? 'edge' : undefined;
+  } else {
+    // Legacy spec-driven behaviour: same `shape` restriction as the
+    // extractor. An unknown string would silently degrade to non-edge
+    // behaviour and `normalizeOp` would push the components into
+    // `produces` and strip them from `requires` — the exact opposite
+    // of the intended edge semantics. Reject unknown shapes wholesale.
+    const shapeValid = rawShape === undefined || rawShape === 'edge';
+    if (!shapeValid) return undefined;
+    resolvedShape = rawShape === 'edge' ? 'edge' : undefined;
+  }
   return {
     kind: r.kind,
-    shape: rawShape === 'edge' ? 'edge' : undefined,
+    shape: resolvedShape,
     identifiedBy,
   };
+}
+
+/**
+ * Lift 3 / #208: detect drift between the edges ABox (authoritative
+ * for `shape: 'edge'`) and the per-op `x-semantic-establishes.shape`
+ * annotations from the spec. Returns one human-readable line per
+ * disagreement; an empty array means the two are consistent.
+ *
+ * Two drift kinds:
+ *   - **ABox lists op X but spec annotation says non-edge** (or no
+ *     annotation at all): the planner will treat X as an edge
+ *     establisher, but the spec disagrees — likely an ABox typo or a
+ *     stale spec annotation.
+ *   - **Spec says X is `shape: 'edge'` but ABox does not list X**: the
+ *     planner now treats X as a non-edge (per ABox); the spec
+ *     annotation is being ignored — likely an ABox missed an op or a
+ *     spec annotation is stale.
+ *
+ * Either condition is loud: silently letting the planner classify the
+ * op the wrong way would re-introduce the partial-state hazard #112
+ * was meant to close.
+ */
+function detectEdgeAnnotationDrift(
+  candidateOps: Record<string, RawOp> | RawOp[],
+  edgeEstablishers: Set<string>,
+  operations: Record<string, OperationNode>,
+): string[] {
+  const drift: string[] = [];
+  const specEdgeOps = new Set<string>();
+  const iterate = (cb: (opId: string, op: RawOp) => void) => {
+    if (Array.isArray(candidateOps)) {
+      for (const op of candidateOps) {
+        const opId = op?.operationId || op?.id || op?.name;
+        if (opId) cb(opId, op);
+      }
+    } else {
+      for (const [opId, op] of Object.entries(candidateOps)) cb(opId, op);
+    }
+  };
+  iterate((opId, op) => {
+    const est = op.establishes;
+    if (est === null || typeof est !== 'object') return;
+    // biome-ignore lint/plugin: drift detection inspects raw spec-annotation contract; result is narrowed by literal comparison below.
+    const shape = (est as Record<string, unknown>).shape;
+    if (shape === 'edge') {
+      specEdgeOps.add(opId);
+    }
+  });
+  for (const opId of edgeEstablishers) {
+    if (!(opId in operations)) {
+      drift.push(`ABox lists '${opId}' as an edge establisher, but the op is not in the spec`);
+      continue;
+    }
+    if (!specEdgeOps.has(opId)) {
+      drift.push(
+        `ABox lists '${opId}' as an edge establisher, but the spec annotation does not have shape: 'edge' (ABox is authoritative; spec annotation will be ignored)`,
+      );
+    }
+  }
+  for (const opId of specEdgeOps) {
+    if (!edgeEstablishers.has(opId)) {
+      drift.push(
+        `spec annotates '${opId}' with shape: 'edge', but the ABox does not list it as an edge establisher (ABox is authoritative; '${opId}' will be treated as a non-edge establisher)`,
+      );
+    }
+  }
+  return drift;
 }
 
 function extractPathParameters(op: RawOp): { name: string; semanticType?: string }[] | undefined {

--- a/path-analyser/src/ontology/loader.ts
+++ b/path-analyser/src/ontology/loader.ts
@@ -56,7 +56,18 @@ function formatErrors(errors: ErrorObject[] | null | undefined): string {
  * @throws if the file exists but does not validate against the TBox.
  */
 export function loadEdgesAbox(repoRoot: string): EdgesAbox | null {
-  const aboxPath = path.join(getActiveConfigDir(repoRoot), 'ontology', 'edges.json');
+  // The active-config resolver depends on a `configs.json` index at the
+  // repo root. Tests that exercise loadGraph against an isolated
+  // tmpDir don't ship one, and the right fallback there is "no ABox"
+  // (the test will then exercise the legacy spec-annotation path).
+  // Treat any resolver failure as "no ABox available" — symmetrical to
+  // the ENOENT-on-edges.json case below.
+  let aboxPath: string;
+  try {
+    aboxPath = path.join(getActiveConfigDir(repoRoot), 'ontology', 'edges.json');
+  } catch {
+    return null;
+  }
   let raw: string;
   try {
     raw = readFileSync(aboxPath, 'utf8');
@@ -92,4 +103,29 @@ export function loadEdgesAbox(repoRoot: string): EdgesAbox | null {
     throw new Error(`Edges ABox at ${aboxPath} has duplicate edge name(s): ${dupes.join(', ')}`);
   }
   return parsed;
+}
+
+/**
+ * Derive the set of operationIds that establish an edge, sourced from
+ * the edges ABox for the active config.
+ *
+ * Lift 3 / #208: the ABox is the authoritative source for "is this op
+ * an edge establisher" — a domain claim with no wire signature, per
+ * the principle in #198. Per-op `x-semantic-establishes: { shape:
+ * "edge" }` annotations in the upstream spec are no longer
+ * authoritative at runtime; the planner derives `op.establishes.shape`
+ * from the result of this function instead.
+ *
+ * @returns A Set of opIds, or `null` if no edges ABox exists for the
+ *   active config (in which case the caller falls back to the spec
+ *   annotation's `shape` field for backward compatibility).
+ */
+export function loadEdgeEstablishers(repoRoot: string): Set<string> | null {
+  const abox = loadEdgesAbox(repoRoot);
+  if (abox === null) return null;
+  const set = new Set<string>();
+  for (const e of abox.edges) {
+    set.add(e.establishedBy);
+  }
+  return set;
 }

--- a/semantic-graph-extractor/index.ts
+++ b/semantic-graph-extractor/index.ts
@@ -217,6 +217,17 @@ function loadKindRegistry():
       const kinds: Array<{ name: string; shape?: string; identifiers?: string[] }> = [];
       for (const k of parsed.kinds) {
         if (!k || typeof k.name !== 'string') continue;
+        // Lift 3 / #208: the runtime planner only consumes `shape:
+        // 'external-entity'` entries from this registry (graphLoader
+        // builds an external-entity identifier set from them). Edge
+        // entries (`shape: 'edge'`) are now sourced authoritatively
+        // from the per-config ABox at `configs/<name>/ontology/
+        // edges.json`; the spec-derived edge entries here are dead
+        // weight at runtime and pruning them avoids wire-format
+        // confusion when the ABox and spec disagree. Plain entity
+        // entries (no `shape`) are kept for now — they will be lifted
+        // in Lift 4.
+        if (k.shape === 'edge') continue;
         const entry: { name: string; shape?: string; identifiers?: string[] } = { name: k.name };
         if (typeof k.shape === 'string') entry.shape = k.shape;
         if (Array.isArray(k.identifiers)) {

--- a/tests/fixtures/integration/edges-abox-authoritative.test.ts
+++ b/tests/fixtures/integration/edges-abox-authoritative.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Integration fixture for Lift 3 (#208): the edges ABox is the
+ * authoritative source for `op.establishes.shape === 'edge'` at runtime.
+ *
+ * The principle (#198): an annotation belongs in the spec iff a
+ * non-Camunda implementer of the API would need it to implement a
+ * conformant server. The `shape: 'edge'` classifier on
+ * `x-semantic-establishes` is a domain claim with no wire signature,
+ * so it belongs in the ABox.
+ *
+ * Three observable behaviours guarded by this fixture:
+ *
+ *   1. **ABox authoritative — promotes**: the spec annotation has no
+ *      `shape` value (or `undefined`); the ABox lists the op in
+ *      `establishedBy`. After loadGraph, `op.establishes.shape ===
+ *      'edge'` (sourced from the ABox, not the spec annotation).
+ *
+ *   2. **ABox authoritative — demotes**: the spec annotation says
+ *      `shape: 'edge'`; the ABox does NOT list the op. After loadGraph,
+ *      `op.establishes.shape === undefined` (the spec annotation is
+ *      ignored), and a drift warning is emitted to stderr.
+ *
+ *   3. **Strict mode**: with `STRICT_EDGES_ABOX=1`, drift becomes a
+ *      hard error.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadGraph } from '../../../path-analyser/src/graphLoader.ts';
+
+const CONFIG_NAME = 'lift3-edges-test';
+
+let workdir: string;
+let baseDir: string;
+const ORIGINAL = {
+  CONFIG: process.env.CONFIG,
+  OPERATION_GRAPH_PATH: process.env.OPERATION_GRAPH_PATH,
+  OPENAPI_SPEC_PATH: process.env.OPENAPI_SPEC_PATH,
+  STRICT_EDGES_ABOX: process.env.STRICT_EDGES_ABOX,
+};
+
+function writeWorkspace(opts: {
+  edgesAbox: object | null;
+  graphOps: Record<string, unknown>;
+}): void {
+  // loadGraph computes `repoRoot = path.resolve(baseDir, '..')`; place
+  // configs.json + the ABox under repoRoot, and the graph file under
+  // baseDir. Mirrors the real layout (path-analyser as workspace).
+  const repoRoot = workdir;
+  baseDir = join(repoRoot, 'path-analyser');
+  mkdirSync(baseDir, { recursive: true });
+  writeFileSync(
+    join(repoRoot, 'configs.json'),
+    JSON.stringify({ default: CONFIG_NAME, configs: { [CONFIG_NAME]: {} } }),
+  );
+  if (opts.edgesAbox !== null) {
+    const aboxDir = join(repoRoot, 'configs', CONFIG_NAME, 'ontology');
+    mkdirSync(aboxDir, { recursive: true });
+    writeFileSync(join(aboxDir, 'edges.json'), JSON.stringify(opts.edgesAbox));
+  }
+  const graphPath = join(baseDir, 'operation-dependency-graph.json');
+  writeFileSync(graphPath, JSON.stringify({ operations: opts.graphOps }));
+  process.env.OPERATION_GRAPH_PATH = graphPath;
+  process.env.CONFIG = CONFIG_NAME;
+  // Ensure the (optional) hint-merge loader doesn't try to read a real spec.
+  process.env.OPENAPI_SPEC_PATH = join(baseDir, 'no-such-spec.yaml');
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'lift3-edges-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+  for (const [k, v] of Object.entries(ORIGINAL)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe('Lift 3 (#208): edges ABox is authoritative for op.establishes.shape', () => {
+  it('promotes a non-edge spec annotation to shape: edge when the ABox lists the op', async () => {
+    writeWorkspace({
+      edgesAbox: {
+        version: 1,
+        edges: [
+          {
+            name: 'GroupUserMembership',
+            endpoints: { from: 'Group', to: 'User' },
+            identifiedBy: ['GroupId', 'Username'],
+            establishedBy: 'assignUserToGroup',
+            observableVia: 'searchUsersForGroup',
+            description: 'fixture',
+          },
+        ],
+      },
+      graphOps: {
+        assignUserToGroup: {
+          operationId: 'assignUserToGroup',
+          method: 'POST',
+          path: '/groups/{groupId}/users/{username}',
+          requires: { required: [], optional: [] },
+          produces: [],
+          // Spec annotation has NO `shape` value — pre-Lift-3 the
+          // planner would have classified this as a non-edge.
+          establishes: {
+            kind: 'GroupUserMembership',
+            identifiedBy: [
+              { in: 'path', name: 'groupId', semanticType: 'GroupId' },
+              { in: 'path', name: 'username', semanticType: 'Username' },
+            ],
+          },
+        },
+      },
+    });
+    const graph = await loadGraph(baseDir);
+    expect(graph.operations.assignUserToGroup?.establishes?.shape).toBe('edge');
+  });
+
+  it('demotes a spec shape: edge to undefined when the ABox does not list the op', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writeWorkspace({
+      // ABox ships an unrelated edge — the schema requires at least
+      // one entry. The op under test is intentionally NOT listed in
+      // `establishedBy`, which is what triggers the demote.
+      edgesAbox: {
+        version: 1,
+        edges: [
+          {
+            name: 'UnrelatedEdge',
+            endpoints: { from: 'P', to: 'Q' },
+            identifiedBy: ['PId', 'QId'],
+            establishedBy: 'unrelatedEstablisher',
+            observableVia: 'unrelatedObserver',
+            description: 'unrelated to the op under test',
+          },
+        ],
+      },
+      graphOps: {
+        notReallyAnEdge: {
+          operationId: 'notReallyAnEdge',
+          method: 'POST',
+          path: '/x/{xId}/y/{yId}',
+          requires: { required: [], optional: [] },
+          produces: [],
+          establishes: {
+            kind: 'WhateverKind',
+            shape: 'edge',
+            identifiedBy: [
+              { in: 'path', name: 'xId', semanticType: 'XId' },
+              { in: 'path', name: 'yId', semanticType: 'YId' },
+            ],
+          },
+        },
+      },
+    });
+    const graph = await loadGraph(baseDir);
+    expect(graph.operations.notReallyAnEdge?.establishes?.shape).toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+    const allWarnings = warn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).toMatch(/edges ABox \/ spec-annotation drift/);
+    expect(allWarnings).toMatch(/notReallyAnEdge/);
+    warn.mockRestore();
+  });
+
+  it('hard-errors on drift when STRICT_EDGES_ABOX=1', async () => {
+    process.env.STRICT_EDGES_ABOX = '1';
+    writeWorkspace({
+      edgesAbox: {
+        version: 1,
+        edges: [
+          {
+            name: 'UnrelatedEdge',
+            endpoints: { from: 'P', to: 'Q' },
+            identifiedBy: ['PId', 'QId'],
+            establishedBy: 'unrelatedEstablisher',
+            observableVia: 'unrelatedObserver',
+            description: 'unrelated',
+          },
+        ],
+      },
+      graphOps: {
+        spuriousEdge: {
+          operationId: 'spuriousEdge',
+          method: 'POST',
+          path: '/a/{aId}/b/{bId}',
+          requires: { required: [], optional: [] },
+          produces: [],
+          establishes: {
+            kind: 'SpuriousKind',
+            shape: 'edge',
+            identifiedBy: [
+              { in: 'path', name: 'aId', semanticType: 'AId' },
+              { in: 'path', name: 'bId', semanticType: 'BId' },
+            ],
+          },
+        },
+      },
+    });
+    await expect(loadGraph(baseDir)).rejects.toThrow(/edges ABox \/ spec-annotation drift/);
+  });
+
+  it('falls back to legacy spec-driven behaviour when no ABox file is present', async () => {
+    writeWorkspace({
+      edgesAbox: null,
+      graphOps: {
+        legacyEdge: {
+          operationId: 'legacyEdge',
+          method: 'POST',
+          path: '/a/{aId}/b/{bId}',
+          requires: { required: [], optional: [] },
+          produces: [],
+          establishes: {
+            kind: 'LegacyEdge',
+            shape: 'edge',
+            identifiedBy: [
+              { in: 'path', name: 'aId', semanticType: 'AId' },
+              { in: 'path', name: 'bId', semanticType: 'BId' },
+            ],
+          },
+        },
+      },
+    });
+    const graph = await loadGraph(baseDir);
+    expect(graph.operations.legacyEdge?.establishes?.shape).toBe('edge');
+  });
+});

--- a/tests/fixtures/loader/edges-abox-loader.test.ts
+++ b/tests/fixtures/loader/edges-abox-loader.test.ts
@@ -23,7 +23,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { loadEdgesAbox } from '../../../path-analyser/src/ontology/loader.ts';
+import { loadEdgeEstablishers, loadEdgesAbox } from '../../../path-analyser/src/ontology/loader.ts';
 
 let workdir: string;
 const CONFIG_NAME = 'unit-test-config';
@@ -126,5 +126,53 @@ describe('loadEdgesAbox: documented branches (#201 review)', () => {
     const abox = loadEdgesAbox(workdir);
     expect(abox?.edges).toHaveLength(1);
     expect(abox?.edges[0]?.name).toBe('OnlyEdge');
+  });
+});
+
+describe('loadEdgeEstablishers: Lift 3 (#208) — ABox-derived edge-establisher set', () => {
+  it('returns null when the ABox file does not exist (caller falls back to spec-driven shape)', () => {
+    expect(loadEdgeEstablishers(workdir)).toBeNull();
+  });
+
+  it('returns null when configs.json itself is missing (test-isolation fallback)', () => {
+    // The integration tests run loadGraph against a tmpDir that
+    // doesn't ship a configs.json; loadEdgeEstablishers must degrade
+    // to "no ABox" so the legacy spec-driven behaviour is preserved.
+    rmSync(join(workdir, 'configs.json'));
+    expect(loadEdgeEstablishers(workdir)).toBeNull();
+  });
+
+  it('returns the set of opIds from `establishedBy` across all edges', () => {
+    writeAbox(
+      JSON.stringify({
+        version: 1,
+        edges: [
+          {
+            name: 'EdgeOne',
+            endpoints: { from: 'A', to: 'B' },
+            identifiedBy: ['AId', 'BId'],
+            establishedBy: 'establishOne',
+            observableVia: 'observeOne',
+            description: 'fixture-one',
+          },
+          {
+            name: 'EdgeTwo',
+            endpoints: { from: 'C', to: 'D' },
+            identifiedBy: ['CId', 'DId'],
+            establishedBy: 'establishTwo',
+            observableVia: 'observeTwo',
+            description: 'fixture-two',
+          },
+        ],
+      }),
+    );
+    const set = loadEdgeEstablishers(workdir);
+    expect(set).not.toBeNull();
+    expect(set).toEqual(new Set(['establishOne', 'establishTwo']));
+  });
+
+  it("propagates the loader's validation failure (does not silently swallow malformed ABox)", () => {
+    writeAbox('{ this is not json');
+    expect(() => loadEdgeEstablishers(workdir)).toThrow(/Failed to parse edges ABox/);
   });
 });


### PR DESCRIPTION
Closes #208. Implements Lift 3 of the ontology migration tracked in #199, applying the operational principle landed in #198: "an annotation belongs in the spec iff a non-Camunda implementer of the API would need it to implement a conformant server".

The `shape: "edge"` classifier on `x-semantic-establishes` is a domain claim with no wire signature (e.g. `assignUserToGroup` returns 204 with no body), so the ABox is now authoritative for it.

## Changes

- **`path-analyser/src/ontology/loader.ts`**: new `loadEdgeEstablishers()` returns the Set of opIds in `establishedBy` across the per-config edges ABox, or `null` when no ABox is shipped (legacy fallback). `loadEdgesAbox()` now also returns `null` when the active-config resolver fails (test isolation with isolated tmpDirs).
- **`path-analyser/src/graphLoader.ts`**: `loadGraph` loads the edge-establisher Set up front and threads it into `normalizeOp` / `normalizeEstablishes`. The eight call sites that gate on `establishes.shape !== 'edge'` are unchanged — only the **source** of `shape` changes.
- **`detectEdgeAnnotationDrift()`**: cross-validates ABox vs spec annotations and surfaces disagreement. Drift is logged as `console.warn` by default; `STRICT_EDGES_ABOX=1` escalates to a hard error (mirrors the Lift 2 `STRICT_BOOTSTRAP_ABOX` pattern).
- **`semantic-graph-extractor/index.ts`**: `loadKindRegistry()` prunes `shape: 'edge'` entries (dead weight at runtime; the planner only consumed external-entity entries).

## Bundled graph diff

Only the 12 edge entries in `kindRegistry` are pruned. `bootstrapSequences` and all other graph fields are byte-identical to the pre-lift baseline. ABox + spec agree on the OCA config, so no drift warnings are emitted.

## Tests

- 4 new unit tests for `loadEdgeEstablishers`: happy path, missing ABox, missing `configs.json` fallback, malformed ABox propagation.
- 4 new integration tests for the ABox-authoritative shape resolution: ABox promotes a non-edge spec annotation, ABox demotes a spec `shape: edge`, `STRICT_EDGES_ABOX` hard-errors on drift, no-ABox falls back to legacy spec-driven behaviour.

Pre-push checklist: lint clean, 4× tsc clean, tests/tsconfig.json clean, 433 passed | 6 skipped.