### PR TITLE
feat: lift semanticTypes + capabilities + identifiers to per-config ABox (#216)

### DIFF
--- a/configs/camunda-oca/ontology/semantics.json
+++ b/configs/camunda-oca/ontology/semantics.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://camunda.github.io/api-test-generator/ns/v1/semantics.schema.json",
+  "@context": "https://camunda.github.io/api-test-generator/ns/v1/context.jsonld",
+  "version": 1,
+  "semanticTypes": [
+    {
+      "name": "ProcessDefinitionKey",
+      "witnesses": "ProcessDefinitionDeployed"
+    },
+    {
+      "name": "ProcessInstanceKey",
+      "witnesses": "ProcessInstanceExists"
+    },
+    {
+      "name": "DecisionDefinitionKey",
+      "witnesses": "DecisionDefinitionDeployed"
+    },
+    {
+      "name": "DecisionRequirementsKey",
+      "witnesses": "DecisionRequirementsDeployed"
+    },
+    {
+      "name": "FormKey",
+      "witnesses": "FormDeployed"
+    },
+    {
+      "name": "JobKey",
+      "witnesses": "JobAvailableForActivation"
+    },
+    {
+      "name": "ElementId",
+      "kind": "modelDerived",
+      "$comment": "Element IDs are defined inside the deployed BPMN model. The planner reads them out-of-band from the chosen fixture's providesValues at plan time \u2014 no Camunda API round-trip required. See #162 PR 1."
+    },
+    {
+      "name": "JobType",
+      "kind": "modelDerived",
+      "$comment": "zeebe:taskDefinition type is encoded in the BPMN model on each service-task element. Read out-of-band from the chosen fixture's providesValues. Subsumes the pre-#162 ad-hoc `parameters.jobType` handling in the registry."
+    },
+    {
+      "name": "Tag",
+      "kind": "attribute",
+      "clientMinted": true,
+      "$comment": "Free-form label attached to an entity (createProcessInstance.tags[], searchProcessInstances.filter.tags[], etc.). No producer endpoint and no first-order entity retrievable by tag \u2014 the planner mints a deterministic value at setter sites (createProcessInstance.tags[]). Filter-consumer reuse \u2014 threading the same minted value into searchProcessInstances.filter.tags[] and similar \u2014 is deferred (see #168). See #162 PR 2."
+    },
+    {
+      "name": "BusinessId",
+      "kind": "attribute",
+      "clientMinted": true,
+      "$comment": "Free-form correlation identifier attached to a process instance (createProcessInstance.businessId, searchProcessInstances.filter.businessId, etc.). Like Tag: client-minted, no producer endpoint, no first-order entity retrievable by it. The planner mints a deterministic value at the setter site; filter-consumer reuse is deferred (see #168)."
+    },
+    {
+      "name": "AgentInstanceKey",
+      "kind": "serverEmergent",
+      "$comment": "Server-minted lifecycle key for AI agent instances. No client API directly creates an AgentInstance with a returned key \u2014 instances emerge from agent runtime activity and are discoverable only via search/get. Used as a search-filter input; the planner mints a deterministic placeholder so the request validates and an empty result set is acceptable. See #162 PR 5."
+    },
+    {
+      "name": "AuditLogKey",
+      "kind": "serverEmergent",
+      "$comment": "Server-minted lifecycle key for audit-log entries. Audit logs are produced as a side-effect of audited writes \u2014 no direct create API. Search-filter input only; planner mints a deterministic placeholder. See #162 PR 5."
+    },
+    {
+      "name": "AuditLogEntityKey",
+      "kind": "serverEmergent",
+      "$comment": "Server-minted reference to the entity an audit-log entry was emitted for. Same lifecycle as AuditLogKey \u2014 emerges from audited writes, never directly minted via a client API. See #162 PR 5."
+    },
+    {
+      "name": "DeploymentKey",
+      "kind": "serverEmergent",
+      "$comment": "Temporary classification pending upstream spec fix camunda/camunda#52926. createDeployment returns deploymentKey in its 200 response but the response field is currently flagged provider:false in the bundled spec, so the planner cannot bind it as a producerBound semantic. Once upstream marks deploymentKey as provider:true, this entry should be removed and DeploymentKey will classify as producerBound automatically. See #162 PR 5."
+    },
+    {
+      "name": "MessageSubscriptionKey",
+      "kind": "serverEmergent",
+      "$comment": "Server-minted lifecycle key for a message subscription. Subscriptions emerge when a deployed process reaches a message catch event \u2014 no direct create API. Search-filter input only; planner mints a deterministic placeholder. See #162 PR 5."
+    },
+    {
+      "name": "IncidentKey",
+      "kind": "serverEmergent",
+      "$comment": "Server-minted lifecycle key for an incident. Incidents emerge from runtime failures during process execution \u2014 no direct create API. Search-filter input only; planner mints a deterministic placeholder. See #162 PR 5."
+    },
+    {
+      "name": "UserTaskKey",
+      "kind": "serverEmergent",
+      "$comment": "Server-minted lifecycle key for a user task instance. User tasks emerge when a deployed process reaches a user-task element \u2014 no direct create API. Search-filter input only; planner mints a deterministic placeholder. See #162 PR 5."
+    },
+    {
+      "name": "VariableKey",
+      "kind": "serverEmergent",
+      "$comment": "Server-minted key for a variable row. Variables are managed by process execution and via setVariables, but no client API mints a variable atomically with a returned key. Search-filter input only; planner mints a deterministic placeholder. See #162 PR 5."
+    },
+    {
+      "name": "ScopeKey",
+      "kind": "serverEmergent",
+      "$comment": "Server-minted key identifying the scope (process instance / element instance) a variable lives in. Same lifecycle as VariableKey \u2014 managed by process execution, never directly minted via a client API. Search-filter input only. See #162 PR 5."
+    }
+  ],
+  "capabilities": [
+    {
+      "name": "ModelHasServiceTaskType",
+      "parameter": "jobType",
+      "producedBy": [
+        "createDeployment"
+      ],
+      "dependsOn": [
+        "ProcessDefinitionDeployed"
+      ]
+    }
+  ],
+  "identifiers": [
+    {
+      "name": "ProcessDefinitionId",
+      "validityState": "ProcessDefinitionDeployed",
+      "boundBy": [
+        "createDeployment"
+      ],
+      "fieldPaths": [
+        "deployments[].processDefinition.processDefinitionId"
+      ]
+    },
+    {
+      "name": "JobTypeValue",
+      "boundBy": [
+        "createDeployment"
+      ],
+      "derivedVia": "ModelHasServiceTaskType"
+    }
+  ]
+}

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -4828,13 +4828,29 @@ describeForThisConfig(
         }
       }
       for (const s of abox.states) for (const x of s.requires ?? []) referenced.add(x);
-      // Also count witness references from sibling sub-trees that have
-      // not yet migrated to their own ABoxes (Lift 7): semanticTypes
-      // and capabilities still live in domain-semantics.json and may
-      // reference states via `witnesses`. Without this, states only
-      // referenced by a semanticType.witnesses (e.g.
-      // `ProcessDefinitionDeployed` ← `ProcessDefinitionKey.witnesses`)
-      // would be flagged as dead even though they are live.
+      // Also count witness references from sibling sub-trees:
+      // semanticTypes.witnesses (now in the semantics ABox / Lift 7) and
+      // capabilities.dependsOn (semantics ABox) reference runtime-state
+      // names. Without this, states only referenced by a witness coupling
+      // (e.g. `ProcessDefinitionDeployed` ←
+      // `ProcessDefinitionKey.witnesses`) would be flagged as dead even
+      // though they are live. We read the semantics ABox first; the
+      // legacy `domain-semantics.json` block below remains as a fallback
+      // for configs that haven't migrated yet (or for the
+      // pre-Lift-8 transitional state).
+      const { loadSemanticsAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const semantics = loadSemanticsAbox(REPO_ROOT);
+      if (semantics !== null) {
+        for (const t of semantics.semanticTypes) {
+          if (typeof t.witnesses === 'string') referenced.add(t.witnesses);
+        }
+        for (const c of semantics.capabilities ?? []) {
+          for (const dep of c.dependsOn ?? []) referenced.add(dep);
+        }
+        for (const i of semantics.identifiers ?? []) {
+          if (typeof i.validityState === 'string') referenced.add(i.validityState);
+        }
+      }
       interface DomainSemanticsLite {
         semanticTypes?: Record<string, { witnesses?: string }>;
         capabilities?: Record<string, { witnesses?: string }>;
@@ -4924,3 +4940,158 @@ describeForThisConfig(
     });
   },
 );
