### PR TITLE
feat: lift the artifact-kinds sub-trees to a per-config ABox (#212)

### DIFF
--- a/configs/camunda-oca/ontology/artifact-kinds.json
+++ b/configs/camunda-oca/ontology/artifact-kinds.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://camunda.github.io/api-test-generator/ns/v1/artifact-kinds.schema.json",
+  "@context": "https://camunda.github.io/api-test-generator/ns/v1/context.jsonld",
+  "version": 1,
+  "kinds": [
+    {
+      "@type": "ArtifactKind",
+      "name": "bpmnProcess",
+      "identifierType": "ProcessDefinitionId",
+      "producesStates": ["ProcessDefinitionDeployed"],
+      "producibleStates": ["ModelHasServiceTaskType", "ProcessInstanceCompleted"],
+      "producesSemantics": ["ProcessDefinitionKey"],
+      "deploymentSlices": ["processDefinition"],
+      "description": "A BPMN process model. Kind-level producesStates lists what EVERY bpmnProcess fixture deploys; producibleStates lists what SOME fixture of this kind can deliver (planner uses producesStates ∪ producibleStates for chain-feasibility BFS; the selector matches per-fixture providesStates in path-analyser/fixtures/deployment-artifacts.json at emission time, see #159)."
+    },
+    {
+      "@type": "ArtifactKind",
+      "name": "dmnDecision",
+      "identifierType": "DecisionDefinitionId",
+      "producesStates": ["DecisionDefinitionDeployed"],
+      "producesSemantics": ["DecisionDefinitionKey"],
+      "deploymentSlices": ["decisionDefinition"],
+      "description": "A standalone DMN decision (no DRD wrapper)."
+    },
+    {
+      "@type": "ArtifactKind",
+      "name": "dmnDrd",
+      "identifierType": "DecisionRequirementsId",
+      "producesStates": ["DecisionRequirementsDeployed"],
+      "producesSemantics": ["DecisionRequirementsKey"],
+      "deploymentSlices": ["decisionRequirements"],
+      "description": "A DMN decision-requirements diagram (DRD), grouping one or more decisions."
+    },
+    {
+      "@type": "ArtifactKind",
+      "name": "form",
+      "identifierType": "FormId",
+      "producesStates": ["FormDeployed"],
+      "producesSemantics": ["FormKey"],
+      "deploymentSlices": ["form"],
+      "description": "A Camunda Forms JSON form definition."
+    }
+  ],
+  "semanticTypeMap": [
+    { "@type": "SemanticTypeMapping", "semanticType": "ProcessDefinitionKey", "artifactKind": "bpmnProcess" },
+    { "@type": "SemanticTypeMapping", "semanticType": "DecisionDefinitionKey", "artifactKind": "dmnDecision" },
+    { "@type": "SemanticTypeMapping", "semanticType": "DecisionRequirementsKey", "artifactKind": "dmnDrd" },
+    { "@type": "SemanticTypeMapping", "semanticType": "FormKey", "artifactKind": "form" }
+  ],
+  "operationRules": [
+    {
+      "@type": "OperationArtifactRule",
+      "operationId": "createDeployment",
+      "composable": true,
+      "rules": [
+        { "id": "bpmn", "artifactKind": "bpmnProcess" },
+        { "id": "form", "artifactKind": "form" },
+        { "id": "dmn", "artifactKind": "dmnDecision" },
+        { "id": "drd", "artifactKind": "dmnDrd" }
+      ]
+    }
+  ],
+  "fileExtensionMap": [
+    { "@type": "FileExtensionMapping", "extension": ".bpmn", "artifactKinds": ["bpmnProcess"] },
+    { "@type": "FileExtensionMapping", "extension": ".dmn", "artifactKinds": ["dmnDecision", "dmnDrd"] },
+    { "@type": "FileExtensionMapping", "extension": ".form", "artifactKinds": ["form"] },
+    { "@type": "FileExtensionMapping", "extension": ".json", "artifactKinds": ["form"] }
+  ]
+}

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -4494,3 +4494,212 @@ describeForThisConfig('bundled-spec invariants: entity-kinds ABox cross-referenc
     );
   });
 });
