### PR TITLE
feat: drive ensureArtifactBindings semantic→model-kind mapping from the ABox (#227)

### DIFF
--- a/configs/camunda-oca/ontology/artifact-kinds.json
+++ b/configs/camunda-oca/ontology/artifact-kinds.json
@@ -11,6 +11,7 @@
       "producibleStates": ["ModelHasServiceTaskType", "ProcessInstanceCompleted"],
       "producesSemantics": ["ProcessDefinitionKey"],
       "deploymentSlices": ["processDefinition"],
+      "modelKind": "bpmn",
       "description": "A BPMN process model. Kind-level producesStates lists what EVERY bpmnProcess fixture deploys; producibleStates lists what SOME fixture of this kind can deliver (planner uses producesStates ∪ producibleStates for chain-feasibility BFS; the selector matches per-fixture providesStates in path-analyser/fixtures/deployment-artifacts.json at emission time, see #159)."
     },
     {
@@ -38,6 +39,7 @@
       "producesStates": ["FormDeployed"],
       "producesSemantics": ["FormKey"],
       "deploymentSlices": ["form"],
+      "modelKind": "form",
       "description": "A Camunda Forms JSON form definition."
     }
   ],

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -4718,6 +4718,23 @@ describeForThisConfig(
       expect(opsWithDeploymentGateway).toEqual(['createDeployment']);
     });
 
