### PR TITLE
feat: lift runtime-states + operationRequirements to per-config ABox (#214)

### DIFF
--- a/configs/camunda-oca/ontology/runtime-states.json
+++ b/configs/camunda-oca/ontology/runtime-states.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://camunda.github.io/api-test-generator/ns/v1/runtime-states.schema.json",
+  "@context": "https://camunda.github.io/api-test-generator/ns/v1/context.jsonld",
+  "version": 1,
+  "states": [
+    {
+      "name": "ProcessDefinitionDeployed",
+      "parameter": "processDefinitionId",
+      "producedBy": [
+        "createDeployment"
+      ]
+    },
+    {
+      "name": "ProcessInstanceExists",
+      "parameter": "processDefinitionId",
+      "producedBy": [
+        "createProcessInstance"
+      ],
+      "requires": [
+        "ProcessDefinitionDeployed"
+      ]
+    },
+    {
+      "name": "ProcessInstanceCompleted",
+      "parameter": "processInstanceKey",
+      "producedBy": [
+        "createProcessInstance"
+      ],
+      "requires": [
+        "ProcessDefinitionDeployed"
+      ],
+      "eventual": true,
+      "witness": {
+        "operationId": "getProcessInstance",
+        "predicate": {
+          "path": "state",
+          "equals": "COMPLETED"
+        }
+      }
+    },
+    {
+      "name": "JobAvailableForActivation",
+      "parameters": [
+        "jobType",
+        "processDefinitionId"
+      ],
+      "producedBy": [
+        "activateJobs"
+      ],
+      "requires": [
+        "ProcessInstanceExists",
+        "ModelHasServiceTaskType"
+      ]
+    },
+    {
+      "name": "FormDeployed",
+      "parameter": "formKey",
+      "producedBy": [
+        "createDeployment"
+      ]
+    },
+    {
+      "name": "DecisionDefinitionDeployed",
+      "parameter": "decisionDefinitionId",
+      "producedBy": [
+        "createDeployment"
+      ]
+    },
+    {
+      "name": "DecisionRequirementsDeployed",
+      "parameter": "decisionRequirementsId",
+      "producedBy": [
+        "createDeployment"
+      ]
+    }
+  ],
+  "operationRequirements": [
+    {
+      "operationId": "createProcessInstance",
+      "requires": [
+        "ProcessDefinitionDeployed"
+      ],
+      "implicitAdds": [
+        "ProcessInstanceExists"
+      ],
+      "valueBindings": {
+        "request.processDefinitionId": "ProcessDefinitionDeployed.processDefinitionId",
+        "request.processDefinitionKey": "semantic:ProcessDefinitionKey",
+        "response.processInstanceKey": "semantic:ProcessInstanceKey"
+      }
+    },
+    {
+      "operationId": "activateJobs",
+      "requires": [
+        "ProcessInstanceExists",
+        "ModelHasServiceTaskType"
+      ],
+      "produces": [
+        "JobAvailableForActivation"
+      ],
+      "valueBindings": {
+        "request.jobType": "ModelHasServiceTaskType.jobType"
+      }
+    },
+    {
+      "operationId": "searchJobs",
+      "requires": [
+        "ProcessInstanceExists",
+        "ModelHasServiceTaskType"
+      ]
+    },
+    {
+      "operationId": "getUserTask",
+      "requires": [
+        "ProcessInstanceExists"
+      ]
+    },
+    {
+      "operationId": "searchProcessInstances",
+      "requires": [
+        "ProcessInstanceExists"
+      ]
+    },
+    {
+      "operationId": "deleteProcessInstance",
+      "requires": [
+        "ProcessInstanceCompleted"
+      ]
+    },
+    {
+      "operationId": "createDeployment",
+      "valueBindings": {
+        "response.deployments[].processDefinition.processDefinitionId": "ProcessDefinitionDeployed.processDefinitionId",
+        "response.deployments[].processDefinition.processDefinitionKey": "semantic:ProcessDefinitionKey",
+        "response.deployments[].form.formKey": "FormDeployed.formKey"
+      }
+    },
+    {
+      "operationId": "searchProcessDefinitions",
+      "requires": [
+        "ProcessDefinitionDeployed"
+      ]
+    }
+  ]
+}

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -4751,3 +4751,176 @@ describeForThisConfig(
     });
   },
 );