+
+describeForThisConfig(
+  'bundled-spec invariants: artifact-kinds ABox cross-references (#212)',
+  () => {
+    // Lift 5 / #212: the artifact-kinds ABox is now the authoritative
+    // source for the four artifact-related sub-trees (artifactKinds,
+    // semanticTypeToArtifactKind, operationArtifactRules,
+    // artifactFileKinds) previously carried in domain-semantics.json.
+    //
+    // Unlike Lifts 3/4, the data was never sourced from upstream
+    // OpenAPI annotations — so there is no `spec-vs-abox` (sense-1)
+    // drift to guard. These invariants encode the durable
+    // `abox-vs-graph` (sense-2) coverage gates only: the locality-loss
+    // replacement signal that catches stale ABox entries against
+    // runtime use of the bundled graph.
+
+    it('loads the artifact-kinds ABox via the generic loader (proves the load path)', async () => {
+      const { loadArtifactKindsAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const abox = loadArtifactKindsAbox(REPO_ROOT);
+      expect(abox, 'artifact-kinds ABox file must exist for the camunda-oca config').not.toBeNull();
+      expect(abox?.kinds.length).toBeGreaterThan(0);
+      expect(abox?.operationRules.length).toBeGreaterThan(0);
+    });
+
+    it('every operationRules entry references a real opId in the bundled graph (sense-2: abox-vs-graph)', async () => {
+      const { loadArtifactKindsAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const abox = loadArtifactKindsAbox(REPO_ROOT);
+      if (!abox) throw new Error('artifact-kinds ABox missing');
+      if (!existsSync(GRAPH_PATH)) {
+        throw new Error(
+          `Graph not found at ${GRAPH_PATH}. Run 'npm run testsuite:generate' first.`,
+        );
+      }
+      interface GraphOp {
+        operationId?: string;
+      }
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const graph = JSON.parse(readFileSync(GRAPH_PATH, 'utf8')) as {
+        operationsById?: Record<string, GraphOp>;
+        operations?: Record<string, GraphOp> | GraphOp[];
+      };
+      const opIds = new Set<string>(
+        Object.keys(graph.operationsById ?? {}).length > 0
+          ? Object.keys(graph.operationsById ?? {})
+          : Array.isArray(graph.operations)
+            ? graph.operations
+                .map((o) => o.operationId)
+                .filter((s): s is string => typeof s === 'string')
+            : Object.keys(graph.operations ?? {}),
+      );
+      const dangling = abox.operationRules.map((r) => r.operationId).filter((id) => !opIds.has(id));
+      expect(
+        dangling,
+        'artifact-kinds ABox operationRules entries reference opIds that do not exist in the bundled graph — typo, renamed-upstream op, or stale entry; remove or fix in configs/<config>/ontology/artifact-kinds.json',
+      ).toEqual([]);
+    });
+
+    it('every artifact-kind referenced by operationRules / semanticTypeMap / fileExtensionMap is defined in `kinds`', async () => {
+      const { loadArtifactKindsAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const abox = loadArtifactKindsAbox(REPO_ROOT);
+      if (!abox) throw new Error('artifact-kinds ABox missing');
+      const kindNames = new Set(abox.kinds.map((k) => k.name));
+      const dangling: string[] = [];
+      for (const rule of abox.operationRules) {
+        for (const r of rule.rules) {
+          if (!kindNames.has(r.artifactKind))
+            dangling.push(
+              `operationRules['${rule.operationId}'].rules['${r.id}'] → '${r.artifactKind}'`,
+            );
+        }
+      }
+      for (const m of abox.semanticTypeMap) {
+        if (!kindNames.has(m.artifactKind))
+          dangling.push(`semanticTypeMap['${m.semanticType}'] → '${m.artifactKind}'`);
+      }
+      for (const m of abox.fileExtensionMap) {
+        for (const k of m.artifactKinds) {
+          if (!kindNames.has(k)) dangling.push(`fileExtensionMap['${m.extension}'] → '${k}'`);
+        }
+      }
+      expect(
+        dangling,
+        'artifact-kinds ABox cross-references unknown kind name(s) — define the missing kind in `kinds[]` or fix the reference',
+      ).toEqual([]);
+    });
+
+    it('every artifact-kind in the ABox is referenced by at least one operationRules / semanticTypeMap / fileExtensionMap entry (no dead kinds)', async () => {
+      const { loadArtifactKindsAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const abox = loadArtifactKindsAbox(REPO_ROOT);
+      if (!abox) throw new Error('artifact-kinds ABox missing');
+      const referenced = new Set<string>();
+      for (const rule of abox.operationRules) {
+        for (const r of rule.rules) referenced.add(r.artifactKind);
+      }
+      for (const m of abox.semanticTypeMap) referenced.add(m.artifactKind);
+      for (const m of abox.fileExtensionMap) {
+        for (const k of m.artifactKinds) referenced.add(k);
+      }
+      const dead = abox.kinds.filter((k) => !referenced.has(k.name)).map((k) => k.name);
+      expect(
+        dead,
+        'artifact-kinds ABox lists kind(s) referenced by no rule, semanticTypeMap entry, or fileExtensionMap entry — kind is dead weight; either remove it or add a reference',
+      ).toEqual([]);
+    });
+
+    it('every semantic-type produced by some artifact kind has a matching semanticTypeMap entry (catches new kinds with no reverse-mapping)', async () => {
+      // Heuristic gate: when a new kind is added with `producesSemantics:
+      // ['NewKey']` but no corresponding `semanticTypeMap` entry mapping
+      // `NewKey → newKind`, the planner can't reverse-look up which kind
+      // produces NewKey. Surface as drift before runtime breakage.
+      const { loadArtifactKindsAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const abox = loadArtifactKindsAbox(REPO_ROOT);
+      if (!abox) throw new Error('artifact-kinds ABox missing');
+      const mapped = new Map<string, string>();
+      for (const m of abox.semanticTypeMap) mapped.set(m.semanticType, m.artifactKind);
+      const missing: string[] = [];
+      for (const kind of abox.kinds) {
+        for (const sem of kind.producesSemantics) {
+          const mappedKind = mapped.get(sem);
+          if (mappedKind === undefined) {
+            missing.push(`'${sem}' (produced by '${kind.name}', no semanticTypeMap entry)`);
+          } else if (mappedKind !== kind.name) {
+            missing.push(
+              `'${sem}' (produced by '${kind.name}' but semanticTypeMap maps it to '${mappedKind}')`,
+            );
+          }
+        }
+      }
+      expect(
+        missing,
+        'artifact-kinds ABox has kinds whose `producesSemantics` are not (or are wrongly) mapped in `semanticTypeMap` — every produced semantic type must reverse-map to its producer kind',
+      ).toEqual([]);
+    });
+
+    it('graph.domain.artifactKinds matches the ABox `kinds[]` (planner contract — ABox supersedes domain-semantics.json)', async () => {
+      const { loadArtifactKindsAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const { loadGraph } = await import('../../path-analyser/src/graphLoader.js');
+      const abox = loadArtifactKindsAbox(REPO_ROOT);
+      if (!abox) throw new Error('artifact-kinds ABox missing');
+      const graph = await loadGraph(join(REPO_ROOT, 'path-analyser'));
+      const expected = abox.kinds.map((k) => k.name).sort();
+      const actual = Object.keys(graph.domain?.artifactKinds ?? {}).sort();
+      expect(
+        actual,
+        'graph.domain.artifactKinds keys do not match the ABox `kinds[]` names — the loader may have failed to overlay the ABox onto graph.domain',
+      ).toEqual(expected);
+      // Spot-check: a kind's identifierType comes from the ABox, not the legacy sidecar.
+      for (const k of abox.kinds) {
+        expect(graph.domain?.artifactKinds?.[k.name]?.identifierType).toBe(k.identifierType);
+      }
+    });
+
+    it('graph.domain.operationArtifactRules matches the ABox `operationRules[]` (planner contract)', async () => {
+      const { loadArtifactKindsAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const { loadGraph } = await import('../../path-analyser/src/graphLoader.js');
+      const abox = loadArtifactKindsAbox(REPO_ROOT);
+      if (!abox) throw new Error('artifact-kinds ABox missing');
+      const graph = await loadGraph(join(REPO_ROOT, 'path-analyser'));
+      const expectedOps = abox.operationRules.map((r) => r.operationId).sort();
+      const actualOps = Object.keys(graph.domain?.operationArtifactRules ?? {}).sort();
+      expect(actualOps).toEqual(expectedOps);
+      for (const rule of abox.operationRules) {
+        const actual = graph.domain?.operationArtifactRules?.[rule.operationId];
+        expect(actual?.composable).toBe(rule.composable);
+        expect(actual?.rules?.map((r) => r.artifactKind).sort()).toEqual(
+          rule.rules.map((r) => r.artifactKind).sort(),
+        );
+      }
+    });
+
+    it('the committed artifact-kinds vocabulary JSON matches the regenerated TBox (drift detector)', async () => {
+      const { ARTIFACTS, renderSchema } = await import('../../scripts/build-ontology.ts');
+      const target = ARTIFACTS.find((a) => a.jsonPath.endsWith('artifact-kinds.schema.json'));
+      expect(target, 'build-ontology must include artifact-kinds.schema.json').toBeDefined();
+      if (!target) return;
+      const onDisk = readFileSync(target.jsonPath, 'utf8');
+      const rendered = renderSchema(target.schema);
+      expect(
+        onDisk,
+        `Generated ontology artefact at ${target.jsonPath} is stale. Run 'npm run build:ontology' to refresh it.`,
+      ).toBe(rendered);
+    });
+
+    it("the artifact-kinds ABox's $schema field resolves to the published TBox JSON", () => {
+      const aboxPath = join(REPO_ROOT, 'configs', CONFIG_NAME, 'ontology', 'artifact-kinds.json');
+      const expectedTboxPath = join(
+        REPO_ROOT,
+        'ontology',
+        'vocabulary',
+        'artifact-kinds.schema.json',
+      );
+      expect(
+        existsSync(expectedTboxPath),
+        `Published TBox at '${expectedTboxPath}' does not exist — vocabulary file may have been deleted or renamed`,
+      ).toBe(true);
+      interface AboxHeader {
+        $schema?: unknown;
+      }
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const aboxJson = JSON.parse(readFileSync(aboxPath, 'utf8')) as AboxHeader;
+      const schemaField = aboxJson.$schema;
+      expect(typeof schemaField, 'ABox must declare a string `$schema` field').toBe('string');
+      if (typeof schemaField !== 'string') return;
+      expect(schemaField).toBe(
+        'https://camunda.github.io/api-test-generator/ns/v1/artifact-kinds.schema.json',
+      );
+    });
+  },
+);

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -4558,10 +4558,10 @@ describeForThisConfig(
       const kindNames = new Set(abox.kinds.map((k) => k.name));
       const dangling: string[] = [];
       for (const rule of abox.operationRules) {
-        for (const r of rule.rules) {
+        for (const r of rule.rules ?? []) {
           if (!kindNames.has(r.artifactKind))
             dangling.push(
-              `operationRules['${rule.operationId}'].rules['${r.id}'] → '${r.artifactKind}'`,
+              `operationRules['${rule.operationId}'].rules['${r.id ?? '<unnamed>'}'] → '${r.artifactKind}'`,
             );
         }
       }
@@ -4586,7 +4586,7 @@ describeForThisConfig(
       if (!abox) throw new Error('artifact-kinds ABox missing');
       const referenced = new Set<string>();
       for (const rule of abox.operationRules) {
-        for (const r of rule.rules) referenced.add(r.artifactKind);
+        for (const r of rule.rules ?? []) referenced.add(r.artifactKind);
       }
       for (const m of abox.semanticTypeMap) referenced.add(m.artifactKind);
       for (const m of abox.fileExtensionMap) {
@@ -4599,32 +4599,49 @@ describeForThisConfig(
       ).toEqual([]);
     });
 
-    it('every semantic-type produced by some artifact kind has a matching semanticTypeMap entry (catches new kinds with no reverse-mapping)', async () => {
-      // Heuristic gate: when a new kind is added with `producesSemantics:
-      // ['NewKey']` but no corresponding `semanticTypeMap` entry mapping
-      // `NewKey → newKind`, the planner can't reverse-look up which kind
-      // produces NewKey. Surface as drift before runtime breakage.
+    it('the `producesSemantics` ↔ `semanticTypeMap` relation is bidirectionally consistent (no dead or wrong reverse mappings)', async () => {
+      // Bidirectional gate. Forward direction: every semantic type a
+      // kind claims to produce must reverse-map to that kind. Reverse
+      // direction: every semanticTypeMap entry must point to a kind
+      // that actually claims (in `producesSemantics`) the mapped
+      // semantic type. Without the reverse check, a stale or
+      // misspelled `semanticTypeMap` entry that maps a type the kind
+      // does not produce would still pass the forward-only test.
       const { loadArtifactKindsAbox } = await import('../../path-analyser/src/ontology/loader.js');
       const abox = loadArtifactKindsAbox(REPO_ROOT);
       if (!abox) throw new Error('artifact-kinds ABox missing');
-      const mapped = new Map<string, string>();
-      for (const m of abox.semanticTypeMap) mapped.set(m.semanticType, m.artifactKind);
-      const missing: string[] = [];
+      const mappedToKind = new Map<string, string>();
+      for (const m of abox.semanticTypeMap) mappedToKind.set(m.semanticType, m.artifactKind);
+      const kindByName = new Map(abox.kinds.map((k) => [k.name, k]));
+      const issues: string[] = [];
+      // Forward: kind.producesSemantics → semanticTypeMap.
       for (const kind of abox.kinds) {
         for (const sem of kind.producesSemantics) {
-          const mappedKind = mapped.get(sem);
+          const mappedKind = mappedToKind.get(sem);
           if (mappedKind === undefined) {
-            missing.push(`'${sem}' (produced by '${kind.name}', no semanticTypeMap entry)`);
+            issues.push(
+              `[forward] '${sem}' is produced by kind '${kind.name}' but has no semanticTypeMap entry`,
+            );
           } else if (mappedKind !== kind.name) {
-            missing.push(
-              `'${sem}' (produced by '${kind.name}' but semanticTypeMap maps it to '${mappedKind}')`,
+            issues.push(
+              `[forward] '${sem}' is produced by kind '${kind.name}' but semanticTypeMap maps it to '${mappedKind}'`,
             );
           }
         }
       }
+      // Reverse: semanticTypeMap → kind.producesSemantics.
+      for (const m of abox.semanticTypeMap) {
+        const kind = kindByName.get(m.artifactKind);
+        if (!kind) continue; // dangling-kind reference is already caught by another invariant
+        if (!kind.producesSemantics.includes(m.semanticType)) {
+          issues.push(
+            `[reverse] semanticTypeMap maps '${m.semanticType}' to kind '${m.artifactKind}', but '${m.artifactKind}.producesSemantics' does not list '${m.semanticType}'`,
+          );
+        }
+      }
       expect(
-        missing,
-        'artifact-kinds ABox has kinds whose `producesSemantics` are not (or are wrongly) mapped in `semanticTypeMap` — every produced semantic type must reverse-map to its producer kind',
+        issues,
+        'artifact-kinds ABox `semanticTypeMap` is not in bidirectional sync with `kinds[].producesSemantics` — every produced semantic type must reverse-map to its producer kind, and every map entry must point to a kind that actually produces the mapped type',
       ).toEqual([]);
     });
 
@@ -4646,22 +4663,53 @@ describeForThisConfig(
       }
     });
 
-    it('graph.domain.operationArtifactRules matches the ABox `operationRules[]` (planner contract)', async () => {
-      const { loadArtifactKindsAbox } = await import('../../path-analyser/src/ontology/loader.js');
+    it('graph.domain.operationArtifactRules matches the ABox `operationRules[]` (planner contract — full per-rule fields)', async () => {
+      const { loadArtifactKindsAbox, deriveArtifactKindsViews } = await import(
+        '../../path-analyser/src/ontology/loader.js'
+      );
       const { loadGraph } = await import('../../path-analyser/src/graphLoader.js');
       const abox = loadArtifactKindsAbox(REPO_ROOT);
-      if (!abox) throw new Error('artifact-kinds ABox missing');
+      const expectedViews = deriveArtifactKindsViews(REPO_ROOT);
+      if (!abox || !expectedViews) throw new Error('artifact-kinds ABox missing');
       const graph = await loadGraph(join(REPO_ROOT, 'path-analyser'));
-      const expectedOps = abox.operationRules.map((r) => r.operationId).sort();
-      const actualOps = Object.keys(graph.domain?.operationArtifactRules ?? {}).sort();
-      expect(actualOps).toEqual(expectedOps);
-      for (const rule of abox.operationRules) {
-        const actual = graph.domain?.operationArtifactRules?.[rule.operationId];
-        expect(actual?.composable).toBe(rule.composable);
-        expect(actual?.rules?.map((r) => r.artifactKind).sort()).toEqual(
-          rule.rules.map((r) => r.artifactKind).sort(),
-        );
-      }
+      // Compare the full record-shaped views: keys, composable flag,
+      // and every rule-level field (id, artifactKind, priority,
+      // producesSemantics, producesStates). A regression that drops
+      // any of those is caught directly because the rule.id is what
+      // the emitter uses to look up the chosen rule, and the
+      // optional override fields drive the planner's output.
+      expect(
+        graph.domain?.operationArtifactRules,
+        'graph.domain.operationArtifactRules does not match the record-shaped view derived from the ABox — the loader may have failed to overlay the ABox onto graph.domain or may be dropping rule-level fields',
+      ).toEqual(expectedViews.operationArtifactRules);
+    });
+
+    it('graph.domain.semanticTypeToArtifactKind matches the ABox `semanticTypeMap[]` (planner contract)', async () => {
+      const { deriveArtifactKindsViews } = await import(
+        '../../path-analyser/src/ontology/loader.js'
+      );
+      const { loadGraph } = await import('../../path-analyser/src/graphLoader.js');
+      const expectedViews = deriveArtifactKindsViews(REPO_ROOT);
+      if (!expectedViews) throw new Error('artifact-kinds ABox missing');
+      const graph = await loadGraph(join(REPO_ROOT, 'path-analyser'));
+      expect(
+        graph.domain?.semanticTypeToArtifactKind,
+        'graph.domain.semanticTypeToArtifactKind does not match the ABox semanticTypeMap — overlay regression',
+      ).toEqual(expectedViews.semanticTypeToArtifactKind);
+    });
+
+    it('graph.domain.artifactFileKinds matches the ABox `fileExtensionMap[]` (planner contract)', async () => {
+      const { deriveArtifactKindsViews } = await import(
+        '../../path-analyser/src/ontology/loader.js'
+      );
+      const { loadGraph } = await import('../../path-analyser/src/graphLoader.js');
+      const expectedViews = deriveArtifactKindsViews(REPO_ROOT);
+      if (!expectedViews) throw new Error('artifact-kinds ABox missing');
+      const graph = await loadGraph(join(REPO_ROOT, 'path-analyser'));
+      expect(
+        graph.domain?.artifactFileKinds,
+        'graph.domain.artifactFileKinds does not match the ABox fileExtensionMap — overlay regression',
+      ).toEqual(expectedViews.artifactFileKinds);
     });
 
     it('the committed artifact-kinds vocabulary JSON matches the regenerated TBox (drift detector)', async () => {

--- a/ontology/vocabulary/artifact-kinds.schema.json
+++ b/ontology/vocabulary/artifact-kinds.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://camunda.github.io/api-test-generator/ns/v1/artifact-kinds.schema.json",
   "title": "Artifact-kinds ABox (api-test-generator ontology, v1)",
-  "description": "TBox JSON Schema for an ABox file describing the artifact kinds an API can deploy plus the rules that classify operations and uploaded files into those kinds. Each entry asserts: an artifact kind exists with a stable identifier-type and deployment-slice list; a semantic-type maps to a single artifact kind; an operation deploys one or more artifact kinds (optionally composable); a file extension classifies as one or more candidate kinds. The schema is intentionally agnostic to which API ships the kinds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/artifact-kinds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (operationIds existing, semantic-types being live, kinds being referenced by some op) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them.",
+  "description": "TBox JSON Schema for an ABox file describing the artifact kinds an API can deploy plus the rules that classify operations and uploaded files into those kinds. Each entry asserts: an artifact kind exists with a stable identifier-type and deployment-slice list; a semantic-type maps to a single artifact kind; an operation deploys one or more artifact kinds (optionally composable); a file extension classifies as one or more candidate kinds. The schema is intentionally agnostic to which API ships the kinds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/artifact-kinds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (operationIds existing, artifact kind names being internally consistent across rules / semanticTypeMap / fileExtensionMap, kinds being referenced by some entry) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them. Cross-references against `runtimeStates`/`semanticTypes` (sibling sub-trees in `domain-semantics.json` that the artifact-kinds ABox references via `producesStates`, `producibleStates`, and `producesSemantics`) are re-validated at load time by re-running `validateDomainSemantics` against the post-overlay `graph.domain` — see `graphLoader.ts`.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -149,9 +149,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "operationId",
-        "composable",
-        "rules"
+        "operationId"
       ],
       "properties": {
         "@type": {
@@ -165,14 +163,15 @@
         },
         "composable": {
           "type": "boolean",
-          "description": "When true, the planner may compose multiple `rules` into a single deployment request via set-cover (e.g. `createDeployment` accepts a multi-file payload)."
+          "description": "When true, the planner may compose multiple `rules` into a single deployment request via set-cover (e.g. `createDeployment` accepts a multi-file payload). Optional — mirrors the legacy `OperationArtifactRuleSpec.composable` contract; absence is treated as `false` by the planner."
         },
         "rules": {
           "type": "array",
           "minItems": 1,
           "items": {
             "$ref": "#/definitions/ArtifactRule"
-          }
+          },
+          "description": "Optional list of artifact rules for this operation. Mirrors the legacy `OperationArtifactRuleSpec.rules` contract — an entry with no `rules` is permitted so a future composable-only opcode can declare itself without listing concrete rules."
         }
       }
     },
@@ -180,19 +179,38 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "id",
         "artifactKind"
       ],
       "properties": {
         "id": {
           "type": "string",
           "minLength": 1,
-          "description": "Stable identifier for this rule within its operation (e.g. `bpmn`, `dmn`). Used by the scenario emitter to reference a specific rule."
+          "description": "Optional stable identifier for this rule within its operation (e.g. `bpmn`, `dmn`). Used by the scenario emitter to reference a specific rule. Mirrors the legacy `ArtifactRule.id` contract — when present it must be unique within the operation (checked by the loader)."
         },
         "artifactKind": {
           "type": "string",
           "minLength": 1,
           "description": "Name of the artifact kind this rule deploys. Must reference an entry in `kinds`."
+        },
+        "priority": {
+          "type": "integer",
+          "description": "Optional priority hint for the planner: lower number = higher priority. Mirrors the legacy `ArtifactRule.priority` contract."
+        },
+        "producesSemantics": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Optional explicit override of the semantic types this rule produces. When omitted, the planner derives the list from `kinds[artifactKind].producesSemantics` and `semanticTypeMap`. Mirrors the legacy `ArtifactRule.producesSemantics` contract."
+        },
+        "producesStates": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Optional additional domain states this rule produces beyond the kind-level `producesStates`. Mirrors the legacy `ArtifactRule.producesStates` contract."
         }
       }
     },

--- a/ontology/vocabulary/artifact-kinds.schema.json
+++ b/ontology/vocabulary/artifact-kinds.schema.json
@@ -1,0 +1,228 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://camunda.github.io/api-test-generator/ns/v1/artifact-kinds.schema.json",
+  "title": "Artifact-kinds ABox (api-test-generator ontology, v1)",
+  "description": "TBox JSON Schema for an ABox file describing the artifact kinds an API can deploy plus the rules that classify operations and uploaded files into those kinds. Each entry asserts: an artifact kind exists with a stable identifier-type and deployment-slice list; a semantic-type maps to a single artifact kind; an operation deploys one or more artifact kinds (optionally composable); a file extension classifies as one or more candidate kinds. The schema is intentionally agnostic to which API ships the kinds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/artifact-kinds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (operationIds existing, semantic-types being live, kinds being referenced by some op) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "kinds",
+    "semanticTypeMap",
+    "operationRules",
+    "fileExtensionMap"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "@context": {
+      "description": "Optional JSON-LD context. Ignored by the loader; preserved verbatim so external RDF tooling can resolve term IRIs without modification.",
+      "type": [
+        "object",
+        "string",
+        "array"
+      ]
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Schema version of this ABox file. Bumped only when the TBox shape changes incompatibly."
+    },
+    "kinds": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/ArtifactKind"
+      }
+    },
+    "semanticTypeMap": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/SemanticTypeMapping"
+      }
+    },
+    "operationRules": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/OperationArtifactRule"
+      }
+    },
+    "fileExtensionMap": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/FileExtensionMapping"
+      }
+    }
+  },
+  "definitions": {
+    "ArtifactKind": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "identifierType",
+        "producesSemantics",
+        "producesStates",
+        "deploymentSlices",
+        "description"
+      ],
+      "properties": {
+        "@type": {
+          "description": "Optional JSON-LD type IRI. Ignored by the loader.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][A-Za-z0-9]+$",
+          "description": "camelCase noun naming the artifact kind (e.g. `bpmnProcess`, `dmnDrd`)."
+        },
+        "identifierType": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Semantic identifier-type produced by deploying this kind (e.g. `ProcessDefinitionId`)."
+        },
+        "producesStates": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Runtime states EVERY fixture of this kind delivers unconditionally on a successful deployment (e.g. `ProcessDefinitionDeployed`)."
+        },
+        "producibleStates": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Runtime states SOME fixture of this kind CAN deliver, conditional on which checked-in file the selector picks (#159). The planner reads `producesStates ∪ producibleStates` for chain-feasibility BFS; the per-fixture `providesStates` in `path-analyser/fixtures/deployment-artifacts.json` then narrows the choice at emission time. Optional — omit when no fixture offers any optional state."
+        },
+        "producesSemantics": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Semantic identifier-types this kind produces (typically a single-element list containing the canonical key type, e.g. `ProcessDefinitionKey`)."
+        },
+        "deploymentSlices": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Top-level keys of the createDeployment response payload that this kind populates (e.g. `[\"processDefinition\"]`, or `[\"decisionDefinition\", \"decisionRequirements\"]` for a kind whose deployment yields two slices)."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "SemanticTypeMapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "semanticType",
+        "artifactKind"
+      ],
+      "properties": {
+        "@type": {
+          "description": "Optional JSON-LD type IRI. Ignored by the loader.",
+          "type": "string"
+        },
+        "semanticType": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Semantic identifier-type name (e.g. `ProcessDefinitionKey`). Reverse-mapped to the artifact kind that produces it."
+        },
+        "artifactKind": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of the artifact kind that produces this semantic type. Must reference an entry in `kinds`."
+        }
+      }
+    },
+    "OperationArtifactRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operationId",
+        "composable",
+        "rules"
+      ],
+      "properties": {
+        "@type": {
+          "description": "Optional JSON-LD type IRI. Ignored by the loader.",
+          "type": "string"
+        },
+        "operationId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "OpenAPI operationId of the deploy operation (e.g. `createDeployment`). Must reference a real op in the bundled spec — checked as an L3 abox-vs-graph invariant."
+        },
+        "composable": {
+          "type": "boolean",
+          "description": "When true, the planner may compose multiple `rules` into a single deployment request via set-cover (e.g. `createDeployment` accepts a multi-file payload)."
+        },
+        "rules": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/ArtifactRule"
+          }
+        }
+      }
+    },
+    "ArtifactRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "artifactKind"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable identifier for this rule within its operation (e.g. `bpmn`, `dmn`). Used by the scenario emitter to reference a specific rule."
+        },
+        "artifactKind": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of the artifact kind this rule deploys. Must reference an entry in `kinds`."
+        }
+      }
+    },
+    "FileExtensionMapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "extension",
+        "artifactKinds"
+      ],
+      "properties": {
+        "@type": {
+          "description": "Optional JSON-LD type IRI. Ignored by the loader.",
+          "type": "string"
+        },
+        "extension": {
+          "type": "string",
+          "pattern": "^\\.[a-z0-9]+$",
+          "description": "Lowercase file extension including the leading dot (e.g. `.bpmn`, `.dmn`)."
+        },
+        "artifactKinds": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Candidate artifact kinds for files with this extension. Multiple entries express ambiguity (e.g. `.dmn` may carry a single decision or a full DRD); the selector then disambiguates per-fixture. Each entry must reference a name in `kinds`."
+        }
+      }
+    }
+  }
+}