+
+describeForThisConfig('bundled-spec invariants: semantics ABox cross-references (#216)', () => {
+  // Lift 7 / #216: the semantics ABox is now the authoritative
+  // source for the three value-source sub-trees (semanticTypes,
+  // capabilities, identifiers) previously carried in
+  // domain-semantics.json. Same coverage strategy as Lifts 5 and 6.
+
+  it('loads the semantics ABox via the generic loader (proves the load path)', async () => {
+    const { loadSemanticsAbox } = await import('../../path-analyser/src/ontology/loader.js');
+    const abox = loadSemanticsAbox(REPO_ROOT);
+    expect(abox, 'semantics ABox file must exist for the camunda-oca config').not.toBeNull();
+    expect(abox?.semanticTypes.length).toBeGreaterThan(0);
+  });
+
+  it('every capabilities.producedBy / identifiers.boundBy references a real opId in the bundled graph (sense-2: abox-vs-graph)', async () => {
+    const { loadSemanticsAbox } = await import('../../path-analyser/src/ontology/loader.js');
+    const abox = loadSemanticsAbox(REPO_ROOT);
+    if (!abox) throw new Error('semantics ABox missing');
+    if (!existsSync(GRAPH_PATH)) {
+      throw new Error(`Graph not found at ${GRAPH_PATH}. Run 'npm run testsuite:generate' first.`);
+    }
+    interface GraphOp {
+      operationId?: string;
+    }
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const graph = JSON.parse(readFileSync(GRAPH_PATH, 'utf8')) as {
+      operationsById?: Record<string, GraphOp>;
+      operations?: Record<string, GraphOp> | GraphOp[];
+    };
+    const opIds = new Set<string>(
+      Object.keys(graph.operationsById ?? {}).length > 0
+        ? Object.keys(graph.operationsById ?? {})
+        : Array.isArray(graph.operations)
+          ? graph.operations
+              .map((o) => o.operationId)
+              .filter((s): s is string => typeof s === 'string')
+          : Object.keys(graph.operations ?? {}),
+    );
+    const dangling: string[] = [];
+    for (const c of abox.capabilities ?? []) {
+      for (const op of c.producedBy ?? []) {
+        if (!opIds.has(op)) dangling.push(`capabilities['${c.name}'].producedBy -> '${op}'`);
+      }
+    }
+    for (const i of abox.identifiers ?? []) {
+      for (const op of i.boundBy ?? []) {
+        if (!opIds.has(op)) dangling.push(`identifiers['${i.name}'].boundBy -> '${op}'`);
+      }
+    }
+    expect(
+      dangling,
+      'semantics ABox references opIds that do not exist in the bundled graph - typo, renamed-upstream op, or stale entry; remove or fix in configs/<config>/ontology/semantics.json',
+    ).toEqual([]);
+  });
+
+  it('every semanticTypes.witnesses / capabilities.dependsOn / identifiers.validityState resolves to a runtime-states ABox state OR a capability declared in the same semantics ABox (cross-ABox integrity)', async () => {
+    const { loadSemanticsAbox, loadRuntimeStatesAbox } = await import(
+      '../../path-analyser/src/ontology/loader.js'
+    );
+    const semanticsAbox = loadSemanticsAbox(REPO_ROOT);
+    const runtimeStatesAbox = loadRuntimeStatesAbox(REPO_ROOT);
+    if (!semanticsAbox) throw new Error('semantics ABox missing');
+    if (!runtimeStatesAbox) throw new Error('runtime-states ABox missing');
+    const stateNames = new Set(runtimeStatesAbox.states.map((s) => s.name));
+    const capNames = new Set((semanticsAbox.capabilities ?? []).map((c) => c.name));
+    const dangling: string[] = [];
+    for (const t of semanticsAbox.semanticTypes) {
+      if (
+        typeof t.witnesses === 'string' &&
+        !stateNames.has(t.witnesses) &&
+        !capNames.has(t.witnesses)
+      ) {
+        dangling.push(
+          `semanticTypes['${t.name}'].witnesses -> '${t.witnesses}' (not a runtime state or capability)`,
+        );
+      }
+    }
+    for (const c of semanticsAbox.capabilities ?? []) {
+      for (const dep of c.dependsOn ?? []) {
+        if (!stateNames.has(dep)) {
+          dangling.push(`capabilities['${c.name}'].dependsOn -> '${dep}' (not a runtime state)`);
+        }
+      }
+    }
+    for (const i of semanticsAbox.identifiers ?? []) {
+      if (typeof i.validityState === 'string' && !stateNames.has(i.validityState)) {
+        dangling.push(
+          `identifiers['${i.name}'].validityState -> '${i.validityState}' (not a runtime state)`,
+        );
+      }
+      if (typeof i.derivedVia === 'string' && !capNames.has(i.derivedVia)) {
+        dangling.push(
+          `identifiers['${i.name}'].derivedVia -> '${i.derivedVia}' (not a capability)`,
+        );
+      }
+    }
+    expect(
+      dangling,
+      'semantics ABox references targets that do not exist in either the semantics or runtime-states ABox - cross-ABox integrity broken',
+    ).toEqual([]);
+  });
+
+  it('graph.domain.semanticTypes / capabilities / identifiers match the record-shaped views derived from the ABox (planner contract - ABox supersedes domain-semantics.json)', async () => {
+    const { deriveSemanticsViews } = await import('../../path-analyser/src/ontology/loader.js');
+    const { loadGraph } = await import('../../path-analyser/src/graphLoader.js');
+    const expectedViews = deriveSemanticsViews(REPO_ROOT);
+    if (!expectedViews) throw new Error('semantics ABox missing');
+    const graph = await loadGraph(join(REPO_ROOT, 'path-analyser'));
+    expect(
+      graph.domain?.semanticTypes,
+      'graph.domain.semanticTypes does not match the ABox-derived view - overlay regression',
+    ).toEqual(expectedViews.semanticTypes);
+    expect(
+      graph.domain?.capabilities,
+      'graph.domain.capabilities does not match the ABox-derived view - overlay regression',
+    ).toEqual(expectedViews.capabilities);
+    expect(
+      graph.domain?.identifiers,
+      'graph.domain.identifiers does not match the ABox-derived view - overlay regression',
+    ).toEqual(expectedViews.identifiers);
+  });
+
+  it('the committed semantics vocabulary JSON matches the regenerated TBox (drift detector)', async () => {
+    const { ARTIFACTS, renderSchema } = await import('../../scripts/build-ontology.ts');
+    const target = ARTIFACTS.find((a) => a.jsonPath.endsWith('semantics.schema.json'));
+    expect(target, 'build-ontology must include semantics.schema.json').toBeDefined();
+    if (!target) return;
+    const onDisk = readFileSync(target.jsonPath, 'utf8');
+    const rendered = renderSchema(target.schema);
+    expect(
+      onDisk,
+      `Generated ontology artefact at ${target.jsonPath} is stale. Run 'npm run build:ontology' to refresh it.`,
+    ).toBe(rendered);
+  });
+
+  it("the semantics ABox's $schema field resolves to the published TBox JSON", () => {
+    const aboxPath = join(REPO_ROOT, 'configs', CONFIG_NAME, 'ontology', 'semantics.json');
+    const expectedTboxPath = join(REPO_ROOT, 'ontology', 'vocabulary', 'semantics.schema.json');
+    expect(
+      existsSync(expectedTboxPath),
+      `Published TBox at '${expectedTboxPath}' does not exist`,
+    ).toBe(true);
+    interface AboxHeader {
+      $schema?: unknown;
+    }
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const aboxJson = JSON.parse(readFileSync(aboxPath, 'utf8')) as AboxHeader;
+    const schemaField = aboxJson.$schema;
+    expect(typeof schemaField, 'ABox must declare a string `$schema` field').toBe('string');
+    if (typeof schemaField !== 'string') return;
+    expect(schemaField).toBe(
+      'https://camunda.github.io/api-test-generator/ns/v1/semantics.schema.json',
+    );
+  });
+});

--- a/ontology/vocabulary/semantics.schema.json
+++ b/ontology/vocabulary/semantics.schema.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://camunda.github.io/api-test-generator/ns/v1/semantics.schema.json",
+  "title": "Semantics ABox (api-test-generator ontology, v1)",
+  "description": "TBox JSON Schema for an ABox file describing the value-source declarations a deployed API surfaces — semantic types, capabilities, and identifiers. The three sub-trees co-locate because they cross-reference each other (semanticTypes.witnesses → runtimeStates|capabilities; capabilities.dependsOn → runtimeStates; identifiers.validityState → runtimeStates; identifiers.derivedVia → capabilities). The schema is intentionally agnostic to which API ships the entries — instance data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/semantics.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (operationIds existing; witness/dependsOn/validityState/derivedVia targets resolving against runtime-states / capabilities) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts and via post-overlay re-validation in graphLoader.ts, rather than being re-encoded here, because Draft-07 cannot express them.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "semanticTypes"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "@context": {
+      "description": "Optional JSON-LD context. Ignored by the loader; preserved verbatim so external RDF tooling can resolve term IRIs without modification.",
+      "type": [
+        "object",
+        "string",
+        "array"
+      ]
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Schema version of this ABox file. Bumped only when the TBox shape changes incompatibly."
+    },
+    "semanticTypes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/SemanticType"
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Capability"
+      }
+    },
+    "identifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Identifier"
+      }
+    }
+  },
+  "definitions": {
+    "SemanticType": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "@type": {
+          "description": "Optional JSON-LD type IRI. Ignored by the loader.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Semantic-type name (e.g. `ProcessDefinitionKey`). Must be unique across `semanticTypes` (checked by the loader)."
+        },
+        "witnesses": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of a runtime state (`runtimeStates`) or a capability (`capabilities`) that producing a value of this semantic type implies the existence of. The cross-reference is checked at load time against the post-overlay `domain.runtimeStates` / `domain.capabilities` views."
+        },
+        "kind": {
+          "enum": [
+            "modelDerived",
+            "attribute",
+            "serverEmergent"
+          ],
+          "description": "How the planner obtains a value for this semantic type (#162). `modelDerived` reads from a deployment artifact in the same chain. `attribute` is a free-form label minted by the planner; requires `clientMinted: true`. `serverEmergent` is a server-minted lifecycle key the client cannot pre-mint. Absent `kind` falls back to the existing planner classification chain."
+        },
+        "clientMinted": {
+          "type": "boolean",
+          "description": "When true, values are minted by the planner / client rather than returned by a producer endpoint. Required when `kind === \"attribute\"` (loader-enforced)."
+        },
+        "$comment": {
+          "type": "string",
+          "description": "Optional human-readable comment. Ignored by the loader; preserved on disk so authors can leave maintenance notes alongside the entry."
+        }
+      }
+    },
+    "Capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "parameter"
+      ],
+      "properties": {
+        "@type": {
+          "description": "Optional JSON-LD type IRI. Ignored by the loader.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Capability name (e.g. `ModelHasServiceTaskType`). Must be unique across `capabilities` (checked by the loader)."
+        },
+        "parameter": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Parameter variable name that keys this capability (e.g. `jobType`)."
+        },
+        "producedBy": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "OpenAPI operationIds whose successful invocation establishes this capability. Each entry must reference an op present in the bundled graph — checked as an L3 abox-vs-graph invariant."
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Prerequisite runtime states that must hold before this capability can be produced. Each entry must reference a state in `runtimeStates` (cross-ABox check enforced at load time)."
+        }
+      }
+    },
+    "Identifier": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "@type": {
+          "description": "Optional JSON-LD type IRI. Ignored by the loader.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Identifier name (e.g. `ProcessDefinitionId`). Must be unique across `identifiers` (checked by the loader)."
+        },
+        "validityState": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Runtime-state name produced when this identifier is bound. Must reference a state in `runtimeStates`. Identifiers without a `validityState` are skipped at load (mirrors the legacy `IdentifierSpec` semantics)."
+        },
+        "boundBy": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "OpenAPI operationIds that bind this identifier (and therefore produce its `validityState`). Each entry must reference an op present in the bundled graph — checked as an L3 abox-vs-graph invariant."
+        },
+        "fieldPaths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Response field paths where the identifier value appears (e.g. `deployments[].processDefinition.processDefinitionId`). Documentary; the planner does not currently parse these."
+        },
+        "derivedVia": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Capability name through which this identifier is derived. Must reference a capability in `capabilities` (cross-sub-tree check enforced at load time)."
+        }
+      }
+    }
+  }
+}

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -741,25 +741,33 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     }
   }
   // Re-run the cross-reference invariants from `validateDomainSemantics`