+
+describeForThisConfig(
+  'bundled-spec invariants: runtime-states ABox cross-references (#214)',
+  () => {
+    // Lift 6 / #214: the runtime-states ABox is now the authoritative
+    // source for the two runtime-related sub-trees (runtimeStates and
+    // operationRequirements) previously carried in
+    // domain-semantics.json. Same coverage strategy as Lift 5.
+
+    it('loads the runtime-states ABox via the generic loader (proves the load path)', async () => {
+      const { loadRuntimeStatesAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const abox = loadRuntimeStatesAbox(REPO_ROOT);
+      expect(abox, 'runtime-states ABox file must exist for the camunda-oca config').not.toBeNull();
+      expect(abox?.states.length).toBeGreaterThan(0);
+      expect(abox?.operationRequirements.length).toBeGreaterThan(0);
+    });
+
+    it('every state.producedBy / state.witness.operationId / operationRequirements.operationId references a real opId in the bundled graph (sense-2: abox-vs-graph)', async () => {
+      const { loadRuntimeStatesAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const abox = loadRuntimeStatesAbox(REPO_ROOT);
+      if (!abox) throw new Error('runtime-states ABox missing');
+      if (!existsSync(GRAPH_PATH)) {
+        throw new Error(
+          `Graph not found at ${GRAPH_PATH}. Run 'npm run testsuite:generate' first.`,
+        );
+      }
+      interface GraphOp {
+        operationId?: string;
+      }
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const graph = JSON.parse(readFileSync(GRAPH_PATH, 'utf8')) as {
+        operationsById?: Record<string, GraphOp>;
+        operations?: Record<string, GraphOp> | GraphOp[];
+      };
+      const opIds = new Set<string>(
+        Object.keys(graph.operationsById ?? {}).length > 0
+          ? Object.keys(graph.operationsById ?? {})
+          : Array.isArray(graph.operations)
+            ? graph.operations
+                .map((o) => o.operationId)
+                .filter((s): s is string => typeof s === 'string')
+            : Object.keys(graph.operations ?? {}),
+      );
+      const dangling: string[] = [];
+      for (const s of abox.states) {
+        for (const op of s.producedBy ?? []) {
+          if (!opIds.has(op)) dangling.push(`states['${s.name}'].producedBy -> '${op}'`);
+        }
+        if (s.witness && !opIds.has(s.witness.operationId)) {
+          dangling.push(`states['${s.name}'].witness.operationId -> '${s.witness.operationId}'`);
+        }
+      }
+      for (const r of abox.operationRequirements) {
+        if (!opIds.has(r.operationId)) dangling.push(`operationRequirements['${r.operationId}']`);
+      }
+      expect(
+        dangling,
+        'runtime-states ABox references opIds that do not exist in the bundled graph - typo, renamed-upstream op, or stale entry; remove or fix in configs/<config>/ontology/runtime-states.json',
+      ).toEqual([]);
+    });
+
+    it('every state declared in the ABox is referenced by at least one operationRequirement / state.requires / semanticTypes.witnesses (no dead states)', async () => {
+      const { loadRuntimeStatesAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const abox = loadRuntimeStatesAbox(REPO_ROOT);
+      if (!abox) throw new Error('runtime-states ABox missing');
+      const referenced = new Set<string>();
+      for (const r of abox.operationRequirements) {
+        for (const x of r.requires ?? []) referenced.add(x);
+        for (const d of r.disjunctions ?? []) for (const x of d) referenced.add(x);
+        for (const x of r.implicitAdds ?? []) referenced.add(x);
+        for (const x of r.produces ?? []) referenced.add(x);
+        for (const v of Object.values(r.valueBindings ?? {})) {
+          const dot = v.indexOf('.');
+          if (dot > 0 && !v.startsWith('semantic:')) referenced.add(v.slice(0, dot));
+        }
+      }
+      for (const s of abox.states) for (const x of s.requires ?? []) referenced.add(x);
+      // Also count witness references from sibling sub-trees that have
+      // not yet migrated to their own ABoxes (Lift 7): semanticTypes
+      // and capabilities still live in domain-semantics.json and may
+      // reference states via `witnesses`. Without this, states only
+      // referenced by a semanticType.witnesses (e.g.
+      // `ProcessDefinitionDeployed` ← `ProcessDefinitionKey.witnesses`)
+      // would be flagged as dead even though they are live.
+      interface DomainSemanticsLite {
+        semanticTypes?: Record<string, { witnesses?: string }>;
+        capabilities?: Record<string, { witnesses?: string }>;
+      }
+      const domainPath = join(REPO_ROOT, 'configs', CONFIG_NAME, 'domain-semantics.json');
+      if (existsSync(domainPath)) {
+        // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+        const ds = JSON.parse(readFileSync(domainPath, 'utf8')) as DomainSemanticsLite;
+        for (const t of Object.values(ds.semanticTypes ?? {})) {
+          if (typeof t.witnesses === 'string') referenced.add(t.witnesses);
+        }
+        for (const c of Object.values(ds.capabilities ?? {})) {
+          if (typeof c.witnesses === 'string') referenced.add(c.witnesses);
+        }
+      }
+      const dead = abox.states.filter((s) => !referenced.has(s.name)).map((s) => s.name);
+      expect(
+        dead,
+        'runtime-states ABox lists state(s) referenced by no operationRequirement / state.requires / semanticTypes.witnesses entry - dead weight; either remove or add a reference',
+      ).toEqual([]);
+    });
+
+    it('graph.domain.runtimeStates matches the record-shaped view derived from the ABox (planner contract - ABox supersedes domain-semantics.json)', async () => {
+      const { deriveRuntimeStatesViews } = await import(
+        '../../path-analyser/src/ontology/loader.js'
+      );
+      const { loadGraph } = await import('../../path-analyser/src/graphLoader.js');
+      const expectedViews = deriveRuntimeStatesViews(REPO_ROOT);
+      if (!expectedViews) throw new Error('runtime-states ABox missing');
+      const graph = await loadGraph(join(REPO_ROOT, 'path-analyser'));
+      expect(
+        graph.domain?.runtimeStates,
+        'graph.domain.runtimeStates does not match the ABox-derived view - overlay regression',
+      ).toEqual(expectedViews.runtimeStates);
+    });
+
+    it('graph.domain.operationRequirements matches the record-shaped view derived from the ABox (planner contract)', async () => {
+      const { deriveRuntimeStatesViews } = await import(
+        '../../path-analyser/src/ontology/loader.js'
+      );
+      const { loadGraph } = await import('../../path-analyser/src/graphLoader.js');
+      const expectedViews = deriveRuntimeStatesViews(REPO_ROOT);
+      if (!expectedViews) throw new Error('runtime-states ABox missing');
+      const graph = await loadGraph(join(REPO_ROOT, 'path-analyser'));
+      expect(
+        graph.domain?.operationRequirements,
+        'graph.domain.operationRequirements does not match the ABox-derived view - overlay regression',
+      ).toEqual(expectedViews.operationRequirements);
+    });
+
+    it('the committed runtime-states vocabulary JSON matches the regenerated TBox (drift detector)', async () => {
+      const { ARTIFACTS, renderSchema } = await import('../../scripts/build-ontology.ts');
+      const target = ARTIFACTS.find((a) => a.jsonPath.endsWith('runtime-states.schema.json'));
+      expect(target, 'build-ontology must include runtime-states.schema.json').toBeDefined();
+      if (!target) return;
+      const onDisk = readFileSync(target.jsonPath, 'utf8');
+      const rendered = renderSchema(target.schema);
+      expect(
+        onDisk,
+        `Generated ontology artefact at ${target.jsonPath} is stale. Run 'npm run build:ontology' to refresh it.`,
+      ).toBe(rendered);
+    });
+
+    it("the runtime-states ABox's $schema field resolves to the published TBox JSON", () => {
+      const aboxPath = join(REPO_ROOT, 'configs', CONFIG_NAME, 'ontology', 'runtime-states.json');
+      const expectedTboxPath = join(
+        REPO_ROOT,
+        'ontology',
+        'vocabulary',
+        'runtime-states.schema.json',
+      );
+      expect(
+        existsSync(expectedTboxPath),
+        `Published TBox at '${expectedTboxPath}' does not exist`,
+      ).toBe(true);
+      interface AboxHeader {
+        $schema?: unknown;
+      }
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const aboxJson = JSON.parse(readFileSync(aboxPath, 'utf8')) as AboxHeader;
+      const schemaField = aboxJson.$schema;
+      expect(typeof schemaField, 'ABox must declare a string `$schema` field').toBe('string');
+      if (typeof schemaField !== 'string') return;
+      expect(schemaField).toBe(
+        'https://camunda.github.io/api-test-generator/ns/v1/runtime-states.schema.json',
+      );
+    });
+  },
+);

--- a/ontology/vocabulary/runtime-states.schema.json
+++ b/ontology/vocabulary/runtime-states.schema.json
@@ -1,0 +1,215 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://camunda.github.io/api-test-generator/ns/v1/runtime-states.schema.json",
+  "title": "Runtime-states ABox (api-test-generator ontology, v1)",
+  "description": "TBox JSON Schema for an ABox file describing the runtime states a deployed API surfaces, plus the per-operation requirements that reference those states. Each entry asserts: a runtime state exists with a known parameter shape and producer set; an operation requires (or produces, or binds values from) a set of states. The schema is intentionally agnostic to which API ships the states — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/runtime-states.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (operationIds existing, state names being internally consistent across `producedBy`, `requires`, `implicitAdds`, `produces`, `valueBindings`, `requires`-chains terminating, no orphan states) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them. Cross-references against `semanticTypes`/`capabilities` (sibling sub-trees in `domain-semantics.json` that this ABox transitively references via `valueBindings` RHS like `semantic:ProcessDefinitionKey` or via `requires`-of-capability entries) are re-validated at load time by re-running `validateDomainSemantics` against the post-overlay `graph.domain` — see `graphLoader.ts`.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "states",
+    "operationRequirements"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "@context": {
+      "description": "Optional JSON-LD context. Ignored by the loader; preserved verbatim so external RDF tooling can resolve term IRIs without modification.",
+      "type": [
+        "object",
+        "string",
+        "array"
+      ]
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Schema version of this ABox file. Bumped only when the TBox shape changes incompatibly."
+    },
+    "states": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/RuntimeState"
+      }
+    },
+    "operationRequirements": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/OperationRequirement"
+      }
+    }
+  },
+  "definitions": {
+    "RuntimeState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "@type": {
+          "description": "Optional JSON-LD type IRI. Ignored by the loader.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "PascalCase name of the runtime state (e.g. `ProcessDefinitionDeployed`). Must be unique across `states` (checked by the loader)."
+        },
+        "parameter": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Single-parameter name that keys this state (e.g. `processDefinitionId`). Mutually exclusive with `parameters` — exactly one of `parameter` or `parameters` should be present (the loader does not enforce the XOR; presence is documentary)."
+        },
+        "parameters": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Multi-parameter list that jointly keys this state (e.g. `[\"jobType\", \"processDefinitionId\"]`). Mutually exclusive with `parameter`."
+        },
+        "producedBy": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "OpenAPI operationIds whose successful invocation establishes this state. Each entry must reference an op present in the bundled graph — checked as an L3 abox-vs-graph invariant."
+        },
+        "requires": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Prerequisite states that must hold before this state can be produced. Each entry must reference another state in `states` or a capability declared in `domain-semantics.json` (capabilities migrate in Lift 7)."
+        },
+        "eventual": {
+          "type": "boolean",
+          "description": "When true, the state is not immediately observable on the producer response — the planner inserts an `awaitEventually(witness)` wait before any consumer step (#159 PR B). Requires `witness`."
+        },
+        "witness": {
+          "$ref": "#/definitions/WitnessSpec",
+          "description": "Witness used by `awaitEventually` when `eventual === true`. The witness invokes a read-shape operation and polls until the predicate holds against the response body."
+        }
+      }
+    },
+    "WitnessSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operationId",
+        "predicate"
+      ],
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Operation invoked to observe the state. Must reference a real operationId in the graph (PR B constrains this to GET-shape ops)."
+        },
+        "predicate": {
+          "$ref": "#/definitions/WitnessPredicate"
+        },
+        "waitUpToMs": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Optional total wait budget in ms; defaults to the awaitEventually helper built-in."
+        },
+        "pollIntervalMs": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Optional poll interval in ms; defaults to the awaitEventually helper built-in."
+        }
+      }
+    },
+    "WitnessPredicate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "equals"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*$",
+          "description": "Top-level field on the response body. Constrained so the emitter can render it as a safe bracket-access key without an escape pass."
+        },
+        "equals": {
+          "description": "Expected scalar compared with strict equality. The emitter JSON-stringifies it directly, so it is constrained to JSON primitives.",
+          "type": [
+            "string",
+            "number",
+            "boolean"
+          ]
+        }
+      }
+    },
+    "OperationRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operationId"
+      ],
+      "properties": {
+        "@type": {
+          "description": "Optional JSON-LD type IRI. Ignored by the loader.",
+          "type": "string"
+        },
+        "operationId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "OpenAPI operationId. Must reference a real op in the bundled graph — checked as an L3 abox-vs-graph invariant."
+        },
+        "requires": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "States that must hold before invoking this op. Each entry must reference a state in `states` or a capability in `domain-semantics.json` (capabilities migrate in Lift 7)."
+        },
+        "disjunctions": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "description": "Sets of alternative prerequisites — at least one entry from each disjunction must hold. Each entry resolves the same way as `requires`."
+        },
+        "implicitAdds": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "States produced implicitly on success (in addition to whatever the upstream API documents). Each entry must reference a state in `states`."
+        },
+        "produces": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Explicit producer override (rare — used when a state is produced by an op that does not appear in the state's `producedBy`). Each entry must reference a state in `states`."
+        },
+        "valueBindings": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Map from request/response field path (e.g. `request.processDefinitionId`, `response.processInstanceKey`) to either `<StateName>.<parameter>` (resolves at emission to the value bound for that parameter when the state was produced) or `semantic:<SemanticTypeName>` (resolves to the semantic-type producer chain — semanticTypes migrate in Lift 7)."
+        }
+      }
+    }
+  }
+}

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -566,6 +566,80 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     }
   }
   if (runtimeStatesAboxPresent) postOverlayReValidationNeeded = true;