--- a/path-analyser/src/domainSemanticsValidator.ts
+++ b/path-analyser/src/domainSemanticsValidator.ts
@@ -123,15 +123,33 @@ export const GlobalContextSeedSchema = z
   })
   .strict();
 
-// Top-level shape — `passthrough` so unrelated fields (operationArtifactRules,
-// artifactFileKinds, semanticTypeToArtifactKind, identifiers, version, $schema)
-// flow through unmodified.
+const ArtifactRuleSchema = z
+  .object({
+    id: z.string().optional(),
+    artifactKind: z.string(),
+    priority: z.number().optional(),
+    producesSemantics: z.array(z.string()).optional(),
+    producesStates: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+const OperationArtifactRuleSpecSchema = z
+  .object({
+    composable: z.boolean().optional(),
+    rules: z.array(ArtifactRuleSchema).optional(),
+  })
+  .passthrough();
+
+// Top-level shape — `passthrough` so unrelated fields
+// (artifactFileKinds, semanticTypeToArtifactKind, identifiers, version,
+// $schema) flow through unmodified.
 const DomainSemanticsShape = z
   .object({
     runtimeStates: z.record(z.string(), RuntimeStateSpecSchema).optional(),
     capabilities: z.record(z.string(), z.unknown()).optional(),
     semanticTypes: z.record(z.string(), SemanticTypeSpecSchema).optional(),
     artifactKinds: z.record(z.string(), ArtifactKindSpecSchema).optional(),
+    operationArtifactRules: z.record(z.string(), OperationArtifactRuleSpecSchema).optional(),
     operationRequirements: z.record(z.string(), OperationDomainRequirementsSchema).optional(),
     globalContextSeeds: z.array(GlobalContextSeedSchema).optional(),
   })
@@ -187,6 +205,25 @@ function checkArtifactKindStateDeclared(d: DomainSemanticsShape): CrossRefIssue[
       }
     }
   }
+  // Lift 5 / #212: rule-level overrides on operationArtifactRules carry the
+  // same cross-reference invariant as kind-level producesStates — the planner
+  // reads them via getEffectiveProducesStates() during chain-feasibility BFS.
+  // Without this check, an ABox-introduced (or hand-edited legacy) override
+  // pointing at an undeclared state silently breaks the BFS rather than
+  // surfacing as a load-time config error.
+  for (const [op, spec] of Object.entries(d.operationArtifactRules ?? {})) {
+    for (const rule of spec.rules ?? []) {
+      const ruleId = rule.id ?? '<unnamed>';
+      for (const state of rule.producesStates ?? []) {
+        if (!declared.has(state)) {
+          issues.push({
+            code: 'artifactKindStateDeclared',
+            message: `operationArtifactRules.${op}.rules['${ruleId}'].producesStates references "${state}", which is not declared in runtimeStates or capabilities`,
+          });
+        }
+      }
+    }
+  }
   return issues;
 }
 
@@ -201,6 +238,24 @@ function checkArtifactKindWitnessDeclared(d: DomainSemanticsShape): CrossRefIssu
           code: 'artifactKindWitnessDeclared',
           message: `artifactKinds.${kind}.producesSemantics references "${type}", which has no semanticTypes.${type}.witnesses declaration`,
         });
+      }
+    }
+  }
+  // Lift 5 / #212: same coverage extension as
+  // checkArtifactKindStateDeclared — rule-level producesSemantics
+  // overrides also reach the planner via getEffectiveProducesSemantics()
+  // and a stale/ABox-introduced typo would otherwise pass through.
+  for (const [op, spec] of Object.entries(d.operationArtifactRules ?? {})) {
+    for (const rule of spec.rules ?? []) {
+      const ruleId = rule.id ?? '<unnamed>';
+      for (const type of rule.producesSemantics ?? []) {
+        const entry = declared[type];
+        if (!entry || typeof entry.witnesses !== 'string' || entry.witnesses.length === 0) {
+          issues.push({
+            code: 'artifactKindWitnessDeclared',
+            message: `operationArtifactRules.${op}.rules['${ruleId}'].producesSemantics references "${type}", which has no semanticTypes.${type}.witnesses declaration`,
+          });
+        }
       }
     }
   }

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -329,7 +329,25 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     const domainRaw = await readFile(domainPath, 'utf8');
     // biome-ignore lint/plugin: JSON.parse returns `any`; domain-semantics.json is the runtime contract.
     const parsedDomain = JSON.parse(domainRaw) as DomainSemantics;
-    const issues = validateDomainSemantics(parsedDomain);
+    // Lift 5 / #212: when an artifact-kinds ABox is present it is the
+    // authoritative source for the four artifact sub-trees; the legacy
+    // sidecar's copy is about to be replaced by the post-overlay step
+    // below. Strip those keys before pre-overlay validation so a stale
+    // legacy entry (e.g. a `producesStates` referencing a state that
+    // the legacy sidecar no longer declares) cannot fail load when the
+    // ABox already supersedes it. The post-overlay re-validation
+    // covers the ABox values via the same Zod-driven validator.
+    const aboxPresent = loadArtifactKindsAbox(repoRoot) !== null;
+    let validationTarget: DomainSemantics = parsedDomain;
+    if (aboxPresent) {
+      const stripped: DomainSemantics = { ...parsedDomain };
+      delete stripped.artifactKinds;
+      delete stripped.semanticTypeToArtifactKind;
+      delete stripped.operationArtifactRules;
+      delete stripped.artifactFileKinds;
+      validationTarget = stripped;
+    }
+    const issues = validateDomainSemantics(validationTarget);
     if (issues.length > 0) {
       const detail = issues.map((i) => `  - [${i.invariant}] ${i.message}`).join('\n');
       throw new DomainSemanticsValidationFailure(

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -8,6 +8,8 @@ import {
   validateRuntimeStateWitnessGraphRefs,
 } from './domainSemanticsValidator.js';
 import {
+  deriveArtifactKindsViews,
+  loadArtifactKindsAbox,
   loadEdgeEstablishers,
   loadEntityKindsAbox,
   loadExternalEntityIdentifiers,
@@ -467,6 +469,32 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     // ENOENT or non-Error throw: sidecar absent — domain analysis disabled
   }
 
+  // Lift 5 / #212: artifact-kinds ABox supersedes the legacy
+  // `domain-semantics.json` keys when present. Per #198, artifact
+  // dispatch is domain knowledge with no wire signature, so it lives
+  // in the per-config ontology rather than in the freeform sidecar.
+  // The legacy keys remain a transitional fallback so unmigrated
+  // configs (and tests that exercise loadGraph against an isolated
+  // tmpDir without a domain-semantics.json) keep working until Lift 8
+  // retires them. When both are present, the ABox is authoritative —
+  // `detectArtifactKindsDrift` surfaces dead/dangling entries (the
+  // durable abox-vs-graph signal) before the override can silently
+  // mask them. Placed outside the domain-semantics try/catch so a
+  // shipped ABox is honoured even when the legacy sidecar is absent.
+  {
+    const artifactViews = deriveArtifactKindsViews(repoRoot);
+    if (artifactViews !== null) {
+      const baseDomain: DomainSemantics = domain ?? { version: 1 };
+      domain = {
+        ...baseDomain,
+        artifactKinds: artifactViews.artifactKinds,
+        semanticTypeToArtifactKind: artifactViews.semanticTypeToArtifactKind,
+        operationArtifactRules: artifactViews.operationArtifactRules,
+        artifactFileKinds: artifactViews.artifactFileKinds,
+      };
+    }
+  }
+
   // Lift 4 / #210: the entity-kinds ABox is the authoritative runtime
   // source for the external-entity identifier set. Falls back to the
   // spec-emitted `kindRegistry` (Issue #134 / camunda/camunda#52320)
@@ -513,6 +541,29 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
       }
       console.warn(
         `WARNING: ${message}\n  (set STRICT_ENTITY_KINDS_ABOX=1 to fail-fast on drift.)`,
+      );
+    }
+  }
+
+  // Lift 5 / #212: cross-validate the artifact-kinds ABox against the
+  // bundled graph (durable, sense 2 only — there is no spec source for
+  // these facts to disagree with). Catches: rules naming nonexistent
+  // operations / artifact kinds; semantic-types mapped to nonexistent
+  // kinds; file-extension entries pointing at nonexistent kinds; kinds
+  // not referenced by any rule, semanticTypeMap entry, or
+  // fileExtensionMap entry (dead weight). The locality-loss
+  // replacement signal: surfaces drift when the upstream API adds a
+  // new artifact-flavoured op and the ABox isn't updated.
+  {
+    const drift = detectArtifactKindsDrift(operations, repoRoot);
+    if (drift.length > 0) {
+      const detail = drift.map((d) => `  - ${d}`).join('\n');
+      const message = `artifact-kinds ABox drift detected:\n${detail}`;
+      if (process.env.STRICT_ARTIFACT_KINDS_ABOX === '1') {
+        throw new Error(message);
+      }
+      console.warn(
+        `WARNING: ${message}\n  (set STRICT_ARTIFACT_KINDS_ABOX=1 to fail-fast on drift.)`,
       );
     }
   }
