### PR TITLE
feat: lift entity-kinds classification to ABox + add coverage gates (#210, Lift 4)

### DIFF
--- a/configs/camunda-oca/ontology/entity-kinds.json
+++ b/configs/camunda-oca/ontology/entity-kinds.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://camunda.github.io/api-test-generator/ns/v1/entity-kinds.schema.json",
+  "@context": "https://camunda.github.io/api-test-generator/ns/v1/context.jsonld",
+  "version": 1,
+  "kinds": [
+    {
+      "@type": "EntityKind",
+      "name": "Role",
+      "shape": "entity",
+      "identifiers": [
+        "RoleId"
+      ],
+      "description": "A role entity, identified by its client-minted roleId."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "User",
+      "shape": "entity",
+      "identifiers": [
+        "Username"
+      ],
+      "description": "A user entity, identified by its client-minted username."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "Tenant",
+      "shape": "entity",
+      "identifiers": [
+        "TenantId"
+      ],
+      "description": "A tenant entity, identified by its client-minted tenantId."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "Group",
+      "shape": "entity",
+      "identifiers": [
+        "GroupId"
+      ],
+      "description": "A group entity, identified by its client-minted groupId."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "MappingRule",
+      "shape": "entity",
+      "identifiers": [
+        "MappingRuleId"
+      ],
+      "description": "A mapping rule entity, identified by its client-minted mappingRuleId."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "GlobalTaskListener",
+      "shape": "entity",
+      "identifiers": [
+        "GlobalListenerId"
+      ],
+      "description": "A global user task listener entity, identified by its client-minted id (a GlobalListenerId)."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "GlobalClusterVariable",
+      "shape": "entity",
+      "identifiers": [
+        "ClusterVariableName"
+      ],
+      "description": "A global-scoped cluster variable, identified by its client-minted name (a ClusterVariableName). Established by createGlobalClusterVariable."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "TenantClusterVariable",
+      "shape": "entity",
+      "identifiers": [
+        "ClusterVariableName"
+      ],
+      "description": "A tenant-scoped cluster variable, identified by the (tenantId, name) tuple. Established by createTenantClusterVariable. Only ClusterVariableName is listed in 'identifiers' here because TenantId is owned by the Tenant entity and must remain single-owner for the edge-derivation rule; the Tenant requirement of tenant-scoped operations is expressed via the tenantId path parameter."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "Client",
+      "shape": "external-entity",
+      "identifiers": [
+        "ClientId"
+      ],
+      "description": "An OAuth client. Minted outside the Camunda REST API: by Console in SaaS, by the configured external IdP (EntraID, Keycloak, Okta, …) in Self-Managed with OIDC. Not modelled at all under Self-Managed Basic auth, where m2m apps are users instead. Referenced by the client-membership edges only — never established or fetched via this API."
+    }
+  ]
+}

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -4445,12 +4445,8 @@ describeForThisConfig('bundled-spec invariants: entity-kinds ABox cross-referenc
     // to silently fall back to the legacy spec-emitted kindRegistry
     // path (e.g. ABox file moves and ENOENT swallows the error),
     // this invariant fails by direct comparison.
-    const { loadEntityKindsAbox, loadGraph } = await import(
-      '../../path-analyser/src/ontology/loader.js'
-    ).then(async (m) => ({
-      ...m,
-      loadGraph: (await import('../../path-analyser/src/graphLoader.js')).loadGraph,
-    }));
+    const { loadEntityKindsAbox } = await import('../../path-analyser/src/ontology/loader.js');
+    const { loadGraph } = await import('../../path-analyser/src/graphLoader.js');
     const abox = loadEntityKindsAbox(REPO_ROOT);
     if (!abox) throw new Error('entity-kinds ABox missing');
     const expected = new Set<string>();
@@ -4481,6 +4477,10 @@ describeForThisConfig('bundled-spec invariants: entity-kinds ABox cross-referenc
   it("the entity-kinds ABox's $schema field resolves to the published TBox JSON", () => {
     const aboxPath = join(REPO_ROOT, 'configs', CONFIG_NAME, 'ontology', 'entity-kinds.json');
     const expectedTboxPath = join(REPO_ROOT, 'ontology', 'vocabulary', 'entity-kinds.schema.json');
+    expect(
+      existsSync(expectedTboxPath),
+      `Published TBox at '${expectedTboxPath}' does not exist — vocabulary file may have been deleted or renamed`,
+    ).toBe(true);
     interface AboxHeader {
       $schema?: unknown;
     }
@@ -4492,6 +4492,5 @@ describeForThisConfig('bundled-spec invariants: entity-kinds ABox cross-referenc
     expect(schemaField).toBe(
       'https://camunda.github.io/api-test-generator/ns/v1/entity-kinds.schema.json',
     );
-    void expectedTboxPath;
   });
 });

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -4248,3 +4248,250 @@ describeForThisConfig(
     });
   },
 );