+
+  // Lift 6 / #214: when the runtime-states ABox is shipped but no
+  // legacy `domain-semantics.json` sidecar exists (the future
+  // Lift 8-style ABox-authoritative configs, and any test fixture
+  // that exercises ABox-only loading), the consumer logic that lives
+  // inside the legacy try block above is never reached — leaving
+  // `graph.domain.runtimeStates`, `graph.domain.operationRequirements`,
+  // `producersByState`, and `node.domainRequiresAll`/etc. all
+  // unpopulated even though the ABox declares them. Mirror the
+  // artifact-kinds post-try overlay here: synthesize a minimal
+  // `domain` from the ABox views and re-run the same consumer logic
+  // against it. Only runtime-states + operationRequirements come
+  // from this ABox; semanticTypes/capabilities/identifiers stay
+  // legacy-only until Lift 7, so the witness-implication loop and
+  // capability/identifier producer expansion are intentionally
+  // omitted (they are no-ops without a legacy sidecar).
+  if (runtimeStatesAboxPresent && !legacyDomainLoaded) {
+    const views = deriveRuntimeStatesViews(repoRoot);
+    if (views !== null) {
+      const baseDomain: DomainSemantics = domain ?? { version: 1 };
+      domain = {
+        ...baseDomain,
+        runtimeStates: views.runtimeStates,
+        operationRequirements: views.operationRequirements,
+      };
+      // node.domainRequiresAll / domainDisjunctions / domainProduces /
+      // domainImplicitAdds setters — same shape as the in-try loop.
+      for (const [opId, req] of Object.entries(views.operationRequirements)) {
+        const node = operations[opId];
+        if (!node) continue;
+        if (req.requires) node.domainRequiresAll = req.requires;
+        if (req.disjunctions) node.domainDisjunctions = req.disjunctions;
+        if (req.produces) node.domainProduces = req.produces;
+        if (req.implicitAdds) node.domainImplicitAdds = req.implicitAdds;
+      }
+      // producersByState builder — same dedup contract as the in-try
+      // builder. Surfaces `domainProduces` on the producing nodes too,
+      // so semantic BFS sees the same picture.
+      const producers: Record<string, string[]> = producersByState ?? {};
+      producersByState = producers;
+      const addProducer = (state: string, opId: string) => {
+        const list = producers[state] ?? [];
+        if (!list.includes(opId)) list.push(opId);
+        producers[state] = list;
+        const node = operations[opId];
+        if (node) {
+          if (!node.domainProduces) node.domainProduces = [state];
+          else if (!node.domainProduces.includes(state)) node.domainProduces.push(state);
+        }
+      };
+      for (const [stateName, spec] of Object.entries(views.runtimeStates)) {
+        for (const opId of spec.producedBy ?? []) {
+          if (operations[opId]) addProducer(stateName, opId);
+        }
+      }
+      for (const [opId, spec] of Object.entries(views.operationRequirements)) {
+        if (!operations[opId]) continue;
+        for (const st of spec.produces ?? []) addProducer(st, opId);
+        for (const st of spec.implicitAdds ?? []) addProducer(st, opId);
+      }
+      // #56 mirror: surface ABox-declared `produces` into op.produces /
+      // producersByType so semantic BFS sees them.
+      for (const [opId, spec] of Object.entries(views.operationRequirements)) {
+        const node = operations[opId];
+        if (!node) continue;
+        for (const st of spec.produces ?? []) {
+          if (!node.produces.includes(st)) node.produces.push(st);
+          const list = producersByType[st] ?? [];
+          if (!list.includes(opId)) list.push(opId);
+          producersByType[st] = list;
+        }
+      }
+    }
+  }
   // Re-run the cross-reference invariants from `validateDomainSemantics`
   // against the post-overlay value, but only when a legacy
   // `domain-semantics.json` sidecar was loaded. The pre-overlay

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -9,10 +9,12 @@ import {
 } from './domainSemanticsValidator.js';
 import {
   deriveArtifactKindsViews,
+  deriveRuntimeStatesViews,
   loadArtifactKindsAbox,
   loadEdgeEstablishers,
   loadEntityKindsAbox,
   loadExternalEntityIdentifiers,
+  loadRuntimeStatesAbox,
 } from './ontology/loader.js';
 import type { BootstrapSequence, DomainSemantics, OperationGraph, OperationNode } from './types.js';
 
@@ -323,29 +325,51 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
   // path-analyser workspace, so the repo root is its parent.
   let domain: DomainSemantics | undefined;
   let producersByState: Record<string, string[]> | undefined;
+  let legacyDomainLoaded = false;
+  // Determined once before the try block so the post-overlay
+  // re-validation (after the try/catch) can also see the flags.
+  const artifactAboxPresent = loadArtifactKindsAbox(repoRoot) !== null;
+  const runtimeStatesAboxPresent = loadRuntimeStatesAbox(repoRoot) !== null;
   try {
-    const repoRoot = path.resolve(baseDir, '..');
     const domainPath = path.resolve(getActiveConfigDir(repoRoot), 'domain-semantics.json');
     const domainRaw = await readFile(domainPath, 'utf8');
     // biome-ignore lint/plugin: JSON.parse returns `any`; domain-semantics.json is the runtime contract.
     const parsedDomain = JSON.parse(domainRaw) as DomainSemantics;
-    // Lift 5 / #212: when an artifact-kinds ABox is present it is the
-    // authoritative source for the four artifact sub-trees; the legacy
-    // sidecar's copy is about to be replaced by the post-overlay step
-    // below. Strip those keys before pre-overlay validation so a stale
-    // legacy entry (e.g. a `producesStates` referencing a state that
-    // the legacy sidecar no longer declares) cannot fail load when the
-    // ABox already supersedes it. The post-overlay re-validation
-    // covers the ABox values via the same Zod-driven validator.
-    const aboxPresent = loadArtifactKindsAbox(repoRoot) !== null;
+    // Lift 5 / #212 + Lift 6 / #214: when a per-config ABox is present
+    // it is the authoritative source for the corresponding sub-tree,
+    // and the post-overlay step below replaces the legacy sidecar's
+    // copy. Pre-overlay validation must therefore see the ABox values
+    // — not the legacy ones — so that:
+    //   (a) a stale legacy entry whose state name no longer exists in
+    //       the ABox cannot fail load (was the original strip
+    //       motivation); and
+    //   (b) cross-references from sub-trees that have NOT yet
+    //       migrated (e.g. semanticTypes.witnesses → runtimeStates,
+    //       capabilities → runtimeStates) still resolve through the
+    //       authoritative ABox values during pre-overlay validation.
+    // Stripping alone (Lift 5's first attempt) breaks (b) because the
+    // unmigrated sub-trees still expect their cross-refs to resolve.
+    // Overlaying both pre- and post- gives one consistent view.
     let validationTarget: DomainSemantics = parsedDomain;
-    if (aboxPresent) {
-      const stripped: DomainSemantics = { ...parsedDomain };
-      delete stripped.artifactKinds;
-      delete stripped.semanticTypeToArtifactKind;
-      delete stripped.operationArtifactRules;
-      delete stripped.artifactFileKinds;
-      validationTarget = stripped;
+    if (artifactAboxPresent || runtimeStatesAboxPresent) {
+      const overlaid: DomainSemantics = { ...parsedDomain };
+      if (artifactAboxPresent) {
+        const av = deriveArtifactKindsViews(repoRoot);
+        if (av !== null) {
+          overlaid.artifactKinds = av.artifactKinds;
+          overlaid.semanticTypeToArtifactKind = av.semanticTypeToArtifactKind;
+          overlaid.operationArtifactRules = av.operationArtifactRules;
+          overlaid.artifactFileKinds = av.artifactFileKinds;
+        }
+      }
+      if (runtimeStatesAboxPresent) {
+        const rv = deriveRuntimeStatesViews(repoRoot);
+        if (rv !== null) {
+          overlaid.runtimeStates = rv.runtimeStates;
+          overlaid.operationRequirements = rv.operationRequirements;
+        }
+      }
+      validationTarget = overlaid;
     }
     const issues = validateDomainSemantics(validationTarget);
     if (issues.length > 0) {
@@ -355,6 +379,28 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
       );
     }
     domain = parsedDomain;
+    legacyDomainLoaded = true;
+    // Lift 6 / #214: runtime-states ABox supersedes the legacy
+    // `runtimeStates` and `operationRequirements` sub-trees. Performed
+    // inside the try block (and right after `domain = parsedDomain`)
+    // so the existing consumer loops below — building `producersByState`,
+    // setting `node.domainRequiresAll`/`domainImplicitAdds`/`domainProduces`,
+    // resolving `operationRequirements.valueBindings` — see the
+    // overlaid values without further plumbing. The pre-overlay strip
+    // above ensures the validator already accepted this swap; the
+    // post-overlay re-validation block (after the try/catch) catches
+    // ABox-introduced cross-reference violations against the
+    // unmigrated `semanticTypes`/`capabilities` sub-trees.
+    if (runtimeStatesAboxPresent) {
+      const views = deriveRuntimeStatesViews(repoRoot);
+      if (views !== null) {
+        domain = {
+          ...domain,
+          runtimeStates: views.runtimeStates,
+          operationRequirements: views.operationRequirements,
+        };
+      }
+    }
     // debug: domain semantics sidecar loaded
     if (domain?.operationRequirements) {
       for (const [opId, req] of Object.entries(domain.operationRequirements)) {
@@ -487,22 +533,27 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     // ENOENT or non-Error throw: sidecar absent — domain analysis disabled
   }
 
-  // Lift 5 / #212: artifact-kinds ABox supersedes the legacy
-  // `domain-semantics.json` keys when present. Per #198, artifact
-  // dispatch is domain knowledge with no wire signature, so it lives
-  // in the per-config ontology rather than in the freeform sidecar.
-  // The legacy keys remain a transitional fallback so unmigrated
-  // configs (and tests that exercise loadGraph against an isolated
-  // tmpDir without a domain-semantics.json) keep working until Lift 8
-  // retires them. When both are present, the ABox is authoritative —
+  // Lift 5 / #212 + Lift 6 / #214: per-config ABoxes supersede the
+  // legacy `domain-semantics.json` keys when present. Per #198, the
+  // domain knowledge with no wire signature lives in the per-config
+  // ontology rather than in the freeform sidecar. The legacy keys
+  // remain a transitional fallback so unmigrated configs (and tests
+  // that exercise loadGraph against an isolated tmpDir without a
+  // domain-semantics.json) keep working until Lift 8 retires them.
+  // When both are present, the ABox is authoritative —
   // `detectArtifactKindsDrift` surfaces dead/dangling entries (the
   // durable abox-vs-graph signal) before the override can silently
   // mask them. Placed outside the domain-semantics try/catch so a
   // shipped ABox is honoured even when the legacy sidecar is absent.
+  // Note: the runtime-states ABox overlay happens INSIDE the try
+  // block (right after `domain = parsedDomain`) because its values
+  // are consumed by the producersByState-building loop further down
+  // in that block. The post-overlay re-validation here covers BOTH
+  // overlays (artifact-kinds AND runtime-states).
+  let postOverlayReValidationNeeded = false;
   {
     const artifactViews = deriveArtifactKindsViews(repoRoot);
     if (artifactViews !== null) {
-      const hadLegacyDomain = domain !== undefined;
       const baseDomain: DomainSemantics = domain ?? { version: 1 };
       domain = {
         ...baseDomain,
@@ -511,30 +562,32 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
         operationArtifactRules: artifactViews.operationArtifactRules,
         artifactFileKinds: artifactViews.artifactFileKinds,
       };
-      // Re-run the cross-reference invariants from
-      // `validateDomainSemantics` against the post-overlay value, but
-      // only when a legacy `domain-semantics.json` sidecar was loaded.
-      // The pre-overlay validation only sees the legacy artifact
-      // sub-trees, so an ABox that introduces an undeclared
-      // `producesStates`/`producibleStates` (not in
-      // `runtimeStates`/`capabilities`) or a `producesSemantics` entry
-      // without a `semanticTypes.witnesses` declaration would
-      // otherwise slip through. When no sidecar is present the
-      // validator has no `runtimeStates`/`semanticTypes` to cross-check
-      // against — the ABox stands alone, and Lift 6/7 will move those
-      // declarations into their own ABoxes. Reuses the same Zod-driven
-      // validator and the same DomainSemanticsValidationFailure error
-      // type so the diagnostic surfaces with one well-known shape
-      // regardless of which source (legacy sidecar or ABox) tripped it.
-      if (hadLegacyDomain) {
-        const overlayIssues = validateDomainSemantics(domain);
-        if (overlayIssues.length > 0) {
-          const detail = overlayIssues.map((i) => `  - [${i.invariant}] ${i.message}`).join('\n');
-          throw new DomainSemanticsValidationFailure(
-            `artifact-kinds ABox introduced cross-reference violation(s) when overlaid on domain-semantics.json:\n${detail}`,
-          );
-        }
-      }
+      postOverlayReValidationNeeded = true;
+    }
+  }
+  if (runtimeStatesAboxPresent) postOverlayReValidationNeeded = true;
+  // Re-run the cross-reference invariants from `validateDomainSemantics`
+  // against the post-overlay value, but only when a legacy
+  // `domain-semantics.json` sidecar was loaded. The pre-overlay
+  // validation only sees the (already-stripped) legacy sub-trees, so
+  // an ABox that introduces an undeclared `producesStates` /
+  // `producibleStates` (not in `runtimeStates` / `capabilities`), or a
+  // `producesSemantics` entry without a `semanticTypes.witnesses`
+  // declaration, or an `operationRequirements.requires` referencing an
+  // undeclared state, would otherwise slip through. When no sidecar
+  // is present the validator has no `semanticTypes` / `capabilities`
+  // to cross-check against — the ABox stands alone, and Lift 7 will
+  // move those declarations into their own ABox. Reuses the same
+  // Zod-driven validator and the same DomainSemanticsValidationFailure
+  // error type so the diagnostic surfaces with one well-known shape
+  // regardless of which ABox tripped it.
+  if (postOverlayReValidationNeeded && legacyDomainLoaded && domain !== undefined) {
+    const overlayIssues = validateDomainSemantics(domain);
+    if (overlayIssues.length > 0) {
+      const detail = overlayIssues.map((i) => `  - [${i.invariant}] ${i.message}`).join('\n');
+      throw new DomainSemanticsValidationFailure(
+        `ontology ABox introduced cross-reference violation(s) when overlaid on domain-semantics.json:\n${detail}`,
+      );
     }
   }
 
@@ -609,6 +662,29 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
       }
       console.warn(
         `WARNING: ${message}\n  (set STRICT_ARTIFACT_KINDS_ABOX=1 to fail-fast on drift.)`,
+      );
+    }
+  }
+
+  // Lift 6 / #214: same per-fact-class drift detector for the
+  // runtime-states ABox. Catches: producedBy / witness.operationId /
+  // operationRequirements.operationId references to opIds that don't
+  // exist in the bundled graph (typo, renamed-upstream op, or stale
+  // entry). Cross-references to capabilities / semanticTypes are not
+  // checked here — they live in the unmigrated `domain-semantics.json`
+  // sub-trees and are covered by the post-overlay re-validation
+  // (`validateDomainSemantics`) above. Lift 7 will fold them into this
+  // detector.
+  {
+    const drift = detectRuntimeStatesDrift(operations, repoRoot);
+    if (drift.length > 0) {
+      const detail = drift.map((d) => `  - ${d}`).join('\n');
+      const message = `runtime-states ABox drift detected:\n${detail}`;
+      if (process.env.STRICT_RUNTIME_STATES_ABOX === '1') {
+        throw new Error(message);
+      }
+      console.warn(
+        `WARNING: ${message}\n  (set STRICT_RUNTIME_STATES_ABOX=1 to fail-fast on drift.)`,
       );
     }
   }