@@ -970,6 +1021,87 @@ function detectEntityKindsDrift(
     if (!used) {
       drift.push(
         `[abox-vs-graph] ABox lists kind '${name}' (identifiers: ${kind.identifiers.join(', ')}), but none of those identifier types are referenced by any operation in the graph (kind is dead weight; either remove from ABox or add a consumer op)`,
+      );
+    }
+  }
+
+  return drift;
+}
+
+/**
+ * Cross-validate the artifact-kinds ABox against the bundled-graph
+ * use-sites. Lift 5 / #212. Unlike the entity-kinds detector, there is
+ * no transitional `spec-vs-abox` sense — the data was never sourced
+ * from the upstream OpenAPI spec, so there is no second source of
+ * truth for the ABox to disagree with. Only the durable
+ * `abox-vs-graph` (sense-2) checks apply:
+ *
+ *   - rule operationIds reference real ops in the graph;
+ *   - rule artifactKind / semanticTypeMap.artifactKind /
+ *     fileExtensionMap.artifactKinds entries reference real kinds;
+ *   - every kind is referenced by at least one rule, semanticTypeMap
+ *     entry, or fileExtensionMap entry (no dead kinds).
+ *
+ * Returns an empty list when no ABox is shipped, so the caller treats
+ * the legacy `domain-semantics.json` fallback as drift-free.
+ */
+function detectArtifactKindsDrift(
+  operations: Record<string, OperationNode>,
+  repoRoot: string,
+): string[] {
+  const drift: string[] = [];
+  const abox = loadArtifactKindsAbox(repoRoot);
+  if (abox === null) return drift;
+
+  const kindNames = new Set(abox.kinds.map((k) => k.name));
+
+  for (const rule of abox.operationRules) {
+    if (!operations[rule.operationId]) {
+      drift.push(
+        `[abox-vs-graph] operationRules entry '${rule.operationId}' references an opId that does not exist in the bundled graph (typo, renamed-upstream op, or stale entry)`,
+      );
+    }
+    for (const r of rule.rules) {
+      if (!kindNames.has(r.artifactKind)) {
+        drift.push(
+          `[abox-vs-graph] operationRules['${rule.operationId}'].rules['${r.id}'] references unknown artifactKind '${r.artifactKind}'`,
+        );
+      }
+    }
+  }
+  for (const m of abox.semanticTypeMap) {
+    if (!kindNames.has(m.artifactKind)) {
+      drift.push(
+        `[abox-vs-graph] semanticTypeMap entry '${m.semanticType}' → '${m.artifactKind}' references unknown artifactKind`,
+      );
+    }
+  }
+  for (const m of abox.fileExtensionMap) {
+    for (const kind of m.artifactKinds) {
+      if (!kindNames.has(kind)) {
+        drift.push(
+          `[abox-vs-graph] fileExtensionMap entry '${m.extension}' references unknown artifactKind '${kind}'`,
+        );
+      }
+    }
+  }
+
+  // Dead-weight check: every kind must be referenced from at least one
+  // of the three side-tables. A kind that nothing references can never
+  // be dispatched to, and is almost certainly a stale entry from an
+  // earlier API surface.
+  const referencedKinds = new Set<string>();
+  for (const rule of abox.operationRules) {
+    for (const r of rule.rules) referencedKinds.add(r.artifactKind);
+  }
+  for (const m of abox.semanticTypeMap) referencedKinds.add(m.artifactKind);
+  for (const m of abox.fileExtensionMap) {
+    for (const k of m.artifactKinds) referencedKinds.add(k);
+  }
+  for (const k of abox.kinds) {
+    if (!referencedKinds.has(k.name)) {
+      drift.push(
+        `[abox-vs-graph] ABox lists kind '${k.name}' but no operationRules / semanticTypeMap / fileExtensionMap entry references it (dead weight; either remove from ABox or add a referencing entry)`,
       );
     }
   }

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -484,6 +484,7 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
   {
     const artifactViews = deriveArtifactKindsViews(repoRoot);
     if (artifactViews !== null) {
+      const hadLegacyDomain = domain !== undefined;
       const baseDomain: DomainSemantics = domain ?? { version: 1 };
       domain = {
         ...baseDomain,
@@ -492,6 +493,30 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
         operationArtifactRules: artifactViews.operationArtifactRules,
         artifactFileKinds: artifactViews.artifactFileKinds,
       };
+      // Re-run the cross-reference invariants from
+      // `validateDomainSemantics` against the post-overlay value, but
+      // only when a legacy `domain-semantics.json` sidecar was loaded.
+      // The pre-overlay validation only sees the legacy artifact
+      // sub-trees, so an ABox that introduces an undeclared
+      // `producesStates`/`producibleStates` (not in
+      // `runtimeStates`/`capabilities`) or a `producesSemantics` entry
+      // without a `semanticTypes.witnesses` declaration would
+      // otherwise slip through. When no sidecar is present the
+      // validator has no `runtimeStates`/`semanticTypes` to cross-check
+      // against — the ABox stands alone, and Lift 6/7 will move those
+      // declarations into their own ABoxes. Reuses the same Zod-driven
+      // validator and the same DomainSemanticsValidationFailure error
+      // type so the diagnostic surfaces with one well-known shape
+      // regardless of which source (legacy sidecar or ABox) tripped it.
+      if (hadLegacyDomain) {
+        const overlayIssues = validateDomainSemantics(domain);
+        if (overlayIssues.length > 0) {
+          const detail = overlayIssues.map((i) => `  - [${i.invariant}] ${i.message}`).join('\n');
+          throw new DomainSemanticsValidationFailure(
+            `artifact-kinds ABox introduced cross-reference violation(s) when overlaid on domain-semantics.json:\n${detail}`,
+          );
+        }
+      }
     }
   }
 
@@ -551,9 +576,11 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
   // operations / artifact kinds; semantic-types mapped to nonexistent
   // kinds; file-extension entries pointing at nonexistent kinds; kinds
   // not referenced by any rule, semanticTypeMap entry, or
-  // fileExtensionMap entry (dead weight). The locality-loss
-  // replacement signal: surfaces drift when the upstream API adds a
-  // new artifact-flavoured op and the ABox isn't updated.
+  // fileExtensionMap entry (dead weight). Validates only entries that
+  // are present in the ABox — there is no reverse heuristic for
+  // discovering newly-added artifact-flavoured ops in the bundled
+  // graph that should have been added to the ABox; that direction is
+  // the open coverage gap a future iteration could close.
   {
     const drift = detectArtifactKindsDrift(operations, repoRoot);
     if (drift.length > 0) {
@@ -1061,10 +1088,10 @@ function detectArtifactKindsDrift(
         `[abox-vs-graph] operationRules entry '${rule.operationId}' references an opId that does not exist in the bundled graph (typo, renamed-upstream op, or stale entry)`,
       );
     }
-    for (const r of rule.rules) {
+    for (const r of rule.rules ?? []) {
       if (!kindNames.has(r.artifactKind)) {
         drift.push(
-          `[abox-vs-graph] operationRules['${rule.operationId}'].rules['${r.id}'] references unknown artifactKind '${r.artifactKind}'`,
+          `[abox-vs-graph] operationRules['${rule.operationId}'].rules['${r.id ?? '<unnamed>'}'] references unknown artifactKind '${r.artifactKind}'`,
         );
       }
     }
@@ -1092,7 +1119,7 @@ function detectArtifactKindsDrift(
   // earlier API surface.
   const referencedKinds = new Set<string>();
   for (const rule of abox.operationRules) {
-    for (const r of rule.rules) referencedKinds.add(r.artifactKind);
+    for (const r of rule.rules ?? []) referencedKinds.add(r.artifactKind);
   }
   for (const m of abox.semanticTypeMap) referencedKinds.add(m.artifactKind);
   for (const m of abox.fileExtensionMap) {

--- a/path-analyser/src/ontology/artifactKindsSchema.ts
+++ b/path-analyser/src/ontology/artifactKindsSchema.ts
@@ -1,0 +1,251 @@
+// Source of truth for the artifact-kinds ABox TBox (api-test-generator
+// ontology, v1).
+//
+// Mirrors the pattern established by `edgeSchema.ts` (Lift 3 / #208)
+// and `entityKindsSchema.ts` (Lift 4 / #210): this TypeScript module is
+// the authoritative declaration; the matching
+// `ontology/vocabulary/artifact-kinds.schema.json` file is generated
+// from it by `scripts/build-ontology.ts` and committed solely so
+// external SPARQL/SHACL/OWL consumers can fetch a plain JSON Schema by
+// URL. A regression invariant in
+// `configs/<config>/regression-invariants.test.ts` asserts the two are
+// in sync.
+//
+// What this ABox encodes (Lift 5 / #212): the catalogue of *artifact
+// kinds* an API can deploy and the rules that map operations and
+// uploaded files to those kinds. Today (camunda-oca) this means BPMN
+// processes, DMN decisions, DMN DRDs, and forms; the four sub-trees
+// were carried in `configs/<config>/domain-semantics.json` until this
+// lift moved them to a per-config ontology ABox.
+//
+// Unlike Lifts 3 and 4, the data was never sourced from upstream
+// OpenAPI annotations — it has always lived in the per-config sidecar.
+// Consequence: there is no `spec-vs-abox` (sense-1) drift to detect.
+// The ABox supersedes the legacy `domain-semantics.json` keys when
+// present; coverage gates check the durable `abox-vs-graph` (sense-2)
+// invariants only (kinds reach the graph; rules reference real ops; no
+// dead kinds).
+//
+// Four entry classes:
+//
+//   - `kinds`              — per-artifact-kind metadata: which runtime
+//                            states every fixture of this kind delivers
+//                            unconditionally (`producesStates`); which
+//                            states some fixture CAN deliver
+//                            (`producibleStates`, see #159); which
+//                            semantic identifier-types it produces
+//                            (`producesSemantics` + the singleton
+//                            `identifierType`); which keys of the
+//                            createDeployment response payload it
+//                            populates (`deploymentSlices`).
+//
+//   - `semanticTypeMap`    — reverse lookup: semantic-type name →
+//                            artifact-kind name. Drives "which kind
+//                            produces this semantic?" lookups in the
+//                            planner.
+//
+//   - `operationRules`     — per-operation deployment rules: which
+//                            artifact kinds an op can deploy and
+//                            whether they may be combined in one
+//                            request (`composable: true`).
+//
+//   - `fileExtensionMap`   — file-extension → candidate kinds, used by
+//                            the deployment-artifact selector to
+//                            classify uploaded fixtures.
+//
+// JSON-LD (`@context`, `@type`) is accepted and preserved verbatim but
+// not interpreted by the loader — same convention as the other ABoxes.
+
+export const artifactKindsSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'https://camunda.github.io/api-test-generator/ns/v1/artifact-kinds.schema.json',
+  title: 'Artifact-kinds ABox (api-test-generator ontology, v1)',
+  description:
+    'TBox JSON Schema for an ABox file describing the artifact kinds an API can deploy plus the rules that classify operations and uploaded files into those kinds. Each entry asserts: an artifact kind exists with a stable identifier-type and deployment-slice list; a semantic-type maps to a single artifact kind; an operation deploys one or more artifact kinds (optionally composable); a file extension classifies as one or more candidate kinds. The schema is intentionally agnostic to which API ships the kinds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/artifact-kinds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (operationIds existing, semantic-types being live, kinds being referenced by some op) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them.',
+  type: 'object',
+  additionalProperties: false,
+  required: ['version', 'kinds', 'semanticTypeMap', 'operationRules', 'fileExtensionMap'],
+  properties: {
+    $schema: { type: 'string' },
+    '@context': {
+      description:
+        'Optional JSON-LD context. Ignored by the loader; preserved verbatim so external RDF tooling can resolve term IRIs without modification.',
+      type: ['object', 'string', 'array'],
+    },
+    version: {
+      type: 'integer',
+      minimum: 1,
+      description:
+        'Schema version of this ABox file. Bumped only when the TBox shape changes incompatibly.',
+    },
+    kinds: {
+      type: 'array',
+      minItems: 1,
+      items: { $ref: '#/definitions/ArtifactKind' },
+    },
+    semanticTypeMap: {
+      type: 'array',
+      items: { $ref: '#/definitions/SemanticTypeMapping' },
+    },
+    operationRules: {
+      type: 'array',
+      items: { $ref: '#/definitions/OperationArtifactRule' },
+    },
+    fileExtensionMap: {
+      type: 'array',
+      items: { $ref: '#/definitions/FileExtensionMapping' },
+    },
+  },
+  definitions: {
+    ArtifactKind: {
+      type: 'object',
+      additionalProperties: false,
+      required: [
+        'name',
+        'identifierType',
+        'producesSemantics',
+        'producesStates',
+        'deploymentSlices',
+        'description',
+      ],
+      properties: {
+        '@type': {
+          description: 'Optional JSON-LD type IRI. Ignored by the loader.',
+          type: 'string',
+        },
+        name: {
+          type: 'string',
+          pattern: '^[a-z][A-Za-z0-9]+$',
+          description: 'camelCase noun naming the artifact kind (e.g. `bpmnProcess`, `dmnDrd`).',
+        },
+        identifierType: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Semantic identifier-type produced by deploying this kind (e.g. `ProcessDefinitionId`).',
+        },
+        producesStates: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description:
+            'Runtime states EVERY fixture of this kind delivers unconditionally on a successful deployment (e.g. `ProcessDefinitionDeployed`).',
+        },
+        producibleStates: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description:
+            'Runtime states SOME fixture of this kind CAN deliver, conditional on which checked-in file the selector picks (#159). The planner reads `producesStates ∪ producibleStates` for chain-feasibility BFS; the per-fixture `providesStates` in `path-analyser/fixtures/deployment-artifacts.json` then narrows the choice at emission time. Optional — omit when no fixture offers any optional state.',
+        },
+        producesSemantics: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description:
+            'Semantic identifier-types this kind produces (typically a single-element list containing the canonical key type, e.g. `ProcessDefinitionKey`).',
+        },
+        deploymentSlices: {
+          type: 'array',
+          minItems: 1,
+          items: { type: 'string', minLength: 1 },
+          description:
+            'Top-level keys of the createDeployment response payload that this kind populates (e.g. `["processDefinition"]`, or `["decisionDefinition", "decisionRequirements"]` for a kind whose deployment yields two slices).',
+        },
+        description: {
+          type: 'string',
+          minLength: 1,
+        },
+      },
+    },
+    SemanticTypeMapping: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['semanticType', 'artifactKind'],
+      properties: {
+        '@type': {
+          description: 'Optional JSON-LD type IRI. Ignored by the loader.',
+          type: 'string',
+        },
+        semanticType: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Semantic identifier-type name (e.g. `ProcessDefinitionKey`). Reverse-mapped to the artifact kind that produces it.',
+        },
+        artifactKind: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Name of the artifact kind that produces this semantic type. Must reference an entry in `kinds`.',
+        },
+      },
+    },
+    OperationArtifactRule: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['operationId', 'composable', 'rules'],
+      properties: {
+        '@type': {
+          description: 'Optional JSON-LD type IRI. Ignored by the loader.',
+          type: 'string',
+        },
+        operationId: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'OpenAPI operationId of the deploy operation (e.g. `createDeployment`). Must reference a real op in the bundled spec — checked as an L3 abox-vs-graph invariant.',
+        },
+        composable: {
+          type: 'boolean',
+          description:
+            'When true, the planner may compose multiple `rules` into a single deployment request via set-cover (e.g. `createDeployment` accepts a multi-file payload).',
+        },
+        rules: {
+          type: 'array',
+          minItems: 1,
+          items: { $ref: '#/definitions/ArtifactRule' },
+        },
+      },
+    },
+    ArtifactRule: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['id', 'artifactKind'],
+      properties: {
+        id: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Stable identifier for this rule within its operation (e.g. `bpmn`, `dmn`). Used by the scenario emitter to reference a specific rule.',
+        },
+        artifactKind: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Name of the artifact kind this rule deploys. Must reference an entry in `kinds`.',
+        },
+      },
+    },
+    FileExtensionMapping: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['extension', 'artifactKinds'],
+      properties: {
+        '@type': {
+          description: 'Optional JSON-LD type IRI. Ignored by the loader.',
+          type: 'string',
+        },
+        extension: {
+          type: 'string',
+          pattern: '^\\.[a-z0-9]+$',
+          description: 'Lowercase file extension including the leading dot (e.g. `.bpmn`, `.dmn`).',
+        },
+        artifactKinds: {
+          type: 'array',
+          minItems: 1,
+          items: { type: 'string', minLength: 1 },
+          description:
+            'Candidate artifact kinds for files with this extension. Multiple entries express ambiguity (e.g. `.dmn` may carry a single decision or a full DRD); the selector then disambiguates per-fixture. Each entry must reference a name in `kinds`.',
+        },
+      },
+    },
+  },
+} as const;