-  // against the post-overlay value, but only when a legacy
-  // `domain-semantics.json` sidecar was loaded. The pre-overlay
-  // validation already saw the ABox values via the merged
-  // validationTarget, so this catches only ABox-introduced
-  // cross-reference drift relative to the in-try-promoted `domain` —
-  // mostly redundant after Lift 7, but kept as belt-and-braces. When
-  // no sidecar is present the validator has no `globalContextSeeds`
-  // (the only remaining sub-tree pre-Lift-8) to cross-check against;
-  // ABox-only paths are re-validated by the per-ABox drift detectors
-  // above and by the L3 invariants. Reuses the same Zod-driven
-  // validator and the same DomainSemanticsValidationFailure error
-  // type so the diagnostic surfaces with one well-known shape
-  // regardless of which ABox tripped it.
-  if (postOverlayReValidationNeeded && legacyDomainLoaded && domain !== undefined) {
+  // against the post-overlay value in BOTH the legacy-sidecar path
+  // and the ABox-only path (PR #217 review). The per-ABox drift
+  // detectors (detectArtifactKindsDrift / detectRuntimeStatesDrift /
+  // detectSemanticsDrift) only check abox-vs-graph opId references;
+  // they do NOT check cross-ABox references like
+  // `semanticTypes.witnesses → runtimeStates|capabilities`,
+  // `capabilities.dependsOn → runtimeStates`,
+  // `identifiers.validityState → runtimeStates`, or
+  // `identifiers.derivedVia → capabilities`. Without this re-validation
+  // pass an ABox-only config could ship a `semantics.json` whose
+  // `witnesses` points at a now-removed runtime state and `loadGraph`
+  // would still return an invalid `graph.domain`. The validator is
+  // structural (zod `safeParse`) and tolerant of any subset of
+  // sub-trees being absent, so it is safe to invoke on the synthesized
+  // ABox-only domain too. Reuses the same validator and the same
+  // DomainSemanticsValidationFailure error type so the diagnostic
+  // surfaces with one well-known shape regardless of which ABox
+  // tripped it.
+  if (postOverlayReValidationNeeded && domain !== undefined) {
     const overlayIssues = validateDomainSemantics(domain);
     if (overlayIssues.length > 0) {
       const detail = overlayIssues.map((i) => `  - [${i.invariant}] ${i.message}`).join('\n');
+      const sourceDescription = legacyDomainLoaded
+        ? 'when overlaid on domain-semantics.json'
+        : 'in the ABox-only authoritative domain';
       throw new DomainSemanticsValidationFailure(
-        `ontology ABox introduced cross-reference violation(s) when overlaid on domain-semantics.json:\n${detail}`,
+        `ontology ABox introduced cross-reference violation(s) ${sourceDescription}:\n${detail}`,
       );
     }
   }
@@ -1492,9 +1500,10 @@ function detectSemanticsDrift(
   // Cross-sub-tree integrity (witnesses target runtimeStates|capabilities,
   // dependsOn / validityState target runtimeStates, derivedVia targets
   // capabilities) is enforced by post-overlay `validateDomainSemantics`
-  // for the legacy-sidecar path and by the L3 invariant in
-  // `configs/<name>/regression-invariants.test.ts` for the
-  // ABox-authoritative path.
+  // in `loadGraph` for both the legacy-sidecar and ABox-only paths
+  // (PR #217 review), and by the L3 invariant in
+  // `configs/<name>/regression-invariants.test.ts` as a build-time
+  // belt-and-braces check.
   return drift;
 }
 

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -10,11 +10,13 @@ import {
 import {
   deriveArtifactKindsViews,
   deriveRuntimeStatesViews,
+  deriveSemanticsViews,
   loadArtifactKindsAbox,
   loadEdgeEstablishers,
   loadEntityKindsAbox,
   loadExternalEntityIdentifiers,
   loadRuntimeStatesAbox,
+  loadSemanticsAbox,
 } from './ontology/loader.js';
 import type { BootstrapSequence, DomainSemantics, OperationGraph, OperationNode } from './types.js';
 
@@ -330,6 +332,7 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
   // re-validation (after the try/catch) can also see the flags.
   const artifactAboxPresent = loadArtifactKindsAbox(repoRoot) !== null;
   const runtimeStatesAboxPresent = loadRuntimeStatesAbox(repoRoot) !== null;
+  const semanticsAboxPresent = loadSemanticsAbox(repoRoot) !== null;
   try {
     const domainPath = path.resolve(getActiveConfigDir(repoRoot), 'domain-semantics.json');
     const domainRaw = await readFile(domainPath, 'utf8');
@@ -351,7 +354,7 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     // unmigrated sub-trees still expect their cross-refs to resolve.
     // Overlaying both pre- and post- gives one consistent view.
     let validationTarget: DomainSemantics = parsedDomain;
-    if (artifactAboxPresent || runtimeStatesAboxPresent) {
+    if (artifactAboxPresent || runtimeStatesAboxPresent || semanticsAboxPresent) {
       const overlaid: DomainSemantics = { ...parsedDomain };
       if (artifactAboxPresent) {
         const av = deriveArtifactKindsViews(repoRoot);
@@ -367,6 +370,14 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
         if (rv !== null) {
           overlaid.runtimeStates = rv.runtimeStates;
           overlaid.operationRequirements = rv.operationRequirements;
+        }
+      }
+      if (semanticsAboxPresent) {
+        const sv = deriveSemanticsViews(repoRoot);
+        if (sv !== null) {
+          overlaid.semanticTypes = sv.semanticTypes;
+          overlaid.capabilities = sv.capabilities;
+          overlaid.identifiers = sv.identifiers;
         }
       }
       validationTarget = overlaid;
@@ -398,6 +409,28 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
           ...domain,
           runtimeStates: views.runtimeStates,
           operationRequirements: views.operationRequirements,
+        };
+      }
+    }
+    // Lift 7 / #216: semantics ABox supersedes the legacy
+    // `semanticTypes` / `capabilities` / `identifiers` sub-trees.
+    // Performed inside the try block (and right after `domain =
+    // parsedDomain`) so the existing consumer loops below — building
+    // `producersByState` from `capabilities.producedBy` and
+    // `identifiers.boundBy`, the #56 producersByType propagation, the
+    // #70 witness-implication loop — see the overlaid values without
+    // further plumbing. The pre-overlay step above ensures the
+    // validator already accepted this swap; the post-overlay
+    // re-validation block (after the try/catch) catches
+    // ABox-introduced cross-reference violations.
+    if (semanticsAboxPresent) {
+      const sv = deriveSemanticsViews(repoRoot);
+      if (sv !== null) {
+        domain = {
+          ...domain,
+          semanticTypes: sv.semanticTypes,
+          capabilities: sv.capabilities,
+          identifiers: sv.identifiers,
         };
       }
     }
@@ -566,6 +599,7 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     }
   }
   if (runtimeStatesAboxPresent) postOverlayReValidationNeeded = true;
+  if (semanticsAboxPresent) postOverlayReValidationNeeded = true;
 
   // Lift 6 / #214: when the runtime-states ABox is shipped but no
   // legacy `domain-semantics.json` sidecar exists (the future
@@ -640,20 +674,85 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
       }
     }
   }
+  // Lift 7 / #216: when the semantics ABox is shipped but no legacy
+  // `domain-semantics.json` sidecar exists, the in-try consumer loops
+  // (capability/identifier producer expansion at lines ~444-466 and
+  // the #70 witness-implication loop at lines ~508-520) are never
+  // reached — leaving `graph.domain.semanticTypes`/`capabilities`/
+  // `identifiers` and the dependent `producersByState` /
+  // `node.domainProduces` entries unpopulated even though the ABox
+  // declares them. Mirror the runtime-states post-try block:
+  // synthesize `domain` from the views and re-run the same consumer
+  // logic against it. Safe to compose with the runtime-states post-try
+  // block because that one only writes runtime-state-derived
+  // producers; this one writes capability- / identifier- /
+  // witness-derived producers — disjoint addProducer key sets in
+  // practice (and `addProducer` here dedups against the existing
+  // `producersByState`).
+  if (semanticsAboxPresent && !legacyDomainLoaded) {
+    const sv = deriveSemanticsViews(repoRoot);
+    if (sv !== null) {
+      const baseDomain: DomainSemantics = domain ?? { version: 1 };
+      domain = {
+        ...baseDomain,
+        semanticTypes: sv.semanticTypes,
+        capabilities: sv.capabilities,
+        identifiers: sv.identifiers,
+      };
+      const producers: Record<string, string[]> = producersByState ?? {};
+      producersByState = producers;
+      const addProducer = (state: string, opId: string) => {
+        const list = producers[state] ?? [];
+        if (!list.includes(opId)) list.push(opId);
+        producers[state] = list;
+        const node = operations[opId];
+        if (node) {
+          if (!node.domainProduces) node.domainProduces = [state];
+          else if (!node.domainProduces.includes(state)) node.domainProduces.push(state);
+        }
+      };
+      // capabilities.producedBy → producersByState[capName]
+      for (const [capName, spec] of Object.entries(sv.capabilities)) {
+        for (const opId of spec.producedBy ?? []) {
+          if (operations[opId]) addProducer(capName, opId);
+        }
+      }
+      // identifiers.boundBy → producersByState[validityState]
+      for (const [, spec] of Object.entries(sv.identifiers)) {
+        const state = spec.validityState;
+        if (state == null) continue;
+        for (const opId of spec.boundBy ?? []) {
+          if (operations[opId]) addProducer(state, opId);
+        }
+      }
+      // #70 witness implication, gated on providerMap[T] === true (#95).
+      // Same shape as the in-try loop at lines ~508-520.
+      for (const [semanticType, spec] of Object.entries(sv.semanticTypes)) {
+        const witnessed = spec.witnesses;
+        if (typeof witnessed !== 'string' || witnessed.length === 0) continue;
+        const ops = producersByType[semanticType] ?? [];
+        for (const opId of ops) {
+          const op = operations[opId];
+          if (!op) continue;
+          if (op.providerMap?.[semanticType] !== true) continue;
+          addProducer(witnessed, opId);
+        }
+      }
+    }
+  }
   // Re-run the cross-reference invariants from `validateDomainSemantics`
   // against the post-overlay value, but only when a legacy
   // `domain-semantics.json` sidecar was loaded. The pre-overlay