+
+describeForThisConfig('bundled-spec invariants: entity-kinds ABox cross-references (#210)', () => {
+  // Lift 4 / #210: the entity-kinds ABox is now the authoritative
+  // source for `graph.externalEntityIdentifiers` (and, transitionally,
+  // for the inventory of in-API entity kinds). These invariants are
+  // the locality-loss replacement signal: where the spec gave us
+  // "missing annotation lints at the operation site" for free, we
+  // now manufacture the same completeness signal as named L3
+  // assertions over ABox + spec + bundled graph. See #210 §4b/§4c
+  // for the rationale and the two-sense framing of drift.
+
+  it('loads the entity-kinds ABox via the generic loader (proves the load path)', async () => {
+    const { loadEntityKindsAbox } = await import('../../path-analyser/src/ontology/loader.js');
+    const abox = loadEntityKindsAbox(REPO_ROOT);
+    expect(abox, 'entity-kinds ABox file must exist for the camunda-oca config').not.toBeNull();
+    expect(abox?.kinds.length).toBeGreaterThan(0);
+  });
+
+  it('every kind name in the ABox appears in the spec semantic-kinds.json (sense-1: spec-vs-abox, ABox-stale)', async () => {
+    // Transitional check (Lift 4 §4b sense 1). Becomes a no-op once
+    // upstream retires `x-semantic-kind`; until then it catches
+    // typos and stale ABox entries against the live spec.
+    const { loadEntityKindsAbox } = await import('../../path-analyser/src/ontology/loader.js');
+    const abox = loadEntityKindsAbox(REPO_ROOT);
+    if (!abox) throw new Error('entity-kinds ABox missing');
+    const kindsPath = join(getSpecBundleDir(REPO_ROOT), 'semantic-kinds.json');
+    if (!existsSync(kindsPath)) {
+      throw new Error(
+        `semantic-kinds.json not found at ${kindsPath}. Run 'npm run fetch-spec' first.`,
+      );
+    }
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const specKinds = JSON.parse(readFileSync(kindsPath, 'utf8')) as {
+      kinds?: { name?: unknown }[];
+    };
+    const specNames = new Set<string>();
+    for (const k of specKinds.kinds ?? []) {
+      if (k && typeof k.name === 'string') specNames.add(k.name);
+    }
+    const aboxOnly = abox.kinds.map((k) => k.name).filter((n) => !specNames.has(n));
+    expect(
+      aboxOnly,
+      'entity-kinds ABox lists kind names that the spec semantic-kinds.json does not — either the ABox is stale or the spec was regenerated against a ref that retired the kind',
+    ).toEqual([]);
+  });
+
+  it('every non-edge kind in the spec semantic-kinds.json is listed in the ABox (sense-1: spec-vs-abox, ABox-incomplete)', async () => {
+    // Transitional check (Lift 4 §4b sense 1). Until `x-semantic-kind`
+    // retires upstream, the spec's kind list is the second source of
+    // truth — every entry that isn't an `edge` shape (edges are owned
+    // by the edges ABox post-Lift-3) must be classified by the
+    // entity-kinds ABox. Without this, a new upstream kind would
+    // ship with no domain classification and the planner would
+    // silently treat any of its identifier types as "ordinary value
+    // field, must have a producer" — usually wrong for external
+    // entities and silently wrong for in-API entities.
+    const { loadEntityKindsAbox } = await import('../../path-analyser/src/ontology/loader.js');
+    const abox = loadEntityKindsAbox(REPO_ROOT);
+    if (!abox) throw new Error('entity-kinds ABox missing');
+    const kindsPath = join(getSpecBundleDir(REPO_ROOT), 'semantic-kinds.json');
+    if (!existsSync(kindsPath)) {
+      throw new Error(
+        `semantic-kinds.json not found at ${kindsPath}. Run 'npm run fetch-spec' first.`,
+      );
+    }
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const specKinds = JSON.parse(readFileSync(kindsPath, 'utf8')) as {
+      kinds?: { name?: unknown; shape?: unknown }[];
+    };
+    const aboxNames = new Set(abox.kinds.map((k) => k.name));
+    const specOnly: string[] = [];
+    for (const k of specKinds.kinds ?? []) {
+      if (k && typeof k.name === 'string' && k.shape !== 'edge' && !aboxNames.has(k.name)) {
+        specOnly.push(k.name);
+      }
+    }
+    expect(
+      specOnly,
+      "spec semantic-kinds.json lists non-edge kind names that the entity-kinds ABox does not classify — add the kind to configs/<config>/ontology/entity-kinds.json (or, if it's an edge kind, to edges.json instead)",
+    ).toEqual([]);
+  });
+
+  it('every kind in the ABox has at least one identifier referenced by some operation in the bundled graph (sense-2: abox-vs-graph, ABox-stale-vs-use)', async () => {
+    // Durable check (Lift 4 §4b sense 2). Survives the upstream
+    // retirement of `x-semantic-kind` because it grounds drift in
+    // actual runtime use of the bundled graph: a kind whose
+    // identifier types appear nowhere in produces/requires/
+    // establishes is dead weight in this API.
+    const { loadEntityKindsAbox } = await import('../../path-analyser/src/ontology/loader.js');
+    const abox = loadEntityKindsAbox(REPO_ROOT);
+    if (!abox) throw new Error('entity-kinds ABox missing');
+    if (!existsSync(GRAPH_PATH)) {
+      throw new Error(`Graph not found at ${GRAPH_PATH}. Run 'npm run testsuite:generate' first.`);
+    }
+    interface GraphOp {
+      operationId?: string;
+      requires?: { required?: unknown; optional?: unknown };
+      produces?: unknown;
+      establishes?: { identifiedBy?: { semanticType?: unknown }[] };
+    }
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const graph = JSON.parse(readFileSync(GRAPH_PATH, 'utf8')) as {
+      operationsById?: Record<string, GraphOp>;
+      operations?: Record<string, GraphOp> | GraphOp[];
+    };
+    const ops: GraphOp[] = graph.operationsById
+      ? Object.values(graph.operationsById)
+      : Array.isArray(graph.operations)
+        ? graph.operations
+        : Object.values(graph.operations ?? {});
+    const referenced = new Set<string>();
+    for (const op of ops) {
+      if (Array.isArray(op.produces))
+        for (const t of op.produces) if (typeof t === 'string') referenced.add(t);
+      const req = op.requires;
+      if (req && typeof req === 'object') {
+        if (Array.isArray(req.required))
+          for (const t of req.required) if (typeof t === 'string') referenced.add(t);
+        if (Array.isArray(req.optional))
+          for (const t of req.optional) if (typeof t === 'string') referenced.add(t);
+      }
+      const est = op.establishes;
+      if (est && Array.isArray(est.identifiedBy)) {
+        for (const id of est.identifiedBy) {
+          if (id && typeof id.semanticType === 'string') referenced.add(id.semanticType);
+        }
+      }
+    }
+    const dead = abox.kinds.filter((k) => !k.identifiers.some((t) => referenced.has(t)));
+    expect(
+      dead.map((k) => ({ kind: k.name, identifiers: k.identifiers })),
+      'entity-kinds ABox lists kinds whose identifier types are not referenced by any operation in the bundled graph — either remove the kind or add an operation that consumes one of its identifiers',
+    ).toEqual([]);
+  });
+
+  it('every semantic identifier type used in any op.establishes.identifiedBy[] is claimed by some kind in the ABox (sense-2: abox-vs-graph, ABox-incomplete-vs-use)', async () => {
+    // Durable check (Lift 4 §4b/§4c sense 2). This is the locality-
+    // loss replacement signal in its strongest form: when an upstream
+    // PR adds a new `x-semantic-establishes.identifiedBy` whose
+    // semanticType refers to a new identifier kind we forgot to
+    // classify in the ABox, this invariant fails immediately with the
+    // offending type. Without it, the new identifier would silently
+    // fall through to the "ordinary value field" path and the
+    // planner's kind-aware behaviour (externalBoundary
+    // short-circuit, identifier minting) would no longer apply.
+    const { loadEntityKindsAbox, loadEdgesAbox } = await import(
+      '../../path-analyser/src/ontology/loader.js'
+    );
+    const entityAbox = loadEntityKindsAbox(REPO_ROOT);
+    if (!entityAbox) throw new Error('entity-kinds ABox missing');
+    const edgesAbox = loadEdgesAbox(REPO_ROOT);
+    if (!existsSync(GRAPH_PATH)) {
+      throw new Error(`Graph not found at ${GRAPH_PATH}. Run 'npm run testsuite:generate' first.`);
+    }
+    interface GraphOp {
+      operationId?: string;
+      establishes?: { identifiedBy?: { semanticType?: unknown }[] };
+    }
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const graph = JSON.parse(readFileSync(GRAPH_PATH, 'utf8')) as {
+      operationsById?: Record<string, GraphOp>;
+      operations?: Record<string, GraphOp> | GraphOp[];
+    };
+    const ops: GraphOp[] = graph.operationsById
+      ? Object.values(graph.operationsById)
+      : Array.isArray(graph.operations)
+        ? graph.operations
+        : Object.values(graph.operations ?? {});
+    // Union of every identifier-shaped semantic type appearing in any
+    // op's establish-identifiedBy list.
+    const identifierTypes = new Set<string>();
+    for (const op of ops) {
+      const ids = op.establishes?.identifiedBy ?? [];
+      for (const id of ids) {
+        if (id && typeof id.semanticType === 'string') identifierTypes.add(id.semanticType);
+      }
+    }
+    // Set of every identifier type claimed by some entity-kinds ABox kind
+    // (or, for edge kinds, by the edges ABox's identifiedBy tuples — edges
+    // own their own identifier classification post-Lift-3).
+    const claimed = new Set<string>();
+    for (const k of entityAbox.kinds) for (const t of k.identifiers) claimed.add(t);
+    for (const e of edgesAbox?.edges ?? []) for (const t of e.identifiedBy) claimed.add(t);
+    const unclassified = [...identifierTypes].filter((t) => !claimed.has(t));
+    expect(
+      unclassified,
+      "semantic identifier type(s) appear in some op's x-semantic-establishes.identifiedBy[] but are not claimed by any kind in the entity-kinds ABox or the edges ABox — add the type to a kind's identifiers[] in configs/<config>/ontology/entity-kinds.json (or, for edge identifiers, to the appropriate edge's identifiedBy in edges.json)",
+    ).toEqual([]);
+  });
+
+  it('graph.externalEntityIdentifiers is sourced from the entity-kinds ABox (planner contract)', async () => {
+    // Closes the loop: the loader is supposed to source
+    // graph.externalEntityIdentifiers from the entity-kinds ABox's
+    // `external-entity` kinds. If a future change causes the loader
+    // to silently fall back to the legacy spec-emitted kindRegistry
+    // path (e.g. ABox file moves and ENOENT swallows the error),
+    // this invariant fails by direct comparison.
+    const { loadEntityKindsAbox, loadGraph } = await import(
+      '../../path-analyser/src/ontology/loader.js'
+    ).then(async (m) => ({
+      ...m,
+      loadGraph: (await import('../../path-analyser/src/graphLoader.js')).loadGraph,
+    }));
+    const abox = loadEntityKindsAbox(REPO_ROOT);
+    if (!abox) throw new Error('entity-kinds ABox missing');
+    const expected = new Set<string>();
+    for (const k of abox.kinds) {
+      if (k.shape === 'external-entity') for (const t of k.identifiers) expected.add(t);
+    }
+    const graph = await loadGraph(join(REPO_ROOT, 'path-analyser'));
+    const actual = graph.externalEntityIdentifiers ?? new Set<string>();
+    expect(
+      [...actual].sort(),
+      'graph.externalEntityIdentifiers does not match the union of identifiers across `external-entity` kinds in the entity-kinds ABox',
+    ).toEqual([...expected].sort());
+  });
+
+  it('the committed entity-kinds vocabulary JSON matches the regenerated TBox (drift detector)', async () => {
+    const { ARTIFACTS, renderSchema } = await import('../../scripts/build-ontology.ts');
+    const target = ARTIFACTS.find((a) => a.jsonPath.endsWith('entity-kinds.schema.json'));
+    expect(target, 'build-ontology must include entity-kinds.schema.json').toBeDefined();
+    if (!target) return;
+    const onDisk = readFileSync(target.jsonPath, 'utf8');
+    const rendered = renderSchema(target.schema);
+    expect(
+      onDisk,
+      `Generated ontology artefact at ${target.jsonPath} is stale. Run 'npm run build:ontology' to refresh it.`,
+    ).toBe(rendered);
+  });
+
+  it("the entity-kinds ABox's $schema field resolves to the published TBox JSON", () => {
+    const aboxPath = join(REPO_ROOT, 'configs', CONFIG_NAME, 'ontology', 'entity-kinds.json');
+    const expectedTboxPath = join(REPO_ROOT, 'ontology', 'vocabulary', 'entity-kinds.schema.json');
+    interface AboxHeader {
+      $schema?: unknown;
+    }
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const aboxJson = JSON.parse(readFileSync(aboxPath, 'utf8')) as AboxHeader;
+    const schemaField = aboxJson.$schema;
+    expect(typeof schemaField, 'ABox must declare a string `$schema` field').toBe('string');
+    if (typeof schemaField !== 'string') return;
+    expect(schemaField).toBe(
+      'https://camunda.github.io/api-test-generator/ns/v1/entity-kinds.schema.json',
+    );
+    void expectedTboxPath;
+  });
+});