--- a/path-analyser/src/ontology/artifactKindsSchema.ts
+++ b/path-analyser/src/ontology/artifactKindsSchema.ts
@@ -61,7 +61,7 @@ export const artifactKindsSchema = {
   $id: 'https://camunda.github.io/api-test-generator/ns/v1/artifact-kinds.schema.json',
   title: 'Artifact-kinds ABox (api-test-generator ontology, v1)',
   description:
-    'TBox JSON Schema for an ABox file describing the artifact kinds an API can deploy plus the rules that classify operations and uploaded files into those kinds. Each entry asserts: an artifact kind exists with a stable identifier-type and deployment-slice list; a semantic-type maps to a single artifact kind; an operation deploys one or more artifact kinds (optionally composable); a file extension classifies as one or more candidate kinds. The schema is intentionally agnostic to which API ships the kinds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/artifact-kinds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (operationIds existing, semantic-types being live, kinds being referenced by some op) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them.',
+    'TBox JSON Schema for an ABox file describing the artifact kinds an API can deploy plus the rules that classify operations and uploaded files into those kinds. Each entry asserts: an artifact kind exists with a stable identifier-type and deployment-slice list; a semantic-type maps to a single artifact kind; an operation deploys one or more artifact kinds (optionally composable); a file extension classifies as one or more candidate kinds. The schema is intentionally agnostic to which API ships the kinds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/artifact-kinds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (operationIds existing, artifact kind names being internally consistent across rules / semanticTypeMap / fileExtensionMap, kinds being referenced by some entry) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them. Cross-references against `runtimeStates`/`semanticTypes` (sibling sub-trees in `domain-semantics.json` that the artifact-kinds ABox references via `producesStates`, `producibleStates`, and `producesSemantics`) are re-validated at load time by re-running `validateDomainSemantics` against the post-overlay `graph.domain` — see `graphLoader.ts`.',
   type: 'object',
   additionalProperties: false,
   required: ['version', 'kinds', 'semanticTypeMap', 'operationRules', 'fileExtensionMap'],
@@ -181,7 +181,7 @@ export const artifactKindsSchema = {
     OperationArtifactRule: {
       type: 'object',
       additionalProperties: false,
-      required: ['operationId', 'composable', 'rules'],
+      required: ['operationId'],
       properties: {
         '@type': {
           description: 'Optional JSON-LD type IRI. Ignored by the loader.',
@@ -196,31 +196,50 @@ export const artifactKindsSchema = {
         composable: {
           type: 'boolean',
           description:
-            'When true, the planner may compose multiple `rules` into a single deployment request via set-cover (e.g. `createDeployment` accepts a multi-file payload).',
+            'When true, the planner may compose multiple `rules` into a single deployment request via set-cover (e.g. `createDeployment` accepts a multi-file payload). Optional — mirrors the legacy `OperationArtifactRuleSpec.composable` contract; absence is treated as `false` by the planner.',
         },
         rules: {
           type: 'array',
           minItems: 1,
           items: { $ref: '#/definitions/ArtifactRule' },
+          description:
+            'Optional list of artifact rules for this operation. Mirrors the legacy `OperationArtifactRuleSpec.rules` contract — an entry with no `rules` is permitted so a future composable-only opcode can declare itself without listing concrete rules.',
         },
       },
     },
     ArtifactRule: {
       type: 'object',
       additionalProperties: false,
-      required: ['id', 'artifactKind'],
+      required: ['artifactKind'],
       properties: {
         id: {
           type: 'string',
           minLength: 1,
           description:
-            'Stable identifier for this rule within its operation (e.g. `bpmn`, `dmn`). Used by the scenario emitter to reference a specific rule.',
+            'Optional stable identifier for this rule within its operation (e.g. `bpmn`, `dmn`). Used by the scenario emitter to reference a specific rule. Mirrors the legacy `ArtifactRule.id` contract — when present it must be unique within the operation (checked by the loader).',
         },
         artifactKind: {
           type: 'string',
           minLength: 1,
           description:
             'Name of the artifact kind this rule deploys. Must reference an entry in `kinds`.',
+        },
+        priority: {
+          type: 'integer',
+          description:
+            'Optional priority hint for the planner: lower number = higher priority. Mirrors the legacy `ArtifactRule.priority` contract.',
+        },
+        producesSemantics: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description:
+            'Optional explicit override of the semantic types this rule produces. When omitted, the planner derives the list from `kinds[artifactKind].producesSemantics` and `semanticTypeMap`. Mirrors the legacy `ArtifactRule.producesSemantics` contract.',
+        },
+        producesStates: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description:
+            'Optional additional domain states this rule produces beyond the kind-level `producesStates`. Mirrors the legacy `ArtifactRule.producesStates` contract.',
         },
       },
     },

--- a/path-analyser/src/ontology/loader.ts
+++ b/path-analyser/src/ontology/loader.ts
@@ -318,6 +318,20 @@ export function loadArtifactKindsAbox(repoRoot: string): ArtifactKindsAbox | nul
       `Artifact-kinds ABox at ${aboxPath} has duplicate operationRules entries for: ${dupeOps.join(', ')}`,
     );
   }
+  // Per-operation rule-id uniqueness — `id` is optional but when
+  // present it is used by the emitter to look up the chosen rule via
+  // `find(...)`, so a duplicate would silently mask one of the rules.
+  // Skip undefined ids (legacy rules need not name themselves).
+  for (const rule of parsed.operationRules) {
+    if (!rule.rules) continue;
+    const ids = rule.rules.map((r) => r.id).filter((id): id is string => typeof id === 'string');
+    const dupeRuleIds = duplicates(ids);
+    if (dupeRuleIds.length > 0) {
+      throw new Error(
+        `Artifact-kinds ABox at ${aboxPath} operationRules['${rule.operationId}'] has duplicate rule id(s): ${dupeRuleIds.join(', ')}`,
+      );
+    }
+  }
   const dupeExts = duplicates(parsed.fileExtensionMap.map((m) => m.extension));
   if (dupeExts.length > 0) {
     throw new Error(
@@ -353,7 +367,16 @@ export interface ArtifactKindsViews {
   semanticTypeToArtifactKind: Record<string, string>;
   operationArtifactRules: Record<
     string,
-    { composable?: boolean; rules?: { id?: string; artifactKind: string }[] }
+    {
+      composable?: boolean;
+      rules?: {
+        id?: string;
+        artifactKind: string;
+        priority?: number;
+        producesSemantics?: string[];
+        producesStates?: string[];
+      }[];
+    }
   >;
   artifactFileKinds: Record<string, string[]>;
 }
@@ -378,10 +401,23 @@ export function deriveArtifactKindsViews(repoRoot: string): ArtifactKindsViews |
   }
   const operationArtifactRules: ArtifactKindsViews['operationArtifactRules'] = {};
   for (const r of abox.operationRules) {
-    operationArtifactRules[r.operationId] = {
-      composable: r.composable,
-      rules: r.rules.map((rule) => ({ id: rule.id, artifactKind: rule.artifactKind })),
-    };
+    const entry: ArtifactKindsViews['operationArtifactRules'][string] = {};
+    if (r.composable !== undefined) entry.composable = r.composable;
+    if (r.rules !== undefined) {
+      entry.rules = r.rules.map((rule) => {
+        const out: NonNullable<
+          ArtifactKindsViews['operationArtifactRules'][string]['rules']
+        >[number] = {
+          artifactKind: rule.artifactKind,
+        };
+        if (rule.id !== undefined) out.id = rule.id;
+        if (rule.priority !== undefined) out.priority = rule.priority;
+        if (rule.producesSemantics !== undefined) out.producesSemantics = rule.producesSemantics;
+        if (rule.producesStates !== undefined) out.producesStates = rule.producesStates;
+        return out;
+      });
+    }
+    operationArtifactRules[r.operationId] = entry;
   }
   const artifactFileKinds: Record<string, string[]> = {};
   for (const m of abox.fileExtensionMap) {

--- a/path-analyser/src/ontology/loader.ts
+++ b/path-analyser/src/ontology/loader.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { Ajv, type ErrorObject } from 'ajv';
 import type { FromSchema } from 'json-schema-to-ts';
 import { getActiveConfigDir } from '../configResolver.js';
+import { artifactKindsSchema } from './artifactKindsSchema.js';
 import { edgeSchema } from './edgeSchema.js';
 import { entityKindsSchema } from './entityKindsSchema.js';
 
@@ -39,12 +40,19 @@ export type Edge = EdgesAbox['edges'][number];
 export type EntityKindsAbox = FromSchema<typeof entityKindsSchema>;
 export type EntityKind = EntityKindsAbox['kinds'][number];
 
+export type ArtifactKindsAbox = FromSchema<typeof artifactKindsSchema>;
+export type ArtifactKindEntry = ArtifactKindsAbox['kinds'][number];
+export type ArtifactSemanticTypeMapping = ArtifactKindsAbox['semanticTypeMap'][number];
+export type ArtifactOperationRule = ArtifactKindsAbox['operationRules'][number];
+export type ArtifactFileExtensionMapping = ArtifactKindsAbox['fileExtensionMap'][number];
+
 // `Ajv` is the named export pointing at the constructor; the namespace
 // also has a self-referential default but the named export is the
 // least error-prone form under module=nodenext.
 const ajv = new Ajv({ allErrors: true, strict: false });
 const validateEdgesAbox = ajv.compile<EdgesAbox>(edgeSchema);
 const validateEntityKindsAbox = ajv.compile<EntityKindsAbox>(entityKindsSchema);
+const validateArtifactKindsAbox = ajv.compile<ArtifactKindsAbox>(artifactKindsSchema);
 
 function formatErrors(errors: ErrorObject[] | null | undefined): string {
   return (errors ?? [])
@@ -228,4 +236,161 @@ export function loadExternalEntityIdentifiers(repoRoot: string): Set<string> | n
     }
   }
   return set;
+}
+
+/**
+ * Load and validate the artifact-kinds ABox file for the active config.
+ *
+ * Lift 5 / #212: the artifact-kinds ABox is the authoritative runtime
+ * source for the four artifact-related sub-trees previously carried in
+ * `configs/<config>/domain-semantics.json` (`artifactKinds`,
+ * `semanticTypeToArtifactKind`, `operationArtifactRules`,
+ * `artifactFileKinds`). Per the principle landed in #198: artifact
+ * dispatch is domain knowledge with no wire signature, so it belongs
+ * in the per-config ontology rather than scattered across spec
+ * annotations or freeform sidecars.
+ *
+ * Unlike the edges and entity-kinds ABoxes, the data here was never
+ * sourced from upstream OpenAPI annotations — there is no
+ * `spec-vs-abox` (sense-1) drift to detect, only the durable
+ * `abox-vs-graph` (sense-2) cross-references which are enforced by
+ * `detectArtifactKindsDrift` in `graphLoader.ts`.
+ *
+ * @param repoRoot Absolute path to the api-test-generator repository root.
+ * @returns The parsed ABox, or `null` if the file does not exist (configs
+ *   are not required to ship one; a missing file leaves the legacy
+ *   `domain-semantics.json` keys authoritative for backward compatibility).
+ * @throws if the file exists but does not validate against the TBox, or
+ *   if it contains duplicate kind / operationId / extension / semanticType
+ *   keys.
+ */
+export function loadArtifactKindsAbox(repoRoot: string): ArtifactKindsAbox | null {
+  // Symmetric with `loadEdgesAbox` / `loadEntityKindsAbox` — tests that
+  // exercise loadGraph against an isolated tmpDir don't ship a
+  // `configs.json`, and the right fallback there is "no ABox available"
+  // so the test exercises the legacy domain-semantics.json path.
+  let aboxPath: string;
+  try {
+    aboxPath = path.join(getActiveConfigDir(repoRoot), 'ontology', 'artifact-kinds.json');
+  } catch {
+    return null;
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(aboxPath, 'utf8');
+  } catch (err) {
+    if (err !== null && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+      return null;
+    }
+    throw err;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse artifact-kinds ABox at ${aboxPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!validateArtifactKindsAbox(parsed)) {
+    throw new Error(
+      `Artifact-kinds ABox at ${aboxPath} failed TBox validation:\n${formatErrors(validateArtifactKindsAbox.errors)}`,
+    );
+  }
+  // Reject duplicate keys up front — Draft-07 cannot express
+  // uniqueness, but a duplicate would silently shadow facts at query
+  // time. Same defensive check as in the other ABox loaders.
+  const dupeKinds = duplicates(parsed.kinds.map((k) => k.name));
+  if (dupeKinds.length > 0) {
+    throw new Error(
+      `Artifact-kinds ABox at ${aboxPath} has duplicate kind name(s): ${dupeKinds.join(', ')}`,
+    );
+  }
+  const dupeSemantics = duplicates(parsed.semanticTypeMap.map((m) => m.semanticType));
+  if (dupeSemantics.length > 0) {
+    throw new Error(
+      `Artifact-kinds ABox at ${aboxPath} has duplicate semanticTypeMap entries for: ${dupeSemantics.join(', ')}`,
+    );
+  }
+  const dupeOps = duplicates(parsed.operationRules.map((r) => r.operationId));
+  if (dupeOps.length > 0) {
+    throw new Error(
+      `Artifact-kinds ABox at ${aboxPath} has duplicate operationRules entries for: ${dupeOps.join(', ')}`,
+    );
+  }
+  const dupeExts = duplicates(parsed.fileExtensionMap.map((m) => m.extension));
+  if (dupeExts.length > 0) {
+    throw new Error(
+      `Artifact-kinds ABox at ${aboxPath} has duplicate fileExtensionMap entries for: ${dupeExts.join(', ')}`,
+    );
+  }
+  return parsed;
+}
+
+function duplicates(values: string[]): string[] {
+  const counts = new Map<string, number>();
+  for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1);
+  return [...counts.entries()].filter(([, n]) => n > 1).map(([v]) => v);
+}
+
+/**
+ * Derive the four record-shaped views of the artifact-kinds ABox that
+ * `graph.domain.*` consumers (planner, codegen, feature-coverage)
+ * expect. Returning `null` when no ABox is shipped lets `loadGraph`
+ * fall back to the legacy `domain-semantics.json` keys.
+ */
+export interface ArtifactKindsViews {
+  artifactKinds: Record<
+    string,
+    {
+      producesStates?: string[];
+      producibleStates?: string[];
+      producesSemantics?: string[];
+      identifierType?: string;
+      deploymentSlices?: string[];
+    }
+  >;
+  semanticTypeToArtifactKind: Record<string, string>;
+  operationArtifactRules: Record<
+    string,
+    { composable?: boolean; rules?: { id?: string; artifactKind: string }[] }
+  >;
+  artifactFileKinds: Record<string, string[]>;
+}
+
+export function deriveArtifactKindsViews(repoRoot: string): ArtifactKindsViews | null {
+  const abox = loadArtifactKindsAbox(repoRoot);
+  if (abox === null) return null;
+  const artifactKinds: ArtifactKindsViews['artifactKinds'] = {};
+  for (const k of abox.kinds) {
+    const entry: ArtifactKindsViews['artifactKinds'][string] = {
+      producesStates: k.producesStates,
+      producesSemantics: k.producesSemantics,
+      identifierType: k.identifierType,
+      deploymentSlices: k.deploymentSlices,
+    };
+    if (k.producibleStates !== undefined) entry.producibleStates = k.producibleStates;
+    artifactKinds[k.name] = entry;
+  }
+  const semanticTypeToArtifactKind: Record<string, string> = {};
+  for (const m of abox.semanticTypeMap) {
+    semanticTypeToArtifactKind[m.semanticType] = m.artifactKind;
+  }
+  const operationArtifactRules: ArtifactKindsViews['operationArtifactRules'] = {};
+  for (const r of abox.operationRules) {
+    operationArtifactRules[r.operationId] = {
+      composable: r.composable,
+      rules: r.rules.map((rule) => ({ id: rule.id, artifactKind: rule.artifactKind })),
+    };
+  }
+  const artifactFileKinds: Record<string, string[]> = {};
+  for (const m of abox.fileExtensionMap) {
+    artifactFileKinds[m.extension] = [...m.artifactKinds];
+  }
+  return {
+    artifactKinds,
+    semanticTypeToArtifactKind,
+    operationArtifactRules,
+    artifactFileKinds,
+  };
 }

