### PR TITLE
feat: replace createDeployment literals with ABox-driven deploymentGateway role (#225)

### DIFF
--- a/configs/camunda-oca/ontology/artifact-kinds.json
+++ b/configs/camunda-oca/ontology/artifact-kinds.json
@@ -51,6 +51,7 @@
     {
       "@type": "OperationArtifactRule",
       "operationId": "createDeployment",
+      "role": "deploymentGateway",
       "composable": true,
       "rules": [
         { "id": "bpmn", "artifactKind": "bpmnProcess" },

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -4699,6 +4699,25 @@ describeForThisConfig(
       ).toEqual(expectedViews.operationArtifactRules);
     });
 
+    it('exactly one operation has role "deploymentGateway" and it is `createDeployment` (Lift 9 / #225)', async () => {
+      // The deployment-gateway role discriminates the operation whose
+      // multipart response surfaces deployed artifact identifiers.
+      // The planner and Playwright emitter rely on this role to decide
+      // which step uses the `deploy()` helper and whose extracts feed
+      // model-derived bindings. Two operations with the role would make
+      // those decisions ambiguous; zero would silently disable the
+      // deploy() path. The role must map to `createDeployment` for the
+      // camunda-oca config because that is the upstream multipart
+      // deployment endpoint.
+      const { loadGraph } = await import('../../path-analyser/src/graphLoader.js');
+      const graph = await loadGraph(join(REPO_ROOT, 'path-analyser'));
+      const rules = graph.domain?.operationArtifactRules ?? {};
+      const opsWithDeploymentGateway = Object.entries(rules)
+        .filter(([, spec]) => spec.role === 'deploymentGateway')
+        .map(([opId]) => opId);
+      expect(opsWithDeploymentGateway).toEqual(['createDeployment']);
+    });
+
     it('graph.domain.semanticTypeToArtifactKind matches the ABox `semanticTypeMap[]` (planner contract)', async () => {
       const { deriveArtifactKindsViews } = await import(
         '../../path-analyser/src/ontology/loader.js'

--- a/ontology/vocabulary/artifact-kinds.schema.json
+++ b/ontology/vocabulary/artifact-kinds.schema.json
@@ -165,6 +165,11 @@
           "type": "boolean",
           "description": "When true, the planner may compose multiple `rules` into a single deployment request via set-cover (e.g. `createDeployment` accepts a multi-file payload). Optional — mirrors the legacy `OperationArtifactRuleSpec.composable` contract; absence is treated as `false` by the planner."
         },
+        "role": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional ontological role this operation plays in the API surface. Used by the planner and Playwright emitter to discriminate special-case behaviour (e.g. multipart deployment routing) against the ABox instead of against a hard-coded operationId. Conventional values include `deploymentGateway` (the multipart deploy operation whose response surfaces deployed artifact identifiers). Lift 9 / #225: introduced to retire ~20 hard-coded `=== \"createDeployment\"` literals across `path-analyser/src/{scenarioGenerator,index,codegen/playwright/emitter}.ts`."
+        },
         "rules": {
           "type": "array",
           "minItems": 1,

--- a/path-analyser/src/codegen/emitter.ts
+++ b/path-analyser/src/codegen/emitter.ts
@@ -33,6 +33,17 @@ export interface EmitContext {
    * pre-config behaviour. Only the Playwright emitter consumes this today.
    */
   recordResponses?: boolean;
+  /**
+   * OperationId of the deployment-gateway operation in the active config
+   * (per `artifact-kinds.json#operationRules[].role === "deploymentGateway"`,
+   * Lift 9 / #225). When set, the Playwright emitter routes 200-expected
+   * multipart steps for this op through the `deploy()` support helper;
+   * otherwise every multipart step takes the inline-request path.
+   *
+   * Optional — when omitted (e.g. unit tests that don't exercise the
+   * deployment routing), no step is treated as a deployment gateway.
+   */
+  deploymentGatewayOpId?: string;
 }
 
 /**

--- a/path-analyser/src/codegen/index.ts
+++ b/path-analyser/src/codegen/index.ts
@@ -6,7 +6,12 @@ import {
   getPlaywrightSuiteDir,
   getVariantOutputDir,
 } from '../configResolver.js';
-import { assertSafeGlobalContextSeeds, deriveGlobalContextSeedsViews } from '../ontology/loader.js';
+import {
+  assertSafeGlobalContextSeeds,
+  deriveArtifactKindsViews,
+  deriveGlobalContextSeedsViews,
+} from '../ontology/loader.js';
+import { findDeploymentGatewayOpId } from '../ontology/operationRoles.js';
 import type { EndpointScenarioCollection, GlobalContextSeed } from '../types.js';
 import { parseCliArgs } from './cli-args.js';
 import { writeEmitted } from './orchestrator.js';
@@ -121,6 +126,15 @@ async function run() {
 
   const files = (await fs.readdir(featureDir)).filter((f) => f.endsWith('-scenarios.json'));
   const globalContextSeeds = await loadGlobalContextSeeds(baseDir);
+  // Lift 9 / #225: discriminator for the deployment-gateway routing in
+  // the Playwright emitter, sourced from the active config's
+  // artifact-kinds ABox (`operationRules[].role === "deploymentGateway"`).
+  // `null` when no ABox is shipped — the emitter will then take the
+  // inline-multipart path for every step.
+  const artifactViews = deriveArtifactKindsViews(repoRoot);
+  const deploymentGatewayOpId = findDeploymentGatewayOpId(
+    artifactViews ? { operationArtifactRules: artifactViews.operationArtifactRules } : undefined,
+  );
 
   if (positional === '--all') {
     let count = 0;
@@ -135,6 +149,7 @@ async function run() {
           mode: 'feature',
           globalContextSeeds,
           recordResponses,
+          deploymentGatewayOpId,
         });
         count++;
       } catch (e) {
@@ -170,6 +185,7 @@ async function run() {
           mode: 'variant',
           globalContextSeeds,
           recordResponses,
+          deploymentGatewayOpId,
         });
         variantCount++;
       } catch (e) {
@@ -208,6 +224,7 @@ async function run() {
     mode: 'feature',
     globalContextSeeds,
     recordResponses,
+    deploymentGatewayOpId,
   });
   console.log('Generated test suite for', endpointOpId, 'at', outDir, `(target: ${emitter.id})`);
 }

--- a/path-analyser/src/codegen/index.ts
+++ b/path-analyser/src/codegen/index.ts
@@ -129,8 +129,9 @@ async function run() {
   // Lift 9 / #225: discriminator for the deployment-gateway routing in
   // the Playwright emitter, sourced from the active config's
   // artifact-kinds ABox (`operationRules[].role === "deploymentGateway"`).
-  // `null` when no ABox is shipped — the emitter will then take the
-  // inline-multipart path for every step.
+  // `undefined` when no ABox is shipped, or when no rule declares the
+  // role — the emitter will then take the inline-multipart path for
+  // every step.
   const artifactViews = deriveArtifactKindsViews(repoRoot);
   const deploymentGatewayOpId = findDeploymentGatewayOpId(
     artifactViews ? { operationArtifactRules: artifactViews.operationArtifactRules } : undefined,

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -28,6 +28,12 @@ interface EmitOptions {
    * emitted suite.
    */
   recordResponses?: boolean;
+  /**
+   * See {@link EmitContext.deploymentGatewayOpId}. Forwarded verbatim
+   * from the orchestrator. When present, multipart-200 steps for this
+   * operationId are routed through the `deploy()` support helper.
+   */
+  deploymentGatewayOpId?: string;
 }
 
 /**
@@ -53,6 +59,7 @@ export function renderPlaywrightSuite(
     mode?: 'feature' | 'integration' | 'variant';
     globalContextSeeds?: readonly GlobalContextSeed[];
     recordResponses?: boolean;
+    deploymentGatewayOpId?: string;
   },
 ): string {
   return buildSuiteSource(collection, {
@@ -61,6 +68,7 @@ export function renderPlaywrightSuite(
     mode: opts.mode,
     globalContextSeeds: opts.globalContextSeeds,
     recordResponses: opts.recordResponses,
+    deploymentGatewayOpId: opts.deploymentGatewayOpId,
   });
 }
 
@@ -107,6 +115,7 @@ export const PlaywrightEmitter: Emitter = {
       mode: ctx.mode,
       globalContextSeeds: ctx.globalContextSeeds,
       recordResponses: ctx.recordResponses,
+      deploymentGatewayOpId: ctx.deploymentGatewayOpId,
     });
     return [
       {
@@ -136,6 +145,12 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   }
   const lines: string[] = [];
   const suiteName = opts.suiteName || collection.endpoint.operationId;
+  // Lift 9 / #225: discriminator for the deployment-gateway routing
+  // (was a hard-coded `=== 'createDeployment'` literal). Sourced from the
+  // active-config artifact-kinds ABox by the orchestrator; an emitter
+  // invocation that does not supply it produces a suite with no
+  // deploy()-helper routing — every multipart step takes the inline path.
+  const deploymentGatewayOpId = opts.deploymentGatewayOpId;
 
   // Determine upfront whether any scenario will emit a validateResponse() call
   // so we can conditionally include the import and constant.
@@ -188,7 +203,8 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   const hasAnyExtract = collection.scenarios.some((s) =>
     (s.requestPlan ?? []).some((step) => {
       const isDeployStep =
-        step.operationId === 'createDeployment' &&
+        !!deploymentGatewayOpId &&
+        step.operationId === deploymentGatewayOpId &&
         step.bodyKind === 'multipart' &&
         !!step.multipartTemplate &&
         step.expect.status === 200;
@@ -203,15 +219,18 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   } else {
     lines.push("import { seedBinding, initSpecSalt } from './support/seeding';");
   }
-  // deploy() is emitted for 200-expected createDeployment multipart steps; resolveFixture
-  // is emitted for any step that falls through to the inline multipart path — this includes
-  // non-createDeployment multipart steps AND createDeployment steps with a non-200 expected
-  // status (which are not routed through deploy()). Mirror the isDeploymentStep condition
+  // deploy() is emitted for 200-expected multipart steps whose operationId
+  // matches the active config's deployment-gateway role (Lift 9 / #225);
+  // resolveFixture is emitted for any step that falls through to the inline
+  // multipart path — this includes non-deployment-gateway multipart steps
+  // AND deployment-gateway steps with a non-200 expected status (which are
+  // not routed through deploy()). Mirror the isDeploymentStep condition
   // exactly so the two flags stay in sync.
   const hasDeploymentMultipart = collection.scenarios.some((s) =>
     (s.requestPlan ?? []).some(
       (step) =>
-        step.operationId === 'createDeployment' &&
+        !!deploymentGatewayOpId &&
+        step.operationId === deploymentGatewayOpId &&
         step.bodyKind === 'multipart' &&
         !!step.multipartTemplate &&
         step.expect.status === 200,
@@ -222,7 +241,11 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
       (step) =>
         step.bodyKind === 'multipart' &&
         !!step.multipartTemplate &&
-        !(step.operationId === 'createDeployment' && step.expect.status === 200),
+        !(
+          !!deploymentGatewayOpId &&
+          step.operationId === deploymentGatewayOpId &&
+          step.expect.status === 200
+        ),
     ),
   );
   // authHeaders is used in inline request steps and awaitEventually witness blocks.
@@ -231,7 +254,8 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
     (s.requestPlan ?? []).some(
       (step) =>
         !(
-          step.operationId === 'createDeployment' &&
+          !!deploymentGatewayOpId &&
+          step.operationId === deploymentGatewayOpId &&
           step.bodyKind === 'multipart' &&
           !!step.multipartTemplate &&
           step.expect.status === 200
@@ -266,7 +290,7 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   lines.push(`test.describe('${suiteName}', () => {`);
   const seeds = opts.globalContextSeeds ?? [];
   for (const scenario of collection.scenarios) {
-    lines.push(renderScenarioTest(scenario, seeds, recordResponses));
+    lines.push(renderScenarioTest(scenario, seeds, recordResponses, deploymentGatewayOpId));
   }
   lines.push('});');
   return lines.join('\n');
@@ -276,6 +300,7 @@ function renderScenarioTest(
   s: EndpointScenario,
   globalContextSeeds: readonly GlobalContextSeed[],
   recordResponses: boolean,
+  deploymentGatewayOpId: string | undefined,
 ): string {
   const title = `${s.id} - ${escapeQuotes(s.name || 'scenario')}`;
   const body: string[] = [];
@@ -394,7 +419,11 @@ function renderScenarioTest(
     (step) =>
       step.bodyKind === 'multipart' &&
       !!step.multipartTemplate &&
-      !(step.operationId === 'createDeployment' && step.expect.status === 200),
+      !(
+        !!deploymentGatewayOpId &&
+        step.operationId === deploymentGatewayOpId &&
+        step.expect.status === 200
+      ),
   );
   const sentinelLocals = new Map<string, string>(); // fieldName -> local var name
   for (const seed of globalContextSeeds) {
@@ -439,16 +468,19 @@ function renderScenarioTest(
     // confined to the callback.
     body.push(`  await test.step(${JSON.stringify(step.operationId)}, async () => {`);
 
-    // createDeployment multipart steps use the deploy() helper which encapsulates
-    // multipart body building, @@FILE: resolution, auth, HTTP POST, status
-    // assertion (throws on non-200), and extraction of all known deployment
-    // response fields into ctx. This keeps each deployment step as a single
-    // declarative call instead of ~35 lines of boilerplate.
+    // Deployment-gateway multipart steps use the deploy() helper which
+    // encapsulates multipart body building, @@FILE: resolution, auth, HTTP
+    // POST, status assertion (throws on non-200), and extraction of all
+    // known deployment response fields into ctx. This keeps each deployment
+    // step as a single declarative call instead of ~35 lines of boilerplate.
     // Only route 200-expected steps through deploy(): the helper hard-codes a
     // 200 assertion, so a step with a declared non-200 expected status must
     // fall through to the normal request path where step.expect.status is honoured.
+    // Lift 9 / #225: the operationId is sourced from the active config's
+    // artifact-kinds ABox role lookup, not a hard-coded literal.
     const isDeploymentStep =
-      step.operationId === 'createDeployment' &&
+      !!deploymentGatewayOpId &&
+      step.operationId === deploymentGatewayOpId &&
       step.bodyKind === 'multipart' &&
       !!step.multipartTemplate &&
       step.expect.status === 200;

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -13,6 +13,7 @@ import {
 import { writeExtractionOutputs } from './extractSchemas.js';
 import { generateFeatureCoverageForEndpoint } from './featureCoverageGenerator.js';
 import { loadGraph, loadOpenApiSemanticHints } from './graphLoader.js';
+import { findDeploymentGatewayOpId, isDeploymentGatewayOp } from './ontology/operationRoles.js';
 import {
   generateOptionalSubShapeVariants,
   generateScenariosForEndpoint,
@@ -744,9 +745,14 @@ export function bindModelDerivedFromFixture(
   // are out of scope here.
   const subShapes = endpoint?.optionalSubShapes ?? [];
   if (!subShapes.length) return;
-  // Find the first createDeployment step in the chain — single-deploy
-  // only in PR 1; multi-deploy is a follow-up.
-  const deployStep = steps.find((s) => s.operationId === 'createDeployment');
+  // Find the first deployment-gateway step in the chain — single-deploy
+  // only in PR 1; multi-deploy is a follow-up. The op is identified via
+  // the active config's artifact-kinds ABox role lookup
+  // (Lift 9 / #225) instead of a hard-coded `createDeployment` literal.
+  const deploymentGatewayOpId = findDeploymentGatewayOpId(graph.domain);
+  const deployStep = deploymentGatewayOpId
+    ? steps.find((s) => s.operationId === deploymentGatewayOpId)
+    : undefined;
   if (!deployStep) return;
   const fixture = fixtureFromDeployStep(deployStep);
   if (!fixture?.providesValues) return;
@@ -1433,8 +1439,12 @@ function buildRequestBodyFromCanonical(
       const rule = ruleId ? domainRules.find((r) => r.id === ruleId) : undefined;
       let kind = rule?.artifactKind;
       if (!kind) {
-        // Default to BPMN process for deployments when unspecified
-        if (opId === 'createDeployment') kind = 'bpmnProcess';
+        // Default to BPMN process for the deployment-gateway op when
+        // unspecified. Lift 9 / #225: the op is now resolved against the
+        // ABox role mapping; the bpmnProcess default for that op stays
+        // hard-coded here pending Lift 10 (#225 follow-up: derive the
+        // default from operationRules[op].rules[0].artifactKind).
+        if (isDeploymentGatewayOp(graph.domain, opId)) kind = 'bpmnProcess';
       }
       // Map artifact kind -> default fixture path
       const defaultFixtures: Record<string, string> = {
@@ -1757,9 +1767,10 @@ function computeDeploymentRequiredStates(
   }
   // States produced by non-deployment ops earlier in the chain are
   // satisfied by their own producer step; the deployment doesn't need to
-  // provide them.
+  // provide them. Lift 9 / #225: the deployment-gateway op is now
+  // identified via the ABox role lookup instead of a hard-coded literal.
   for (const opRef of scenario.operations) {
-    if (opRef.operationId === 'createDeployment') continue;
+    if (isDeploymentGatewayOp(domain, opRef.operationId)) continue;
     const req = opReqs[opRef.operationId];
     if (!req) continue;
     for (const s of req.produces ?? []) result.delete(s);

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1741,16 +1741,20 @@ function chooseFixtureFromRegistry(
 }
 
 /**
- * Compute the set of runtime states the `createDeployment` step in a chain
+ * Compute the set of runtime states the deployment-gateway step in a chain
  * must provide. Walks every operation in the scenario chain, accumulating
  * required states from `operationRequirements.<op>.requires`, then subtracts
- * states produced by any non-deployment op in the chain (those are
- * satisfied by their own producer step, not by the deployment). The chain
- * is BFS-ordered with producers before their consumers, so a simple
+ * states produced by any non-deployment-gateway op in the chain (those are
+ * satisfied by their own producer step, not by the deployment gateway). The
+ * chain is BFS-ordered with producers before their consumers, so a simple
  * unordered subtraction is equivalent to a left-to-right walk here.
  *
+ * The deployment-gateway op is identified via `isDeploymentGatewayOp`
+ * (Lift 9 / #225 — see `ontology/operationRoles.ts`), not by a hard-coded
+ * operationId.
+ *
  * Returns the residual — states that have to come from the
- * `createDeployment` step's fixture selection. An empty set means any
+ * deployment-gateway step's fixture selection. An empty set means any
  * fixture of the right kind is acceptable.
  */
 function computeDeploymentRequiredStates(
@@ -1765,10 +1769,10 @@ function computeDeploymentRequiredStates(
     if (!req) continue;
     for (const s of req.requires ?? []) result.add(s);
   }
-  // States produced by non-deployment ops earlier in the chain are
-  // satisfied by their own producer step; the deployment doesn't need to
-  // provide them. Lift 9 / #225: the deployment-gateway op is now
-  // identified via the ABox role lookup instead of a hard-coded literal.
+  // States produced by non-deployment-gateway ops earlier in the chain are
+  // satisfied by their own producer step; the deployment gateway doesn't
+  // need to provide them. The deployment-gateway op is identified via the
+  // ABox role lookup (Lift 9 / #225) instead of a hard-coded literal.
   for (const opRef of scenario.operations) {
     if (isDeploymentGatewayOp(domain, opRef.operationId)) continue;
     const req = opReqs[opRef.operationId];

--- a/path-analyser/src/ontology/artifactKindsSchema.ts
+++ b/path-analyser/src/ontology/artifactKindsSchema.ts
@@ -196,6 +196,12 @@ export const artifactKindsSchema = {
           description:
             'When true, the planner may compose multiple `rules` into a single deployment request via set-cover (e.g. `createDeployment` accepts a multi-file payload). Optional — mirrors the legacy `OperationArtifactRuleSpec.composable` contract; absence is treated as `false` by the planner.',
         },
+        role: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Optional ontological role this operation plays in the API surface. Used by the planner and Playwright emitter to discriminate special-case behaviour (e.g. multipart deployment routing) against the ABox instead of against a hard-coded operationId. Conventional values include `deploymentGateway` (the multipart deploy operation whose response surfaces deployed artifact identifiers). Lift 9 / #225: introduced to retire ~20 hard-coded `=== "createDeployment"` literals across `path-analyser/src/{scenarioGenerator,index,codegen/playwright/emitter}.ts`.',
+        },
         rules: {
           type: 'array',
           minItems: 1,

--- a/path-analyser/src/ontology/crossRefValidator.ts
+++ b/path-analyser/src/ontology/crossRefValidator.ts
@@ -136,6 +136,7 @@ const ArtifactRuleSchema = z
 const OperationArtifactRuleSpecSchema = z
   .object({
     composable: z.boolean().optional(),
+    role: z.string().optional(),
     rules: z.array(ArtifactRuleSchema).optional(),
   })
   .passthrough();

--- a/path-analyser/src/ontology/crossRefValidator.ts
+++ b/path-analyser/src/ontology/crossRefValidator.ts
@@ -136,7 +136,7 @@ const ArtifactRuleSchema = z
 const OperationArtifactRuleSpecSchema = z
   .object({
     composable: z.boolean().optional(),
-    role: z.string().optional(),
+    role: z.string().min(1).optional(),
     rules: z.array(ArtifactRuleSchema).optional(),
   })
   .passthrough();

--- a/path-analyser/src/ontology/loader.ts
+++ b/path-analyser/src/ontology/loader.ts
@@ -383,6 +383,7 @@ export interface ArtifactKindsViews {
     string,
     {
       composable?: boolean;
+      role?: string;
       rules?: {
         id?: string;
         artifactKind: string;
@@ -417,6 +418,7 @@ export function deriveArtifactKindsViews(repoRoot: string): ArtifactKindsViews |
   for (const r of abox.operationRules) {
     const entry: ArtifactKindsViews['operationArtifactRules'][string] = {};
     if (r.composable !== undefined) entry.composable = r.composable;
+    if (r.role !== undefined) entry.role = r.role;
     if (r.rules !== undefined) {
       entry.rules = r.rules.map((rule) => {
         const out: NonNullable<

--- a/path-analyser/src/ontology/operationRoles.ts
+++ b/path-analyser/src/ontology/operationRoles.ts
@@ -1,0 +1,78 @@
+// Operation-role accessors over the artifact-kinds ABox (Lift 9 / #225).
+//
+// The artifact-kinds ABox declares an optional `role` per operation rule
+// (see `artifactKindsSchema.ts` and
+// `configs/<config>/ontology/artifact-kinds.json`). Roles let the planner
+// and Playwright emitter discriminate special-case behaviour against the
+// ABox instead of against a hard-coded operationId, so a second API
+// config (with a deployment operation under a different name) can wire
+// the same machinery purely via configuration.
+//
+// `deploymentGateway` is the only role consumed today: it identifies the
+// multipart deploy operation whose response surfaces deployed artifact
+// identifiers (in camunda-oca, `createDeployment`). The planner uses it
+// to gate `applyArtifactRuleSelection`, the per-step
+// modelsDraft/bindingsDraft fallback, and the
+// `computeDeploymentRequiredStates` cross-step state diff; the
+// Playwright emitter uses it to route 200-expected multipart steps
+// through the `deploy()` helper instead of the inline multipart path.
+//
+// All accessors are pure and tolerant of `undefined`/missing ABoxes —
+// callers can safely thread `graph.domain` (which is itself optional)
+// directly through.
+
+import type { DomainSemantics } from '../types.js';
+
+/**
+ * Subset of `DomainSemantics` consumed by the role accessors. Accepting
+ * the narrow shape (instead of the full `DomainSemantics`) lets callers
+ * supply a partially-derived view (e.g. directly from
+ * `deriveArtifactKindsViews`) without having to fabricate the unrelated
+ * top-level fields.
+ */
+type RoleSource = Pick<DomainSemantics, 'operationArtifactRules'>;
+
+export const DEPLOYMENT_GATEWAY_ROLE = 'deploymentGateway';
+
+/**
+ * Look up the ontological role declared for `opId` in the active ABox,
+ * or `undefined` when the op is absent or the rule has no role.
+ */
+export function getRoleForOperation(
+  domain: RoleSource | undefined,
+  opId: string,
+): string | undefined {
+  return domain?.operationArtifactRules?.[opId]?.role;
+}
+
+/**
+ * Whether `opId` is the deployment-gateway operation per the ABox.
+ *
+ * Returns `false` when the ABox is absent — callers that need to
+ * special-case deployment routing should fall back to "no special
+ * casing" rather than to a hard-coded operationId.
+ */
+export function isDeploymentGatewayOp(domain: RoleSource | undefined, opId: string): boolean {
+  return getRoleForOperation(domain, opId) === DEPLOYMENT_GATEWAY_ROLE;
+}
+
+/**
+ * Find the operationId carrying the given role in the active ABox.
+ *
+ * Returns the first match (declaration order in the ABox). Returns
+ * `undefined` when the ABox is absent or no rule declares the role.
+ *
+ * `findDeploymentGatewayOpId` is a convenience for the common case.
+ */
+export function findOpIdByRole(domain: RoleSource | undefined, role: string): string | undefined {
+  const rules = domain?.operationArtifactRules;
+  if (!rules) return undefined;
+  for (const [opId, spec] of Object.entries(rules)) {
+    if (spec?.role === role) return opId;
+  }
+  return undefined;
+}
+
+export function findDeploymentGatewayOpId(domain: RoleSource | undefined): string | undefined {
+  return findOpIdByRole(domain, DEPLOYMENT_GATEWAY_ROLE);
+}

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -370,10 +370,13 @@ export function generateScenariosForEndpoint(
   const maxPreOps = opts.longChains?.maxPreOps ?? 25;
   // Lift 9 / #225: the deployment-gateway operationId for the active config
   // (per `artifact-kinds.json#operationRules[].role === "deploymentGateway"`).
-  // `undefined` when the ABox is absent — every special-case below then
-  // collapses to "no op is the deployment gateway", which preserves the
-  // pre-Lift-9 behaviour for unit tests that build minimal graphs without
-  // a domain.
+  // `undefined` when the ABox is absent or no rule declares the role —
+  // every special-case below then collapses to "no op is the deployment
+  // gateway". This is a behaviour change relative to the pre-Lift-9 code,
+  // which always special-cased the literal `'createDeployment'` opId. Unit
+  // tests that build minimal graphs and rely on the deployment special-
+  // casing must declare the role on their fixture domain (see
+  // `tests/fixtures/planner/classification-dispatch.test.ts`).
   const deploymentGatewayOpId = findDeploymentGatewayOpId(graph.domain);
   while (queue.length && scenarios.length < max) {
     // biome-ignore lint/style/noNonNullAssertion: queue.length is checked in the loop predicate

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -1,5 +1,6 @@
 import { bindSemanticInput } from './bindSemanticInput.js';
 import { deterministicSuffix } from './codegen/support/seeding.js';
+import { findDeploymentGatewayOpId, isDeploymentGatewayOp } from './ontology/operationRoles.js';
 import type {
   ArtifactRule,
   EndpointScenario,
@@ -367,6 +368,13 @@ export function generateScenariosForEndpoint(
 
   const longChainsEnabled = !!opts.longChains?.enabled;
   const maxPreOps = opts.longChains?.maxPreOps ?? 25;
+  // Lift 9 / #225: the deployment-gateway operationId for the active config
+  // (per `artifact-kinds.json#operationRules[].role === "deploymentGateway"`).
+  // `undefined` when the ABox is absent — every special-case below then
+  // collapses to "no op is the deployment gateway", which preserves the
+  // pre-Lift-9 behaviour for unit tests that build minimal graphs without
+  // a domain.
+  const deploymentGatewayOpId = findDeploymentGatewayOpId(graph.domain);
   while (queue.length && scenarios.length < max) {
     // biome-ignore lint/style/noNonNullAssertion: queue.length is checked in the loop predicate
     const state = queue.shift()!;
@@ -396,7 +404,7 @@ export function generateScenariosForEndpoint(
         let models = state.modelsDraft;
         let bindings = state.bindingsDraft;
         // Fallback simple heuristic if drafts absent
-        if (!models && state.ops.includes('createDeployment')) {
+        if (!models && deploymentGatewayOpId && state.ops.includes(deploymentGatewayOpId)) {
           // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder consumed by the test runtime
           bindings = { processDefinitionIdVar1: 'proc_${RANDOM}' };
           if (state.ops.includes('activateJobs'))
@@ -701,7 +709,7 @@ export function generateScenariosForEndpoint(
       // heuristic below writes to it for every producer.
       const workingBindingsDraft = { ...(state.bindingsDraft || {}) };
       let workingState: State;
-      if (producerOpId === 'createDeployment') {
+      if (isDeploymentGatewayOp(graph.domain, producerOpId)) {
         const workingArtifactsApplied = state.artifactsApplied
           ? [...state.artifactsApplied]
           : undefined;
@@ -782,7 +790,7 @@ export function generateScenariosForEndpoint(
       // child without leaking into sibling candidates.
       let modelsDraft = workingState.modelsDraft;
       const bindingsDraft = workingState.bindingsDraft ?? {};
-      if (producerOpId === 'createDeployment' && !modelsDraft) {
+      if (isDeploymentGatewayOp(graph.domain, producerOpId) && !modelsDraft) {
         // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder consumed by the test runtime
         bindingsDraft.processDefinitionIdVar1 = 'proc_${RANDOM}';
         modelsDraft = [{ kind: 'bpmn', processDefinitionIdVar: 'processDefinitionIdVar1' }];
@@ -1205,7 +1213,7 @@ function deferForMissingDomainPrereqs(
     // clone the draft collections only on that path so non-deployment
     // candidates avoid the extra allocations on every BFS iteration.
     let workingState: State;
-    if (candidateOpId === 'createDeployment') {
+    if (isDeploymentGatewayOp(graph.domain, candidateOpId)) {
       const workingArtifactsApplied = state.artifactsApplied
         ? [...state.artifactsApplied]
         : undefined;
@@ -1294,7 +1302,7 @@ function deferForMissingDomainPrereqs(
     // models/bindings/artifactsApplied for the enqueued child state.
     let modelsDraft = workingState.modelsDraft;
     const bindingsDraft = workingState.bindingsDraft ?? {};
-    if (candidateOpId === 'createDeployment' && !modelsDraft) {
+    if (isDeploymentGatewayOp(graph.domain, candidateOpId) && !modelsDraft) {
       // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder consumed by the test runtime
       bindingsDraft.processDefinitionIdVar1 = 'proc_${RANDOM}';
       modelsDraft = [{ kind: 'bpmn', processDefinitionIdVar: 'processDefinitionIdVar1' }];
@@ -1332,7 +1340,10 @@ function deferForMissingDomainPrereqs(
   return enqueued;
 }
 
-// Select minimal artifact rules for createDeployment based on unmet semantic needs.
+// Select minimal artifact rules for the deployment-gateway producer based
+// on unmet semantic needs. Callers gate on `isDeploymentGatewayOp` so the
+// producerNode passed here is always the deployment-gateway op for the
+// active config (Lift 9 / #225).
 function applyArtifactRuleSelection(
   graph: OperationGraph,
   producerNode: OperationNode,
@@ -1347,7 +1358,7 @@ function applyArtifactRuleSelection(
     });
     return;
   }
-  const ruleSpec = domain.operationArtifactRules.createDeployment;
+  const ruleSpec = domain.operationArtifactRules[producerNode.operationId];
   if (!ruleSpec) {
     producerNode.produces.forEach((s: string) => {
       newProduced.add(s);

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -663,6 +663,16 @@ export interface ArtifactRegistryEntry {
 export interface OperationArtifactRuleSpec {
   rules?: ArtifactRule[]; // optional when composable
   composable?: boolean; // if true, generator composes artifacts via set cover
+  /**
+   * Optional ontological role this operation plays in the API surface
+   * (Lift 9 / #225). The planner and Playwright emitter consult this
+   * field via `findOpIdByRole` / `isDeploymentGatewayOp` to discriminate
+   * special-case behaviour against the ABox instead of a hard-coded
+   * operationId. Conventional values include `deploymentGateway` —
+   * the multipart deploy operation whose response surfaces deployed
+   * artifact identifiers.
+   */
+  role?: string;
 }
 
 export interface ArtifactRule {

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -541,6 +541,7 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
       suiteName: 'createDeployment',
       mode: 'feature',
       globalContextSeeds: [TENANT_SEED],
+      deploymentGatewayOpId: 'createDeployment',
     });
     const c = file.content;
     // Seed assignment still emitted (always needed)
@@ -593,6 +594,7 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
       outDir: '/unused',
       suiteName: 'createDeployment',
       mode: 'feature',
+      deploymentGatewayOpId: 'createDeployment',
     });
     const c = file.content;
     // deploy() call must be present
@@ -1143,6 +1145,7 @@ describe('emitter: conditional import gating for deploy() and resolveFixture', (
       suiteName: 'createDeployment',
       mode: 'feature',
       recordResponses: false,
+      deploymentGatewayOpId: 'createDeployment',
     });
     expect(src).toContain("import { deploy } from './support/deployment';");
     expect(src).not.toContain('resolveFixture');
@@ -1162,6 +1165,7 @@ describe('emitter: conditional import gating for deploy() and resolveFixture', (
       suiteName: 'createDeployment',
       mode: 'feature',
       recordResponses: false,
+      deploymentGatewayOpId: 'createDeployment',
     });
     expect(src).toContain('expect(resp1.status()).toBe(200)');
   });
@@ -1262,7 +1266,12 @@ describe('emitter: conditional import gating for deploy() and resolveFixture', (
           },
         ],
       },
-      { suiteName: 'createDeployment', mode: 'feature', recordResponses: false },
+      {
+        suiteName: 'createDeployment',
+        mode: 'feature',
+        recordResponses: false,
+        deploymentGatewayOpId: 'createDeployment',
+      },
     );
     expect(src).toContain("import { deploy } from './support/deployment';");
     expect(src).toContain("import { resolveFixture } from './support/fixtures';");

--- a/tests/fixtures/planner/classification-dispatch.test.ts
+++ b/tests/fixtures/planner/classification-dispatch.test.ts
@@ -151,6 +151,9 @@ const modelDerivedDomain: DomainSemantics = {
   semanticTypes: {
     ElementId: { kind: 'modelDerived' },
   },
+  operationArtifactRules: {
+    createDeployment: { role: 'deploymentGateway' },
+  },
 };
 
 const endpointWithElementIdSubShape: OperationNode = makeOp('createProcessInstance', {


### PR DESCRIPTION
Lift 9 of the per-config ABox/TBox migration (#199).

## Summary
Replace ~14 hard-coded `'createDeployment'` literals across the planner and Playwright emitter with an ABox-driven `role: "deploymentGateway"` discriminator.

## Approach
- **TBox**: add optional `role` field to `OperationArtifactRule` (`artifactKindsSchema.ts` + zod in `crossRefValidator.ts`).
- **ABox**: declare `"role": "deploymentGateway"` on the camunda-oca `createDeployment` rule (`configs/camunda-oca/ontology/artifact-kinds.json`).
- **New module** `path-analyser/src/ontology/operationRoles.ts` exposes `isDeploymentGatewayOp`, `findDeploymentGatewayOpId`, etc.
- **Loader**: `role` propagated into `ArtifactKindsViews.operationArtifactRules`.
- **Planner** (`scenarioGenerator.ts`, `index.ts`): 8 literal sites replaced with role-based lookups.
- **Codegen orchestrator** (`codegen/index.ts`): `deploymentGatewayOpId` computed once and forwarded through all three `writeEmitted` call sites.
- **Playwright emitter**: `deploymentGatewayOpId` threaded through `EmitOptions → renderPlaywrightSuite → buildSuiteSource → renderScenarioTest`; 6 literal sites replaced.

## Output stability
`generated/` is byte-identical for camunda-oca after `testsuite:generate` + `generate:request-validation` (only the two timestamp fields in `scenarios/index.json` and `json-body-assertions/responses.json` differ).

## L3 invariant
Added in `configs/camunda-oca/regression-invariants.test.ts`:
> exactly one operation has `role === 'deploymentGateway'` and it is `createDeployment`.

## Test fixture updates
- `tests/codegen/playwright-emitter.test.ts`: 4 deploy-related tests now pass `deploymentGatewayOpId: 'createDeployment'`.
- `tests/fixtures/planner/classification-dispatch.test.ts`: `modelDerivedDomain` declares the role on `createDeployment`.

## Notes / follow-up
- `applyArtifactRuleSelection` now looks up the rule by `producerNode.operationId` (semantic refinement; caller already gates on `isDeploymentGatewayOp`).
- The `'createDeployment'` default in `path-analyser/src/scripts/debug-canonical.ts` is intentionally retained — developer CLI convenience, not planning logic.
- **Lift 10** (`ensureArtifactBindings` semantic→kind hard-codes) is deliberately deferred to a follow-up PR.

Closes #225
Refs #199