--- a/ontology/vocabulary/entity-kinds.schema.json
+++ b/ontology/vocabulary/entity-kinds.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://camunda.github.io/api-test-generator/ns/v1/entity-kinds.schema.json",
+  "title": "Entity-kinds ABox (api-test-generator ontology, v1)",
+  "description": "TBox JSON Schema for an ABox file describing the entity kinds (the domain nouns) of a single API. Each entry asserts: an entity kind exists; it has one of two shapes (`entity` for in-API-managed, `external-entity` for identifiers minted outside the API); and (for both shapes) a list of semantic identifier-type names that identify it. The schema is intentionally agnostic to which API ships the kinds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/entity-kinds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (kind names appearing in operation `produces[]`/`requires[]`, identifier types being live, etc.) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "kinds"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "@context": {
+      "description": "Optional JSON-LD context. Ignored by the loader; preserved verbatim so external RDF tooling can resolve term IRIs without modification.",
+      "type": [
+        "object",
+        "string",
+        "array"
+      ]
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Schema version of this ABox file. Bumped only when the TBox shape changes incompatibly."
+    },
+    "kinds": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/EntityKind"
+      }
+    }
+  },
+  "definitions": {
+    "EntityKind": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "shape",
+        "identifiers",
+        "description"
+      ],
+      "properties": {
+        "@type": {
+          "description": "Optional JSON-LD type IRI. Ignored by the loader.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Za-z0-9]+$",
+          "description": "PascalCase singular noun naming the entity kind (e.g. `Role`, `Client`)."
+        },
+        "shape": {
+          "type": "string",
+          "enum": [
+            "entity",
+            "external-entity"
+          ],
+          "description": "`entity`: in-API-managed (producer + consumer ops both inside the API). `external-entity`: identifier minted outside the API; planner treats `identifiers[]` as `externalBoundary` (client-mintable, no upstream producer required)."
+        },
+        "identifiers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Semantic identifier-type name (matching the `semanticType` values used in `x-semantic-establishes.identifiedBy` upstream)."
+          }
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -7,7 +7,11 @@ import {
   validateRequestBodySemanticsClassified,
   validateRuntimeStateWitnessGraphRefs,
 } from './domainSemanticsValidator.js';
-import { loadEdgeEstablishers } from './ontology/loader.js';
+import {
+  loadEdgeEstablishers,
+  loadEntityKindsAbox,
+  loadExternalEntityIdentifiers,
+} from './ontology/loader.js';
 import type { BootstrapSequence, DomainSemantics, OperationGraph, OperationNode } from './types.js';
 
 class DomainSemanticsValidationFailure extends Error {
@@ -463,16 +467,20 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     // ENOENT or non-Error throw: sidecar absent — domain analysis disabled
   }
 
-  // Issue #134 / camunda/camunda#52320: build the external-entity
-  // identifier set from the kindRegistry payload (if any). Each kind
-  // with `shape: "external-entity"` contributes its `identifiers`
-  // (e.g. Client → ClientId) — the planner treats these as
-  // automatically client-mintable. Source the registry from the same
-  // root that yielded `candidateOps` so nested-graph layouts
-  // (`parsed.graph` / `parsed.data`) are handled consistently with
-  // the top-level layout.
+  // Lift 4 / #210: the entity-kinds ABox is the authoritative runtime
+  // source for the external-entity identifier set. Falls back to the
+  // spec-emitted `kindRegistry` (Issue #134 / camunda/camunda#52320)
+  // when no ABox is shipped — the legacy path stays alive so
+  // unmigrated configs and tests using isolated tmpDirs still work.
+  // Mirrors the Lift 3 (#208) edges-ABox pattern.
   let externalEntityIdentifiers: Set<string> | undefined;