--- a/scripts/build-ontology.ts
+++ b/scripts/build-ontology.ts
@@ -15,6 +15,7 @@
 import { writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { artifactKindsSchema } from '../path-analyser/src/ontology/artifactKindsSchema.ts';
 import { edgeSchema } from '../path-analyser/src/ontology/edgeSchema.ts';
 import { entityKindsSchema } from '../path-analyser/src/ontology/entityKindsSchema.ts';
 // Namespace import: the schema source lives in the CommonJS-flavoured
@@ -63,6 +64,10 @@ const ARTIFACTS: OntologyArtifact[] = [
   {
     jsonPath: join(REPO_ROOT, 'ontology', 'vocabulary', 'entity-kinds.schema.json'),
     schema: entityKindsSchema,
+  },
+  {
+    jsonPath: join(REPO_ROOT, 'ontology', 'vocabulary', 'artifact-kinds.schema.json'),
+    schema: artifactKindsSchema,
   },
   {
     jsonPath: join(REPO_ROOT, 'ontology', 'vocabulary', 'bootstrap-sequence.schema.json'),

--- a/tests/fixtures/integration/artifact-kinds-abox-authoritative.test.ts
+++ b/tests/fixtures/integration/artifact-kinds-abox-authoritative.test.ts
@@ -397,10 +397,6 @@ describe('Lift 5 (#212): artifact-kinds ABox is authoritative for graph.domain a
   });
 
   it('hard-errors when the ABox introduces a `producesStates` value not declared in domain-semantics.json runtimeStates / capabilities (post-overlay re-validation)', async () => {
-    // Pre-overlay validation only sees the legacy sidecar's
-    // artifactKinds. Without re-validating after the ABox overlay, an
-    // ABox that introduces an undeclared state would slip through and
-    // the planner would silently break at the BFS stage.
     writeWorkspace({
       domainSemantics: {
         version: 1,
@@ -435,5 +431,141 @@ describe('Lift 5 (#212): artifact-kinds ABox is authoritative for graph.domain a
     await expect(loadGraph(baseDir)).rejects.toThrow(
       /artifact-kinds ABox introduced cross-reference violation/,
     );
+  });
+
+  it('hard-errors when an ABox rule-level `producesStates` override references a state not declared in runtimeStates / capabilities (post-overlay re-validation, rule-level)', async () => {
+    // Rule-level overrides on operationArtifactRules feed the planner
+    // via getEffectiveProducesStates(); kind-level-only validation
+    // would let an undeclared rule-level state slip through.
+    writeWorkspace({
+      domainSemantics: {
+        version: 1,
+        runtimeStates: { ProcessDefinitionDeployed: { producedBy: [] } },
+        semanticTypes: { ProcessDefinitionKey: { witnesses: 'ProcessDefinitionDeployed' } },
+      },
+      artifactKindsAbox: {
+        version: 1,
+        kinds: [
+          {
+            name: 'bpmnProcess',
+            identifierType: 'ProcessDefinitionId',
+            producesStates: ['ProcessDefinitionDeployed'],
+            producesSemantics: ['ProcessDefinitionKey'],
+            deploymentSlices: ['processDefinition'],
+            description: 'fixture',
+          },
+        ],
+        semanticTypeMap: [{ semanticType: 'ProcessDefinitionKey', artifactKind: 'bpmnProcess' }],
+        operationRules: [
+          {
+            operationId: 'createDeployment',
+            composable: false,
+            rules: [
+              {
+                id: 'bpmn',
+                artifactKind: 'bpmnProcess',
+                // Rule-level override pointing at an undeclared state.
+                producesStates: ['UndeclaredRuleLevelState'],
+              },
+            ],
+          },
+        ],
+        fileExtensionMap: [{ extension: '.bpmn', artifactKinds: ['bpmnProcess'] }],
+      },
+      graphOps: deployOp(),
+    });
+    await expect(loadGraph(baseDir)).rejects.toThrow(
+      /operationArtifactRules\.createDeployment\.rules\['bpmn'\]\.producesStates references "UndeclaredRuleLevelState"/,
+    );
+  });
+
+  it('hard-errors when an ABox rule-level `producesSemantics` override references a semantic type with no semanticTypes.witnesses declaration', async () => {
+    writeWorkspace({
+      domainSemantics: {
+        version: 1,
+        runtimeStates: { ProcessDefinitionDeployed: { producedBy: [] } },
+        semanticTypes: { ProcessDefinitionKey: { witnesses: 'ProcessDefinitionDeployed' } },
+      },
+      artifactKindsAbox: {
+        version: 1,
+        kinds: [
+          {
+            name: 'bpmnProcess',
+            identifierType: 'ProcessDefinitionId',
+            producesStates: ['ProcessDefinitionDeployed'],
+            producesSemantics: ['ProcessDefinitionKey'],
+            deploymentSlices: ['processDefinition'],
+            description: 'fixture',
+          },
+        ],
+        semanticTypeMap: [{ semanticType: 'ProcessDefinitionKey', artifactKind: 'bpmnProcess' }],
+        operationRules: [
+          {
+            operationId: 'createDeployment',
+            composable: false,
+            rules: [
+              {
+                id: 'bpmn',
+                artifactKind: 'bpmnProcess',
+                producesSemantics: ['UndeclaredKey'],
+              },
+            ],
+          },
+        ],
+        fileExtensionMap: [{ extension: '.bpmn', artifactKinds: ['bpmnProcess'] }],
+      },
+      graphOps: deployOp(),
+    });
+    await expect(loadGraph(baseDir)).rejects.toThrow(
+      /operationArtifactRules\.createDeployment\.rules\['bpmn'\]\.producesSemantics references "UndeclaredKey"/,
+    );
+  });
+
+  it('does not pre-validate the legacy `domain-semantics.json` artifact sub-trees when an ABox is shipped (ABox is truly authoritative)', async () => {
+    // Without the pre-overlay strip, a stale legacy `artifactKinds`
+    // (e.g. referencing a state the legacy sidecar no longer declares)
+    // would fail load even though the ABox already supersedes it.
+    writeWorkspace({
+      domainSemantics: {
+        version: 1,
+        runtimeStates: { ProcessDefinitionDeployed: { producedBy: [] } },
+        semanticTypes: { ProcessDefinitionKey: { witnesses: 'ProcessDefinitionDeployed' } },
+        // Stale legacy entry — references a state NOT declared above.
+        artifactKinds: {
+          staleKind: {
+            producesStates: ['LegacyUndeclaredState'],
+            producesSemantics: ['LegacyUndeclaredKey'],
+            identifierType: 'StaleId',
+            deploymentSlices: ['stale'],
+          },
+        },
+      },
+      artifactKindsAbox: {
+        version: 1,
+        kinds: [
+          {
+            name: 'bpmnProcess',
+            identifierType: 'ProcessDefinitionId',
+            producesStates: ['ProcessDefinitionDeployed'],
+            producesSemantics: ['ProcessDefinitionKey'],
+            deploymentSlices: ['processDefinition'],
+            description: 'fixture',
+          },
+        ],
+        semanticTypeMap: [{ semanticType: 'ProcessDefinitionKey', artifactKind: 'bpmnProcess' }],
+        operationRules: [
+          {
+            operationId: 'createDeployment',
+            composable: false,
+            rules: [{ id: 'bpmn', artifactKind: 'bpmnProcess' }],
+          },
+        ],
+        fileExtensionMap: [{ extension: '.bpmn', artifactKinds: ['bpmnProcess'] }],
+      },
+      graphOps: deployOp(),
+    });
+    const graph = await loadGraph(baseDir);
+    // ABox-derived bpmnProcess is the only kind; staleKind was discarded by overlay.
+    expect(Object.keys(graph.domain?.artifactKinds ?? {})).toEqual(['bpmnProcess']);
   });
 });

--- a/tests/fixtures/integration/artifact-kinds-abox-authoritative.test.ts
+++ b/tests/fixtures/integration/artifact-kinds-abox-authoritative.test.ts
@@ -117,8 +117,16 @@ describe('Lift 5 (#212): artifact-kinds ABox is authoritative for graph.domain a
     writeWorkspace({
       domainSemantics: {
         version: 1,
-        runtimeStates: { ProcessDefinitionDeployed: { producedBy: [] } },
-        semanticTypes: { ProcessDefinitionKey: { witnesses: 'ProcessDefinitionDeployed' } },
+        runtimeStates: {
+          ProcessDefinitionDeployed: { producedBy: [] },
+          ProcessDefinitionIdDeployed: { producedBy: [] },
+          FormIdDeployed: { producedBy: [] },
+        },
+        semanticTypes: {
+          ProcessDefinitionKey: { witnesses: 'ProcessDefinitionDeployed' },
+          bpmnProcessKey: { witnesses: 'ProcessDefinitionIdDeployed' },
+          formKey: { witnesses: 'FormIdDeployed' },
+        },
         // Legacy says only bpmnProcess. ABox will add `form`.
         artifactKinds: {
           bpmnProcess: {
@@ -268,5 +276,164 @@ describe('Lift 5 (#212): artifact-kinds ABox is authoritative for graph.domain a
     expect(allWarnings).toMatch(/deadKind/);
     expect(allWarnings).not.toMatch(/bpmnProcess.*dead weight/);
     warn.mockRestore();
+  });
+
+  it('warns on operationRules entries pointing at unknown opIds (sense-2 abox-vs-graph)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writeWorkspace({
+      artifactKindsAbox: {
+        version: 1,
+        kinds: [minimalKind('bpmnProcess', 'ProcessDefinitionId')],
+        semanticTypeMap: [{ semanticType: 'bpmnProcessKey', artifactKind: 'bpmnProcess' }],
+        operationRules: [
+          {
+            operationId: 'createDeployment',
+            composable: false,
+            rules: [{ id: 'bpmn', artifactKind: 'bpmnProcess' }],
+          },
+          {
+            // Op missing from the graph — must surface as drift.
+            operationId: 'createGhostDeployment',
+            composable: false,
+            rules: [{ id: 'bpmn', artifactKind: 'bpmnProcess' }],
+          },
+        ],
+        fileExtensionMap: [{ extension: '.bpmn', artifactKinds: ['bpmnProcess'] }],
+      },
+      graphOps: deployOp(),
+    });
+    await loadGraph(baseDir);
+    const allWarnings = warn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).toMatch(/abox-vs-graph/);
+    expect(allWarnings).toMatch(/createGhostDeployment/);
+    warn.mockRestore();
+  });
+
+  it('warns on operationRules.rules entries pointing at unknown artifactKinds (sense-2 abox-vs-graph)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writeWorkspace({
+      artifactKindsAbox: {
+        version: 1,
+        kinds: [minimalKind('bpmnProcess', 'ProcessDefinitionId')],
+        semanticTypeMap: [{ semanticType: 'bpmnProcessKey', artifactKind: 'bpmnProcess' }],
+        operationRules: [
+          {
+            operationId: 'createDeployment',
+            composable: false,
+            rules: [
+              { id: 'bpmn', artifactKind: 'bpmnProcess' },
+              { id: 'ghost', artifactKind: 'ghostKind' },
+            ],
+          },
+        ],
+        fileExtensionMap: [{ extension: '.bpmn', artifactKinds: ['bpmnProcess'] }],
+      },
+      graphOps: deployOp(),
+    });
+    await loadGraph(baseDir);
+    const allWarnings = warn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).toMatch(
+      /operationRules\['createDeployment'\]\.rules\['ghost'\] references unknown artifactKind 'ghostKind'/,
+    );
+    warn.mockRestore();
+  });
+
+  it('warns on semanticTypeMap entries pointing at unknown artifactKinds (sense-2 abox-vs-graph)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writeWorkspace({
+      artifactKindsAbox: {
+        version: 1,
+        kinds: [minimalKind('bpmnProcess', 'ProcessDefinitionId')],
+        semanticTypeMap: [
+          { semanticType: 'bpmnProcessKey', artifactKind: 'bpmnProcess' },
+          { semanticType: 'GhostKey', artifactKind: 'ghostKind' },
+        ],
+        operationRules: [
+          {
+            operationId: 'createDeployment',
+            composable: false,
+            rules: [{ id: 'bpmn', artifactKind: 'bpmnProcess' }],
+          },
+        ],
+        fileExtensionMap: [{ extension: '.bpmn', artifactKinds: ['bpmnProcess'] }],
+      },
+      graphOps: deployOp(),
+    });
+    await loadGraph(baseDir);
+    const allWarnings = warn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).toMatch(
+      /semanticTypeMap entry 'GhostKey' → 'ghostKind' references unknown artifactKind/,
+    );
+    warn.mockRestore();
+  });
+
+  it('warns on fileExtensionMap entries pointing at unknown artifactKinds (sense-2 abox-vs-graph)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writeWorkspace({
+      artifactKindsAbox: {
+        version: 1,
+        kinds: [minimalKind('bpmnProcess', 'ProcessDefinitionId')],
+        semanticTypeMap: [{ semanticType: 'bpmnProcessKey', artifactKind: 'bpmnProcess' }],
+        operationRules: [
+          {
+            operationId: 'createDeployment',
+            composable: false,
+            rules: [{ id: 'bpmn', artifactKind: 'bpmnProcess' }],
+          },
+        ],
+        fileExtensionMap: [
+          { extension: '.bpmn', artifactKinds: ['bpmnProcess'] },
+          { extension: '.ghost', artifactKinds: ['ghostKind'] },
+        ],
+      },
+      graphOps: deployOp(),
+    });
+    await loadGraph(baseDir);
+    const allWarnings = warn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).toMatch(
+      /fileExtensionMap entry '\.ghost' references unknown artifactKind 'ghostKind'/,
+    );
+    warn.mockRestore();
+  });
+
+  it('hard-errors when the ABox introduces a `producesStates` value not declared in domain-semantics.json runtimeStates / capabilities (post-overlay re-validation)', async () => {
+    // Pre-overlay validation only sees the legacy sidecar's
+    // artifactKinds. Without re-validating after the ABox overlay, an
+    // ABox that introduces an undeclared state would slip through and
+    // the planner would silently break at the BFS stage.
+    writeWorkspace({
+      domainSemantics: {
+        version: 1,
+        runtimeStates: { ProcessDefinitionDeployed: { producedBy: [] } },
+        semanticTypes: { ProcessDefinitionKey: { witnesses: 'ProcessDefinitionDeployed' } },
+      },
+      artifactKindsAbox: {
+        version: 1,
+        kinds: [
+          {
+            name: 'bpmnProcess',
+            identifierType: 'ProcessDefinitionId',
+            // 'UndeclaredState' is NOT in runtimeStates above.
+            producesStates: ['ProcessDefinitionDeployed', 'UndeclaredState'],
+            producesSemantics: ['ProcessDefinitionKey'],
+            deploymentSlices: ['processDefinition'],
+            description: 'fixture',
+          },
+        ],
+        semanticTypeMap: [{ semanticType: 'ProcessDefinitionKey', artifactKind: 'bpmnProcess' }],
+        operationRules: [
+          {
+            operationId: 'createDeployment',
+            composable: false,
+            rules: [{ id: 'bpmn', artifactKind: 'bpmnProcess' }],
+          },
+        ],
+        fileExtensionMap: [{ extension: '.bpmn', artifactKinds: ['bpmnProcess'] }],
+      },
+      graphOps: deployOp(),
+    });
+    await expect(loadGraph(baseDir)).rejects.toThrow(
+      /artifact-kinds ABox introduced cross-reference violation/,
+    );
   });
 });