+    it('artifactKinds.bpmnProcess.modelKind === "bpmn" and form.modelKind === "form" (Lift 10 / #227)', async () => {
+      // The planner's `ensureArtifactBindings` chooses which
+      // GeneratedModelSpec variant to push (`{ kind: 'bpmn', ... }` vs
+      // `{ kind: 'form', ... }`) by walking semantic→artifactKind→modelKind
+      // through the ABox. If `bpmnProcess.modelKind` ever drifts from
+      // `'bpmn'` (or `form.modelKind` from `'form'`), the planner stops
+      // emitting deployment-model entries for those semantics — every
+      // process-instance / form-related scenario for camunda-oca silently
+      // loses its deployment model. Pin both values to the conventional
+      // GeneratedModelSpec discriminators.
+      const { loadGraph } = await import('../../path-analyser/src/graphLoader.js');
+      const graph = await loadGraph(join(REPO_ROOT, 'path-analyser'));
+      const kinds = graph.domain?.artifactKinds ?? {};
+      expect(kinds.bpmnProcess?.modelKind).toBe('bpmn');
+      expect(kinds.form?.modelKind).toBe('form');
+    });
+
     it('graph.domain.semanticTypeToArtifactKind matches the ABox `semanticTypeMap[]` (planner contract)', async () => {
       const { deriveArtifactKindsViews } = await import(
         '../../path-analyser/src/ontology/loader.js'

--- a/ontology/vocabulary/artifact-kinds.schema.json
+++ b/ontology/vocabulary/artifact-kinds.schema.json
@@ -115,6 +115,11 @@
           },
           "description": "Top-level keys of the createDeployment response payload that this kind populates (e.g. `[\"processDefinition\"]`, or `[\"decisionDefinition\", \"decisionRequirements\"]` for a kind whose deployment yields two slices)."
         },
+        "modelKind": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional discriminator naming the `GeneratedModelSpec` variant the planner should construct when this kind is selected (Lift 10 / #227). Conventional values: `bpmn`, `form`. The planner consults this field via the ABox to pick the model-spec shape, replacing hard-coded semantic→kind comparisons in `ensureArtifactBindings`. Until the `GeneratedModelSpec` discriminated union is generalised (Lift 13), only the conventional values produce model-spec entries; other values are silently ignored by the model-spec construction step."
+        },
         "description": {
           "type": "string",
           "minLength": 1

--- a/path-analyser/src/ontology/artifactKindsSchema.ts
+++ b/path-analyser/src/ontology/artifactKindsSchema.ts
@@ -147,6 +147,12 @@ export const artifactKindsSchema = {
           description:
             'Top-level keys of the createDeployment response payload that this kind populates (e.g. `["processDefinition"]`, or `["decisionDefinition", "decisionRequirements"]` for a kind whose deployment yields two slices).',
         },
+        modelKind: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Optional discriminator naming the `GeneratedModelSpec` variant the planner should construct when this kind is selected (Lift 10 / #227). Conventional values: `bpmn`, `form`. The planner consults this field via the ABox to pick the model-spec shape, replacing hard-coded semantic→kind comparisons in `ensureArtifactBindings`. Until the `GeneratedModelSpec` discriminated union is generalised (Lift 13), only the conventional values produce model-spec entries; other values are silently ignored by the model-spec construction step.',
+        },
         description: {
           type: 'string',
           minLength: 1,

--- a/path-analyser/src/ontology/artifactModelKinds.ts
+++ b/path-analyser/src/ontology/artifactModelKinds.ts
@@ -1,0 +1,47 @@
+// Artifact-kind model-spec accessors over the artifact-kinds ABox
+// (Lift 10 / #227).
+//
+// The artifact-kinds ABox declares an optional `modelKind` per kind
+// (see `artifactKindsSchema.ts` and
+// `configs/<config>/ontology/artifact-kinds.json`). `modelKind`
+// discriminates which `GeneratedModelSpec` variant the planner should
+// construct when binding an artifact to a chain. Conventional values
+// today: `'bpmn'`, `'form'`. The discriminated-union shape of
+// `GeneratedModelSpec` is itself the subject of Lift 13 (#199 / Source
+// 6); until then, only the conventional values map to a model-spec
+// entry — other values (a future second API's kinds) would surface as
+// "no model spec" rather than crash.
+//
+// All accessors are pure and tolerant of `undefined`/missing ABoxes,
+// matching the `operationRoles.ts` pattern.
+
+import type { DomainSemantics } from '../types.js';
+
+/**
+ * Subset of `DomainSemantics` consumed by the model-kind accessors.
+ * Accepting the narrow shape (instead of the full `DomainSemantics`)
+ * lets callers supply a partially-derived view (e.g. directly from
+ * `deriveArtifactKindsViews`) without fabricating unrelated top-level
+ * fields.
+ */
+type ModelKindSource = Pick<DomainSemantics, 'artifactKinds' | 'semanticTypeToArtifactKind'>;
+
+/**
+ * Resolve the `modelKind` discriminator for a semantic type by walking
+ * the ABox: `semantic → artifactKind → modelKind`. Returns `undefined`
+ * when any link in the chain is missing (e.g. the semantic has no
+ * mapping, or the kind has no `modelKind` declared).
+ *
+ * The two-step lookup is intentional: it keeps the planner from
+ * re-deriving the semantic→kind table that already lives in the ABox
+ * (`semanticTypeMap[]`), while letting per-kind `modelKind` declarations
+ * stay close to the rest of the kind's metadata.
+ */
+export function getModelKindForSemantic(
+  domain: ModelKindSource | undefined,
+  semantic: string,
+): string | undefined {
+  const artifactKind = domain?.semanticTypeToArtifactKind?.[semantic];
+  if (!artifactKind) return undefined;
+  return domain?.artifactKinds?.[artifactKind]?.modelKind;
+}

--- a/path-analyser/src/ontology/crossRefValidator.ts
+++ b/path-analyser/src/ontology/crossRefValidator.ts
@@ -57,6 +57,7 @@ const ArtifactKindSpecSchema = z
     producesStates: z.array(z.string()).optional(),
     producibleStates: z.array(z.string()).optional(),
     producesSemantics: z.array(z.string()).optional(),
+    modelKind: z.string().min(1).optional(),
   })
   .passthrough();
 

--- a/path-analyser/src/ontology/loader.ts
+++ b/path-analyser/src/ontology/loader.ts
@@ -376,6 +376,7 @@ export interface ArtifactKindsViews {
       producesSemantics?: string[];
       identifierType?: string;
       deploymentSlices?: string[];
+      modelKind?: string;
     }
   >;
   semanticTypeToArtifactKind: Record<string, string>;
@@ -408,6 +409,7 @@ export function deriveArtifactKindsViews(repoRoot: string): ArtifactKindsViews |
       deploymentSlices: k.deploymentSlices,
     };
     if (k.producibleStates !== undefined) entry.producibleStates = k.producibleStates;
+    if (k.modelKind !== undefined) entry.modelKind = k.modelKind;
     artifactKinds[k.name] = entry;
   }
   const semanticTypeToArtifactKind: Record<string, string> = {};

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -1595,12 +1595,11 @@ function ensureArtifactBindings(
         ? '__PENDING__'
         : `${camelLower(s)}_${deterministicSuffix(`sg:sem:${s}:${varName}`)}`;
     }