-  if (opsRoot) {
+  const aboxExternals = loadExternalEntityIdentifiers(repoRoot);
+  if (aboxExternals !== null) {
+    if (aboxExternals.size > 0) externalEntityIdentifiers = aboxExternals;
+  } else if (opsRoot) {
+    // Source the registry from the same root that yielded `candidateOps`
+    // so nested-graph layouts (`parsed.graph` / `parsed.data`) are
+    // handled consistently with the top-level layout.
     const registry = opsRoot.kindRegistry;
     if (registry && Array.isArray(registry.kinds)) {
       const set = new Set<string>();
@@ -484,6 +492,28 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
         }
       }
       if (set.size > 0) externalEntityIdentifiers = set;
+    }
+  }
+
+  // Lift 4 / #210: cross-validate the entity-kinds ABox against both
+  // the spec-emitted kindRegistry (transitional, sense 1) and the
+  // bundled-graph use-sites (durable, sense 2). The two senses have
+  // different lifetimes — sense 1 is migration scaffolding that
+  // retires when upstream drops `x-semantic-kind`; sense 2 is the
+  // permanent gate that catches "upstream added a new endpoint and
+  // we forgot to update the ABox" (the locality-loss replacement
+  // signal). See #210 §4b for the full rationale.
+  if (aboxExternals !== null) {
+    const drift = detectEntityKindsDrift(opsRoot?.kindRegistry, operations, repoRoot);
+    if (drift.length > 0) {
+      const detail = drift.map((d) => `  - ${d}`).join('\n');
+      const message = `entity-kinds ABox drift detected:\n${detail}`;
+      if (process.env.STRICT_ENTITY_KINDS_ABOX === '1') {
+        throw new Error(message);
+      }
+      console.warn(
+        `WARNING: ${message}\n  (set STRICT_ENTITY_KINDS_ABOX=1 to fail-fast on drift.)`,
+      );
     }
   }
 
@@ -863,6 +893,87 @@ function detectEdgeAnnotationDrift(
       );
     }
   }
+  return drift;
+}
+
+/**
+ * Cross-validate the entity-kinds ABox against (1) the spec-emitted
+ * `kindRegistry` payload and (2) the bundled-graph use-sites. Lift 4 /
+ * #210 introduces two senses of drift with different lifetimes; both
+ * are checked here.
+ *
+ *   - **Sense 1 (transitional, `spec-vs-abox`)**: cross-checks the ABox
+ *     against the spec's `kindRegistry`. Useful migration scaffolding;
+ *     becomes a no-op once `x-semantic-kind` retires upstream.
+ *
+ *       - ABox lists kind X but kindRegistry does not.
+ *       - kindRegistry lists kind X but ABox does not.
+ *
+ *   - **Sense 2 (durable, `abox-vs-graph`)**: grounds drift in actual
+ *     runtime use of the bundled graph. Permanent gate that catches
+ *     "upstream added a new endpoint and we forgot to update the ABox".
+ *
+ *       - ABox lists kind X but no operation in the graph references
+ *         any of X's identifier types in `produces[]`, `requires[]`,
+ *         or `establishes.identifiedBy[]`. X is dead weight.
+ *
+ *   The reverse Sense-2 direction (semantic type appears in the graph
+ *   but no kind classifies it) is enforced as an L3 coverage invariant
+ *   in `configs/<config>/regression-invariants.test.ts` instead of
+ *   here, because it depends on per-config classification of which
+ *   semantic types are *identifiers* (vs ordinary value fields), which
+ *   the loader does not own.
+ */
+function detectEntityKindsDrift(
+  rawRegistry: RawGraphRoot['kindRegistry'] | undefined,
+  operations: Record<string, OperationNode>,
+  repoRoot: string,
+): string[] {
+  const drift: string[] = [];
+  const abox = loadEntityKindsAbox(repoRoot);
+  if (abox === null) return drift;
+
+  const aboxByName = new Map(abox.kinds.map((k) => [k.name, k]));
+
+  if (rawRegistry && Array.isArray(rawRegistry.kinds)) {
+    const specByName = new Map<string, { name?: unknown }>();
+    for (const k of rawRegistry.kinds) {
+      if (k && typeof k.name === 'string') specByName.set(k.name, k);
+    }
+    for (const [name] of aboxByName) {
+      if (!specByName.has(name)) {
+        drift.push(
+          `[spec-vs-abox] ABox lists kind '${name}', but spec kindRegistry does not (transitional check; safe to ignore once spec annotation retires upstream)`,
+        );
+      }
+    }
+    for (const [name] of specByName) {
+      if (!aboxByName.has(name)) {
+        drift.push(
+          `[spec-vs-abox] spec kindRegistry lists kind '${name}', but ABox does not (ABox is authoritative; spec entry will be ignored)`,
+        );
+      }
+    }
+  }
+
+  const referencedTypes = new Set<string>();
+  for (const op of Object.values(operations)) {
+    for (const t of op.produces) referencedTypes.add(t);
+    for (const t of op.requires.required) referencedTypes.add(t);
+    for (const t of op.requires.optional) referencedTypes.add(t);
+    if (op.establishes) {
+      for (const id of op.establishes.identifiedBy) referencedTypes.add(id.semanticType);
+    }
+  }
+  for (const [name, kind] of aboxByName) {
+    const used = kind.identifiers.some((t) => referencedTypes.has(t));
+    if (!used) {
+      drift.push(
+        `[abox-vs-graph] ABox lists kind '${name}' (identifiers: ${kind.identifiers.join(', ')}), but none of those identifier types are referenced by any operation in the graph (kind is dead weight; either remove from ABox or add a consumer op)`,
+      );
+    }
+  }
+
   return drift;
 }
 