@@ -1150,6 +1226,48 @@ function detectArtifactKindsDrift(
       );
     }
   }
+
+  return drift;
+}
+
+function detectRuntimeStatesDrift(
+  operations: Record<string, OperationNode>,
+  repoRoot: string,
+): string[] {
+  const drift: string[] = [];
+  const abox = loadRuntimeStatesAbox(repoRoot);
+  if (abox === null) return drift;
+
+  for (const s of abox.states) {
+    for (const opId of s.producedBy ?? []) {
+      if (!operations[opId]) {
+        drift.push(
+          `[abox-vs-graph] state '${s.name}'.producedBy references opId '${opId}' that does not exist in the bundled graph (typo, renamed-upstream op, or stale entry)`,
+        );
+      }
+    }
+    if (s.witness !== undefined && !operations[s.witness.operationId]) {
+      drift.push(
+        `[abox-vs-graph] state '${s.name}'.witness.operationId '${s.witness.operationId}' does not exist in the bundled graph`,
+      );
+    }
+  }
+  for (const r of abox.operationRequirements) {
+    if (!operations[r.operationId]) {
+      drift.push(
+        `[abox-vs-graph] operationRequirements entry '${r.operationId}' references an opId that does not exist in the bundled graph (typo, renamed-upstream op, or stale entry)`,
+      );
+    }
+  }
+
+  // Dead-state check is deferred to Lift 7 (#199): until
+  // `semanticTypes`/`capabilities` migrate to their own ABox, states
+  // can be referenced from those legacy sidecar sub-trees (e.g.
+  // `semanticTypes.X.witnesses → 'StateName'`). The detector here
+  // sees only the runtime-states ABox, so it would false-positive on
+  // states whose only live reference is via a witness coupling. The
+  // L3 invariant in `configs/<name>/regression-invariants.test.ts`
+  // covers the dead-state check by reading both sources.
 
   return drift;
 }

--- a/path-analyser/src/ontology/loader.ts
+++ b/path-analyser/src/ontology/loader.ts
@@ -6,6 +6,7 @@ import { getActiveConfigDir } from '../configResolver.js';
 import { artifactKindsSchema } from './artifactKindsSchema.js';
 import { edgeSchema } from './edgeSchema.js';
 import { entityKindsSchema } from './entityKindsSchema.js';
+import { runtimeStatesSchema } from './runtimeStatesSchema.js';
 
 // ---------------------------------------------------------------------------
 // path-analyser/src/ontology/loader.ts