-    // If BPMN process definition -> ensure BPMN model spec exists
-    // Lift 10 / #227: dispatch driven by the ABox's `modelKind` field
-    // instead of a hard-coded `s === 'ProcessDefinitionKey'` /
-    // `s === 'FormKey'` literal. The `if (modelKind === 'bpmn'/'form')`
-    // branches stay because the `GeneratedModelSpec` discriminated union
-    // still carries kind-specific fields (Lift 13's concern).
+    // Resolve the GeneratedModelSpec variant for this semantic via the ABox
+    // (Lift 10 / #227): semantic → artifactKind → modelKind. The per-kind
+    // branches stay because the GeneratedModelSpec discriminated union still
+    // carries kind-specific fields (processDefinitionIdVar for bpmn,
+    // formKeyVar for form); generalising that union is Lift 13's concern.
     const modelKind = getModelKindForSemantic(graph.domain, s);
     if (modelKind === 'bpmn' && !state.modelsDraft.find((m) => m.kind === 'bpmn')) {
       state.modelsDraft.push({ kind: 'bpmn', processDefinitionIdVar: varName });

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -1,5 +1,6 @@
 import { bindSemanticInput } from './bindSemanticInput.js';
 import { deterministicSuffix } from './codegen/support/seeding.js';
+import { getModelKindForSemantic } from './ontology/artifactModelKinds.js';
 import { findDeploymentGatewayOpId, isDeploymentGatewayOp } from './ontology/operationRoles.js';
 import type {
   ArtifactRule,
@@ -1595,11 +1596,17 @@ function ensureArtifactBindings(
         : `${camelLower(s)}_${deterministicSuffix(`sg:sem:${s}:${varName}`)}`;
     }
     // If BPMN process definition -> ensure BPMN model spec exists
-    if (s === 'ProcessDefinitionKey' && !state.modelsDraft.find((m) => m.kind === 'bpmn')) {
+    // Lift 10 / #227: dispatch driven by the ABox's `modelKind` field
+    // instead of a hard-coded `s === 'ProcessDefinitionKey'` /
+    // `s === 'FormKey'` literal. The `if (modelKind === 'bpmn'/'form')`
+    // branches stay because the `GeneratedModelSpec` discriminated union
+    // still carries kind-specific fields (Lift 13's concern).
+    const modelKind = getModelKindForSemantic(graph.domain, s);
+    if (modelKind === 'bpmn' && !state.modelsDraft.find((m) => m.kind === 'bpmn')) {
       state.modelsDraft.push({ kind: 'bpmn', processDefinitionIdVar: varName });
     }
     if (
-      s === 'FormKey' &&
+      modelKind === 'form' &&
       !state.modelsDraft.find((m) => m.kind === 'form' && m.formKeyVar === varName)
     ) {
       state.modelsDraft.push({ kind: 'form', formKeyVar: varName });

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -615,6 +615,14 @@ export interface ArtifactKindSpec {
   producesSemantics?: string[];
   identifierType?: string;
   deploymentSlices?: string[]; // e.g., ["processDefinition"] or ["decisionDefinition","decisionRequirements"]
+  /**
+   * Optional discriminator selecting the `GeneratedModelSpec` variant the
+   * planner should construct when this artifact kind is bound to a chain
+   * (Lift 10 / #227). Conventional values: `'bpmn'`, `'form'`. Sourced
+   * from the artifact-kinds ABox so the planner does not need to encode
+   * a semantic→kind table that already exists in `semanticTypeMap`.
+   */
+  modelKind?: string;
 }
 
 /**


### PR DESCRIPTION
Lift 10 of the per-config ABox/TBox migration (#199). The smallest, sharpest demonstration that the planner can read the ABox it already loads.

## Problem
`ensureArtifactBindings` (`scenarioGenerator.ts:1598-1605`) hard-coded `s === 'ProcessDefinitionKey'` → `{ kind: 'bpmn' }` and `s === 'FormKey'` → `{ kind: 'form' }`, duplicating the `semanticTypeMap[]` already shipped in `configs/camunda-oca/ontology/artifact-kinds.json`.

## Approach
- **TBox** (`artifactKindsSchema.ts` + zod): add optional `modelKind` (minLength 1) to the `ArtifactKind` definition.
- **ABox** (`configs/camunda-oca/ontology/artifact-kinds.json`): `bpmnProcess.modelKind = "bpmn"`, `form.modelKind = "form"`.
- **Loader**: propagate `modelKind` through `ArtifactKindsViews.artifactKinds`.
- **New module** `path-analyser/src/ontology/artifactModelKinds.ts`: `getModelKindForSemantic(domain, semantic)` walks `semantic → artifactKind → modelKind`.
- **Planner**: `ensureArtifactBindings` now dispatches on `modelKind` instead of the raw semantic. The `if (mk === 'bpmn'/'form')` branches stay because the `GeneratedModelSpec` discriminated union still carries kind-specific fields (Lift 13's concern).

## L3 invariant
Added: `artifactKinds.bpmnProcess.modelKind === 'bpmn'` and `form.modelKind === 'form'`. Drift would silently disable deployment-model emission for those semantics.

## Output stability
`generated/` is byte-identical for camunda-oca after `testsuite:generate` + `generate:request-validation` (only the two timestamp fields differ).

## Out of scope (deferred)
- The 3 fallback-path `{ kind: 'bpmn', ... }` literals at `scenarioGenerator.ts:418, 799, 1311` (they construct kind-specific fields like `serviceTasks`) — Lift 13.
- The `GeneratedModelSpec` discriminated-union generalisation — Lift 13 (Source 6).
- The `activateJobs` job-worker special-case — Lift 14.

Closes #227
Refs #199