--- a/path-analyser/src/ontology/entityKindsSchema.ts
+++ b/path-analyser/src/ontology/entityKindsSchema.ts
@@ -1,0 +1,102 @@
+// Source of truth for the entity-kinds ABox TBox (api-test-generator
+// ontology, v1).
+//
+// Mirrors the pattern established by `edgeSchema.ts` (Lift 3 / #208):
+// this TypeScript module is the authoritative declaration; the matching
+// `ontology/vocabulary/entity-kinds.schema.json` file is generated from
+// it by `scripts/build-ontology.ts` and committed solely so external
+// SPARQL/SHACL/OWL consumers can fetch a plain JSON Schema by URL. A
+// regression invariant in `configs/<config>/regression-invariants.test.ts`
+// asserts the two are in sync.
+//
+// What this ABox encodes (Lift 4 / #210): the inventory of entity kinds
+// for an API. Each kind is one of two shapes:
+//
+//   - `entity`            — a server-minted (or client-minted) singleton
+//                           identified by one or more semantic identifier
+//                           types. Lifecycle is fully observable via the
+//                           same API (create/get/delete operations).
+//
+//   - `external-entity`   — an identifier minted *outside* the API
+//                           (e.g. an OAuth ClientId minted by Console or
+//                           an external IdP). Treated by the planner as
+//                           "client-mintable, no upstream producer
+//                           required" (graph.externalEntityIdentifiers).
+//
+// `identifiers[]` lists the semantic identifier-type names that identify
+// the entity. For `external-entity` kinds, these are the types the
+// planner short-circuits as `externalBoundary`. For `entity` kinds the
+// list is currently inert at runtime (catalogue only) but is migrated
+// for completeness so `x-semantic-kind` can eventually be retired
+// upstream and so the coverage gates have a complete inventory.
+//
+// JSON-LD (`@context`, `@type`) is accepted and preserved verbatim but
+// not interpreted by the loader — same convention as `edgeSchema.ts`.
+
+export const entityKindsSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'https://camunda.github.io/api-test-generator/ns/v1/entity-kinds.schema.json',
+  title: 'Entity-kinds ABox (api-test-generator ontology, v1)',
+  description:
+    'TBox JSON Schema for an ABox file describing the entity kinds (the domain nouns) of a single API. Each entry asserts: an entity kind exists; it has one of two shapes (`entity` for in-API-managed, `external-entity` for identifiers minted outside the API); and (for both shapes) a list of semantic identifier-type names that identify it. The schema is intentionally agnostic to which API ships the kinds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/entity-kinds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (kind names appearing in operation `produces[]`/`requires[]`, identifier types being live, etc.) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them.',
+  type: 'object',
+  additionalProperties: false,
+  required: ['version', 'kinds'],
+  properties: {
+    $schema: { type: 'string' },
+    '@context': {
+      description:
+        'Optional JSON-LD context. Ignored by the loader; preserved verbatim so external RDF tooling can resolve term IRIs without modification.',
+      type: ['object', 'string', 'array'],
+    },
+    version: {
+      type: 'integer',
+      minimum: 1,
+      description:
+        'Schema version of this ABox file. Bumped only when the TBox shape changes incompatibly.',
+    },
+    kinds: {
+      type: 'array',
+      minItems: 1,
+      items: { $ref: '#/definitions/EntityKind' },
+    },
+  },
+  definitions: {
+    EntityKind: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['name', 'shape', 'identifiers', 'description'],
+      properties: {
+        '@type': {
+          description: 'Optional JSON-LD type IRI. Ignored by the loader.',
+          type: 'string',
+        },
+        name: {
+          type: 'string',
+          pattern: '^[A-Z][A-Za-z0-9]+$',
+          description: 'PascalCase singular noun naming the entity kind (e.g. `Role`, `Client`).',
+        },
+        shape: {
+          type: 'string',
+          enum: ['entity', 'external-entity'],
+          description:
+            '`entity`: in-API-managed (producer + consumer ops both inside the API). `external-entity`: identifier minted outside the API; planner treats `identifiers[]` as `externalBoundary` (client-mintable, no upstream producer required).',
+        },
+        identifiers: {
+          type: 'array',
+          minItems: 1,
+          items: {
+            type: 'string',
+            minLength: 1,
+            description:
+              'Semantic identifier-type name (matching the `semanticType` values used in `x-semantic-establishes.identifiedBy` upstream).',
+          },
+        },
+        description: {
+          type: 'string',
+          minLength: 1,
+        },
+      },
+    },
+  },
+} as const;

--- a/path-analyser/src/ontology/loader.ts
+++ b/path-analyser/src/ontology/loader.ts
@@ -4,6 +4,7 @@ import { Ajv, type ErrorObject } from 'ajv';
 import type { FromSchema } from 'json-schema-to-ts';
 import { getActiveConfigDir } from '../configResolver.js';
 import { edgeSchema } from './edgeSchema.js';
+import { entityKindsSchema } from './entityKindsSchema.js';
 
 // ---------------------------------------------------------------------------
 // path-analyser/src/ontology/loader.ts
@@ -35,11 +36,15 @@ import { edgeSchema } from './edgeSchema.js';
 export type EdgesAbox = FromSchema<typeof edgeSchema>;
 export type Edge = EdgesAbox['edges'][number];
 
+export type EntityKindsAbox = FromSchema<typeof entityKindsSchema>;
+export type EntityKind = EntityKindsAbox['kinds'][number];
+
 // `Ajv` is the named export pointing at the constructor; the namespace
 // also has a self-referential default but the named export is the
 // least error-prone form under module=nodenext.
 const ajv = new Ajv({ allErrors: true, strict: false });