--- a/tests/fixtures/integration/artifact-kinds-abox-authoritative.test.ts
+++ b/tests/fixtures/integration/artifact-kinds-abox-authoritative.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Integration fixture for Lift 5 (#212): the artifact-kinds ABox is
+ * the authoritative source for `graph.domain.artifactKinds`,
+ * `semanticTypeToArtifactKind`, `operationArtifactRules`, and
+ * `artifactFileKinds` at runtime. Mirrors
+ * `entity-kinds-abox-authoritative.test.ts` (Lift 4 / #210).
+ *
+ * Unlike Lift 4, the migrated facts were never carried in upstream
+ * OpenAPI annotations — only in `configs/<config>/domain-semantics.json`.
+ * Consequence: the integration only exercises the durable
+ * `abox-vs-graph` (sense-2) drift signal; there is no transitional
+ * `spec-vs-abox` (sense-1) sense to test.
+ *
+ * Five observable behaviours guarded here:
+ *
+ *   1. **ABox authoritative — promotes**: `domain-semantics.json`
+ *      declares one set of artifactKinds; the ABox declares a
+ *      different set. After loadGraph, `graph.domain.artifactKinds`
+ *      reflects the ABox.
+ *
+ *   2. **ABox authoritative — works without domain-semantics.json**:
+ *      no legacy sidecar shipped at all; the ABox alone populates the
+ *      four sub-trees on `graph.domain`.
+ *
+ *   3. **Strict mode**: with `STRICT_ARTIFACT_KINDS_ABOX=1`, an
+ *      abox-vs-graph drift is a hard error.
+ *
+ *   4. **Legacy fallback**: with no ABox shipped, the legacy
+ *      `domain-semantics.json` keys remain authoritative.
+ *
+ *   5. **Sense-2 drift warnings**: dead-kind / unknown-opId /
+ *      unknown-artifactKind references are flagged.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadGraph } from '../../../path-analyser/src/graphLoader.ts';
+
+const CONFIG_NAME = 'lift5-artifact-kinds-test';
+
+let workdir: string;
+let baseDir: string;
+const ORIGINAL = {
+  CONFIG: process.env.CONFIG,
+  OPERATION_GRAPH_PATH: process.env.OPERATION_GRAPH_PATH,
+  OPENAPI_SPEC_PATH: process.env.OPENAPI_SPEC_PATH,
+  STRICT_ARTIFACT_KINDS_ABOX: process.env.STRICT_ARTIFACT_KINDS_ABOX,
+};
+
+function writeWorkspace(opts: {
+  artifactKindsAbox: object | null;
+  domainSemantics?: object;
+  graphOps: Record<string, unknown>;
+}): void {
+  const repoRoot = workdir;
+  baseDir = join(repoRoot, 'path-analyser');
+  mkdirSync(baseDir, { recursive: true });
+  writeFileSync(
+    join(repoRoot, 'configs.json'),
+    JSON.stringify({ default: CONFIG_NAME, configs: { [CONFIG_NAME]: {} } }),
+  );
+  const configDir = join(repoRoot, 'configs', CONFIG_NAME);
+  mkdirSync(configDir, { recursive: true });
+  if (opts.domainSemantics !== undefined) {
+    writeFileSync(join(configDir, 'domain-semantics.json'), JSON.stringify(opts.domainSemantics));
+  }
+  if (opts.artifactKindsAbox !== null) {
+    const aboxDir = join(configDir, 'ontology');
+    mkdirSync(aboxDir, { recursive: true });
+    writeFileSync(join(aboxDir, 'artifact-kinds.json'), JSON.stringify(opts.artifactKindsAbox));
+  }
+  const graphPath = join(baseDir, 'operation-dependency-graph.json');
+  writeFileSync(graphPath, JSON.stringify({ operations: opts.graphOps }));
+  process.env.OPERATION_GRAPH_PATH = graphPath;
+  process.env.CONFIG = CONFIG_NAME;
+  process.env.OPENAPI_SPEC_PATH = join(baseDir, 'no-such-spec.yaml');
+}
+
+function deployOp(): Record<string, unknown> {
+  return {
+    createDeployment: {
+      operationId: 'createDeployment',
+      method: 'POST',
+      path: '/deployments',
+      requires: { required: [], optional: [] },
+      produces: [],
+    },
+  };
+}
+
+function minimalKind(name: string, identifierType: string): Record<string, unknown> {
+  return {
+    name,
+    identifierType,
+    producesStates: [`${identifierType}Deployed`],
+    producesSemantics: [`${name}Key`],
+    deploymentSlices: [name],
+    description: `${name} fixture`,
+  };
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'lift5-artifact-kinds-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+  for (const [k, v] of Object.entries(ORIGINAL)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe('Lift 5 (#212): artifact-kinds ABox is authoritative for graph.domain artifact sub-trees', () => {
+  it('overrides domain-semantics.json artifactKinds with the ABox values when both are present (promote)', async () => {
+    writeWorkspace({
+      domainSemantics: {
+        version: 1,
+        runtimeStates: { ProcessDefinitionDeployed: { producedBy: [] } },
+        semanticTypes: { ProcessDefinitionKey: { witnesses: 'ProcessDefinitionDeployed' } },
+        // Legacy says only bpmnProcess. ABox will add `form`.
+        artifactKinds: {
+          bpmnProcess: {
+            producesStates: ['ProcessDefinitionDeployed'],
+            producesSemantics: ['ProcessDefinitionKey'],
+            identifierType: 'ProcessDefinitionId',
+            deploymentSlices: ['processDefinition'],
+          },
+        },
+        semanticTypeToArtifactKind: { ProcessDefinitionKey: 'bpmnProcess' },
+        operationArtifactRules: {
+          createDeployment: {
+            composable: false,
+            rules: [{ id: 'bpmn', artifactKind: 'bpmnProcess' }],
+          },
+        },
+        artifactFileKinds: { '.bpmn': ['bpmnProcess'] },
+      },
+      artifactKindsAbox: {
+        version: 1,
+        kinds: [minimalKind('bpmnProcess', 'ProcessDefinitionId'), minimalKind('form', 'FormId')],
+        semanticTypeMap: [
+          { semanticType: 'bpmnProcessKey', artifactKind: 'bpmnProcess' },
+          { semanticType: 'formKey', artifactKind: 'form' },
+        ],
+        operationRules: [
+          {
+            operationId: 'createDeployment',
+            composable: true,
+            rules: [
+              { id: 'bpmn', artifactKind: 'bpmnProcess' },
+              { id: 'form', artifactKind: 'form' },
+            ],
+          },
+        ],
+        fileExtensionMap: [
+          { extension: '.bpmn', artifactKinds: ['bpmnProcess'] },
+          { extension: '.form', artifactKinds: ['form'] },
+        ],
+      },
+      graphOps: deployOp(),
+    });
+    const graph = await loadGraph(baseDir);
+    // ABox supersedes — `form` is now part of artifactKinds, composable is true.
+    expect(Object.keys(graph.domain?.artifactKinds ?? {})).toEqual(['bpmnProcess', 'form']);
+    expect(graph.domain?.operationArtifactRules?.createDeployment?.composable).toBe(true);
+    expect(graph.domain?.artifactFileKinds?.['.form']).toEqual(['form']);
+  });
+
+  it('populates graph.domain artifact sub-trees from the ABox even when no domain-semantics.json is shipped', async () => {
+    writeWorkspace({
+      artifactKindsAbox: {
+        version: 1,
+        kinds: [minimalKind('bpmnProcess', 'ProcessDefinitionId')],
+        semanticTypeMap: [{ semanticType: 'bpmnProcessKey', artifactKind: 'bpmnProcess' }],
+        operationRules: [
+          {
+            operationId: 'createDeployment',
+            composable: false,
+            rules: [{ id: 'bpmn', artifactKind: 'bpmnProcess' }],
+          },
+        ],
+        fileExtensionMap: [{ extension: '.bpmn', artifactKinds: ['bpmnProcess'] }],
+      },
+      graphOps: deployOp(),
+    });
+    const graph = await loadGraph(baseDir);
+    expect(graph.domain?.artifactKinds?.bpmnProcess?.identifierType).toBe('ProcessDefinitionId');
+    expect(graph.domain?.semanticTypeToArtifactKind).toEqual({
+      bpmnProcessKey: 'bpmnProcess',
+    });
+  });
+
+  it('hard-errors on abox-vs-graph drift when STRICT_ARTIFACT_KINDS_ABOX=1', async () => {
+    process.env.STRICT_ARTIFACT_KINDS_ABOX = '1';
+    writeWorkspace({
+      artifactKindsAbox: {
+        version: 1,
+        kinds: [minimalKind('bpmnProcess', 'ProcessDefinitionId')],
+        semanticTypeMap: [{ semanticType: 'bpmnProcessKey', artifactKind: 'bpmnProcess' }],
+        operationRules: [
+          {
+            // Op doesn't exist in the graph.
+            operationId: 'createNonexistentDeployment',
+            composable: false,
+            rules: [{ id: 'bpmn', artifactKind: 'bpmnProcess' }],
+          },
+        ],
+        fileExtensionMap: [{ extension: '.bpmn', artifactKinds: ['bpmnProcess'] }],
+      },
+      graphOps: deployOp(),
+    });
+    await expect(loadGraph(baseDir)).rejects.toThrow(/artifact-kinds ABox drift detected/);
+  });
+
+  it('preserves legacy domain-semantics.json artifact sub-trees when no ABox is shipped', async () => {
+    writeWorkspace({
+      artifactKindsAbox: null,
+      domainSemantics: {
+        version: 1,
+        runtimeStates: { LegacyDeployed: { producedBy: [] } },
+        semanticTypes: { LegacyKey: { witnesses: 'LegacyDeployed' } },
+        artifactKinds: {
+          legacyKind: {
+            producesStates: ['LegacyDeployed'],
+            producesSemantics: ['LegacyKey'],
+            identifierType: 'LegacyId',
+            deploymentSlices: ['legacy'],
+          },
+        },
+        semanticTypeToArtifactKind: { LegacyKey: 'legacyKind' },
+        operationArtifactRules: {},
+        artifactFileKinds: { '.legacy': ['legacyKind'] },
+      },
+      graphOps: deployOp(),
+    });
+    const graph = await loadGraph(baseDir);
+    expect(graph.domain?.artifactKinds?.legacyKind?.identifierType).toBe('LegacyId');
+    expect(graph.domain?.semanticTypeToArtifactKind?.LegacyKey).toBe('legacyKind');
+  });
+
+  it('warns on dead artifact kinds (sense-2 abox-vs-graph)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writeWorkspace({
+      artifactKindsAbox: {
+        version: 1,
+        kinds: [
+          minimalKind('bpmnProcess', 'ProcessDefinitionId'),
+          minimalKind('deadKind', 'DeadId'),
+        ],
+        semanticTypeMap: [{ semanticType: 'bpmnProcessKey', artifactKind: 'bpmnProcess' }],
+        operationRules: [
+          {
+            operationId: 'createDeployment',
+            composable: false,
+            rules: [{ id: 'bpmn', artifactKind: 'bpmnProcess' }],
+          },
+        ],
+        fileExtensionMap: [{ extension: '.bpmn', artifactKinds: ['bpmnProcess'] }],
+      },
+      graphOps: deployOp(),
+    });
+    await loadGraph(baseDir);
+    const allWarnings = warn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).toMatch(/artifact-kinds ABox drift detected/);
+    expect(allWarnings).toMatch(/abox-vs-graph/);
+    expect(allWarnings).toMatch(/deadKind/);
+    expect(allWarnings).not.toMatch(/bpmnProcess.*dead weight/);
+    warn.mockRestore();
+  });
+});