@@ -46,6 +47,10 @@ export type ArtifactSemanticTypeMapping = ArtifactKindsAbox['semanticTypeMap'][n
 export type ArtifactOperationRule = ArtifactKindsAbox['operationRules'][number];
 export type ArtifactFileExtensionMapping = ArtifactKindsAbox['fileExtensionMap'][number];
 
+export type RuntimeStatesAbox = FromSchema<typeof runtimeStatesSchema>;
+export type RuntimeStateEntry = RuntimeStatesAbox['states'][number];
+export type OperationRequirementEntry = RuntimeStatesAbox['operationRequirements'][number];
+
 // `Ajv` is the named export pointing at the constructor; the namespace
 // also has a self-referential default but the named export is the
 // least error-prone form under module=nodenext.
@@ -53,6 +58,7 @@ const ajv = new Ajv({ allErrors: true, strict: false });
 const validateEdgesAbox = ajv.compile<EdgesAbox>(edgeSchema);
 const validateEntityKindsAbox = ajv.compile<EntityKindsAbox>(entityKindsSchema);
 const validateArtifactKindsAbox = ajv.compile<ArtifactKindsAbox>(artifactKindsSchema);
+const validateRuntimeStatesAbox = ajv.compile<RuntimeStatesAbox>(runtimeStatesSchema);
 
 function formatErrors(errors: ErrorObject[] | null | undefined): string {
   return (errors ?? [])
@@ -429,4 +435,151 @@ export function deriveArtifactKindsViews(repoRoot: string): ArtifactKindsViews |
     operationArtifactRules,
     artifactFileKinds,
   };
+}
+
+/**
+ * Load and validate the runtime-states ABox file for the active config.
+ *
+ * @param repoRoot Absolute path to the api-test-generator repository root.
+ * @returns The parsed ABox, or `null` if the file does not exist (configs
+ *   are not required to ship one; a missing file leaves the legacy
+ *   `domain-semantics.json` `runtimeStates`/`operationRequirements` keys
+ *   authoritative for backward compatibility).
+ * @throws if the file exists but does not validate against the TBox, or
+ *   if it contains duplicate state names or duplicate operationRequirements
+ *   entries.
+ */
+export function loadRuntimeStatesAbox(repoRoot: string): RuntimeStatesAbox | null {
+  // Symmetric with the other loadXxxAbox helpers — tests that exercise
+  // loadGraph against an isolated tmpDir don't ship a `configs.json`,
+  // and the right fallback there is "no ABox available" so the test
+  // exercises the legacy domain-semantics.json path.
+  let aboxPath: string;
+  try {
+    aboxPath = path.join(getActiveConfigDir(repoRoot), 'ontology', 'runtime-states.json');
+  } catch {
+    return null;
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(aboxPath, 'utf8');
+  } catch (err) {
+    if (err !== null && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+      return null;
+    }
+    throw err;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse runtime-states ABox at ${aboxPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!validateRuntimeStatesAbox(parsed)) {
+    throw new Error(
+      `Runtime-states ABox at ${aboxPath} failed TBox validation:\n${formatErrors(validateRuntimeStatesAbox.errors)}`,
+    );
+  }
+  // Reject duplicate keys up front — Draft-07 cannot express
+  // uniqueness, but a duplicate would silently shadow facts at query
+  // time. Same defensive check as in the other ABox loaders.
+  const dupeStates = duplicates(parsed.states.map((s) => s.name));
+  if (dupeStates.length > 0) {
+    throw new Error(
+      `Runtime-states ABox at ${aboxPath} has duplicate state name(s): ${dupeStates.join(', ')}`,
+    );
+  }
+  const dupeOps = duplicates(parsed.operationRequirements.map((r) => r.operationId));
+  if (dupeOps.length > 0) {
+    throw new Error(
+      `Runtime-states ABox at ${aboxPath} has duplicate operationRequirements entries for: ${dupeOps.join(', ')}`,
+    );
+  }
+  // `eventual: true` requires a witness — same coupling as the legacy
+  // `RuntimeStateSpec` (#159 PR B). The TBox cannot express this
+  // without `if/then` (Draft-07 supports it, but for consistency with
+  // the other ABoxes we keep the cross-property invariants in the
+  // loader).
+  for (const s of parsed.states) {
+    if (s.eventual === true && s.witness === undefined) {
+      throw new Error(
+        `Runtime-states ABox at ${aboxPath} state '${s.name}' has eventual: true but no witness — eventual states require a witness for the planner's awaitEventually wait`,
+      );
+    }
+  }
+  return parsed;
+}
+
+/**
+ * Derive the two record-shaped views of the runtime-states ABox that
+ * `graph.domain.*` consumers (planner BFS, value-binding emitter,
+ * witness machinery) expect. Returning `null` when no ABox is shipped
+ * lets `loadGraph` fall back to the legacy `domain-semantics.json`
+ * keys.
+ */
+export interface RuntimeStatesViews {
+  runtimeStates: Record<
+    string,
+    {
+      kind: 'state';
+      producedBy?: string[];
+      parameter?: string;
+      parameters?: string[];
+      requires?: string[];
+      eventual?: boolean;
+      witness?: {
+        operationId: string;
+        predicate: { path: string; equals: string | number | boolean };
+        waitUpToMs?: number;
+        pollIntervalMs?: number;
+      };
+    }
+  >;
+  operationRequirements: Record<
+    string,
+    {
+      requires?: string[];
+      disjunctions?: string[][];
+      implicitAdds?: string[];
+      produces?: string[];
+      valueBindings?: Record<string, string>;
+    }
+  >;
+}
+
+export function deriveRuntimeStatesViews(repoRoot: string): RuntimeStatesViews | null {
+  const abox = loadRuntimeStatesAbox(repoRoot);
+  if (abox === null) return null;
+  const runtimeStates: RuntimeStatesViews['runtimeStates'] = {};
+  for (const s of abox.states) {
+    const entry: RuntimeStatesViews['runtimeStates'][string] = { kind: 'state' };
+    if (s.producedBy !== undefined) entry.producedBy = [...s.producedBy];
+    if (s.parameter !== undefined) entry.parameter = s.parameter;
+    if (s.parameters !== undefined) entry.parameters = [...s.parameters];
+    if (s.requires !== undefined) entry.requires = [...s.requires];
+    if (s.eventual !== undefined) entry.eventual = s.eventual;
+    if (s.witness !== undefined) {
+      entry.witness = {
+        operationId: s.witness.operationId,
+        predicate: { path: s.witness.predicate.path, equals: s.witness.predicate.equals },
+      };
+      if (s.witness.waitUpToMs !== undefined) entry.witness.waitUpToMs = s.witness.waitUpToMs;
+      if (s.witness.pollIntervalMs !== undefined)
+        entry.witness.pollIntervalMs = s.witness.pollIntervalMs;
+    }
+    runtimeStates[s.name] = entry;
+  }
+  const operationRequirements: RuntimeStatesViews['operationRequirements'] = {};
+  for (const r of abox.operationRequirements) {
+    const entry: RuntimeStatesViews['operationRequirements'][string] = {};
+    if (r.requires !== undefined) entry.requires = [...r.requires];
+    if (r.disjunctions !== undefined) entry.disjunctions = r.disjunctions.map((d) => [...d]);
+    if (r.implicitAdds !== undefined) entry.implicitAdds = [...r.implicitAdds];
+    if (r.produces !== undefined) entry.produces = [...r.produces];
+    if (r.valueBindings !== undefined) entry.valueBindings = { ...r.valueBindings };
+    operationRequirements[r.operationId] = entry;
+  }
+  return { runtimeStates, operationRequirements };
 }

--- a/path-analyser/src/ontology/runtimeStatesSchema.ts
+++ b/path-analyser/src/ontology/runtimeStatesSchema.ts
@@ -1,0 +1,237 @@
+// Source of truth for the runtime-states ABox TBox (api-test-generator
+// ontology, v1).
+//
+// Mirrors the pattern established by `edgeSchema.ts` (Lift 3 / #208),
+// `entityKindsSchema.ts` (Lift 4 / #210), and `artifactKindsSchema.ts`
+// (Lift 5 / #212): this TypeScript module is the authoritative
+// declaration; the matching
+// `ontology/vocabulary/runtime-states.schema.json` file is generated
+// from it by `scripts/build-ontology.ts` and committed solely so
+// external SPARQL/SHACL/OWL consumers can fetch a plain JSON Schema by
+// URL. A regression invariant in
+// `configs/<config>/regression-invariants.test.ts` asserts the two are
+// in sync.
+//
+// What this ABox encodes (Lift 6 / #214): the catalogue of *runtime
+// states* a deployed API surfaces, plus the per-operation
+// requirements that reference them. The two sub-trees co-locate in
+// one ABox because `operationRequirements` cross-references state
+// names declared in `states` (in `requires`/`implicitAdds`/`produces`
+// and in `valueBindings` RHS). Splitting them would let one drift
+// from the other; co-locating makes the cross-reference a single
+// ABox-level invariant rather than an inter-file one.
+//
+// Like Lift 5, the data was never sourced from upstream OpenAPI
+// annotations — it has always lived in the per-config
+// `domain-semantics.json` sidecar. Consequence: there is no
+// `spec-vs-abox` (sense-1) drift to detect. The ABox supersedes the
+// legacy `domain-semantics.json` keys when present; coverage gates
+// check the durable `abox-vs-graph` (sense-2) invariants only (states
+// reach the graph; ops reference real ops; no dead states).
+//
+// Two entry classes:
+//
+//   - `states`               — per-runtime-state metadata: how the
+//                              state is keyed (`parameter` /
+//                              `parameters`); which ops produce it
+//                              (`producedBy`); which other states are
+//                              prerequisites (`requires`); whether it
+//                              lags asynchronously behind the
+//                              producer's response (`eventual` +
+//                              `witness`, see #159 PR B).
+//
+//   - `operationRequirements` — per-operation requirement metadata:
+//                              required prerequisite states
+//                              (`requires`), disjunctive alternatives
+//                              (`disjunctions`), states implicitly
+//                              produced on success (`implicitAdds`),
+//                              explicit producer overrides
+//                              (`produces`), and request/response
+//                              field bindings to state parameters or
+//                              semantic types (`valueBindings`).
+//
+// JSON-LD (`@context`, `@type`) is accepted and preserved verbatim but
+// not interpreted by the loader — same convention as the other ABoxes.
+
+export const runtimeStatesSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'https://camunda.github.io/api-test-generator/ns/v1/runtime-states.schema.json',
+  title: 'Runtime-states ABox (api-test-generator ontology, v1)',
+  description:
+    'TBox JSON Schema for an ABox file describing the runtime states a deployed API surfaces, plus the per-operation requirements that reference those states. Each entry asserts: a runtime state exists with a known parameter shape and producer set; an operation requires (or produces, or binds values from) a set of states. The schema is intentionally agnostic to which API ships the states — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/runtime-states.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (operationIds existing, state names being internally consistent across `producedBy`, `requires`, `implicitAdds`, `produces`, `valueBindings`, `requires`-chains terminating, no orphan states) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them. Cross-references against `semanticTypes`/`capabilities` (sibling sub-trees in `domain-semantics.json` that this ABox transitively references via `valueBindings` RHS like `semantic:ProcessDefinitionKey` or via `requires`-of-capability entries) are re-validated at load time by re-running `validateDomainSemantics` against the post-overlay `graph.domain` — see `graphLoader.ts`.',
+  type: 'object',
+  additionalProperties: false,
+  required: ['version', 'states', 'operationRequirements'],
+  properties: {
+    $schema: { type: 'string' },
+    '@context': {
+      description:
+        'Optional JSON-LD context. Ignored by the loader; preserved verbatim so external RDF tooling can resolve term IRIs without modification.',
+      type: ['object', 'string', 'array'],
+    },
+    version: {
+      type: 'integer',
+      minimum: 1,
+      description:
+        'Schema version of this ABox file. Bumped only when the TBox shape changes incompatibly.',
+    },
+    states: {
+      type: 'array',
+      minItems: 1,
+      items: { $ref: '#/definitions/RuntimeState' },
+    },
+    operationRequirements: {
+      type: 'array',
+      items: { $ref: '#/definitions/OperationRequirement' },
+    },
+  },
+  definitions: {
+    RuntimeState: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['name'],
+      properties: {
+        '@type': {
+          description: 'Optional JSON-LD type IRI. Ignored by the loader.',
+          type: 'string',
+        },
+        name: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'PascalCase name of the runtime state (e.g. `ProcessDefinitionDeployed`). Must be unique across `states` (checked by the loader).',
+        },
+        parameter: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Single-parameter name that keys this state (e.g. `processDefinitionId`). Mutually exclusive with `parameters` — exactly one of `parameter` or `parameters` should be present (the loader does not enforce the XOR; presence is documentary).',
+        },
+        parameters: {
+          type: 'array',
+          minItems: 1,
+          items: { type: 'string', minLength: 1 },
+          description:
+            'Multi-parameter list that jointly keys this state (e.g. `["jobType", "processDefinitionId"]`). Mutually exclusive with `parameter`.',
+        },
+        producedBy: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description:
+            'OpenAPI operationIds whose successful invocation establishes this state. Each entry must reference an op present in the bundled graph — checked as an L3 abox-vs-graph invariant.',
+        },
+        requires: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description:
+            'Prerequisite states that must hold before this state can be produced. Each entry must reference another state in `states` or a capability declared in `domain-semantics.json` (capabilities migrate in Lift 7).',
+        },
+        eventual: {
+          type: 'boolean',
+          description:
+            'When true, the state is not immediately observable on the producer response — the planner inserts an `awaitEventually(witness)` wait before any consumer step (#159 PR B). Requires `witness`.',
+        },
+        witness: {
+          $ref: '#/definitions/WitnessSpec',
+          description:
+            'Witness used by `awaitEventually` when `eventual === true`. The witness invokes a read-shape operation and polls until the predicate holds against the response body.',
+        },
+      },
+    },
+    WitnessSpec: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['operationId', 'predicate'],
+      properties: {
+        operationId: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Operation invoked to observe the state. Must reference a real operationId in the graph (PR B constrains this to GET-shape ops).',
+        },
+        predicate: { $ref: '#/definitions/WitnessPredicate' },
+        waitUpToMs: {
+          type: 'integer',
+          minimum: 1,
+          description:
+            'Optional total wait budget in ms; defaults to the awaitEventually helper built-in.',
+        },
+        pollIntervalMs: {
+          type: 'integer',
+          minimum: 1,
+          description:
+            'Optional poll interval in ms; defaults to the awaitEventually helper built-in.',
+        },
+      },
+    },
+    WitnessPredicate: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['path', 'equals'],
+      properties: {
+        path: {
+          type: 'string',
+          pattern: '^[A-Za-z_$][A-Za-z0-9_$]*$',
+          description:
+            'Top-level field on the response body. Constrained so the emitter can render it as a safe bracket-access key without an escape pass.',
+        },
+        equals: {
+          description:
+            'Expected scalar compared with strict equality. The emitter JSON-stringifies it directly, so it is constrained to JSON primitives.',
+          type: ['string', 'number', 'boolean'],
+        },
+      },
+    },
+    OperationRequirement: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['operationId'],
+      properties: {
+        '@type': {
+          description: 'Optional JSON-LD type IRI. Ignored by the loader.',
+          type: 'string',
+        },
+        operationId: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'OpenAPI operationId. Must reference a real op in the bundled graph — checked as an L3 abox-vs-graph invariant.',
+        },
+        requires: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description:
+            'States that must hold before invoking this op. Each entry must reference a state in `states` or a capability in `domain-semantics.json` (capabilities migrate in Lift 7).',
+        },
+        disjunctions: {
+          type: 'array',
+          items: {
+            type: 'array',
+            minItems: 1,
+            items: { type: 'string', minLength: 1 },
+          },
+          description:
+            'Sets of alternative prerequisites — at least one entry from each disjunction must hold. Each entry resolves the same way as `requires`.',
+        },
+        implicitAdds: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description:
+            'States produced implicitly on success (in addition to whatever the upstream API documents). Each entry must reference a state in `states`.',
+        },
+        produces: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description:
+            "Explicit producer override (rare — used when a state is produced by an op that does not appear in the state's `producedBy`). Each entry must reference a state in `states`.",
+        },
+        valueBindings: {
+          type: 'object',
+          additionalProperties: { type: 'string', minLength: 1 },
+          description:
+            'Map from request/response field path (e.g. `request.processDefinitionId`, `response.processInstanceKey`) to either `<StateName>.<parameter>` (resolves at emission to the value bound for that parameter when the state was produced) or `semantic:<SemanticTypeName>` (resolves to the semantic-type producer chain — semanticTypes migrate in Lift 7).',
+        },
+      },
+    },
+  },
+} as const;