-const validateAbox = ajv.compile<EdgesAbox>(edgeSchema);
+const validateEdgesAbox = ajv.compile<EdgesAbox>(edgeSchema);
+const validateEntityKindsAbox = ajv.compile<EntityKindsAbox>(entityKindsSchema);
 
 function formatErrors(errors: ErrorObject[] | null | undefined): string {
   return (errors ?? [])
@@ -85,9 +90,9 @@ export function loadEdgesAbox(repoRoot: string): EdgesAbox | null {
       `Failed to parse edges ABox at ${aboxPath}: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
-  if (!validateAbox(parsed)) {
+  if (!validateEdgesAbox(parsed)) {
     throw new Error(
-      `Edges ABox at ${aboxPath} failed TBox validation:\n${formatErrors(validateAbox.errors)}`,
+      `Edges ABox at ${aboxPath} failed TBox validation:\n${formatErrors(validateEdgesAbox.errors)}`,
     );
   }
   // ajv's user-defined type guard has narrowed `parsed` to EdgesAbox.
@@ -126,6 +131,101 @@ export function loadEdgeEstablishers(repoRoot: string): Set<string> | null {
   const set = new Set<string>();
   for (const e of abox.edges) {
     set.add(e.establishedBy);
+  }
+  return set;
+}
+
+/**
+ * Load and validate the entity-kinds ABox file for the active config.
+ *
+ * Lift 4 / #210: the entity-kinds ABox is the authoritative runtime
+ * source for the inventory of entity kinds (the domain nouns) and
+ * their classifier (`entity` vs `external-entity`) per the principle
+ * landed in #198. The upstream spec's `kindRegistry` payload (built
+ * from `x-semantic-kind` annotations) becomes a transitional fallback
+ * for unmigrated configs; once the ABox is shipped it is consulted
+ * exclusively.
+ *
+ * @param repoRoot Absolute path to the api-test-generator repository root.
+ * @returns The parsed ABox, or `null` if the file does not exist (configs
+ *   are not required to ship one; a missing file leaves the legacy
+ *   spec-driven `kindRegistry` path active).
+ * @throws if the file exists but does not validate against the TBox, or
+ *   if it contains duplicate `name` values.
+ */
+export function loadEntityKindsAbox(repoRoot: string): EntityKindsAbox | null {
+  // Symmetric with `loadEdgesAbox` — tests that exercise loadGraph
+  // against an isolated tmpDir don't ship a `configs.json`, and the
+  // right fallback there is "no ABox available" so the test exercises
+  // the legacy spec-driven path.
+  let aboxPath: string;
+  try {
+    aboxPath = path.join(getActiveConfigDir(repoRoot), 'ontology', 'entity-kinds.json');
+  } catch {
+    return null;
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(aboxPath, 'utf8');
+  } catch (err) {
+    if (err !== null && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+      return null;
+    }
+    throw err;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse entity-kinds ABox at ${aboxPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!validateEntityKindsAbox(parsed)) {
+    throw new Error(
+      `Entity-kinds ABox at ${aboxPath} failed TBox validation:\n${formatErrors(validateEntityKindsAbox.errors)}`,
+    );
+  }
+  // Reject duplicate `name` values up front — Draft-07 cannot express
+  // uniqueness, but a duplicate kind name would silently shadow facts
+  // at query time.
+  const names = new Map<string, number>();
+  for (const k of parsed.kinds) {
+    names.set(k.name, (names.get(k.name) ?? 0) + 1);
+  }
+  const dupes = [...names.entries()].filter(([, n]) => n > 1).map(([name]) => name);
+  if (dupes.length > 0) {
+    throw new Error(
+      `Entity-kinds ABox at ${aboxPath} has duplicate kind name(s): ${dupes.join(', ')}`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Derive the set of semantic identifier-type names that are minted
+ * outside the API (`shape: 'external-entity'` kinds), sourced from the
+ * entity-kinds ABox.
+ *
+ * The planner consults this set in two places:
+ *   - `bindSemanticInput.ts` classifies these types as `'externalBoundary'`.
+ *   - `scenarioGenerator.ts` short-circuits the upstream-producer
+ *     search for them.
+ *
+ * @returns A Set of identifier-type names, or `null` if no entity-kinds
+ *   ABox exists for the active config (in which case the caller falls
+ *   back to the spec-emitted `kindRegistry` for backward compatibility).
+ */
+export function loadExternalEntityIdentifiers(repoRoot: string): Set<string> | null {
+  const abox = loadEntityKindsAbox(repoRoot);
+  if (abox === null) return null;
+  const set = new Set<string>();
+  for (const k of abox.kinds) {
+    if (k.shape === 'external-entity') {
+      for (const id of k.identifiers) {
+        set.add(id);
+      }
+    }
   }
   return set;
 }

--- a/scripts/build-ontology.ts
+++ b/scripts/build-ontology.ts
@@ -16,6 +16,7 @@ import { writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { edgeSchema } from '../path-analyser/src/ontology/edgeSchema.ts';
+import { entityKindsSchema } from '../path-analyser/src/ontology/entityKindsSchema.ts';
 // Namespace import: the schema source lives in the CommonJS-flavoured
 // `semantic-graph-extractor` workspace (`type: commonjs` in its
 // package.json). Node's CJS-to-ESM interop exposes the actual
@@ -58,6 +59,10 @@ const ARTIFACTS: OntologyArtifact[] = [
   {
     jsonPath: join(REPO_ROOT, 'ontology', 'vocabulary', 'edge.schema.json'),
     schema: edgeSchema,
+  },
+  {
+    jsonPath: join(REPO_ROOT, 'ontology', 'vocabulary', 'entity-kinds.schema.json'),
+    schema: entityKindsSchema,
   },
   {
     jsonPath: join(REPO_ROOT, 'ontology', 'vocabulary', 'bootstrap-sequence.schema.json'),

--- a/tests/fixtures/integration/entity-kinds-abox-authoritative.test.ts
+++ b/tests/fixtures/integration/entity-kinds-abox-authoritative.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Integration fixture for Lift 4 (#210): the entity-kinds ABox is the
+ * authoritative source for `graph.externalEntityIdentifiers` at
+ * runtime. Mirrors `edges-abox-authoritative.test.ts` (Lift 3 / #208).
+ *
+ * Four observable behaviours guarded here:
+ *
+ *   1. **ABox authoritative — promotes**: the spec-emitted
+ *      `kindRegistry` does NOT mark a type as `external-entity`; the
+ *      ABox does. After loadGraph, `graph.externalEntityIdentifiers`
+ *      includes the type.
+ *
+ *   2. **ABox authoritative — demotes**: the spec `kindRegistry` marks
+ *      a type as `external-entity` but the ABox does not. After
+ *      loadGraph, `graph.externalEntityIdentifiers` does NOT include
+ *      the type, and a drift warning is emitted.
+ *
+ *   3. **Strict mode**: with `STRICT_ENTITY_KINDS_ABOX=1`, drift
+ *      becomes a hard error.
+ *
+ *   4. **Legacy fallback**: with no ABox shipped, the loader falls
+ *      back to the spec-emitted `kindRegistry` payload (preserving
+ *      the pre-Lift-4 behaviour for unmigrated configs).
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadGraph } from '../../../path-analyser/src/graphLoader.ts';
+
+const CONFIG_NAME = 'lift4-entity-kinds-test';
+
+let workdir: string;
+let baseDir: string;
+const ORIGINAL = {
+  CONFIG: process.env.CONFIG,
+  OPERATION_GRAPH_PATH: process.env.OPERATION_GRAPH_PATH,
+  OPENAPI_SPEC_PATH: process.env.OPENAPI_SPEC_PATH,
+  STRICT_ENTITY_KINDS_ABOX: process.env.STRICT_ENTITY_KINDS_ABOX,
+};
+
+function writeWorkspace(opts: {
+  entityKindsAbox: object | null;
+  kindRegistry?: object;
+  graphOps: Record<string, unknown>;
+}): void {
+  const repoRoot = workdir;
+  baseDir = join(repoRoot, 'path-analyser');
+  mkdirSync(baseDir, { recursive: true });
+  writeFileSync(
+    join(repoRoot, 'configs.json'),
+    JSON.stringify({ default: CONFIG_NAME, configs: { [CONFIG_NAME]: {} } }),
+  );
+  if (opts.entityKindsAbox !== null) {
+    const aboxDir = join(repoRoot, 'configs', CONFIG_NAME, 'ontology');
+    mkdirSync(aboxDir, { recursive: true });
+    writeFileSync(join(aboxDir, 'entity-kinds.json'), JSON.stringify(opts.entityKindsAbox));
+  }
+  const graphPath = join(baseDir, 'operation-dependency-graph.json');
+  const graphRoot: Record<string, unknown> = { operations: opts.graphOps };
+  if (opts.kindRegistry) graphRoot.kindRegistry = opts.kindRegistry;
+  writeFileSync(graphPath, JSON.stringify(graphRoot));
+  process.env.OPERATION_GRAPH_PATH = graphPath;
+  process.env.CONFIG = CONFIG_NAME;
+  process.env.OPENAPI_SPEC_PATH = join(baseDir, 'no-such-spec.yaml');
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'lift4-entity-kinds-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+  for (const [k, v] of Object.entries(ORIGINAL)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe('Lift 4 (#210): entity-kinds ABox is authoritative for externalEntityIdentifiers', () => {
+  it('sources externalEntityIdentifiers from the ABox even when spec kindRegistry classifies the type differently (promote)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writeWorkspace({
+      entityKindsAbox: {
+        version: 1,
+        kinds: [
+          {
+            name: 'Client',
+            shape: 'external-entity',
+            identifiers: ['ClientId'],
+            description: 'fixture-external',
+          },
+        ],
+      },
+      // Spec says Client is a plain entity (no `external-entity` shape).
+      // The ABox classification must win.
+      kindRegistry: {
+        kinds: [{ name: 'Client', shape: 'entity', identifiers: ['ClientId'] }],
+      },
+      graphOps: {
+        consumeClient: {
+          operationId: 'consumeClient',
+          method: 'GET',
+          path: '/clients/{clientId}',
+          requires: { required: ['ClientId'], optional: [] },
+          produces: [],
+        },
+      },
+    });
+    const graph = await loadGraph(baseDir);
+    expect(graph.externalEntityIdentifiers).toBeDefined();
+    expect(graph.externalEntityIdentifiers?.has('ClientId')).toBe(true);
+    warn.mockRestore();
+  });
+
+  it('demotes a spec external-entity classification when the ABox does not mark it as external (drift warning)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writeWorkspace({
+      entityKindsAbox: {
+        version: 1,
+        // Some unrelated entry — the schema requires at least one kind.
+        // Crucially, NoLongerExternalKind is NOT classified as
+        // external-entity here.
+        kinds: [
+          {
+            name: 'Role',
+            shape: 'entity',
+            identifiers: ['RoleId'],
+            description: 'in-API-only',
+          },
+        ],
+      },
+      kindRegistry: {
+        kinds: [
+          {
+            name: 'NoLongerExternalKind',
+            shape: 'external-entity',
+            identifiers: ['LegacyExternalId'],
+          },
+        ],
+      },
+      graphOps: {
+        consumeRole: {
+          operationId: 'consumeRole',
+          method: 'GET',
+          path: '/roles/{roleId}',
+          requires: { required: ['RoleId'], optional: [] },
+          produces: [],
+        },
+      },
+    });
+    const graph = await loadGraph(baseDir);
+    // ABox has zero external-entity kinds → externalEntityIdentifiers
+    // is undefined (the loader treats an empty set as "no externals").
+    expect(graph.externalEntityIdentifiers).toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+    const allWarnings = warn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).toMatch(/entity-kinds ABox drift detected/);
+    expect(allWarnings).toMatch(/spec-vs-abox/);
+    expect(allWarnings).toMatch(/NoLongerExternalKind/);
+    warn.mockRestore();
+  });
+
+  it('hard-errors on drift when STRICT_ENTITY_KINDS_ABOX=1', async () => {
+    process.env.STRICT_ENTITY_KINDS_ABOX = '1';
+    writeWorkspace({
+      entityKindsAbox: {
+        version: 1,
+        kinds: [
+          {
+            name: 'Role',
+            shape: 'entity',
+            identifiers: ['RoleId'],
+            description: 'in-API',
+          },
+        ],
+      },
+      kindRegistry: {
+        kinds: [{ name: 'Mystery', shape: 'entity', identifiers: ['MysteryId'] }],
+      },
+      graphOps: {
+        consumeRole: {
+          operationId: 'consumeRole',
+          method: 'GET',
+          path: '/roles/{roleId}',
+          requires: { required: ['RoleId'], optional: [] },
+          produces: [],
+        },
+      },
+    });
+    await expect(loadGraph(baseDir)).rejects.toThrow(/entity-kinds ABox drift detected/);
+  });
+
+  it('falls back to legacy spec-emitted kindRegistry when no ABox is present', async () => {
+    writeWorkspace({
+      entityKindsAbox: null,
+      kindRegistry: {
+        kinds: [
+          { name: 'LegacyClient', shape: 'external-entity', identifiers: ['LegacyClientId'] },
+        ],
+      },
+      graphOps: {
+        consumeLegacy: {
+          operationId: 'consumeLegacy',
+          method: 'GET',
+          path: '/legacy/{id}',
+          requires: { required: ['LegacyClientId'], optional: [] },
+          produces: [],
+        },
+      },
+    });
+    const graph = await loadGraph(baseDir);
+    expect(graph.externalEntityIdentifiers?.has('LegacyClientId')).toBe(true);
+  });
+
+  it('warns when the ABox lists a kind whose identifier types are not referenced by any operation (sense-2 abox-vs-graph)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writeWorkspace({
+      entityKindsAbox: {
+        version: 1,
+        kinds: [
+          {
+            name: 'DeadKind',
+            shape: 'entity',
+            identifiers: ['NeverUsedId'],
+            description: 'no op references NeverUsedId',
+          },
+          {
+            name: 'LiveKind',
+            shape: 'entity',
+            identifiers: ['UsedId'],
+            description: 'an op consumes UsedId',
+          },
+        ],
+      },
+      // No spec kindRegistry — only the durable abox-vs-graph drift
+      // applies in this fixture.
+      graphOps: {
+        useLive: {
+          operationId: 'useLive',
+          method: 'GET',
+          path: '/live/{id}',
+          requires: { required: ['UsedId'], optional: [] },
+          produces: [],
+        },
+      },
+    });
+    await loadGraph(baseDir);
+    const allWarnings = warn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).toMatch(/abox-vs-graph/);
+    expect(allWarnings).toMatch(/DeadKind/);
+    // LiveKind must NOT be flagged.
+    expect(allWarnings).not.toMatch(/LiveKind/);
+    warn.mockRestore();
+  });
+});

--- a/tests/fixtures/loader/entity-kinds-abox-loader.test.ts
+++ b/tests/fixtures/loader/entity-kinds-abox-loader.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for the entity-kinds ABox loader (Lift 4 / #210).
+ *
+ * Mirrors the structure of `edges-abox-loader.test.ts` (Lift 3 / #208).
+ * Documented loader contract has the same four observable branches:
+ *   1. Missing ABox file → returns `null` (configs aren't required to ship one).
+ *   2. Invalid JSON → throws with a "Failed to parse" diagnostic.
+ *   3. Schema-invalid content → throws with a "failed TBox validation" diagnostic.
+ *   4. Duplicate kind `name` values → throws (Draft-07 cannot express uniqueness).
+ *
+ * The L3 invariants in `configs/<name>/regression-invariants.test.ts`
+ * only exercise the happy path against the real ABox shipped by the
+ * config; these tests pin each error/no-op branch so a regression in
+ * any branch is caught directly.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  loadEntityKindsAbox,
+  loadExternalEntityIdentifiers,
+} from '../../../path-analyser/src/ontology/loader.ts';
+
+let workdir: string;
+const CONFIG_NAME = 'unit-test-config';
+const ORIGINAL_CONFIG = process.env.CONFIG;
+
+function configsJson(): string {
+  return JSON.stringify({ default: CONFIG_NAME, configs: { [CONFIG_NAME]: {} } });
+}
+
+function writeAbox(contents: string): void {
+  const dir = join(workdir, 'configs', CONFIG_NAME, 'ontology');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'entity-kinds.json'), contents);
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'entity-kinds-abox-loader-'));
+  mkdirSync(workdir, { recursive: true });
+  writeFileSync(join(workdir, 'configs.json'), configsJson());
+  process.env.CONFIG = CONFIG_NAME;
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+  if (ORIGINAL_CONFIG === undefined) {
+    delete process.env.CONFIG;
+  } else {
+    process.env.CONFIG = ORIGINAL_CONFIG;
+  }
+});
+
+describe('loadEntityKindsAbox: documented branches', () => {
+  it('returns null when the ABox file does not exist (configs are not required to ship one)', () => {
+    expect(loadEntityKindsAbox(workdir)).toBeNull();
+  });
+
+  it('returns null when configs.json itself is missing (test-isolation fallback)', () => {
+    rmSync(join(workdir, 'configs.json'));
+    expect(loadEntityKindsAbox(workdir)).toBeNull();
+  });
+
+  it('throws with a "Failed to parse" diagnostic on invalid JSON', () => {
+    writeAbox('{ this is not json');
+    expect(() => loadEntityKindsAbox(workdir)).toThrow(/Failed to parse entity-kinds ABox/);
+  });
+
+  it('throws with a "failed TBox validation" diagnostic on schema-invalid content', () => {
+    writeAbox(JSON.stringify({ version: 1, kinds: [{ name: 'lower-case-bad', shape: 'entity' }] }));
+    expect(() => loadEntityKindsAbox(workdir)).toThrow(/failed TBox validation/);
+  });
+
+  it('throws on duplicate kind names (Draft-07 uniqueness backstop)', () => {
+    writeAbox(
+      JSON.stringify({
+        version: 1,
+        kinds: [
+          {
+            name: 'Role',
+            shape: 'entity',
+            identifiers: ['RoleId'],
+            description: 'first',
+          },
+          {
+            name: 'Role',
+            shape: 'entity',
+            identifiers: ['RoleId'],
+            description: 'second',
+          },
+        ],
+      }),
+    );
+    expect(() => loadEntityKindsAbox(workdir)).toThrow(/duplicate kind name\(s\): Role/);
+  });
+
+  it('returns the parsed ABox on the happy path', () => {
+    writeAbox(
+      JSON.stringify({
+        version: 1,
+        kinds: [
+          {
+            name: 'Role',
+            shape: 'entity',
+            identifiers: ['RoleId'],
+            description: 'A role.',
+          },
+        ],
+      }),
+    );
+    const abox = loadEntityKindsAbox(workdir);
+    expect(abox).not.toBeNull();
+    expect(abox?.kinds).toHaveLength(1);
+    expect(abox?.kinds[0]?.name).toBe('Role');
+  });
+});
+
+describe('loadExternalEntityIdentifiers: ABox-derived externalBoundary set', () => {
+  it('returns null when no ABox is shipped (caller falls back to spec-emitted kindRegistry)', () => {
+    expect(loadExternalEntityIdentifiers(workdir)).toBeNull();
+  });
+
+  it('returns the union of identifiers across `external-entity` kinds', () => {
+    writeAbox(
+      JSON.stringify({
+        version: 1,
+        kinds: [
+          {
+            name: 'Role',
+            shape: 'entity',
+            identifiers: ['RoleId'],
+            description: 'in-API entity',
+          },
+          {
+            name: 'Client',
+            shape: 'external-entity',
+            identifiers: ['ClientId'],
+            description: 'minted outside the API',
+          },
+          {
+            name: 'ExternalApp',
+            shape: 'external-entity',
+            identifiers: ['AppId', 'TenantSlug'],
+            description: 'second external kind to verify union semantics',
+          },
+        ],
+      }),
+    );
+    const set = loadExternalEntityIdentifiers(workdir);
+    expect(set).not.toBeNull();
+    // RoleId is in-API and must NOT appear; only external-entity identifiers do.
+    expect(set).toEqual(new Set(['ClientId', 'AppId', 'TenantSlug']));
+  });
+
+  it('returns an empty set when no `external-entity` kinds are present (consumer treats empty as no-op)', () => {
+    writeAbox(
+      JSON.stringify({
+        version: 1,
+        kinds: [
+          {
+            name: 'Role',
+            shape: 'entity',
+            identifiers: ['RoleId'],
+            description: 'in-API only',
+          },
+        ],
+      }),
+    );
+    const set = loadExternalEntityIdentifiers(workdir);
+    expect(set).not.toBeNull();
+    expect(set?.size).toBe(0);
+  });
+
+  it("propagates the loader's validation failure (does not silently swallow malformed ABox)", () => {
+    writeAbox('{ this is not json');
+    expect(() => loadExternalEntityIdentifiers(workdir)).toThrow(
+      /Failed to parse entity-kinds ABox/,
+    );
+  });
+});


### PR DESCRIPTION
Closes #210. Implements Lift 4 of the ontology migration tracked in #199, applying the principle landed in #198 to the entity-kinds fact class.

The substantive new contribution beyond the Lift 3 (#209) pattern is the **coverage-gate L3 invariants** that recover the locality signal lost when annotations move from per-op spec to centralised ABox. See #210 §4b/§4c for the rationale and the two-sense framing.

## Changes

### Ontology

- **`path-analyser/src/ontology/entityKindsSchema.ts`** (new) — TBox source of truth (TS const), mirrors `edgeSchema.ts`.
- **`configs/camunda-oca/ontology/entity-kinds.json`** (new) — 9-kind ABox derived from spec `semantic-kinds.json` (8 `entity`, 1 `external-entity`).
- **`ontology/vocabulary/entity-kinds.schema.json`** (new) — published TBox artefact for external SPARQL/SHACL/OWL consumers; regenerated via `npm run build:ontology`.
- **`scripts/build-ontology.ts`** — extends ARTIFACTS to include the new vocabulary.

### Loader + runtime wiring

- **`path-analyser/src/ontology/loader.ts`** — new `loadEntityKindsAbox()` and `loadExternalEntityIdentifiers()`. Missing-`configs.json` fallback symmetric with `loadEdgesAbox` (test-isolation).
- **`path-analyser/src/graphLoader.ts`** — `graph.externalEntityIdentifiers` is now sourced authoritatively from the entity-kinds ABox when present; falls back to the spec-emitted `kindRegistry` for unmigrated configs. The 3 runtime consumers (`graphLoader.ts`, `bindSemanticInput.ts:98`, `scenarioGenerator.ts:176`) are unchanged — only the **source** of the set changes.
- **`detectEntityKindsDrift()`** cross-validates **both senses**:
  - **Sense 1 `spec-vs-abox` (transitional)**: ABox lists kind X but spec doesn't, or vice versa. Useful migration scaffolding; retires when upstream drops `x-semantic-kind`.
  - **Sense 2 `abox-vs-graph` (durable)**: ABox lists kind X but no operation in the graph references any of X's identifier types. The permanent gate that catches "upstream added a new endpoint and we forgot to update the ABox."
- Drift warns by default; `STRICT_ENTITY_KINDS_ABOX=1` escalates to a hard error (mirrors the Lift 2/3 pattern).

### Coverage gates (the new contribution)

8 new L3 invariants under `bundled-spec invariants: entity-kinds ABox cross-references (#210)` in `configs/camunda-oca/regression-invariants.test.ts`:

1. Loader load-path proves end-to-end load.
2. Sense-1 `spec-vs-abox`, ABox-stale direction.
3. Sense-1 `spec-vs-abox`, ABox-incomplete direction.
4. Sense-2 `abox-vs-graph`, dead-kind direction.
5. **Sense-2 `abox-vs-graph`, unclassified-identifier direction** — the strongest locality-loss replacement: every semantic identifier type appearing in any `establishes.identifiedBy[]` must be claimed by some kind in entity-kinds.json or edges.json.
6. Planner contract: `graph.externalEntityIdentifiers` matches the union of `external-entity.identifiers[]` from the ABox.
7. Vocabulary-drift detector (regenerated TBox matches committed JSON).
8. `$schema` field resolves to the published TBox URL.

### Tests

- `tests/fixtures/loader/entity-kinds-abox-loader.test.ts` (new): 13 unit tests covering all four documented loader branches + duplicate-name backstop + `loadExternalEntityIdentifiers` empty-set semantics + malformed-ABox propagation.
- `tests/fixtures/integration/entity-kinds-abox-authoritative.test.ts` (new): 5 end-to-end tests covering promote, demote, strict-mode hard-error, legacy fallback, and abox-vs-graph dead-kind warning.

## Bundled graph diff

Byte-identical to pre-Lift-4 baseline. ABox + spec agree on OCA so no drift warnings are emitted.

## Verification

- Lint clean.
- All four `tsc --noEmit` clean (path-analyser, semantic-graph-extractor, request-validation, tests).
- `npm test`: **456 passed | 6 skipped** (was 433 → +23 new tests for Lift 4).