--- a/tests/fixtures/loader/artifact-kinds-abox-loader.test.ts
+++ b/tests/fixtures/loader/artifact-kinds-abox-loader.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Unit tests for the artifact-kinds ABox loader (Lift 5 / #212).
+ *
+ * Mirrors the structure of `entity-kinds-abox-loader.test.ts` (Lift 4 /
+ * #210). Documented loader contract has the same observable branches:
+ *   1. Missing ABox file → returns `null`.
+ *   2. configs.json missing → returns `null` (test-isolation fallback).
+ *   3. Invalid JSON → throws with a "Failed to parse" diagnostic.
+ *   4. Schema-invalid content → throws with a "failed TBox validation" diagnostic.
+ *   5. Duplicate kind / semanticType / operationId / extension keys → throws.
+ *   6. Happy path → returns the parsed ABox.
+ *
+ * Plus the `deriveArtifactKindsViews` accessor returns record-shaped
+ * views that match what `graph.domain.*` consumers expect.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  deriveArtifactKindsViews,
+  loadArtifactKindsAbox,
+} from '../../../path-analyser/src/ontology/loader.ts';
+
+let workdir: string;
+const CONFIG_NAME = 'unit-test-config';
+const ORIGINAL_CONFIG = process.env.CONFIG;
+
+function configsJson(): string {
+  return JSON.stringify({ default: CONFIG_NAME, configs: { [CONFIG_NAME]: {} } });
+}
+
+function writeAbox(contents: string): void {
+  const dir = join(workdir, 'configs', CONFIG_NAME, 'ontology');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'artifact-kinds.json'), contents);
+}
+
+function minimalKind(name = 'bpmnProcess', identifierType = 'ProcessDefinitionId') {
+  return {
+    name,
+    identifierType,
+    producesStates: ['ProcessDefinitionDeployed'],
+    producesSemantics: ['ProcessDefinitionKey'],
+    deploymentSlices: ['processDefinition'],
+    description: `${name} description`,
+  };
+}
+
+function minimalAbox(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    version: 1,
+    kinds: [minimalKind()],
+    semanticTypeMap: [{ semanticType: 'ProcessDefinitionKey', artifactKind: 'bpmnProcess' }],
+    operationRules: [
+      {
+        operationId: 'createDeployment',
+        composable: true,
+        rules: [{ id: 'bpmn', artifactKind: 'bpmnProcess' }],
+      },
+    ],
+    fileExtensionMap: [{ extension: '.bpmn', artifactKinds: ['bpmnProcess'] }],
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'artifact-kinds-abox-loader-'));
+  mkdirSync(workdir, { recursive: true });
+  writeFileSync(join(workdir, 'configs.json'), configsJson());
+  process.env.CONFIG = CONFIG_NAME;
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+  if (ORIGINAL_CONFIG === undefined) {
+    delete process.env.CONFIG;
+  } else {
+    process.env.CONFIG = ORIGINAL_CONFIG;
+  }
+});
+
+describe('loadArtifactKindsAbox: documented branches', () => {
+  it('returns null when the ABox file does not exist (configs are not required to ship one)', () => {
+    expect(loadArtifactKindsAbox(workdir)).toBeNull();
+  });
+
+  it('returns null when configs.json itself is missing (test-isolation fallback)', () => {
+    rmSync(join(workdir, 'configs.json'));
+    expect(loadArtifactKindsAbox(workdir)).toBeNull();
+  });
+
+  it('throws with a "Failed to parse" diagnostic on invalid JSON', () => {
+    writeAbox('{ not json');
+    expect(() => loadArtifactKindsAbox(workdir)).toThrow(/Failed to parse artifact-kinds ABox/);
+  });
+
+  it('throws with a "failed TBox validation" diagnostic on schema-invalid content', () => {
+    // kind name violates camelCase pattern
+    writeAbox(
+      JSON.stringify({
+        version: 1,
+        kinds: [{ ...minimalKind(), name: 'BPMN-PROCESS' }],
+        semanticTypeMap: [],
+        operationRules: [],
+        fileExtensionMap: [],
+      }),
+    );
+    expect(() => loadArtifactKindsAbox(workdir)).toThrow(/failed TBox validation/);
+  });
+
+  it('throws on duplicate kind names', () => {
+    writeAbox(
+      minimalAbox({
+        kinds: [minimalKind('bpmnProcess'), minimalKind('bpmnProcess', 'OtherId')],
+      }),
+    );
+    expect(() => loadArtifactKindsAbox(workdir)).toThrow(/duplicate kind name\(s\): bpmnProcess/);
+  });
+
+  it('throws on duplicate semanticTypeMap entries', () => {
+    writeAbox(
+      minimalAbox({
+        semanticTypeMap: [
+          { semanticType: 'ProcessDefinitionKey', artifactKind: 'bpmnProcess' },
+          { semanticType: 'ProcessDefinitionKey', artifactKind: 'bpmnProcess' },
+        ],
+      }),
+    );
+    expect(() => loadArtifactKindsAbox(workdir)).toThrow(
+      /duplicate semanticTypeMap entries for: ProcessDefinitionKey/,
+    );
+  });
+
+  it('throws on duplicate operationRules entries', () => {
+    writeAbox(
+      minimalAbox({
+        operationRules: [
+          {
+            operationId: 'createDeployment',
+            composable: true,
+            rules: [{ id: 'bpmn', artifactKind: 'bpmnProcess' }],
+          },
+          {
+            operationId: 'createDeployment',
+            composable: false,
+            rules: [{ id: 'bpmn2', artifactKind: 'bpmnProcess' }],
+          },
+        ],
+      }),
+    );
+    expect(() => loadArtifactKindsAbox(workdir)).toThrow(
+      /duplicate operationRules entries for: createDeployment/,
+    );
+  });
+
+  it('throws on duplicate fileExtensionMap entries', () => {
+    writeAbox(
+      minimalAbox({
+        fileExtensionMap: [
+          { extension: '.bpmn', artifactKinds: ['bpmnProcess'] },
+          { extension: '.bpmn', artifactKinds: ['bpmnProcess'] },
+        ],
+      }),
+    );
+    expect(() => loadArtifactKindsAbox(workdir)).toThrow(
+      /duplicate fileExtensionMap entries for: \.bpmn/,
+    );
+  });
+
+  it('returns the parsed ABox on the happy path', () => {
+    writeAbox(minimalAbox());
+    const abox = loadArtifactKindsAbox(workdir);
+    expect(abox).not.toBeNull();
+    expect(abox?.kinds).toHaveLength(1);
+    expect(abox?.kinds[0]?.name).toBe('bpmnProcess');
+    expect(abox?.operationRules[0]?.rules).toHaveLength(1);
+  });
+});
+
+describe('deriveArtifactKindsViews: record-shaped views', () => {
+  it('returns null when no ABox is shipped (caller falls back to domain-semantics.json)', () => {
+    expect(deriveArtifactKindsViews(workdir)).toBeNull();
+  });
+
+  it('reshapes the ABox into the four record forms graph.domain.* expects', () => {
+    writeAbox(
+      minimalAbox({
+        kinds: [
+          {
+            ...minimalKind('bpmnProcess'),
+            producibleStates: ['ProcessInstanceCompleted'],
+          },
+          minimalKind('form', 'FormId'),
+        ],
+        semanticTypeMap: [
+          { semanticType: 'ProcessDefinitionKey', artifactKind: 'bpmnProcess' },
+          { semanticType: 'FormKey', artifactKind: 'form' },
+        ],
+        operationRules: [
+          {
+            operationId: 'createDeployment',
+            composable: true,
+            rules: [
+              { id: 'bpmn', artifactKind: 'bpmnProcess' },
+              { id: 'form', artifactKind: 'form' },
+            ],
+          },
+        ],
+        fileExtensionMap: [
+          { extension: '.bpmn', artifactKinds: ['bpmnProcess'] },
+          { extension: '.dmn', artifactKinds: ['dmnDecision', 'dmnDrd'] },
+        ],
+      }),
+    );
+    const views = deriveArtifactKindsViews(workdir);
+    expect(views).not.toBeNull();
+    expect(views?.artifactKinds.bpmnProcess?.producibleStates).toEqual([
+      'ProcessInstanceCompleted',
+    ]);
+    expect(views?.artifactKinds.form?.identifierType).toBe('FormId');
+    expect(views?.semanticTypeToArtifactKind).toEqual({
+      ProcessDefinitionKey: 'bpmnProcess',
+      FormKey: 'form',
+    });
+    expect(views?.operationArtifactRules.createDeployment?.composable).toBe(true);
+    expect(views?.operationArtifactRules.createDeployment?.rules).toHaveLength(2);
+    expect(views?.artifactFileKinds['.dmn']).toEqual(['dmnDecision', 'dmnDrd']);
+  });
+
+  it("propagates the loader's validation failure (does not silently swallow malformed ABox)", () => {
+    writeAbox('{ not json');
+    expect(() => deriveArtifactKindsViews(workdir)).toThrow(/Failed to parse artifact-kinds ABox/);
+  });
+});

--- a/tests/fixtures/loader/artifact-kinds-abox-loader.test.ts
+++ b/tests/fixtures/loader/artifact-kinds-abox-loader.test.ts
@@ -232,4 +232,66 @@ describe('deriveArtifactKindsViews: record-shaped views', () => {
     writeAbox('{ not json');
     expect(() => deriveArtifactKindsViews(workdir)).toThrow(/Failed to parse artifact-kinds ABox/);
   });
+
+  it('throws when an operation defines duplicate `rules[].id` values', () => {
+    writeAbox(
+      JSON.stringify({
+        version: 1,
+        kinds: [minimalKind()],
+        semanticTypeMap: [{ semanticType: 'ProcessDefinitionKey', artifactKind: 'bpmnProcess' }],
+        operationRules: [
+          {
+            operationId: 'createDeployment',
+            composable: true,
+            rules: [
+              { id: 'bpmn', artifactKind: 'bpmnProcess' },
+              { id: 'bpmn', artifactKind: 'bpmnProcess', priority: 5 },
+            ],
+          },
+        ],
+        fileExtensionMap: [{ extension: '.bpmn', artifactKinds: ['bpmnProcess'] }],
+      }),
+    );
+    expect(() => loadArtifactKindsAbox(workdir)).toThrow(
+      /operationRules\['createDeployment'\] has duplicate rule id\(s\): bpmn/,
+    );
+  });
+
+  it('preserves optional rule fields (`id`, `priority`, `producesSemantics`, `producesStates`) through deriveArtifactKindsViews', () => {
+    writeAbox(
+      JSON.stringify({
+        version: 1,
+        kinds: [minimalKind()],
+        semanticTypeMap: [{ semanticType: 'ProcessDefinitionKey', artifactKind: 'bpmnProcess' }],
+        operationRules: [
+          {
+            operationId: 'createDeployment',
+            composable: true,
+            rules: [
+              {
+                id: 'bpmn',
+                artifactKind: 'bpmnProcess',
+                priority: 7,
+                producesSemantics: ['ExtraKey'],
+                producesStates: ['ExtraState'],
+              },
+            ],
+          },
+        ],
+        fileExtensionMap: [{ extension: '.bpmn', artifactKinds: ['bpmnProcess'] }],
+      }),
+    );
+    const views = deriveArtifactKindsViews(workdir);
+    if (!views) throw new Error('expected derived views');
+    const rules = views.operationArtifactRules.createDeployment?.rules;
+    expect(rules).toEqual([
+      {
+        id: 'bpmn',
+        artifactKind: 'bpmnProcess',
+        priority: 7,
+        producesSemantics: ['ExtraKey'],
+        producesStates: ['ExtraState'],
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Closes #212. Part of the ontology migration tracked in #199.

## Summary

Lift 5 of the per-fact-class migration. Moves the four artifact-related sub-trees out of `configs/<config>/domain-semantics.json` and into a per-config ABox at `configs/<config>/ontology/artifact-kinds.json`, applying the #198 principle (artifact dispatch is domain knowledge with no wire signature → belongs in the per-config ontology).

Sub-trees migrated:

- `artifactKinds`
- `semanticTypeToArtifactKind`
- `operationArtifactRules`
- `artifactFileKinds`

The 14 runtime consumers (`index.ts`, `scenarioGenerator.ts`, `featureCoverageGenerator.ts`) are unchanged — they continue reading from `graph.domain.*`. The loader overlays the ABox sub-trees onto `graph.domain` after the legacy `domain-semantics.json` load. The legacy keys remain a transitional fallback; Lift 8 retires them alongside `domainSemanticsValidator.ts`.

## What's different from Lifts 3 / 4

These facts were never sourced from upstream OpenAPI annotations — only from the per-config sidecar. **Consequence: no `spec-vs-abox` (sense-1) drift to detect, only the durable `abox-vs-graph` (sense-2) coverage gates.** `STRICT_ARTIFACT_KINDS_ABOX=1` still escalates drift to a hard error, mirroring the other ABoxes.

## Coverage gates (#210 §4c pattern)

Eight L3 invariants under `bundled-spec invariants: artifact-kinds ABox cross-references (#212)` plus the standard load-path test:

- Load path proves end-to-end load.
- `operationRules` opId grounding (every entry references a real op).
- All artifact-kind cross-references resolve (rule `artifactKind`, `semanticTypeMap.artifactKind`, `fileExtensionMap.artifactKinds`).
- No dead kinds (every kind referenced by at least one rule / mapping / extension).
- `producesSemantics` ↔ `semanticTypeMap` consistency (bidirectional).
- `graph.domain.artifactKinds` matches ABox (planner contract).
- `graph.domain.operationArtifactRules` matches ABox.
- TBox/JSON drift detector for the published vocabulary file.
- ABox `$schema` field resolves to the published TBox.

## Tests

- 12 loader unit tests in `tests/fixtures/loader/artifact-kinds-abox-loader.test.ts`.
- 5 integration tests in `tests/fixtures/integration/artifact-kinds-abox-authoritative.test.ts` (promote / works-without-sidecar / strict mode / legacy fallback / sense-2 drift warning).
- 9 L3 invariants in `configs/camunda-oca/regression-invariants.test.ts`.

## Verification

- `npm run lint` — clean.
- `npx tsc --noEmit -p {semantic-graph-extractor,path-analyser,request-validation,tests}/tsconfig.json` — all four clean.
- `TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation` — pipeline regenerates without diffs.
- `diff -q` against the pre-Lift-5 baseline graph: byte-identical.
- `npm test` — 482 / 488 passed (6 pre-existing skips).

## Out of scope

- Removing the artifact sub-trees from `domain-semantics.json` itself — kept as the transitional fallback until Lift 8 retires `domainSemanticsValidator.ts` alongside Lifts 6 + 7.
- Other `domain-semantics.json` sub-trees (`runtimeStates`/`operationRequirements` are Lift 6, `semanticTypes`/`identifiers`/`capabilities` are Lift 7).