-  // validation only sees the (already-stripped) legacy sub-trees, so
-  // an ABox that introduces an undeclared `producesStates` /
-  // `producibleStates` (not in `runtimeStates` / `capabilities`), or a
-  // `producesSemantics` entry without a `semanticTypes.witnesses`
-  // declaration, or an `operationRequirements.requires` referencing an
-  // undeclared state, would otherwise slip through. When no sidecar
-  // is present the validator has no `semanticTypes` / `capabilities`
-  // to cross-check against — the ABox stands alone, and Lift 7 will
-  // move those declarations into their own ABox. Reuses the same
-  // Zod-driven validator and the same DomainSemanticsValidationFailure
-  // error type so the diagnostic surfaces with one well-known shape
+  // validation already saw the ABox values via the merged
+  // validationTarget, so this catches only ABox-introduced
+  // cross-reference drift relative to the in-try-promoted `domain` —
+  // mostly redundant after Lift 7, but kept as belt-and-braces. When
+  // no sidecar is present the validator has no `globalContextSeeds`
+  // (the only remaining sub-tree pre-Lift-8) to cross-check against;
+  // ABox-only paths are re-validated by the per-ABox drift detectors
+  // above and by the L3 invariants. Reuses the same Zod-driven
+  // validator and the same DomainSemanticsValidationFailure error
+  // type so the diagnostic surfaces with one well-known shape
   // regardless of which ABox tripped it.
   if (postOverlayReValidationNeeded && legacyDomainLoaded && domain !== undefined) {
     const overlayIssues = validateDomainSemantics(domain);
@@ -744,11 +843,9 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
   // runtime-states ABox. Catches: producedBy / witness.operationId /
   // operationRequirements.operationId references to opIds that don't
   // exist in the bundled graph (typo, renamed-upstream op, or stale
-  // entry). Cross-references to capabilities / semanticTypes are not
-  // checked here — they live in the unmigrated `domain-semantics.json`
-  // sub-trees and are covered by the post-overlay re-validation
-  // (`validateDomainSemantics`) above. Lift 7 will fold them into this
-  // detector.
+  // entry). Cross-references to capabilities / semanticTypes now live
+  // in the semantics ABox and are covered by `detectSemanticsDrift`
+  // (Lift 7 / #216) and by the L3 cross-ABox invariants.
   {
     const drift = detectRuntimeStatesDrift(operations, repoRoot);
     if (drift.length > 0) {
@@ -760,6 +857,27 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
       console.warn(
         `WARNING: ${message}\n  (set STRICT_RUNTIME_STATES_ABOX=1 to fail-fast on drift.)`,
       );
+    }
+  }
+
+  // Lift 7 / #216: per-fact-class drift detector for the semantics
+  // ABox (semanticTypes + capabilities + identifiers). Catches:
+  // capabilities.producedBy / identifiers.boundBy references to
+  // opIds that don't exist in the bundled graph (typo,
+  // renamed-upstream op, or stale entry). Cross-sub-tree
+  // dead-entry checks (e.g. unreferenced semanticTypes) are
+  // deferred to the L3 invariant in
+  // `configs/<config>/regression-invariants.test.ts`, which sees
+  // both this ABox and the runtime-states ABox at once.
+  {
+    const drift = detectSemanticsDrift(operations, repoRoot);
+    if (drift.length > 0) {
+      const detail = drift.map((d) => `  - ${d}`).join('\n');
+      const message = `semantics ABox drift detected:\n${detail}`;
+      if (process.env.STRICT_SEMANTICS_ABOX === '1') {
+        throw new Error(message);
+      }
+      console.warn(`WARNING: ${message}\n  (set STRICT_SEMANTICS_ABOX=1 to fail-fast on drift.)`);
     }
   }
 
@@ -1334,15 +1452,49 @@ function detectRuntimeStatesDrift(
     }
   }
 
-  // Dead-state check is deferred to Lift 7 (#199): until
-  // `semanticTypes`/`capabilities` migrate to their own ABox, states
-  // can be referenced from those legacy sidecar sub-trees (e.g.
-  // `semanticTypes.X.witnesses → 'StateName'`). The detector here
-  // sees only the runtime-states ABox, so it would false-positive on
-  // states whose only live reference is via a witness coupling. The
-  // L3 invariant in `configs/<name>/regression-invariants.test.ts`
-  // covers the dead-state check by reading both sources.
+  // Cross-sub-tree dead-state check is deferred to the L3 invariant in
+  // `configs/<name>/regression-invariants.test.ts`, which sees both the
+  // runtime-states ABox AND the semantics ABox at once (Lift 7 / #216).
+  // In-graphLoader detection would false-positive on states whose only
+  // live reference is via a `semanticTypes.*.witnesses` coupling, since
+  // this detector sees only the runtime-states ABox.
 
+  return drift;
+}
+
+function detectSemanticsDrift(
+  operations: Record<string, OperationNode>,
+  repoRoot: string,
+): string[] {
+  const drift: string[] = [];
+  const abox = loadSemanticsAbox(repoRoot);
+  if (abox === null) return drift;
+
+  for (const c of abox.capabilities ?? []) {
+    for (const opId of c.producedBy ?? []) {
+      if (!operations[opId]) {
+        drift.push(
+          `[abox-vs-graph] capability '${c.name}'.producedBy references opId '${opId}' that does not exist in the bundled graph (typo, renamed-upstream op, or stale entry)`,
+        );
+      }
+    }
+  }
+  for (const i of abox.identifiers ?? []) {
+    for (const opId of i.boundBy ?? []) {
+      if (!operations[opId]) {
+        drift.push(
+          `[abox-vs-graph] identifier '${i.name}'.boundBy references opId '${opId}' that does not exist in the bundled graph (typo, renamed-upstream op, or stale entry)`,
+        );
+      }
+    }
+  }
+
+  // Cross-sub-tree integrity (witnesses target runtimeStates|capabilities,
+  // dependsOn / validityState target runtimeStates, derivedVia targets
+  // capabilities) is enforced by post-overlay `validateDomainSemantics`
+  // for the legacy-sidecar path and by the L3 invariant in
+  // `configs/<name>/regression-invariants.test.ts` for the
+  // ABox-authoritative path.
   return drift;
 }
 

--- a/path-analyser/src/ontology/loader.ts
+++ b/path-analyser/src/ontology/loader.ts
@@ -7,6 +7,7 @@ import { artifactKindsSchema } from './artifactKindsSchema.js';
 import { edgeSchema } from './edgeSchema.js';
 import { entityKindsSchema } from './entityKindsSchema.js';
 import { runtimeStatesSchema } from './runtimeStatesSchema.js';
+import { semanticsSchema } from './semanticsSchema.js';
 
 // ---------------------------------------------------------------------------
 // path-analyser/src/ontology/loader.ts
@@ -51,6 +52,11 @@ export type RuntimeStatesAbox = FromSchema<typeof runtimeStatesSchema>;
 export type RuntimeStateEntry = RuntimeStatesAbox['states'][number];
 export type OperationRequirementEntry = RuntimeStatesAbox['operationRequirements'][number];
 
+export type SemanticsAbox = FromSchema<typeof semanticsSchema>;
+export type SemanticTypeEntry = SemanticsAbox['semanticTypes'][number];
+export type CapabilityEntry = NonNullable<SemanticsAbox['capabilities']>[number];
+export type IdentifierEntry = NonNullable<SemanticsAbox['identifiers']>[number];
+
 // `Ajv` is the named export pointing at the constructor; the namespace
 // also has a self-referential default but the named export is the
 // least error-prone form under module=nodenext.
@@ -59,6 +65,7 @@ const validateEdgesAbox = ajv.compile<EdgesAbox>(edgeSchema);
 const validateEntityKindsAbox = ajv.compile<EntityKindsAbox>(entityKindsSchema);
 const validateArtifactKindsAbox = ajv.compile<ArtifactKindsAbox>(artifactKindsSchema);
 const validateRuntimeStatesAbox = ajv.compile<RuntimeStatesAbox>(runtimeStatesSchema);
+const validateSemanticsAbox = ajv.compile<SemanticsAbox>(semanticsSchema);
 
 function formatErrors(errors: ErrorObject[] | null | undefined): string {
   return (errors ?? [])
@@ -582,4 +589,160 @@ export function deriveRuntimeStatesViews(repoRoot: string): RuntimeStatesViews |
     operationRequirements[r.operationId] = entry;
   }
   return { runtimeStates, operationRequirements };