--- a/scripts/build-ontology.ts
+++ b/scripts/build-ontology.ts
@@ -18,6 +18,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { artifactKindsSchema } from '../path-analyser/src/ontology/artifactKindsSchema.ts';
 import { edgeSchema } from '../path-analyser/src/ontology/edgeSchema.ts';
 import { entityKindsSchema } from '../path-analyser/src/ontology/entityKindsSchema.ts';
+import { runtimeStatesSchema } from '../path-analyser/src/ontology/runtimeStatesSchema.ts';
 // Namespace import: the schema source lives in the CommonJS-flavoured
 // `semantic-graph-extractor` workspace (`type: commonjs` in its
 // package.json). Node's CJS-to-ESM interop exposes the actual
@@ -68,6 +69,10 @@ const ARTIFACTS: OntologyArtifact[] = [
   {
     jsonPath: join(REPO_ROOT, 'ontology', 'vocabulary', 'artifact-kinds.schema.json'),
     schema: artifactKindsSchema,
+  },
+  {
+    jsonPath: join(REPO_ROOT, 'ontology', 'vocabulary', 'runtime-states.schema.json'),
+    schema: runtimeStatesSchema,
   },
   {
     jsonPath: join(REPO_ROOT, 'ontology', 'vocabulary', 'bootstrap-sequence.schema.json'),

--- a/tests/fixtures/integration/artifact-kinds-abox-authoritative.test.ts
+++ b/tests/fixtures/integration/artifact-kinds-abox-authoritative.test.ts
@@ -396,7 +396,7 @@ describe('Lift 5 (#212): artifact-kinds ABox is authoritative for graph.domain a
     warn.mockRestore();
   });
 
-  it('hard-errors when the ABox introduces a `producesStates` value not declared in domain-semantics.json runtimeStates / capabilities (post-overlay re-validation)', async () => {
+  it('hard-errors when the ABox introduces a `producesStates` value not declared in domain-semantics.json runtimeStates / capabilities (pre-overlay validation sees the merged authoritative view)', async () => {
     writeWorkspace({
       domainSemantics: {
         version: 1,
@@ -428,9 +428,7 @@ describe('Lift 5 (#212): artifact-kinds ABox is authoritative for graph.domain a
       },
       graphOps: deployOp(),
     });
-    await expect(loadGraph(baseDir)).rejects.toThrow(
-      /artifact-kinds ABox introduced cross-reference violation/,
-    );
+    await expect(loadGraph(baseDir)).rejects.toThrow(/artifactKindStateDeclared.*UndeclaredState/);
   });
 
   it('hard-errors when an ABox rule-level `producesStates` override references a state not declared in runtimeStates / capabilities (post-overlay re-validation, rule-level)', async () => {

--- a/tests/fixtures/integration/runtime-states-abox-authoritative.test.ts
+++ b/tests/fixtures/integration/runtime-states-abox-authoritative.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Integration fixture for Lift 6 (#214): the runtime-states ABox is
+ * the authoritative source for `graph.domain.runtimeStates` and
+ * `graph.domain.operationRequirements` at runtime, AND the values it
+ * declares are seen by the producersByState-building loop and the
+ * `node.domainRequiresAll` / `domainImplicitAdds` / `domainProduces`
+ * setters inside loadGraph (because the overlay happens inside the
+ * try block, not in the post-try block where artifact-kinds lives).
+ *
+ * Mirrors `artifact-kinds-abox-authoritative.test.ts` (Lift 5 / #212).
+ *
+ * Six observable behaviours guarded here:
+ *
+ *   1. **ABox authoritative — promotes**: `domain-semantics.json`
+ *      declares one set of runtimeStates; the ABox declares a
+ *      different set. After loadGraph, `graph.domain.runtimeStates`
+ *      reflects the ABox AND `producersByState` is built from the
+ *      ABox values.
+ *
+ *   2. **Strict mode**: with `STRICT_RUNTIME_STATES_ABOX=1`, an
+ *      abox-vs-graph drift (producedBy referencing a nonexistent
+ *      opId) is a hard error.
+ *
+ *   3. **Legacy fallback**: with no ABox shipped, the legacy
+ *      `domain-semantics.json` keys remain authoritative.
+ *
+ *   4. **Sense-2 drift warnings**: dead-state / dangling-opId
+ *      references are flagged.
+ *
+ *   5. **Post-overlay re-validation**: an ABox that introduces an
+ *      `operationRequirements.disjunctions` member referencing an
+ *      undeclared state is rejected, even when the legacy sidecar
+ *      didn't have that member at all.
+ *
+ *   6. **ABox supersedes stale legacy**: a legacy sidecar that
+ *      contains a `runtimeStates` entry referencing a state that
+ *      _itself_ no longer exists in the ABox does NOT fail load —
+ *      because pre-overlay validation overlays the ABox values.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadGraph } from '../../../path-analyser/src/graphLoader.ts';
+
+const CONFIG_NAME = 'lift6-runtime-states-test';
+
+let workdir: string;
+let baseDir: string;
+const ORIGINAL = {
+  CONFIG: process.env.CONFIG,
+  OPERATION_GRAPH_PATH: process.env.OPERATION_GRAPH_PATH,
+  OPENAPI_SPEC_PATH: process.env.OPENAPI_SPEC_PATH,
+  STRICT_RUNTIME_STATES_ABOX: process.env.STRICT_RUNTIME_STATES_ABOX,
+};
+
+function writeWorkspace(opts: {
+  runtimeStatesAbox: object | null;
+  domainSemantics?: object;
+  graphOps: Record<string, unknown>;
+}): void {
+  const repoRoot = workdir;
+  baseDir = join(repoRoot, 'path-analyser');
+  mkdirSync(baseDir, { recursive: true });
+  writeFileSync(
+    join(repoRoot, 'configs.json'),
+    JSON.stringify({ default: CONFIG_NAME, configs: { [CONFIG_NAME]: {} } }),
+  );
+  const configDir = join(repoRoot, 'configs', CONFIG_NAME);
+  mkdirSync(configDir, { recursive: true });
+  if (opts.domainSemantics !== undefined) {
+    writeFileSync(join(configDir, 'domain-semantics.json'), JSON.stringify(opts.domainSemantics));
+  }
+  if (opts.runtimeStatesAbox !== null) {
+    const aboxDir = join(configDir, 'ontology');
+    mkdirSync(aboxDir, { recursive: true });
+    writeFileSync(join(aboxDir, 'runtime-states.json'), JSON.stringify(opts.runtimeStatesAbox));
+  }
+  const graphPath = join(baseDir, 'operation-dependency-graph.json');
+  writeFileSync(graphPath, JSON.stringify({ operations: opts.graphOps }));
+  process.env.OPERATION_GRAPH_PATH = graphPath;
+  process.env.CONFIG = CONFIG_NAME;
+  process.env.OPENAPI_SPEC_PATH = join(baseDir, 'no-such-spec.yaml');
+}
+
+function ops(): Record<string, unknown> {
+  return {
+    createDeployment: {
+      operationId: 'createDeployment',
+      method: 'POST',
+      path: '/deployments',
+      requires: { required: [], optional: [] },
+      produces: [],
+    },
+    createProcessInstance: {
+      operationId: 'createProcessInstance',
+      method: 'POST',
+      path: '/process-instances',
+      requires: { required: [], optional: [] },
+      produces: [],
+    },
+  };
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'lift6-runtime-states-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+  for (const [k, v] of Object.entries(ORIGINAL)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe('Lift 6 (#214): runtime-states ABox is authoritative for graph.domain runtime sub-trees', () => {
+  it('overrides domain-semantics.json runtimeStates+operationRequirements with ABox values (promote) AND propagates to producersByState', async () => {
+    writeWorkspace({
+      domainSemantics: {
+        version: 1,
+        // Legacy declares one state. ABox declares a different one.
+        runtimeStates: {
+          LegacyOnlyState: { kind: 'state', producedBy: ['createDeployment'] },
+        },
+        operationRequirements: {
+          createProcessInstance: { requires: ['LegacyOnlyState'] },
+        },
+      },
+      runtimeStatesAbox: {
+        version: 1,
+        states: [{ name: 'AboxState', producedBy: ['createDeployment'] }],
+        operationRequirements: [{ operationId: 'createProcessInstance', requires: ['AboxState'] }],
+      },
+      graphOps: ops(),
+    });
+    const graph = await loadGraph(baseDir);
+    // graph.domain reflects the ABox.
+    expect(Object.keys(graph.domain?.runtimeStates ?? {})).toEqual(['AboxState']);
+    expect(graph.domain?.operationRequirements?.createProcessInstance?.requires).toEqual([
+      'AboxState',
+    ]);
+    // producersByState is built INSIDE the try block from the overlaid value.
+    expect(graph.producersByState?.AboxState).toEqual(['createDeployment']);
+    expect(graph.producersByState?.LegacyOnlyState).toBeUndefined();
+    // node.domainRequiresAll picks up the ABox-overlaid operationRequirements.
+    expect(graph.operations.createProcessInstance?.domainRequiresAll).toEqual(['AboxState']);
+  });
+
+  it('hard-errors on abox-vs-graph drift when STRICT_RUNTIME_STATES_ABOX=1', async () => {
+    process.env.STRICT_RUNTIME_STATES_ABOX = '1';
+    writeWorkspace({
+      domainSemantics: { version: 1 },
+      runtimeStatesAbox: {
+        version: 1,
+        states: [
+          // producedBy references an opId that doesn't exist in the graph.
+          { name: 'AboxState', producedBy: ['nonexistentOp'] },
+        ],
+        operationRequirements: [{ operationId: 'createProcessInstance', requires: ['AboxState'] }],
+      },
+      graphOps: ops(),
+    });
+    await expect(loadGraph(baseDir)).rejects.toThrow(/runtime-states ABox drift detected/);
+  });
+
+  it('preserves legacy domain-semantics.json runtime sub-trees when no ABox is shipped', async () => {
+    writeWorkspace({
+      runtimeStatesAbox: null,
+      domainSemantics: {
+        version: 1,
+        runtimeStates: { LegacyState: { kind: 'state', producedBy: ['createDeployment'] } },
+        operationRequirements: {
+          createProcessInstance: { requires: ['LegacyState'] },
+        },
+      },
+      graphOps: ops(),
+    });
+    const graph = await loadGraph(baseDir);
+    expect(graph.domain?.runtimeStates?.LegacyState).toBeDefined();
+    expect(graph.producersByState?.LegacyState).toEqual(['createDeployment']);
+  });
+
+  it('warns on dangling opIds (sense-2 abox-vs-graph)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writeWorkspace({
+      domainSemantics: { version: 1 },
+      runtimeStatesAbox: {
+        version: 1,
+        states: [{ name: 'UsedState', producedBy: ['createDeployment'] }],
+        operationRequirements: [
+          { operationId: 'createProcessInstance', requires: ['UsedState'] },
+          // Dangling opId
+          { operationId: 'nonexistentOp', requires: ['UsedState'] },
+        ],
+      },
+      graphOps: ops(),
+    });
+    await loadGraph(baseDir);
+    const messages = warn.mock.calls.map((c) => String(c[0]));
+    const joined = messages.join('\n');
+    expect(joined).toMatch(/runtime-states ABox drift detected/);
+    expect(joined).toMatch(/operationRequirements entry 'nonexistentOp'/);
+    warn.mockRestore();
+  });
+
+  it('post-overlay validation rejects an ABox that introduces a disjunctions member referencing an undeclared state (the validator sees the merged authoritative view)', async () => {
+    writeWorkspace({
+      domainSemantics: {
+        version: 1,
+      },
+      runtimeStatesAbox: {
+        version: 1,
+        states: [{ name: 'DeclaredState', producedBy: ['createDeployment'] }],
+        operationRequirements: [
+          {
+            operationId: 'createProcessInstance',
+            // 'UndeclaredState' is not in states[] and not in capabilities.
+            disjunctions: [['DeclaredState', 'UndeclaredState']],
+          },
+        ],
+      },
+      graphOps: ops(),
+    });
+    await expect(loadGraph(baseDir)).rejects.toThrow(/disjunctionMemberResolves.*UndeclaredState/);
+  });
+
+  it('ABox supersedes a legacy sidecar that itself references a now-removed state (no spurious load failure)', async () => {
+    writeWorkspace({
+      domainSemantics: {
+        version: 1,
+        // Legacy declares an operationRequirements entry that references
+        // a state the legacy sidecar's runtimeStates no longer declares.
+        // Without the pre-overlay overlay, validateDomainSemantics would
+        // fail on this stale entry. With the overlay, the ABox values
+        // are validated instead.
+        runtimeStates: {
+          StaleStateName: { kind: 'state', producedBy: ['createDeployment'] },
+        },
+        operationRequirements: {
+          createProcessInstance: { disjunctions: [['StaleStateName', 'GoneState']] },
+        },
+      },
+      runtimeStatesAbox: {
+        version: 1,
+        states: [{ name: 'AboxState', producedBy: ['createDeployment'] }],
+        operationRequirements: [{ operationId: 'createProcessInstance', requires: ['AboxState'] }],
+      },
+      graphOps: ops(),
+    });
+    const graph = await loadGraph(baseDir);
+    expect(Object.keys(graph.domain?.runtimeStates ?? {})).toEqual(['AboxState']);
+    expect(graph.operations.createProcessInstance?.domainRequiresAll).toEqual(['AboxState']);
+  });
+});

--- a/tests/fixtures/integration/runtime-states-abox-authoritative.test.ts
+++ b/tests/fixtures/integration/runtime-states-abox-authoritative.test.ts
@@ -115,6 +115,36 @@ afterEach(() => {
 });
 
 describe('Lift 6 (#214): runtime-states ABox is authoritative for graph.domain runtime sub-trees', () => {
+  it('populates graph.domain runtime sub-trees AND producersByState from the ABox even when no domain-semantics.json is shipped (Lift 8-style ABox-authoritative)', async () => {
+    writeWorkspace({
+      // No domain-semantics.json sidecar at all.
+      runtimeStatesAbox: {
+        version: 1,
+        states: [{ name: 'AboxOnlyState', producedBy: ['createDeployment'] }],
+        operationRequirements: [
+          {
+            operationId: 'createProcessInstance',
+            requires: ['AboxOnlyState'],
+            produces: ['DerivedState'],
+          },
+        ],
+      },
+      graphOps: ops(),
+    });
+    const graph = await loadGraph(baseDir);
+    // graph.domain populated from the ABox.
+    expect(Object.keys(graph.domain?.runtimeStates ?? {})).toEqual(['AboxOnlyState']);
+    expect(graph.domain?.operationRequirements?.createProcessInstance?.requires).toEqual([
+      'AboxOnlyState',
+    ]);
+    // producersByState built from the ABox (the consumer-loop fix).
+    expect(graph.producersByState?.AboxOnlyState).toEqual(['createDeployment']);
+    expect(graph.producersByState?.DerivedState).toEqual(['createProcessInstance']);
+    // node.domain* setters fired from the ABox.
+    expect(graph.operations.createProcessInstance?.domainRequiresAll).toEqual(['AboxOnlyState']);
+    expect(graph.operations.createProcessInstance?.domainProduces).toContain('DerivedState');
+  });
+
   it('overrides domain-semantics.json runtimeStates+operationRequirements with ABox values (promote) AND propagates to producersByState', async () => {
     writeWorkspace({
       domainSemantics: {

--- a/tests/fixtures/loader/runtime-states-abox-loader.test.ts
+++ b/tests/fixtures/loader/runtime-states-abox-loader.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Unit tests for the runtime-states ABox loader (Lift 6 / #214).
+ *
+ * Mirrors the structure of `artifact-kinds-abox-loader.test.ts` (Lift 5 /
+ * #212). Documented loader contract has the same observable branches:
+ *   1. Missing ABox file → returns `null`.
+ *   2. configs.json missing → returns `null` (test-isolation fallback).
+ *   3. Invalid JSON → throws with a "Failed to parse" diagnostic.
+ *   4. Schema-invalid content → throws with a "failed TBox validation" diagnostic.
+ *   5. Duplicate state name / operationRequirement opId → throws.
+ *   6. `eventual: true` without a witness → throws (cross-property invariant).
+ *   7. Happy path → returns the parsed ABox.
+ *
+ * Plus the `deriveRuntimeStatesViews` accessor returns record-shaped
+ * views that match what `graph.domain.{runtimeStates,operationRequirements}`
+ * consumers expect — including rehydrating the `kind: 'state'` tag that
+ * the ABox drops.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  deriveRuntimeStatesViews,
+  loadRuntimeStatesAbox,
+} from '../../../path-analyser/src/ontology/loader.ts';
+
+let workdir: string;
+const CONFIG_NAME = 'unit-test-config';
+const ORIGINAL_CONFIG = process.env.CONFIG;
+
+function configsJson(): string {
+  return JSON.stringify({ default: CONFIG_NAME, configs: { [CONFIG_NAME]: {} } });
+}
+
+function writeAbox(contents: string): void {
+  const dir = join(workdir, 'configs', CONFIG_NAME, 'ontology');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'runtime-states.json'), contents);
+}
+
+function minimalState(name = 'ProcessDefinitionDeployed') {
+  return {
+    name,
+    producedBy: ['createDeployment'],
+    parameter: 'processDefinitionId',
+  };
+}
+
+function minimalAbox(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    version: 1,
+    states: [minimalState()],
+    operationRequirements: [
+      {
+        operationId: 'createProcessInstance',
+        requires: ['ProcessDefinitionDeployed'],
+      },
+    ],
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'runtime-states-abox-loader-'));
+  mkdirSync(workdir, { recursive: true });
+  writeFileSync(join(workdir, 'configs.json'), configsJson());
+  process.env.CONFIG = CONFIG_NAME;
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+  if (ORIGINAL_CONFIG === undefined) {
+    delete process.env.CONFIG;
+  } else {
+    process.env.CONFIG = ORIGINAL_CONFIG;
+  }
+});
+
+describe('loadRuntimeStatesAbox: documented branches', () => {
+  it('returns null when the ABox file does not exist (configs are not required to ship one)', () => {
+    expect(loadRuntimeStatesAbox(workdir)).toBeNull();
+  });
+
+  it('returns null when configs.json itself is missing (test-isolation fallback)', () => {
+    rmSync(join(workdir, 'configs.json'));
+    expect(loadRuntimeStatesAbox(workdir)).toBeNull();
+  });
+
+  it('throws with a "Failed to parse" diagnostic on invalid JSON', () => {
+    writeAbox('{ not json');
+    expect(() => loadRuntimeStatesAbox(workdir)).toThrow(/Failed to parse runtime-states ABox/);
+  });
+
+  it('throws with a "failed TBox validation" diagnostic on schema-invalid content', () => {
+    // missing required `operationRequirements`
+    writeAbox(JSON.stringify({ version: 1, states: [minimalState()] }));
+    expect(() => loadRuntimeStatesAbox(workdir)).toThrow(/failed TBox validation/);
+  });
+
+  it('throws on duplicate state names', () => {
+    writeAbox(
+      minimalAbox({
+        states: [minimalState('Foo'), minimalState('Foo')],
+      }),
+    );
+    expect(() => loadRuntimeStatesAbox(workdir)).toThrow(/duplicate state name\(s\): Foo/);
+  });
+
+  it('throws on duplicate operationRequirements entries', () => {
+    writeAbox(
+      minimalAbox({
+        operationRequirements: [
+          { operationId: 'op1', requires: ['Foo'] },
+          { operationId: 'op1', requires: ['Bar'] },
+        ],
+      }),
+    );
+    expect(() => loadRuntimeStatesAbox(workdir)).toThrow(
+      /duplicate operationRequirements entries for: op1/,
+    );
+  });
+
+  it('throws when `eventual: true` is set without a witness (planner contract)', () => {
+    writeAbox(
+      minimalAbox({
+        states: [{ name: 'JobAvailableForActivation', eventual: true }],
+      }),
+    );
+    expect(() => loadRuntimeStatesAbox(workdir)).toThrow(
+      /JobAvailableForActivation.*eventual: true but no witness/,
+    );
+  });
+
+  it('returns the parsed ABox on the happy path', () => {
+    writeAbox(minimalAbox());
+    const abox = loadRuntimeStatesAbox(workdir);
+    expect(abox).not.toBeNull();
+    expect(abox?.states).toHaveLength(1);
+    expect(abox?.states[0]?.name).toBe('ProcessDefinitionDeployed');
+    expect(abox?.operationRequirements[0]?.operationId).toBe('createProcessInstance');
+  });
+});
+
+describe('deriveRuntimeStatesViews: record-shaped views', () => {
+  it('returns null when no ABox is shipped (caller falls back to domain-semantics.json)', () => {
+    expect(deriveRuntimeStatesViews(workdir)).toBeNull();
+  });
+
+  it("rehydrates the `kind: 'state'` tag the ABox drops", () => {
+    writeAbox(minimalAbox());
+    const views = deriveRuntimeStatesViews(workdir);
+    expect(views?.runtimeStates.ProcessDefinitionDeployed?.kind).toBe('state');
+  });
+
+  it('reshapes states[] and operationRequirements[] into Record<name, …> form', () => {
+    writeAbox(
+      minimalAbox({
+        states: [
+          minimalState('ProcessDefinitionDeployed'),
+          {
+            name: 'JobAvailableForActivation',
+            eventual: true,
+            requires: ['ProcessInstanceExists'],
+            witness: {
+              operationId: 'searchJobs',
+              predicate: { path: 'state', equals: 'CREATED' },
+              waitUpToMs: 5000,
+              pollIntervalMs: 100,
+            },
+          },
+        ],
+        operationRequirements: [
+          {
+            operationId: 'createProcessInstance',
+            requires: ['ProcessDefinitionDeployed'],
+            valueBindings: { processDefinitionKey: 'semantic:ProcessDefinitionKey' },
+          },
+          {
+            operationId: 'activateJobs',
+            disjunctions: [['JobAvailableForActivation', 'ProcessInstanceExists']],
+            implicitAdds: ['JobsActivated'],
+          },
+        ],
+      }),
+    );
+    const views = deriveRuntimeStatesViews(workdir);
+    if (!views) throw new Error('expected derived views');
+    expect(Object.keys(views.runtimeStates).sort()).toEqual([
+      'JobAvailableForActivation',
+      'ProcessDefinitionDeployed',
+    ]);
+    expect(views.runtimeStates.JobAvailableForActivation?.eventual).toBe(true);
+    expect(views.runtimeStates.JobAvailableForActivation?.witness?.operationId).toBe('searchJobs');
+    expect(views.runtimeStates.JobAvailableForActivation?.witness?.waitUpToMs).toBe(5000);
+    expect(views.operationRequirements.createProcessInstance?.valueBindings).toEqual({
+      processDefinitionKey: 'semantic:ProcessDefinitionKey',
+    });
+    expect(views.operationRequirements.activateJobs?.disjunctions).toEqual([
+      ['JobAvailableForActivation', 'ProcessInstanceExists'],
+    ]);
+    expect(views.operationRequirements.activateJobs?.implicitAdds).toEqual(['JobsActivated']);
+  });
+
+  it('deep-clones array/object fields so callers cannot mutate the cached parse', () => {
+    writeAbox(
+      minimalAbox({
+        states: [{ ...minimalState('S'), producedBy: ['op1'], requires: ['cap1'] }],
+        operationRequirements: [
+          {
+            operationId: 'op1',
+            requires: ['S'],
+            valueBindings: { x: 'S.y' },
+            disjunctions: [['a', 'b']],
+          },
+        ],
+      }),
+    );
+    const v1 = deriveRuntimeStatesViews(workdir);
+    if (!v1) throw new Error('expected views');
+    v1.runtimeStates.S?.producedBy?.push('mutated');
+    if (v1.operationRequirements.op1?.valueBindings) {
+      v1.operationRequirements.op1.valueBindings.x = 'mutated';
+    }
+    v1.operationRequirements.op1?.disjunctions?.[0]?.push('mutated');
+    const v2 = deriveRuntimeStatesViews(workdir);
+    expect(v2?.runtimeStates.S?.producedBy).toEqual(['op1']);
+    expect(v2?.operationRequirements.op1?.valueBindings).toEqual({ x: 'S.y' });
+    expect(v2?.operationRequirements.op1?.disjunctions).toEqual([['a', 'b']]);
+  });
+
+  it("propagates the loader's validation failure (does not silently swallow malformed ABox)", () => {
+    writeAbox('{ not json');
+    expect(() => deriveRuntimeStatesViews(workdir)).toThrow(/Failed to parse runtime-states ABox/);
+  });
+});


### PR DESCRIPTION
Closes #214. Lift 6 of the ontology migration (#199).

Migrates `runtimeStates` (7) + `operationRequirements` (8) from `configs/camunda-oca/domain-semantics.json` into a new per-config ABox at `configs/camunda-oca/ontology/runtime-states.json`, following the Lift 5 (#212/#213) pattern.

## Highlights

- **TS-const TBox** at `path-analyser/src/ontology/runtimeStatesSchema.ts` — same single-source-of-truth pattern as Lifts 3/4/5; generated public JSON Schema at `ontology/vocabulary/runtime-states.schema.json`.
- **Loader + record-shaped views** with duplicate-state / duplicate-opId / eventual-without-witness cross-property checks, deep-cloning nested arrays/objects so callers cannot mutate the cached parse.
- **`graphLoader.ts` overlay placement** — the ABox is overlaid INSIDE the try block right after `domain = parsedDomain`, so the existing consumer loops that build `producersByState` and set `node.domainRequiresAll` / `domainImplicitAdds` / `domainProduces` see the overlaid values without further plumbing. (Crucially different from Lift 5, which overlaid downstream of the try because artifact-kinds is consumed downstream.)
- **Pre-overlay validation: overlay, not strip.** When an ABox is present, OVERLAY (not strip) the ABox values into the validation target so unmigrated cross-refs (`semanticTypes.witnesses` → `runtimeStates`, `capabilities` → `runtimeStates`) still resolve. The Lift 5 strip-then-revalidate approach broke these unmigrated couplings; this PR generalises both lifts to a single overlay-then-validate pass.
- **`detectRuntimeStatesDrift`** (sense-2 abox-vs-graph) — flags dangling opIds in `producedBy` / `witness.operationId` / `operationRequirements.operationId`. Hard-errors under `STRICT_RUNTIME_STATES_ABOX=1`. Dead-state check deferred to Lift 7 (so `semanticTypes.witnesses` references are visible) and covered by the L3 invariant instead.

## Test surface
- 13 loader unit tests (`tests/fixtures/loader/runtime-states-abox-loader.test.ts`)
- 6 integration tests (`tests/fixtures/integration/runtime-states-abox-authoritative.test.ts`) — promote, strict-mode, legacy fallback, dangling-opId warning, post-overlay validation, ABox-supersedes-stale-legacy.
- 7 L3 invariants in `configs/camunda-oca/regression-invariants.test.ts`.

## Verification
- All 4 tsc projects clean, biome clean.
- `npm test` → 520 passed / 6 skipped.
- Generator output byte-identical against pre-Lift-6 baseline (`/tmp/baseline-graph-pre-lift6.json`).