+}
+
+/**
+ * Load and validate the semantics ABox file (semanticTypes +
+ * capabilities + identifiers) for the active config.
+ *
+ * @param repoRoot Absolute path to the api-test-generator repository root.
+ * @returns The parsed ABox, or `null` if the file does not exist
+ *   (configs are not required to ship one; a missing file leaves the
+ *   legacy `domain-semantics.json` `semanticTypes` / `capabilities` /
+ *   `identifiers` keys authoritative for backward compatibility).
+ * @throws if the file exists but does not validate against the TBox,
+ *   if it contains duplicate names within any sub-tree, or if a
+ *   cross-property invariant is violated (e.g. `kind: 'attribute'`
+ *   without `clientMinted: true`).
+ */
+export function loadSemanticsAbox(repoRoot: string): SemanticsAbox | null {
+  // Symmetric with the other loadXxxAbox helpers — tests that exercise
+  // loadGraph against an isolated tmpDir don't ship a `configs.json`,
+  // and the right fallback there is "no ABox available" so the test
+  // exercises the legacy domain-semantics.json path.
+  let aboxPath: string;
+  try {
+    aboxPath = path.join(getActiveConfigDir(repoRoot), 'ontology', 'semantics.json');
+  } catch {
+    return null;
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(aboxPath, 'utf8');
+  } catch (err) {
+    if (err !== null && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+      return null;
+    }
+    throw err;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse semantics ABox at ${aboxPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!validateSemanticsAbox(parsed)) {
+    throw new Error(
+      `Semantics ABox at ${aboxPath} failed TBox validation:\n${formatErrors(validateSemanticsAbox.errors)}`,
+    );
+  }
+  // Reject duplicate keys up front — Draft-07 cannot express
+  // uniqueness, but a duplicate would silently shadow facts at query
+  // time. Same defensive check as in the other ABox loaders.
+  const dupeTypes = duplicates(parsed.semanticTypes.map((t) => t.name));
+  if (dupeTypes.length > 0) {
+    throw new Error(
+      `Semantics ABox at ${aboxPath} has duplicate semanticTypes name(s): ${dupeTypes.join(', ')}`,
+    );
+  }
+  if (parsed.capabilities !== undefined) {
+    const dupeCaps = duplicates(parsed.capabilities.map((c) => c.name));
+    if (dupeCaps.length > 0) {
+      throw new Error(
+        `Semantics ABox at ${aboxPath} has duplicate capabilities name(s): ${dupeCaps.join(', ')}`,
+      );
+    }
+  }
+  if (parsed.identifiers !== undefined) {
+    const dupeIds = duplicates(parsed.identifiers.map((i) => i.name));
+    if (dupeIds.length > 0) {
+      throw new Error(
+        `Semantics ABox at ${aboxPath} has duplicate identifiers name(s): ${dupeIds.join(', ')}`,
+      );
+    }
+  }
+  // Cross-property invariant: `kind: 'attribute'` ⇒ `clientMinted: true`
+  // (#162 PR 2 coupling, was enforced by `domainSemanticsValidator` for the
+  // legacy sidecar). Same shape as the runtime-states `eventual`/`witness`
+  // coupling check.
+  for (const t of parsed.semanticTypes) {
+    if (t.kind === 'attribute' && t.clientMinted !== true) {
+      throw new Error(
+        `Semantics ABox at ${aboxPath} semanticTypes '${t.name}' has kind: 'attribute' but clientMinted is not true — attribute-shaped semantic types must declare clientMinted: true so the planner mints values rather than waiting for a producer`,
+      );
+    }
+  }
+  return parsed;
+}
+
+/**
+ * Derive the three record-shaped views of the semantics ABox that
+ * `graph.domain.*` consumers (planner BFS, value-binding emitter,
+ * #70 witness-implication loop) expect. Returning `null` when no ABox
+ * is shipped lets `loadGraph` fall back to the legacy
+ * `domain-semantics.json` keys.
+ */
+export interface SemanticsViews {
+  semanticTypes: Record<
+    string,
+    {
+      witnesses?: string;
+      kind?: 'modelDerived' | 'attribute' | 'serverEmergent';
+      clientMinted?: boolean;
+    }
+  >;
+  capabilities: Record<
+    string,
+    {
+      kind: 'capability';
+      parameter: string;
+      producedBy?: string[];
+      dependsOn?: string[];
+    }
+  >;
+  identifiers: Record<
+    string,
+    {
+      kind: 'identifier';
+      validityState?: string;
+      boundBy?: string[];
+      fieldPaths?: string[];
+      derivedVia?: string;
+    }
+  >;
+}
+
+export function deriveSemanticsViews(repoRoot: string): SemanticsViews | null {
+  const abox = loadSemanticsAbox(repoRoot);
+  if (abox === null) return null;
+  const semanticTypes: SemanticsViews['semanticTypes'] = {};
+  for (const t of abox.semanticTypes) {
+    const entry: SemanticsViews['semanticTypes'][string] = {};
+    if (t.witnesses !== undefined) entry.witnesses = t.witnesses;
+    if (t.kind !== undefined) entry.kind = t.kind;
+    if (t.clientMinted !== undefined) entry.clientMinted = t.clientMinted;
+    semanticTypes[t.name] = entry;
+  }
+  const capabilities: SemanticsViews['capabilities'] = {};
+  for (const c of abox.capabilities ?? []) {
+    const entry: SemanticsViews['capabilities'][string] = {
+      kind: 'capability',
+      parameter: c.parameter,
+    };
+    if (c.producedBy !== undefined) entry.producedBy = [...c.producedBy];
+    if (c.dependsOn !== undefined) entry.dependsOn = [...c.dependsOn];
+    capabilities[c.name] = entry;
+  }
+  const identifiers: SemanticsViews['identifiers'] = {};
+  for (const i of abox.identifiers ?? []) {
+    const entry: SemanticsViews['identifiers'][string] = { kind: 'identifier' };
+    if (i.validityState !== undefined) entry.validityState = i.validityState;
+    if (i.boundBy !== undefined) entry.boundBy = [...i.boundBy];
+    if (i.fieldPaths !== undefined) entry.fieldPaths = [...i.fieldPaths];
+    if (i.derivedVia !== undefined) entry.derivedVia = i.derivedVia;
+    identifiers[i.name] = entry;
+  }
+  return { semanticTypes, capabilities, identifiers };
 }

--- a/path-analyser/src/ontology/semanticsSchema.ts
+++ b/path-analyser/src/ontology/semanticsSchema.ts
@@ -1,0 +1,223 @@
+// Source of truth for the semantics ABox TBox (api-test-generator
+// ontology, v1).
+//
+// Mirrors the pattern established by `edgeSchema.ts` (Lift 3 / #208),
+// `entityKindsSchema.ts` (Lift 4 / #210), `artifactKindsSchema.ts`
+// (Lift 5 / #212), and `runtimeStatesSchema.ts` (Lift 6 / #214): this
+// TypeScript module is the authoritative declaration; the matching
+// `ontology/vocabulary/semantics.schema.json` file is generated from
+// it by `scripts/build-ontology.ts` and committed solely so external
+// SPARQL/SHACL/OWL consumers can fetch a plain JSON Schema by URL.
+// A regression invariant in
+// `configs/<config>/regression-invariants.test.ts` asserts the two
+// are in sync.
+//
+// What this ABox encodes (Lift 7 / #216): the catalogue of
+// *value-source declarations* — semantic types, capabilities, and
+// identifiers — that the planner reasons about when chaining
+// operations and binding values. The three sub-trees co-locate in
+// one ABox because they cross-reference each other:
+//
+//   - `semanticTypes[T].witnesses → runtimeStates | capabilities`
+//   - `capabilities[C].dependsOn → runtimeStates`
+//   - `identifiers[I].validityState → runtimeStates`
+//   - `identifiers[I].derivedVia → capabilities`
+//
+// Splitting them would let one drift from the other; co-locating
+// makes those cross-references single ABox-level invariants rather
+// than inter-file ones.
+//
+// Like Lifts 5 and 6, the data was never sourced from upstream
+// OpenAPI annotations — it has always lived in the per-config
+// `domain-semantics.json` sidecar. Consequence: there is no
+// `spec-vs-abox` (sense-1) drift to detect. The ABox supersedes the
+// legacy `domain-semantics.json` keys when present; coverage gates
+// check the durable `abox-vs-graph` (sense-2) invariants only
+// (referenced opIds exist in the graph, witness/dependsOn/validityState/
+// derivedVia targets resolve).
+//
+// Three entry classes:
+//
+//   - `semanticTypes` — per-semantic-type metadata: which runtime
+//                       state or capability the value witnesses
+//                       (`witnesses`); the value-source classification
+//                       (`kind`: `modelDerived` | `attribute` |
+//                       `serverEmergent`); whether values are minted
+//                       client-side rather than returned by a producer
+//                       (`clientMinted`).
+//
+//   - `capabilities`  — per-capability metadata: a parameter name
+//                       (`parameter`); which ops produce the
+//                       capability (`producedBy`); which prerequisite
+//                       runtime states must hold (`dependsOn`).
+//
+//   - `identifiers`   — per-identifier metadata: the runtime state
+//                       declared valid once the identifier is bound
+//                       (`validityState`); which ops bind the
+//                       identifier (`boundBy`); response field paths
+//                       where the identifier appears (`fieldPaths`);
+//                       the capability it is derived via, when any
+//                       (`derivedVia`).
+//
+// Cross-property invariants (loader-enforced, since Draft-07 cannot
+// express them):
+//
+//   - `kind: 'attribute'` ⇒ `clientMinted: true` (#162 PR 2 coupling).
+//   - duplicate `name` rejected within each of the three sub-trees.
+//
+// JSON-LD (`@context`, `@type`) is accepted and preserved verbatim
+// but not interpreted by the loader — same convention as the other
+// ABoxes.
+
+export const semanticsSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'https://camunda.github.io/api-test-generator/ns/v1/semantics.schema.json',
+  title: 'Semantics ABox (api-test-generator ontology, v1)',
+  description:
+    'TBox JSON Schema for an ABox file describing the value-source declarations a deployed API surfaces — semantic types, capabilities, and identifiers. The three sub-trees co-locate because they cross-reference each other (semanticTypes.witnesses → runtimeStates|capabilities; capabilities.dependsOn → runtimeStates; identifiers.validityState → runtimeStates; identifiers.derivedVia → capabilities). The schema is intentionally agnostic to which API ships the entries — instance data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/semantics.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (operationIds existing; witness/dependsOn/validityState/derivedVia targets resolving against runtime-states / capabilities) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts and via post-overlay re-validation in graphLoader.ts, rather than being re-encoded here, because Draft-07 cannot express them.',
+  type: 'object',
+  additionalProperties: false,
+  required: ['version', 'semanticTypes'],
+  properties: {
+    $schema: { type: 'string' },
+    '@context': {
+      description:
+        'Optional JSON-LD context. Ignored by the loader; preserved verbatim so external RDF tooling can resolve term IRIs without modification.',
+      type: ['object', 'string', 'array'],
+    },
+    version: {
+      type: 'integer',
+      minimum: 1,
+      description:
+        'Schema version of this ABox file. Bumped only when the TBox shape changes incompatibly.',
+    },
+    semanticTypes: {
+      type: 'array',
+      minItems: 1,
+      items: { $ref: '#/definitions/SemanticType' },
+    },
+    capabilities: {
+      type: 'array',
+      items: { $ref: '#/definitions/Capability' },
+    },
+    identifiers: {
+      type: 'array',
+      items: { $ref: '#/definitions/Identifier' },
+    },
+  },
+  definitions: {
+    SemanticType: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['name'],
+      properties: {
+        '@type': {
+          description: 'Optional JSON-LD type IRI. Ignored by the loader.',
+          type: 'string',
+        },
+        name: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Semantic-type name (e.g. `ProcessDefinitionKey`). Must be unique across `semanticTypes` (checked by the loader).',
+        },
+        witnesses: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Name of a runtime state (`runtimeStates`) or a capability (`capabilities`) that producing a value of this semantic type implies the existence of. The cross-reference is checked at load time against the post-overlay `domain.runtimeStates` / `domain.capabilities` views.',
+        },
+        kind: {
+          enum: ['modelDerived', 'attribute', 'serverEmergent'],
+          description:
+            'How the planner obtains a value for this semantic type (#162). `modelDerived` reads from a deployment artifact in the same chain. `attribute` is a free-form label minted by the planner; requires `clientMinted: true`. `serverEmergent` is a server-minted lifecycle key the client cannot pre-mint. Absent `kind` falls back to the existing planner classification chain.',
+        },
+        clientMinted: {
+          type: 'boolean',
+          description:
+            'When true, values are minted by the planner / client rather than returned by a producer endpoint. Required when `kind === "attribute"` (loader-enforced).',
+        },
+        $comment: {
+          type: 'string',
+          description:
+            'Optional human-readable comment. Ignored by the loader; preserved on disk so authors can leave maintenance notes alongside the entry.',
+        },
+      },
+    },
+    Capability: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['name', 'parameter'],
+      properties: {
+        '@type': {
+          description: 'Optional JSON-LD type IRI. Ignored by the loader.',
+          type: 'string',
+        },
+        name: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Capability name (e.g. `ModelHasServiceTaskType`). Must be unique across `capabilities` (checked by the loader).',
+        },
+        parameter: {
+          type: 'string',
+          minLength: 1,
+          description: 'Parameter variable name that keys this capability (e.g. `jobType`).',
+        },
+        producedBy: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description:
+            'OpenAPI operationIds whose successful invocation establishes this capability. Each entry must reference an op present in the bundled graph — checked as an L3 abox-vs-graph invariant.',
+        },
+        dependsOn: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description:
+            'Prerequisite runtime states that must hold before this capability can be produced. Each entry must reference a state in `runtimeStates` (cross-ABox check enforced at load time).',
+        },
+      },
+    },
+    Identifier: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['name'],
+      properties: {
+        '@type': {
+          description: 'Optional JSON-LD type IRI. Ignored by the loader.',
+          type: 'string',
+        },
+        name: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Identifier name (e.g. `ProcessDefinitionId`). Must be unique across `identifiers` (checked by the loader).',
+        },
+        validityState: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Runtime-state name produced when this identifier is bound. Must reference a state in `runtimeStates`. Identifiers without a `validityState` are skipped at load (mirrors the legacy `IdentifierSpec` semantics).',
+        },
+        boundBy: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description:
+            'OpenAPI operationIds that bind this identifier (and therefore produce its `validityState`). Each entry must reference an op present in the bundled graph — checked as an L3 abox-vs-graph invariant.',
+        },
+        fieldPaths: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description:
+            'Response field paths where the identifier value appears (e.g. `deployments[].processDefinition.processDefinitionId`). Documentary; the planner does not currently parse these.',
+        },
+        derivedVia: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Capability name through which this identifier is derived. Must reference a capability in `capabilities` (cross-sub-tree check enforced at load time).',
+        },
+      },
+    },
+  },
+} as const;

--- a/scripts/build-ontology.ts
+++ b/scripts/build-ontology.ts
@@ -19,6 +19,7 @@ import { artifactKindsSchema } from '../path-analyser/src/ontology/artifactKinds
 import { edgeSchema } from '../path-analyser/src/ontology/edgeSchema.ts';
 import { entityKindsSchema } from '../path-analyser/src/ontology/entityKindsSchema.ts';
 import { runtimeStatesSchema } from '../path-analyser/src/ontology/runtimeStatesSchema.ts';
+import { semanticsSchema } from '../path-analyser/src/ontology/semanticsSchema.ts';
 // Namespace import: the schema source lives in the CommonJS-flavoured
 // `semantic-graph-extractor` workspace (`type: commonjs` in its
 // package.json). Node's CJS-to-ESM interop exposes the actual
@@ -73,6 +74,10 @@ const ARTIFACTS: OntologyArtifact[] = [
   {
     jsonPath: join(REPO_ROOT, 'ontology', 'vocabulary', 'runtime-states.schema.json'),
     schema: runtimeStatesSchema,
+  },
+  {
+    jsonPath: join(REPO_ROOT, 'ontology', 'vocabulary', 'semantics.schema.json'),
+    schema: semanticsSchema,
   },
   {
     jsonPath: join(REPO_ROOT, 'ontology', 'vocabulary', 'bootstrap-sequence.schema.json'),

--- a/tests/fixtures/integration/artifact-kinds-abox-authoritative.test.ts
+++ b/tests/fixtures/integration/artifact-kinds-abox-authoritative.test.ts
@@ -90,11 +90,15 @@ function deployOp(): Record<string, unknown> {
 }
 
 function minimalKind(name: string, identifierType: string): Record<string, unknown> {
+  // Empty producesStates / producesSemantics by default — those would
+  // reference runtimeStates / semanticTypes which most focused fixtures
+  // don't declare. Tests that need cross-ABox validation supply them
+  // inline along with companion declarations (PR #217 review).
   return {
     name,
     identifierType,
-    producesStates: [`${identifierType}Deployed`],
-    producesSemantics: [`${name}Key`],
+    producesStates: [],
+    producesSemantics: [],
     deploymentSlices: [name],
     description: `${name} fixture`,
   };

--- a/tests/fixtures/integration/semantics-abox-authoritative.test.ts
+++ b/tests/fixtures/integration/semantics-abox-authoritative.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Integration fixture for Lift 7 (#216): the semantics ABox is the
+ * authoritative source for `graph.domain.{semanticTypes,capabilities,
+ * identifiers}` at runtime, AND the values it declares are seen by the
+ * producersByState-building loop (capabilities.producedBy →
+ * producersByState[capName]; identifiers.boundBy →
+ * producersByState[validityState]) inside loadGraph (because the
+ * overlay happens inside the try block as well as in the post-try
+ * ABox-only path).
+ *
+ * Mirrors `runtime-states-abox-authoritative.test.ts` (Lift 6 / #214).
+ *
+ * Seven observable behaviours guarded here:
+ *
+ *   1. **ABox-only — populates everything**: with no
+ *      `domain-semantics.json` sidecar, `graph.domain.semanticTypes` /
+ *      `capabilities` / `identifiers` are populated from the ABox AND
+ *      `producersByState` reflects capabilities.producedBy and
+ *      identifiers.boundBy.
+ *
+ *   2. **ABox authoritative — promotes**: legacy declares one set;
+ *      ABox declares a different set. After loadGraph, `graph.domain`
+ *      reflects the ABox AND `producersByState` is built from it.
+ *
+ *   3. **Strict mode**: with `STRICT_SEMANTICS_ABOX=1`, an
+ *      abox-vs-graph drift (capabilities.producedBy referencing a
+ *      nonexistent opId) is a hard error.
+ *
+ *   4. **Legacy fallback**: with no ABox shipped, the legacy
+ *      `domain-semantics.json` keys remain authoritative.
+ *
+ *   5. **Sense-2 drift warnings**: dangling capabilities.producedBy
+ *      / identifiers.boundBy opIds are flagged.
+ *
+ *   6. **Post-overlay re-validation**: an ABox that introduces a
+ *      `semanticTypes.witnesses` referencing an undeclared state is
+ *      rejected when overlaid on a legacy sidecar.
+ *
+ *   7. **ABox supersedes stale legacy**: a legacy sidecar that
+ *      contains a `semanticTypes.X.witnesses` referencing a state that
+ *      _itself_ no longer exists in the ABox does NOT fail load —
+ *      because pre-overlay validation overlays the ABox values first.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadGraph } from '../../../path-analyser/src/graphLoader.ts';
+
+const CONFIG_NAME = 'lift7-semantics-test';
+
+let workdir: string;
+let baseDir: string;
+const ORIGINAL = {
+  CONFIG: process.env.CONFIG,
+  OPERATION_GRAPH_PATH: process.env.OPERATION_GRAPH_PATH,
+  OPENAPI_SPEC_PATH: process.env.OPENAPI_SPEC_PATH,
+  STRICT_SEMANTICS_ABOX: process.env.STRICT_SEMANTICS_ABOX,
+};
+
+function writeWorkspace(opts: {
+  semanticsAbox: object | null;
+  runtimeStatesAbox?: object;
+  domainSemantics?: object;
+  graphOps: Record<string, unknown>;
+}): void {
+  const repoRoot = workdir;
+  baseDir = join(repoRoot, 'path-analyser');
+  mkdirSync(baseDir, { recursive: true });
+  writeFileSync(
+    join(repoRoot, 'configs.json'),
+    JSON.stringify({ default: CONFIG_NAME, configs: { [CONFIG_NAME]: {} } }),
+  );
+  const configDir = join(repoRoot, 'configs', CONFIG_NAME);
+  mkdirSync(configDir, { recursive: true });
+  if (opts.domainSemantics !== undefined) {
+    writeFileSync(join(configDir, 'domain-semantics.json'), JSON.stringify(opts.domainSemantics));
+  }
+  const aboxDir = join(configDir, 'ontology');
+  if (opts.semanticsAbox !== null || opts.runtimeStatesAbox !== undefined) {
+    mkdirSync(aboxDir, { recursive: true });
+  }
+  if (opts.semanticsAbox !== null) {
+    writeFileSync(join(aboxDir, 'semantics.json'), JSON.stringify(opts.semanticsAbox));
+  }
+  if (opts.runtimeStatesAbox !== undefined) {
+    writeFileSync(join(aboxDir, 'runtime-states.json'), JSON.stringify(opts.runtimeStatesAbox));
+  }
+  const graphPath = join(baseDir, 'operation-dependency-graph.json');
+  writeFileSync(graphPath, JSON.stringify({ operations: opts.graphOps }));
+  process.env.OPERATION_GRAPH_PATH = graphPath;
+  process.env.CONFIG = CONFIG_NAME;
+  process.env.OPENAPI_SPEC_PATH = join(baseDir, 'no-such-spec.yaml');
+}
+
+function ops(): Record<string, unknown> {
+  return {
+    createDeployment: {
+      operationId: 'createDeployment',
+      method: 'POST',
+      path: '/deployments',
+      requires: { required: [], optional: [] },
+      produces: [],
+    },
+    createProcessInstance: {
+      operationId: 'createProcessInstance',
+      method: 'POST',
+      path: '/process-instances',
+      requires: { required: [], optional: [] },
+      produces: [],
+    },
+  };
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'lift7-semantics-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+  for (const [k, v] of Object.entries(ORIGINAL)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe('Lift 7 (#216): semantics ABox is authoritative for graph.domain semantic sub-trees', () => {
+  it('populates graph.domain semantic sub-trees AND producersByState from the ABox even when no domain-semantics.json is shipped (Lift 8-style ABox-authoritative)', async () => {
+    writeWorkspace({
+      // No domain-semantics.json sidecar at all.
+      semanticsAbox: {
+        version: 1,
+        semanticTypes: [
+          { name: 'ProcessDefinitionKey', witnesses: 'ProcessDefinitionDeployed' },
+          { name: 'Tag', kind: 'attribute', clientMinted: true },
+        ],
+        capabilities: [
+          {
+            name: 'ModelHasServiceTaskType',
+            parameter: 'jobType',
+            producedBy: ['createDeployment'],
+          },
+        ],
+        identifiers: [
+          {
+            name: 'ProcessDefinitionId',
+            validityState: 'ProcessDefinitionDeployed',
+            boundBy: ['createDeployment'],
+          },
+        ],
+      },
+      graphOps: ops(),
+    });
+    const graph = await loadGraph(baseDir);
+    // graph.domain populated from the ABox.
+    expect(Object.keys(graph.domain?.semanticTypes ?? {}).sort()).toEqual([
+      'ProcessDefinitionKey',
+      'Tag',
+    ]);
+    expect(graph.domain?.capabilities?.ModelHasServiceTaskType?.parameter).toBe('jobType');
+    expect(graph.domain?.identifiers?.ProcessDefinitionId?.validityState).toBe(
+      'ProcessDefinitionDeployed',
+    );
+    // capabilities.producedBy and identifiers.boundBy both surface as producers (the consumer-loop fix).
+    expect(graph.producersByState?.ModelHasServiceTaskType).toEqual(['createDeployment']);
+    expect(graph.producersByState?.ProcessDefinitionDeployed).toEqual(['createDeployment']);
+    // node.domainProduces reflects the produced state set.
+    expect(graph.operations.createDeployment?.domainProduces).toContain('ModelHasServiceTaskType');
+    expect(graph.operations.createDeployment?.domainProduces).toContain(
+      'ProcessDefinitionDeployed',
+    );
+  });
+
+  it('overrides domain-semantics.json semanticTypes/capabilities/identifiers with ABox values (promote) AND propagates to producersByState', async () => {
+    writeWorkspace({
+      domainSemantics: {
+        version: 1,
+        // Legacy declares one capability with createProcessInstance as producer.
+        capabilities: {
+          LegacyCap: { kind: 'capability', parameter: 'p', producedBy: ['createProcessInstance'] },
+        },
+        identifiers: {
+          LegacyId: {
+            kind: 'identifier',
+            validityState: 'LegacyState',
+            boundBy: ['createProcessInstance'],
+          },
+        },
+        semanticTypes: { LegacyType: { witnesses: 'LegacyState' } },
+        runtimeStates: {
+          LegacyState: { kind: 'state', producedBy: ['createProcessInstance'] },
+        },
+      },
+      semanticsAbox: {
+        version: 1,
+        semanticTypes: [{ name: 'AboxType', witnesses: 'LegacyState' }],
+        capabilities: [{ name: 'AboxCap', parameter: 'p', producedBy: ['createDeployment'] }],
+        identifiers: [
+          {
+            name: 'AboxId',
+            validityState: 'LegacyState',
+            boundBy: ['createDeployment'],
+          },
+        ],
+      },
+      graphOps: ops(),
+    });
+    const graph = await loadGraph(baseDir);
+    // graph.domain reflects the ABox.
+    expect(Object.keys(graph.domain?.semanticTypes ?? {})).toEqual(['AboxType']);
+    expect(Object.keys(graph.domain?.capabilities ?? {})).toEqual(['AboxCap']);
+    expect(Object.keys(graph.domain?.identifiers ?? {})).toEqual(['AboxId']);
+    // producersByState built INSIDE the try block from the overlaid value.
+    expect(graph.producersByState?.AboxCap).toEqual(['createDeployment']);
+    // LegacyCap is gone — ABox supersedes.
+    expect(graph.producersByState?.LegacyCap).toBeUndefined();
+    // identifiers.boundBy → validityState route is also exercised.
+    expect(graph.producersByState?.LegacyState).toContain('createDeployment');
+  });
+
+  it('hard-errors on abox-vs-graph drift when STRICT_SEMANTICS_ABOX=1', async () => {
+    process.env.STRICT_SEMANTICS_ABOX = '1';
+    writeWorkspace({
+      domainSemantics: { version: 1 },
+      semanticsAbox: {
+        version: 1,
+        semanticTypes: [{ name: 'T' }],
+        capabilities: [
+          // producedBy references an opId that doesn't exist in the graph.
+          { name: 'Cap', parameter: 'p', producedBy: ['nonexistentOp'] },
+        ],
+      },
+      graphOps: ops(),
+    });
+    await expect(loadGraph(baseDir)).rejects.toThrow(/semantics ABox drift detected/);
+  });
+
+  it('preserves legacy domain-semantics.json semantic sub-trees when no ABox is shipped', async () => {
+    writeWorkspace({
+      semanticsAbox: null,
+      domainSemantics: {
+        version: 1,
+        capabilities: {
+          LegacyCap: { kind: 'capability', parameter: 'p', producedBy: ['createDeployment'] },
+        },
+        semanticTypes: { LegacyType: {} },
+      },
+      graphOps: ops(),
+    });
+    const graph = await loadGraph(baseDir);
+    expect(graph.domain?.capabilities?.LegacyCap).toBeDefined();
+    expect(graph.producersByState?.LegacyCap).toEqual(['createDeployment']);
+  });
+
+  it('warns on dangling capabilities.producedBy / identifiers.boundBy opIds (sense-2 abox-vs-graph)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writeWorkspace({
+      domainSemantics: { version: 1 },
+      semanticsAbox: {
+        version: 1,
+        semanticTypes: [{ name: 'T' }],
+        capabilities: [
+          { name: 'Cap', parameter: 'p', producedBy: ['createDeployment', 'nonexistentOp1'] },
+        ],
+        identifiers: [{ name: 'Id', boundBy: ['nonexistentOp2'] }],
+      },
+      graphOps: ops(),
+    });
+    await loadGraph(baseDir);
+    const messages = warn.mock.calls.map((c) => String(c[0]));
+    const joined = messages.join('\n');
+    expect(joined).toMatch(/semantics ABox drift detected/);
+    expect(joined).toMatch(/capability 'Cap'.*nonexistentOp1/);
+    expect(joined).toMatch(/identifier 'Id'.*nonexistentOp2/);
+    warn.mockRestore();
+  });
+
+  it('post-overlay validation rejects an ABox semanticTypes.witnesses referencing an undeclared state (the validator sees the merged authoritative view)', async () => {
+    writeWorkspace({
+      domainSemantics: {
+        version: 1,
+        // Legacy has nothing relevant; the ABox brings in `Witnesses: 'GoneState'`.
+        runtimeStates: {
+          DeclaredState: { kind: 'state', producedBy: ['createDeployment'] },
+        },
+      },
+      semanticsAbox: {
+        version: 1,
+        // 'GoneState' is not in runtimeStates and not in capabilities.
+        semanticTypes: [{ name: 'BadType', witnesses: 'GoneState' }],
+      },
+      graphOps: ops(),
+    });
+    await expect(loadGraph(baseDir)).rejects.toThrow(
+      /semanticTypeWitnessTargetResolves.*GoneState/,
+    );
+  });
+
+  it('ABox supersedes a legacy sidecar that itself references a now-removed state (no spurious load failure)', async () => {
+    writeWorkspace({
+      domainSemantics: {
+        version: 1,
+        // Legacy semanticTypes.witnesses points at a state the legacy
+        // sidecar's runtimeStates no longer declares — this entry would
+        // fail validation pre-overlay if the ABox didn't supersede it.
+        semanticTypes: { StaleType: { witnesses: 'GoneStateInLegacy' } },
+        runtimeStates: {
+          OnlyAboxStateExists: { kind: 'state', producedBy: ['createDeployment'] },
+        },
+      },
+      semanticsAbox: {
+        version: 1,
+        semanticTypes: [{ name: 'GoodType', witnesses: 'OnlyAboxStateExists' }],
+      },
+      graphOps: ops(),
+    });
+    const graph = await loadGraph(baseDir);
+    expect(Object.keys(graph.domain?.semanticTypes ?? {})).toEqual(['GoodType']);
+  });
+});

--- a/tests/fixtures/integration/semantics-abox-authoritative.test.ts
+++ b/tests/fixtures/integration/semantics-abox-authoritative.test.ts
@@ -128,6 +128,11 @@ describe('Lift 7 (#216): semantics ABox is authoritative for graph.domain semant
   it('populates graph.domain semantic sub-trees AND producersByState from the ABox even when no domain-semantics.json is shipped (Lift 8-style ABox-authoritative)', async () => {
     writeWorkspace({
       // No domain-semantics.json sidecar at all.
+      runtimeStatesAbox: {
+        version: 1,
+        states: [{ name: 'ProcessDefinitionDeployed', producedBy: ['createDeployment'] }],
+        operationRequirements: [],
+      },
       semanticsAbox: {
         version: 1,
         semanticTypes: [
@@ -316,5 +321,27 @@ describe('Lift 7 (#216): semantics ABox is authoritative for graph.domain semant
     });
     const graph = await loadGraph(baseDir);
     expect(Object.keys(graph.domain?.semanticTypes ?? {})).toEqual(['GoodType']);
+  });
+
+  it('PR #217 review: post-overlay cross-reference validation runs in the ABox-only path too (no legacy sidecar present)', async () => {
+    writeWorkspace({
+      // No domain-semantics.json sidecar at all — exercises the
+      // ABox-authoritative branch the reviewer flagged.
+      runtimeStatesAbox: {
+        version: 1,
+        states: [{ name: 'DeclaredState', producedBy: ['createDeployment'] }],
+        operationRequirements: [],
+      },
+      semanticsAbox: {
+        version: 1,
+        // 'GoneState' is not in runtimeStates and not in capabilities,
+        // so witnesses targets nothing in the synthesized ABox-only domain.
+        semanticTypes: [{ name: 'BadType', witnesses: 'GoneState' }],
+      },
+      graphOps: ops(),
+    });
+    await expect(loadGraph(baseDir)).rejects.toThrow(
+      /semanticTypeWitnessTargetResolves.*GoneState/,
+    );
   });
 });

--- a/tests/fixtures/loader/semantics-abox-loader.test.ts
+++ b/tests/fixtures/loader/semantics-abox-loader.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Unit tests for the semantics ABox loader (Lift 7 / #216).
+ *
+ * Mirrors the structure of `runtime-states-abox-loader.test.ts` (Lift 6 /
+ * #214). Documented loader contract has the same observable branches:
+ *   1. Missing ABox file → returns `null`.
+ *   2. configs.json missing → returns `null` (test-isolation fallback).
+ *   3. Invalid JSON → throws with a "Failed to parse" diagnostic.
+ *   4. Schema-invalid content → throws with a "failed TBox validation" diagnostic.
+ *   5. Duplicate name in any sub-tree → throws.
+ *   6. `kind: 'attribute'` without `clientMinted: true` → throws (cross-property invariant, #162 PR 2).
+ *   7. Happy path → returns the parsed ABox.
+ *
+ * Plus the `deriveSemanticsViews` accessor returns record-shaped views
+ * that match what `graph.domain.{semanticTypes,capabilities,identifiers}`
+ * consumers expect — including rehydrating the `kind: 'capability'` /
+ * `kind: 'identifier'` tags the ABox drops.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  deriveSemanticsViews,
+  loadSemanticsAbox,
+} from '../../../path-analyser/src/ontology/loader.ts';
+
+let workdir: string;
+const CONFIG_NAME = 'unit-test-config';
+const ORIGINAL_CONFIG = process.env.CONFIG;
+
+function configsJson(): string {
+  return JSON.stringify({ default: CONFIG_NAME, configs: { [CONFIG_NAME]: {} } });
+}
+
+function writeAbox(contents: string): void {
+  const dir = join(workdir, 'configs', CONFIG_NAME, 'ontology');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'semantics.json'), contents);
+}
+
+function minimalAbox(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    version: 1,
+    semanticTypes: [{ name: 'ProcessDefinitionKey', witnesses: 'ProcessDefinitionDeployed' }],
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'semantics-abox-loader-'));
+  mkdirSync(workdir, { recursive: true });
+  writeFileSync(join(workdir, 'configs.json'), configsJson());
+  process.env.CONFIG = CONFIG_NAME;
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+  if (ORIGINAL_CONFIG === undefined) {
+    delete process.env.CONFIG;
+  } else {
+    process.env.CONFIG = ORIGINAL_CONFIG;
+  }
+});
+
+describe('loadSemanticsAbox: documented branches', () => {
+  it('returns null when the ABox file does not exist (configs are not required to ship one)', () => {
+    expect(loadSemanticsAbox(workdir)).toBeNull();
+  });
+
+  it('returns null when configs.json itself is missing (test-isolation fallback)', () => {
+    rmSync(join(workdir, 'configs.json'));
+    expect(loadSemanticsAbox(workdir)).toBeNull();
+  });
+
+  it('throws with a "Failed to parse" diagnostic on invalid JSON', () => {
+    writeAbox('{ not json');
+    expect(() => loadSemanticsAbox(workdir)).toThrow(/Failed to parse semantics ABox/);
+  });
+
+  it('throws with a "failed TBox validation" diagnostic on schema-invalid content', () => {
+    // missing required `semanticTypes`
+    writeAbox(JSON.stringify({ version: 1 }));
+    expect(() => loadSemanticsAbox(workdir)).toThrow(/failed TBox validation/);
+  });
+
+  it('throws on duplicate semanticTypes names', () => {
+    writeAbox(
+      minimalAbox({
+        semanticTypes: [{ name: 'Foo', witnesses: 'Bar' }, { name: 'Foo' }],
+      }),
+    );
+    expect(() => loadSemanticsAbox(workdir)).toThrow(/duplicate semanticTypes name\(s\): Foo/);
+  });
+
+  it('throws on duplicate capabilities names', () => {
+    writeAbox(
+      minimalAbox({
+        capabilities: [
+          { name: 'Cap', parameter: 'p' },
+          { name: 'Cap', parameter: 'p2' },
+        ],
+      }),
+    );
+    expect(() => loadSemanticsAbox(workdir)).toThrow(/duplicate capabilities name\(s\): Cap/);
+  });
+
+  it('throws on duplicate identifiers names', () => {
+    writeAbox(
+      minimalAbox({
+        identifiers: [{ name: 'Id' }, { name: 'Id' }],
+      }),
+    );
+    expect(() => loadSemanticsAbox(workdir)).toThrow(/duplicate identifiers name\(s\): Id/);
+  });
+
+  it("throws when `kind: 'attribute'` is set without `clientMinted: true` (#162 PR 2 coupling)", () => {
+    writeAbox(
+      minimalAbox({
+        semanticTypes: [{ name: 'Tag', kind: 'attribute' }],
+      }),
+    );
+    expect(() => loadSemanticsAbox(workdir)).toThrow(
+      /Tag.*kind: 'attribute' but clientMinted is not true/,
+    );
+  });
+
+  it("accepts `kind: 'attribute'` when `clientMinted: true` is set", () => {
+    writeAbox(
+      minimalAbox({
+        semanticTypes: [{ name: 'Tag', kind: 'attribute', clientMinted: true }],
+      }),
+    );
+    const abox = loadSemanticsAbox(workdir);
+    expect(abox?.semanticTypes[0]?.kind).toBe('attribute');
+    expect(abox?.semanticTypes[0]?.clientMinted).toBe(true);
+  });
+
+  it('returns the parsed ABox on the happy path', () => {
+    writeAbox(
+      minimalAbox({
+        capabilities: [
+          {
+            name: 'ModelHasServiceTaskType',
+            parameter: 'jobType',
+            producedBy: ['createDeployment'],
+            dependsOn: ['ProcessDefinitionDeployed'],
+          },
+        ],
+        identifiers: [
+          {
+            name: 'ProcessDefinitionId',
+            validityState: 'ProcessDefinitionDeployed',
+            boundBy: ['createDeployment'],
+            fieldPaths: ['deployments[].processDefinition.processDefinitionId'],
+          },
+        ],
+      }),
+    );
+    const abox = loadSemanticsAbox(workdir);
+    expect(abox).not.toBeNull();
+    expect(abox?.semanticTypes).toHaveLength(1);
+    expect(abox?.capabilities).toHaveLength(1);
+    expect(abox?.identifiers).toHaveLength(1);
+  });
+});
+
+describe('deriveSemanticsViews: record-shaped views', () => {
+  it('returns null when no ABox is shipped (caller falls back to domain-semantics.json)', () => {
+    expect(deriveSemanticsViews(workdir)).toBeNull();
+  });
+
+  it("rehydrates the `kind: 'capability'` / `kind: 'identifier'` tags the ABox drops", () => {
+    writeAbox(
+      minimalAbox({
+        capabilities: [{ name: 'Cap', parameter: 'p' }],
+        identifiers: [{ name: 'Id', validityState: 'S' }],
+      }),
+    );
+    const views = deriveSemanticsViews(workdir);
+    expect(views?.capabilities.Cap?.kind).toBe('capability');
+    expect(views?.identifiers.Id?.kind).toBe('identifier');
+  });
+
+  it('reshapes the three sub-trees into Record<name, …> form', () => {
+    writeAbox(
+      minimalAbox({
+        semanticTypes: [
+          { name: 'ProcessDefinitionKey', witnesses: 'ProcessDefinitionDeployed' },
+          { name: 'Tag', kind: 'attribute', clientMinted: true },
+          { name: 'IncidentKey', kind: 'serverEmergent' },
+        ],
+        capabilities: [
+          {
+            name: 'ModelHasServiceTaskType',
+            parameter: 'jobType',
+            producedBy: ['createDeployment'],
+            dependsOn: ['ProcessDefinitionDeployed'],
+          },
+        ],
+        identifiers: [
+          {
+            name: 'JobTypeValue',
+            derivedVia: 'ModelHasServiceTaskType',
+            boundBy: ['createDeployment'],
+          },
+        ],
+      }),
+    );
+    const views = deriveSemanticsViews(workdir);
+    if (!views) throw new Error('expected derived views');
+    expect(Object.keys(views.semanticTypes).sort()).toEqual([
+      'IncidentKey',
+      'ProcessDefinitionKey',
+      'Tag',
+    ]);
+    expect(views.semanticTypes.Tag).toEqual({ kind: 'attribute', clientMinted: true });
+    expect(views.semanticTypes.IncidentKey).toEqual({ kind: 'serverEmergent' });
+    expect(views.capabilities.ModelHasServiceTaskType).toEqual({
+      kind: 'capability',
+      parameter: 'jobType',
+      producedBy: ['createDeployment'],
+      dependsOn: ['ProcessDefinitionDeployed'],
+    });
+    expect(views.identifiers.JobTypeValue).toEqual({
+      kind: 'identifier',
+      derivedVia: 'ModelHasServiceTaskType',
+      boundBy: ['createDeployment'],
+    });
+  });
+
+  it('deep-clones array fields so callers cannot mutate the cached parse', () => {
+    writeAbox(
+      minimalAbox({
+        semanticTypes: [{ name: 'T', witnesses: 'S' }],
+        capabilities: [
+          {
+            name: 'Cap',
+            parameter: 'p',
+            producedBy: ['op1'],
+            dependsOn: ['S'],
+          },
+        ],
+        identifiers: [
+          {
+            name: 'Id',
+            validityState: 'S',
+            boundBy: ['op1'],
+            fieldPaths: ['a.b'],
+          },
+        ],
+      }),
+    );
+    const v1 = deriveSemanticsViews(workdir);
+    if (!v1) throw new Error('expected views');
+    v1.capabilities.Cap?.producedBy?.push('mutated');
+    v1.capabilities.Cap?.dependsOn?.push('mutated');
+    v1.identifiers.Id?.boundBy?.push('mutated');
+    v1.identifiers.Id?.fieldPaths?.push('mutated');
+    const v2 = deriveSemanticsViews(workdir);
+    expect(v2?.capabilities.Cap?.producedBy).toEqual(['op1']);
+    expect(v2?.capabilities.Cap?.dependsOn).toEqual(['S']);
+    expect(v2?.identifiers.Id?.boundBy).toEqual(['op1']);
+    expect(v2?.identifiers.Id?.fieldPaths).toEqual(['a.b']);
+  });
+
+  it("propagates the loader's validation failure (does not silently swallow malformed ABox)", () => {
+    writeAbox('{ not json');
+    expect(() => deriveSemanticsViews(workdir)).toThrow(/Failed to parse semantics ABox/);
+  });
+});


### PR DESCRIPTION
Closes #216. Continues #199 / Lift 7 of the ontology migration.

Migrates the three remaining value-source sub-trees (`semanticTypes` 19 + `capabilities` 1 + `identifiers` 2) from `configs/<config>/domain-semantics.json` into a new per-config ABox at `configs/<config>/ontology/semantics.json`.

The three migrate together because their cross-references (`witnesses → runtimeStates|capabilities`, `dependsOn → runtimeStates`, `validityState → runtimeStates`, `derivedVia → capabilities`) make any single one brittle to migrate alone.

## Pattern (mirrors #213 / #215)

- TS-const TBox: `path-analyser/src/ontology/semanticsSchema.ts` (single source of truth — ajv at runtime + `FromSchema` at type-time).
- Generated public JSON Schema at `ontology/vocabulary/semantics.schema.json` (drift-checked by L3 invariant).
- Loader + record-shaped views: `loadSemanticsAbox` / `deriveSemanticsViews` with duplicate-name + `kind: 'attribute'` ⇒ `clientMinted: true` cross-property check (#162 PR 2 coupling).
- `graphLoader.ts`: overlay-then-validate in pre-overlay, in-try, AND post-try (ABox-only synthesis) paths. The post-try block replays the in-try consumer logic — capability/identifier producer expansion and the #70 witness-implication loop (gated on `providerMap[T] === true` per #95) — so an ABox-authoritative config gets the same `producersByState` / `domainProduces` population as a sidecar-loaded config.
- New `detectSemanticsDrift` (sense-2 abox-vs-graph). Strict mode under `STRICT_SEMANTICS_ABOX=1`.

## Tests

- 15 loader unit tests (`tests/fixtures/loader/semantics-abox-loader.test.ts`) — ENOENT, configs.json missing, parse error, schema-invalid, duplicates per sub-tree, cross-property coupling, happy path, deep-clone isolation.
- 7 integration tests (`tests/fixtures/integration/semantics-abox-authoritative.test.ts`) — ABox-only synthesis populates everything, promote, strict mode, legacy fallback, dangling-opId warnings, post-overlay re-validation, ABox supersedes stale legacy.
- 6 L3 invariants in `configs/camunda-oca/regression-invariants.test.ts` — load path, abox-vs-graph cross-refs, cross-ABox `witnesses/dependsOn/validityState/derivedVia` integrity, planner-contract deep-equal of `graph.domain.{semanticTypes,capabilities,identifiers}` against derived views, vocabulary drift detector, `$schema` URL match.
- Runtime-states dead-state L3 invariant (Lift 6) now also reads the semantics ABox so witness references stay live as semanticTypes migrate.

## Verification

- `npm run lint` clean; 4× `tsc --noEmit` clean (path-analyser, semantic-graph-extractor, request-validation, tests).
- `npm run build:ontology` emits the new schema clean.
- Generator output **byte-identical** to the pre-Lift-7 baseline (`generated/camunda-oca/graph/operation-dependency-graph.json`).
- 549 tests pass (was 521 + 6 skipped; +28 new tests).

After Lift 7, the only remaining sub-tree in `domain-semantics.json` is `globalContextSeeds`. Lift 8 will retire the legacy sidecar and the `domainSemanticsValidator.ts` together.