### PR TITLE
feat: Lift 12 Phases 2+3+4 — role-dispatched deploymentGateway (#231)

### DIFF
--- a/configs/camunda-oca/codegen/playwright/roles/deploymentGateway/call-site.tmpl
+++ b/configs/camunda-oca/codegen/playwright/roles/deploymentGateway/call-site.tmpl
@@ -1,0 +1,2 @@
+const {{{respVar}}} = await deploy({{{ctx}}}, {{{request}}}, {{{body}}}, {{{baseUrl}}} + {{{url}}}, {{{strips}}}, {{{extracts}}});
+expect({{{respVar}}}.status()).toBe({{{expectedStatus}}});

--- a/configs/camunda-oca/codegen/playwright/roles/deploymentGateway/imports.tmpl
+++ b/configs/camunda-oca/codegen/playwright/roles/deploymentGateway/imports.tmpl
@@ -1,0 +1,1 @@
+import { deploy } from '{{{supportImportPath}}}';

--- a/configs/camunda-oca/codegen/playwright/roles/deploymentGateway/match.json
+++ b/configs/camunda-oca/codegen/playwright/roles/deploymentGateway/match.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Gating conditions for the deploymentGateway role (Lift 12 / #231). A step is dispatched to this role only when its operationId carries the deploymentGateway ABox role AND every field below matches. Empty/omitted arrays match every value for that field. This keeps error-scenario createDeployment steps (e.g. expect 400) on the inline-request path, where the helper's 200-only contract doesn't apply.",
+  "bodyKinds": ["multipart"],
+  "expectedStatuses": [200]
+}

--- a/configs/camunda-oca/codegen/playwright/roles/deploymentGateway/support.ts
+++ b/configs/camunda-oca/codegen/playwright/roles/deploymentGateway/support.ts
@@ -1,17 +1,26 @@
-// Runtime helper for createDeployment multipart calls.
+// Runtime helper for the `deploymentGateway` role (Lift 12 / #231).
+//
+// Vendored into every emitted Playwright suite at
+// <outDir>/support/deploymentGateway.ts by the role-overlay materializer
+// (see path-analyser/src/codegen/playwright/materialize-support.ts). The
+// file is renamed on copy from this role directory's `support.ts` to
+// `deploymentGateway.ts` so role-owned helpers cannot collide with
+// built-in support files.
 //
 // Encapsulates the full deployment lifecycle in a single call:
 //   - resolve @@FILE: paths via resolveFixture()
-//   - build the multipart body, stripping tenantId when the default sentinel is active
-//   - POST /deployments with auth headers
+//   - build the multipart body, stripping fields per the strip rules
+//     supplied by the emitter (from globalContextSeeds)
+//   - POST <baseUrl> + the role-bound op's path with auth headers
 //   - throw a descriptive Error on any non-200 response
-//   - extract all known deployment response fields into ctx
-//   - return the APIResponse so callers can optionally call validateResponse()
+//   - walk the spec-derived `extracts` list and populate ctx via
+//     extractInto() — the helper has no hard-coded knowledge of which
+//     response fields are extracted; the list comes from the
+//     extractor's responseSemanticLeaves at codegen time
 //
-// This file is vendored verbatim into every generated Playwright suite under
-// <outDir>/support/deployment.ts by materializeSupport(). Keep it free of npm
-// package imports — only the co-vendored ./env, ./fixtures, and ./seeding
-// helpers are permitted.
+// Keep this file free of npm package imports — only the co-vendored
+// ./env, ./fixtures, and ./seeding helpers (built-in support, sibling
+// in the emitted suite) are permitted.
 
 import { authHeaders } from './env.js';
 import { resolveFixture } from './fixtures.js';
@@ -69,31 +78,49 @@ export interface DeployStripRule {
 }
 
 /**
- * Perform a createDeployment call and extract all known response fields into ctx.
+ * A response-field extraction directive: navigate `segments` on the response
+ * JSON and bind the value to `ctx[varName]` via `extractInto`. Computed at
+ * codegen time from the role-bound op's `responseSemanticLeaves` so the
+ * runtime helper carries zero spec-derived knowledge.
+ *
+ * `segments` mixes string property keys with number array indices. A `null`
+ * or `undefined` encountered partway short-circuits the walk and the
+ * variable is left untouched (extractInto skips undefined values).
+ */
+export interface DeployExtract {
+  varName: string;
+  segments: (string | number)[];
+}
+
+/**
+ * Perform a multipart deploy call against `path` and walk `extracts` against
+ * the response JSON.
  *
  * - Resolves `@@FILE:<path>` entries in `body.files` via resolveFixture().
- * - Strips fields whose resolved value equals the corresponding sentinel in `strips`
- *   (e.g. `{ fieldName: 'tenantId', sentinel: '<default>' }` for single-tenant
- *   deployments). Strips are derived by the emitter from `globalContextSeeds` so
- *   no domain-specific knowledge is hard-coded here.
- * - Throws a descriptive Error on any non-200 response (includes the response body
- *   for diagnosis).
- * - Extracts all known deployment response fields into ctx; extractInto() is a
- *   no-op for fields absent from the response, so pre-seeded ctx bindings are
- *   preserved.
+ * - Strips fields whose resolved value equals the corresponding sentinel in
+ *   `strips` (e.g. `{ fieldName: 'tenantId', sentinel: '<default>' }` for
+ *   single-tenant deployments). Strips are derived by the emitter from
+ *   `globalContextSeeds` so no domain-specific knowledge is hard-coded here.
+ * - Throws a descriptive Error on any non-200 response (includes the response
+ *   body for diagnosis).
+ * - Walks `extracts` against the parsed JSON and assigns each resolved value
+ *   to `ctx[ex.varName]` via `extractInto`. The walker short-circuits to
+ *   `undefined` on a null/missing segment; `extractInto` skips undefined
+ *   values so pre-seeded ctx bindings are preserved.
  * - Returns the APIResponse so callers can optionally call validateResponse().
  */
 export async function deploy(
   ctx: Record<string, unknown>,
   request: ApiRequestContextLike,
   body: DeployBody,
-  baseUrl: string,
-  strips?: DeployStripRule[],
+  url: string,
+  strips: DeployStripRule[],
+  extracts: DeployExtract[],
 ): Promise<ApiResponseLike> {
   const multipart: Record<string, string | { name: string; mimeType: string; buffer: Buffer }> = {};
 
   for (const [k, v] of Object.entries(body.fields ?? {})) {
-    if (strips?.some((s) => s.fieldName === k && String(v) === s.sentinel)) continue;
+    if (strips.some((s) => s.fieldName === k && String(v) === s.sentinel)) continue;
     if (v !== undefined && v !== null) multipart[k] = String(v);
   }
 
@@ -108,55 +135,36 @@ export async function deploy(
     }
   }
 
-  const resp = await request.post(`${baseUrl}/deployments`, {
+  const resp = await request.post(url, {
     headers: await authHeaders(),
     multipart,
   });
 
   if (resp.status() !== 200) {
     const text = await resp.text().catch(() => '(unreadable)');
-    throw new Error(`[createDeployment] expected HTTP 200, got ${resp.status()}: ${text}`);
+    throw new Error(`[deploy ${url}] expected HTTP 200, got ${resp.status()}: ${text}`);
   }
 
   const json = await resp.json();
 
-  // Extract all known deployment response fields. extractInto() skips
-  // undefined values, so fields absent from this response shape leave any
-  // pre-seeded ctx binding untouched.
-  extractInto(
-    ctx,
-    'processDefinitionIdVar',
-    json?.deployments?.[0]?.processDefinition?.processDefinitionId,
-  );
-  extractInto(
-    ctx,
-    'processDefinitionKeyVar',
-    json?.deployments?.[0]?.processDefinition?.processDefinitionKey,
-  );
-  extractInto(ctx, 'formKeyVar', json?.deployments?.[0]?.form?.formKey);
-  extractInto(ctx, 'deploymentKeyVar', json?.deploymentKey);
-  extractInto(ctx, 'tenantIdVar', json?.tenantId);
-  extractInto(
-    ctx,
-    'decisionDefinitionIdVar',
-    json?.deployments?.[0]?.decisionDefinition?.decisionDefinitionId,
-  );
-  extractInto(
-    ctx,
-    'decisionDefinitionKeyVar',
-    json?.deployments?.[0]?.decisionDefinition?.decisionDefinitionKey,
-  );
-  extractInto(
-    ctx,
-    'decisionRequirementsIdVar',
-    json?.deployments?.[0]?.decisionDefinition?.decisionRequirementsId,
-  );
-  extractInto(
-    ctx,
-    'decisionRequirementsKeyVar',
-    json?.deployments?.[0]?.decisionDefinition?.decisionRequirementsKey,
-  );
-  extractInto(ctx, 'formIdVar', json?.deployments?.[0]?.form?.formId);
+  for (const ex of extracts) {
+    let v: unknown = json;
+    for (const seg of ex.segments) {
+      if (v === null || v === undefined) {
+        v = undefined;
+        break;
+      }
+      if (typeof seg === 'number') {
+        v = Array.isArray(v) ? v[seg] : undefined;
+      } else if (typeof v === 'object') {
+        v = (v as Record<string, unknown>)[seg];
+      } else {
+        v = undefined;
+        break;
+      }
+    }
+    extractInto(ctx, ex.varName, v);
+  }
 
   return resp;
 }

--- a/path-analyser/scripts/copy-support-templates.js
+++ b/path-analyser/scripts/copy-support-templates.js
@@ -16,7 +16,6 @@
 //     fixtures.ts
 //     seed-rules.json
 //     await-eventually.ts
-//     deployment.ts
 // ---------------------------------------------------------------------------
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
@@ -28,7 +27,6 @@ const SUPPORT_FILES = [
   'fixtures.ts',
   'seed-rules.json',
   'await-eventually.ts',
-  'deployment.ts',
 ];
 
 async function main() {

--- a/path-analyser/src/codegen/deploymentExtracts.ts
+++ b/path-analyser/src/codegen/deploymentExtracts.ts
@@ -1,0 +1,108 @@
+// Derive the spec-driven response-extracts list for a deployment-gateway-style
+// operation (Lift 12 / #231).
+//
+// Replaces the hard-coded sequence of `extractInto(ctx, '...Var', json?...)`
+// lines inside the vendored `deploy()` helper with a list computed from the
+// role-bound operation's `responseSemanticLeaves` (harvested at load time by
+// the semantic-graph extractor from the spec's `x-semantic-type` /
+// `x-semantic-provider` annotations).
+//
+// Filtering rules (mirrors the legacy hard-coded set so this is
+// behaviour-preserving):
+//   - keep leaves whose `provider === true`
+//   - also keep top-level leaves (no `.` and no `[` in `fieldPath`) so the
+//     two depth-1 fields the legacy helper extracted (`deploymentKey`,
+//     `tenantId`) still land in ctx even though they are flagged
+//     `provider: false` in the spec
+//   - skip paths containing `.resource.` — these are the oneOf-flattened
+//     `ResourceKey` projections, which double up on values the planner reads
+//     from the typed `processDefinition`/`decisionDefinition`/`form` siblings
+//   - convert `[]` array markers to literal `[0]` index — the legacy helper
+//     only ever read the first deployments[] entry, so preserve that
+//   - dedup by `varName`, keeping the first occurrence under the
+//     deterministic sort below (so an extract is bound to exactly one path)
+//   - sort by `JSON.stringify(segments)`, then varName, so the emitted JSON
+//     literal is byte-stable across runs and machines
+//
+// `varName = <camelLower(semanticType)>Var` matches the convention used
+// throughout the planner (see `scenarioGenerator.ts:semanticToVarName()`)
+// so the extracted bindings flow into the same `ctx['...Var']` keys
+// downstream consumers expect.
+
+import type { OperationNode } from '../types.js';
+
+export interface DeploymentExtract {
+  /** ctx binding name (e.g. `processDefinitionKeyVar`). */
+  varName: string;
+  /**
+   * Path segments to walk on the deploy response JSON. String entries are
+   * object property names; number entries are array indices.
+   */
+  segments: (string | number)[];
+}
+
+function semanticToVarName(semantic: string): string {
+  // Match scenarioGenerator.ts:semanticToVarName — lowercase first char,
+  // append `Var`. E.g. `ProcessDefinitionKey` -> `processDefinitionKeyVar`.
+  if (!semantic) return 'unknownVar';
+  return `${semantic.charAt(0).toLowerCase()}${semantic.slice(1)}Var`;
+}
+
+function fieldPathToSegments(fieldPath: string): (string | number)[] {
+  // `deployments[].processDefinition.processDefinitionKey`
+  //   -> ['deployments', 0, 'processDefinition', 'processDefinitionKey']
+  const out: (string | number)[] = [];
+  for (const part of fieldPath.split('.')) {
+    const m = part.match(/^([^[]+)(\[\])?$/);
+    if (!m) {
+      out.push(part);
+      continue;
+    }
+    out.push(m[1]);
+    if (m[2] === '[]') out.push(0);
+  }
+  return out;
+}
+
+/**
+ * Compute the deterministic, deduplicated list of `(varName, segments)`
+ * tuples the deploy() helper should extract for the given role-bound op.
+ *
+ * Returns `[]` when `op` is undefined (no deployment-gateway role active in
+ * the ABox, or the role-bound op carries no response leaves). The materialized
+ * helper then runs through an empty extract loop and the test simply skips
+ * extraction — which is the correct behaviour for a config that hasn't
+ * declared a deployment gateway.
+ */
+export function computeDeploymentExtracts(op: OperationNode | undefined): DeploymentExtract[] {
+  const leaves = op?.responseSemanticLeaves ?? [];
+  const candidates = leaves
+    .filter((l) => l.status === '200')
+    .filter((l) => l.provider || !(l.fieldPath.includes('.') || l.fieldPath.includes('[')))
+    .filter((l) => !l.fieldPath.includes('.resource.'))
+    .map((l) => ({
+      varName: semanticToVarName(l.semantic),
+      segments: fieldPathToSegments(l.fieldPath),
+    }));
+
+  // Sort first by segments JSON (so a candidate with a "preferred" path —
+  // shorter/lexicographically earlier — comes before duplicates), then by
+  // varName. Dedup keeps the first occurrence per varName.
+  candidates.sort((a, b) => {
+    const aS = JSON.stringify(a.segments);
+    const bS = JSON.stringify(b.segments);
+    if (aS !== bS) return aS < bS ? -1 : 1;
+    return a.varName < b.varName ? -1 : a.varName > b.varName ? 1 : 0;
+  });
+
+  const seen = new Set<string>();
+  const result: DeploymentExtract[] = [];
+  for (const c of candidates) {
+    if (seen.has(c.varName)) continue;
+    seen.add(c.varName);
+    result.push(c);
+  }
+  // Final sort by varName for stable emission regardless of input ordering.
+  result.sort((a, b) => (a.varName < b.varName ? -1 : a.varName > b.varName ? 1 : 0));
+  return result;
+}

--- a/path-analyser/src/codegen/deploymentExtracts.ts
+++ b/path-analyser/src/codegen/deploymentExtracts.ts
@@ -88,10 +88,16 @@ export function computeDeploymentExtracts(op: OperationNode | undefined): Deploy
       segments: fieldPathToSegments(l.fieldPath),
     }));
 
-  // Sort first by segments JSON (so a candidate with a "preferred" path —
-  // shorter/lexicographically earlier — comes before duplicates), then by
-  // varName. Dedup keeps the first occurrence per varName.
+  // Sort candidates so the "preferred" path wins during dedup: shorter
+  // segment paths first (top-level wins over nested), then lexicographic
+  // JSON of segments as a deterministic tie-breaker, then varName. Without
+  // the explicit length comparison, lexicographic JSON ordering does not
+  // guarantee shorter arrays sort earlier (e.g. ["a",0,"b"] compares
+  // before ["a",0] because `,` < `]`).
   candidates.sort((a, b) => {
+    if (a.segments.length !== b.segments.length) {
+      return a.segments.length - b.segments.length;
+    }
     const aS = JSON.stringify(a.segments);
     const bS = JSON.stringify(b.segments);
     if (aS !== bS) return aS < bS ? -1 : 1;

--- a/path-analyser/src/codegen/deploymentExtracts.ts
+++ b/path-analyser/src/codegen/deploymentExtracts.ts
@@ -21,8 +21,11 @@
 //     only ever read the first deployments[] entry, so preserve that
 //   - dedup by `varName`, keeping the first occurrence under the
 //     deterministic sort below (so an extract is bound to exactly one path)
-//   - sort by `JSON.stringify(segments)`, then varName, so the emitted JSON
-//     literal is byte-stable across runs and machines
+//   - sort by `JSON.stringify(segments)`, then varName, so the
+//     shortest/lexicographically-earliest path comes first during dedup;
+//     then stabilize the final deduplicated list with a second varName sort
+//     so the emitted JSON literal is byte-stable across runs and machines
+//     regardless of the order that responseSemanticLeaves are delivered
 //
 // `varName = <camelLower(semanticType)>Var` matches the convention used
 // throughout the planner (see `scenarioGenerator.ts:semanticToVarName()`)

--- a/path-analyser/src/codegen/emitter.ts
+++ b/path-analyser/src/codegen/emitter.ts
@@ -1,4 +1,5 @@
 import type { EndpointScenarioCollection, GlobalContextSeed } from '../types.js';
+import type { LoadedRoleBundle } from './playwright/roleRenderer.js';
 
 /**
  * Context passed to an {@link Emitter} on every invocation.
@@ -34,16 +35,32 @@ export interface EmitContext {
    */
   recordResponses?: boolean;
   /**
-   * OperationId of the deployment-gateway operation in the active config
-   * (per `artifact-kinds.json#operationRules[].role === "deploymentGateway"`,
-   * Lift 9 / #225). When set, the Playwright emitter routes 200-expected
-   * multipart steps for this op through the `deploy()` support helper;
-   * otherwise every multipart step takes the inline-request path.
-   *
-   * Optional — when omitted (e.g. unit tests that don't exercise the
-   * deployment routing), no step is treated as a deployment gateway.
+   * Resolver returning the ontological role (per the active config's
+   * artifact-kinds ABox) bound to `opId`, or `undefined` when no role is
+   * declared. The Playwright emitter uses this to route role-bound steps
+   * through `roleBundles` (Lift 12 / #231) instead of the generic
+   * per-method path. Optional — emitters that omit it produce a suite
+   * with no role-dispatched steps (every step takes the inline path).
    */
-  deploymentGatewayOpId?: string;
+  getRoleForOperation?: (opId: string) => string | undefined;
+  /**
+   * Loaded per-role template bundles for the active emitter, keyed by
+   * role name. Populated by the orchestrator via
+   * `loadRoleBundlesForActiveConfig` (Lift 12 / #231). Bound roles whose
+   * bundle is missing raise a hard error during rendering — there is no
+   * silent fallback.
+   */
+  roleBundles?: Map<string, LoadedRoleBundle>;
+  /**
+   * Per-role scope additions exposed to role templates as extra Mustache
+   * variables. Keyed by role name. The renderer merges these into
+   * `PlaywrightRoleScope` before rendering `call-site.tmpl`. For the
+   * `deploymentGateway` role (Lift 12 / Phase 4) this carries an
+   * `extracts` JSON literal computed from the role-bound op's
+   * `responseSemanticLeaves`. Optional and emitter-agnostic — future
+   * roles populate their own keys.
+   */
+  roleExtras?: Map<string, Record<string, unknown>>;
 }
 
 /**

--- a/path-analyser/src/codegen/index.ts
+++ b/path-analyser/src/codegen/index.ts
@@ -6,21 +6,29 @@ import {
   getPlaywrightSuiteDir,
   getVariantOutputDir,
 } from '../configResolver.js';
+import { loadGraph } from '../graphLoader.js';
 import {
   assertSafeGlobalContextSeeds,
   deriveArtifactKindsViews,
   deriveGlobalContextSeedsViews,
 } from '../ontology/loader.js';
-import { findDeploymentGatewayOpId } from '../ontology/operationRoles.js';
+import {
+  DEPLOYMENT_GATEWAY_ROLE,
+  findDeploymentGatewayOpId,
+  getRoleForOperation,
+} from '../ontology/operationRoles.js';
 import type { EndpointScenarioCollection, GlobalContextSeed } from '../types.js';
 import { parseCliArgs } from './cli-args.js';
+import { computeDeploymentExtracts } from './deploymentExtracts.js';
 import { writeEmitted } from './orchestrator.js';
 import { PlaywrightEmitter } from './playwright/emitter.js';
 import {
   materializeFixtures,
   materializeResponseSchemas,
+  materializeRoleSupportFiles,
   materializeSupport,
 } from './playwright/materialize-support.js';
+import { loadRoleBundlesForActiveConfig } from './playwright/roleRenderer.js';
 import { getEmitter, listEmitters, registerEmitter } from './registry.js';
 
 // Built-in emitter registration. New emitters register themselves here.
@@ -104,15 +112,26 @@ async function run() {
   // forward it; non-Playwright targets see `undefined`, which the
   // EmitContext schema already treats as "use the default".
   let recordResponses: boolean | undefined;
-  // Vendor the runtime support helpers into <outDir>/support/ so the
-  // emitted suite is self-contained (no imports back into this generator).
-  // Only the Playwright emitter currently needs these; gate on the emitter id
-  // so future targets that don't depend on these helpers don't pay the cost.
+  // Lift 12 / #231: per-role template bundles for the active config's
+  // Playwright emitter. Loaded from configs/<config>/codegen/playwright/roles/
+  // and threaded into every EmitContext below. `undefined` for non-Playwright
+  // emitters (computed inside the gate below). Per-role scope additions
+  // (e.g. spec-derived `extracts` for deploymentGateway) live in
+  // `roleExtras`, keyed by role name.
+  let roleBundles: Map<string, import('./playwright/roleRenderer.js').LoadedRoleBundle> | undefined;
+  let roleExtras: Map<string, Record<string, unknown>> | undefined;
+  let getRoleForOperationFn: ((opId: string) => string | undefined) | undefined;
   if (emitter.id === 'playwright') {
     const codegenOpts = getPlaywrightCodegenOptions(repoRoot);
     recordResponses = codegenOpts.recordResponses;
     const excludeSupportFiles = recordResponses ? undefined : ['recorder.ts'];
     await materializeSupport(outDir, undefined, undefined, true, excludeSupportFiles);
+    // Lift 12 / #231: load per-role bundles and vendor their helper files
+    // alongside the built-in support files. Roles bound in the ABox but
+    // missing a bundle raise at render time (see roleRenderer.findRoleForStep
+    // in playwright/emitter.ts).
+    roleBundles = loadRoleBundlesForActiveConfig(repoRoot);
+    await materializeRoleSupportFiles(outDir, roleBundles);
     // Copy BPMN/DMN/form fixture files into <outDir>/fixtures/ so the suite
     // is self-contained: @@FILE:<rel-path> markers in emitted tests resolve
     // via support/fixtures.ts regardless of process.cwd().
@@ -136,6 +155,26 @@ async function run() {
   const deploymentGatewayOpId = findDeploymentGatewayOpId(
     artifactViews ? { operationArtifactRules: artifactViews.operationArtifactRules } : undefined,
   );
+  // Lift 12 / #231: per-role scope additions exposed to role templates as
+  // extra Mustache variables. For deploymentGateway, derive the
+  // spec-driven extracts list from the role-bound op's
+  // responseSemanticLeaves. The full operation graph is required because
+  // responseSemanticLeaves is loader-computed (not persisted in
+  // operation-dependency-graph.json), so we re-run loadGraph here.
+  if (emitter.id === 'playwright' && deploymentGatewayOpId) {
+    const graph = await loadGraph(baseDir);
+    const deployOp = graph.operations[deploymentGatewayOpId];
+    const extracts = computeDeploymentExtracts(deployOp);
+    roleExtras = new Map<string, Record<string, unknown>>();
+    roleExtras.set(DEPLOYMENT_GATEWAY_ROLE, { extracts: JSON.stringify(extracts) });
+    // Build the role-lookup closure over the same ABox view used by
+    // findDeploymentGatewayOpId so the emitter's role-dispatch path
+    // sees an identical ontology snapshot.
+    const domain = artifactViews
+      ? { operationArtifactRules: artifactViews.operationArtifactRules }
+      : undefined;
+    getRoleForOperationFn = (opId: string) => getRoleForOperation(domain, opId);
+  }
 
   if (positional === '--all') {
     let count = 0;
@@ -150,7 +189,9 @@ async function run() {
           mode: 'feature',
           globalContextSeeds,
           recordResponses,
-          deploymentGatewayOpId,
+          getRoleForOperation: getRoleForOperationFn,
+          roleBundles,
+          roleExtras,
         });
         count++;
       } catch (e) {
@@ -186,7 +227,9 @@ async function run() {
           mode: 'variant',
           globalContextSeeds,
           recordResponses,
-          deploymentGatewayOpId,
+          getRoleForOperation: getRoleForOperationFn,
+          roleBundles,
+          roleExtras,
         });
         variantCount++;
       } catch (e) {
@@ -225,7 +268,9 @@ async function run() {
     mode: 'feature',
     globalContextSeeds,
     recordResponses,
-    deploymentGatewayOpId,
+    getRoleForOperation: getRoleForOperationFn,
+    roleBundles,
+    roleExtras,
   });
   console.log('Generated test suite for', endpointOpId, 'at', outDir, `(target: ${emitter.id})`);
 }

--- a/path-analyser/src/codegen/index.ts
+++ b/path-analyser/src/codegen/index.ts
@@ -155,25 +155,27 @@ async function run() {
   const deploymentGatewayOpId = findDeploymentGatewayOpId(
     artifactViews ? { operationArtifactRules: artifactViews.operationArtifactRules } : undefined,
   );
-  // Lift 12 / #231: per-role scope additions exposed to role templates as
-  // extra Mustache variables. For deploymentGateway, derive the
-  // spec-driven extracts list from the role-bound op's
-  // responseSemanticLeaves. The full operation graph is required because
-  // responseSemanticLeaves is loader-computed (not persisted in
-  // operation-dependency-graph.json), so we re-run loadGraph here.
-  if (emitter.id === 'playwright' && deploymentGatewayOpId) {
-    const graph = await loadGraph(baseDir);
-    const deployOp = graph.operations[deploymentGatewayOpId];
-    const extracts = computeDeploymentExtracts(deployOp);
-    roleExtras = new Map<string, Record<string, unknown>>();
-    roleExtras.set(DEPLOYMENT_GATEWAY_ROLE, { extracts: JSON.stringify(extracts) });
-    // Build the role-lookup closure over the same ABox view used by
-    // findDeploymentGatewayOpId so the emitter's role-dispatch path
-    // sees an identical ontology snapshot.
+  // Lift 12 / #231: wire role dispatch for all Playwright configs that ship
+  // an ABox view, regardless of whether a deploymentGateway op is bound.
+  // Gating getRoleForOperationFn on deploymentGatewayOpId would silently
+  // disable role dispatch for any config that defines roles other than
+  // deploymentGateway (or defines deploymentGateway roles but hasn't yet
+  // bound the gateway op).
+  if (emitter.id === 'playwright') {
     const domain = artifactViews
       ? { operationArtifactRules: artifactViews.operationArtifactRules }
       : undefined;
     getRoleForOperationFn = (opId: string) => getRoleForOperation(domain, opId);
+    // Gate the deploymentGateway-specific roleExtras on deploymentGatewayOpId
+    // since loading the full operation graph is only needed to compute the
+    // spec-driven extracts list for that role.
+    if (deploymentGatewayOpId) {
+      const graph = await loadGraph(baseDir);
+      const deployOp = graph.operations[deploymentGatewayOpId];
+      const extracts = computeDeploymentExtracts(deployOp);
+      roleExtras = new Map<string, Record<string, unknown>>();
+      roleExtras.set(DEPLOYMENT_GATEWAY_ROLE, { extracts: JSON.stringify(extracts) });
+    }
   }
 
   if (positional === '--all') {

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -9,7 +9,14 @@ import type {
   RequestStep,
 } from '../../types.js';
 import type { EmitContext, EmittedFile, Emitter } from '../emitter.js';
+import type { ImportsTemplateScope, PlaywrightRoleScope } from '../roles.js';
 import { materializeFixtures, materializeSupport } from './materialize-support.js';
+import {
+  type LoadedRoleBundle,
+  renderRoleCallSite,
+  renderRoleImports,
+  stepMatchesRole,
+} from './roleRenderer.js';
 
 interface EmitOptions {
   outDir: string;
@@ -29,11 +36,17 @@ interface EmitOptions {
    */
   recordResponses?: boolean;
   /**
-   * See {@link EmitContext.deploymentGatewayOpId}. Forwarded verbatim
-   * from the orchestrator. When present, multipart-200 steps for this
-   * operationId are routed through the `deploy()` support helper.
+   * See {@link EmitContext.getRoleForOperation}. Together with
+   * {@link roleBundles} drives the role-dispatch hook (Lift 12 / #231).
+   * When either is missing, every step takes the inline (no-role-bound)
+   * path — equivalent to the pre-Lift-12 behaviour minus the legacy
+   * `isDeploymentStep` branch.
    */
-  deploymentGatewayOpId?: string;
+  getRoleForOperation?: (opId: string) => string | undefined;
+  /** See {@link EmitContext.roleBundles}. */
+  roleBundles?: Map<string, LoadedRoleBundle>;
+  /** See {@link EmitContext.roleExtras}. */
+  roleExtras?: Map<string, Record<string, unknown>>;
 }
 
 /**
@@ -59,7 +72,9 @@ export function renderPlaywrightSuite(
     mode?: 'feature' | 'integration' | 'variant';
     globalContextSeeds?: readonly GlobalContextSeed[];
     recordResponses?: boolean;
-    deploymentGatewayOpId?: string;
+    getRoleForOperation?: (opId: string) => string | undefined;
+    roleBundles?: Map<string, LoadedRoleBundle>;
+    roleExtras?: Map<string, Record<string, unknown>>;
   },
 ): string {
   return buildSuiteSource(collection, {
@@ -68,7 +83,9 @@ export function renderPlaywrightSuite(
     mode: opts.mode,
     globalContextSeeds: opts.globalContextSeeds,
     recordResponses: opts.recordResponses,
-    deploymentGatewayOpId: opts.deploymentGatewayOpId,
+    getRoleForOperation: opts.getRoleForOperation,
+    roleBundles: opts.roleBundles,
+    roleExtras: opts.roleExtras,
   });
 }
 
@@ -115,7 +132,9 @@ export const PlaywrightEmitter: Emitter = {
       mode: ctx.mode,
       globalContextSeeds: ctx.globalContextSeeds,
       recordResponses: ctx.recordResponses,
-      deploymentGatewayOpId: ctx.deploymentGatewayOpId,
+      getRoleForOperation: ctx.getRoleForOperation,
+      roleBundles: ctx.roleBundles,
+      roleExtras: ctx.roleExtras,
     });
     return [
       {
@@ -145,12 +164,32 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   }
   const lines: string[] = [];
   const suiteName = opts.suiteName || collection.endpoint.operationId;
-  // Lift 9 / #225: discriminator for the deployment-gateway routing
-  // (was a hard-coded `=== 'createDeployment'` literal). Sourced from the
-  // active-config artifact-kinds ABox by the orchestrator; an emitter
-  // invocation that does not supply it produces a suite with no
-  // deploy()-helper routing — every multipart step takes the inline path.
-  const deploymentGatewayOpId = opts.deploymentGatewayOpId;
+
+  // Lift 12 / #231: per-step role lookup. A step is dispatched to a role
+  // when (a) the active config's ABox maps its opId to a role name, AND
+  // (b) the role's loaded bundle is present, AND (c) the role's optional
+  // `match.json` gating permits the step's shape. Otherwise the step
+  // takes the generic per-method (inline) path. A step bound to a role
+  // whose bundle is missing raises in findRoleForStep — there is no
+  // silent fallback.
+  function findRoleForStep(
+    step: RequestStep,
+  ): { roleName: string; bundle: LoadedRoleBundle } | null {
+    if (!opts.getRoleForOperation || !opts.roleBundles) return null;
+    const roleName = opts.getRoleForOperation(step.operationId);
+    if (!roleName) return null;
+    const bundle = opts.roleBundles.get(roleName);
+    if (!bundle) {
+      throw new Error(
+        `Operation '${step.operationId}' is bound to role '${roleName}' in the active ABox, ` +
+          `but no template bundle is loaded for that role. Either add ` +
+          `configs/<config>/codegen/playwright/roles/${roleName}/call-site.tmpl ` +
+          `or remove the role binding from the operation rule.`,
+      );
+    }
+    if (!stepMatchesRole(step, bundle)) return null;
+    return { roleName, bundle };
+  }
 
   // Determine upfront whether any scenario will emit a validateResponse() call
   // so we can conditionally include the import and constant.
@@ -194,21 +233,16 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   if (recordResponses) {
     lines.push("import { recordResponse, sanitizeBody } from './support/recorder';");
   }
-  // extractInto is used in the per-step extract loop. For deploy() steps only
-  // placeholderAlias extracts are emitted (all others are handled internally by
-  // deploy()). Mirror that filter here so the import is not emitted when all
-  // extracts for a deployment step are non-alias entries — those generate no
-  // extractInto() calls in the suite, which would produce a Biome noUnusedImports
-  // error.
+  // extractInto is used in the per-step extract loop. For role-bound steps
+  // only placeholderAlias extracts are emitted (all others are handled
+  // internally by the role's helper). Mirror that filter here so the
+  // import is not emitted when all extracts for a roled step are non-alias
+  // entries — those generate no extractInto() calls in the suite, which
+  // would produce a Biome noUnusedImports error.
   const hasAnyExtract = collection.scenarios.some((s) =>
     (s.requestPlan ?? []).some((step) => {
-      const isDeployStep =
-        !!deploymentGatewayOpId &&
-        step.operationId === deploymentGatewayOpId &&
-        step.bodyKind === 'multipart' &&
-        !!step.multipartTemplate &&
-        step.expect.status === 200;
-      const relevant = isDeployStep
+      const role = findRoleForStep(step);
+      const relevant = role
         ? (step.extract ?? []).filter((ex) => ex.note === 'placeholderAlias')
         : (step.extract ?? []);
       return relevant.length > 0;
@@ -219,56 +253,54 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   } else {
     lines.push("import { seedBinding, initSpecSalt } from './support/seeding';");
   }
-  // deploy() is emitted for 200-expected multipart steps whose operationId
-  // matches the active config's deployment-gateway role (Lift 9 / #225);
-  // resolveFixture is emitted for any step that falls through to the inline
-  // multipart path — this includes non-deployment-gateway multipart steps
-  // AND deployment-gateway steps with a non-200 expected status (which are
-  // not routed through deploy()). Mirror the isDeploymentStep condition
-  // exactly so the two flags stay in sync.
-  const hasDeploymentMultipart = collection.scenarios.some((s) =>
-    (s.requestPlan ?? []).some(
-      (step) =>
-        !!deploymentGatewayOpId &&
-        step.operationId === deploymentGatewayOpId &&
-        step.bodyKind === 'multipart' &&
-        !!step.multipartTemplate &&
-        step.expect.status === 200,
-    ),
-  );
+  // resolveFixture is emitted for every step that falls through to the
+  // inline multipart path — i.e. multipart steps with no role match. Role
+  // helpers vendor their own fixture access internally.
   const hasOtherMultipart = collection.scenarios.some((s) =>
     (s.requestPlan ?? []).some(
-      (step) =>
-        step.bodyKind === 'multipart' &&
-        !!step.multipartTemplate &&
-        !(
-          !!deploymentGatewayOpId &&
-          step.operationId === deploymentGatewayOpId &&
-          step.expect.status === 200
-        ),
+      (step) => step.bodyKind === 'multipart' && !!step.multipartTemplate && !findRoleForStep(step),
     ),
   );
-  // authHeaders is used in inline request steps and awaitEventually witness blocks.
-  // deploy() calls authHeaders internally, so deploy()-only suites don't need this import.
+  // authHeaders is used in inline request steps and awaitEventually witness
+  // blocks. Role helpers call authHeaders internally, so role-only suites
+  // don't need this import.
   const hasInlineRequestStep = collection.scenarios.some((s) =>
-    (s.requestPlan ?? []).some(
-      (step) =>
-        !(
-          !!deploymentGatewayOpId &&
-          step.operationId === deploymentGatewayOpId &&
-          step.bodyKind === 'multipart' &&
-          !!step.multipartTemplate &&
-          step.expect.status === 200
-        ),
-    ),
+    (s.requestPlan ?? []).some((step) => !findRoleForStep(step)),
   );
   if (hasInlineRequestStep || needsAwaitEventually) {
     lines.push("import { buildBaseUrl, authHeaders } from './support/env';");
   } else {
     lines.push("import { buildBaseUrl } from './support/env';");
   }
-  if (hasDeploymentMultipart) {
-    lines.push("import { deploy } from './support/deployment';");
+  // Per-role imports (Lift 12 / #231): for every role used by at least one
+  // step in the collection, render the role's `imports.tmpl` once with a
+  // role-static scope ({ roleName, supportImportPath }). Roles without an
+  // `imports.tmpl` contribute nothing. The renderer trims trailing
+  // newlines so the emitted block sits cleanly alongside hand-written
+  // import lines.
+  const usedRoles = new Set<string>();
+  for (const s of collection.scenarios) {
+    for (const step of s.requestPlan ?? []) {
+      const role = findRoleForStep(step);
+      if (role) usedRoles.add(role.roleName);
+    }
+  }
+  // Deterministic emission order: alphabetical by role name. Avoids spec
+  // file churn when role discovery order changes between runs.
+  const sortedRoles = [...usedRoles].sort();
+  for (const roleName of sortedRoles) {
+    const bundle = opts.roleBundles?.get(roleName);
+    if (!bundle) continue;
+    const importsScope: ImportsTemplateScope = {
+      roleName,
+      supportImportPath: `./support/${roleName}`,
+    };
+    const rendered = renderRoleImports(bundle, importsScope).trim();
+    if (rendered) {
+      for (const line of rendered.split('\n')) {
+        if (line.trim()) lines.push(line);
+      }
+    }
   }
   if (hasOtherMultipart) {
     lines.push("import { resolveFixture } from './support/fixtures';");
@@ -290,7 +322,9 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   lines.push(`test.describe('${suiteName}', () => {`);
   const seeds = opts.globalContextSeeds ?? [];
   for (const scenario of collection.scenarios) {
-    lines.push(renderScenarioTest(scenario, seeds, recordResponses, deploymentGatewayOpId));
+    lines.push(
+      renderScenarioTest(scenario, seeds, recordResponses, findRoleForStep, opts.roleExtras),
+    );
   }
   lines.push('});');
   return lines.join('\n');
@@ -300,7 +334,8 @@ function renderScenarioTest(
   s: EndpointScenario,
   globalContextSeeds: readonly GlobalContextSeed[],
   recordResponses: boolean,
-  deploymentGatewayOpId: string | undefined,
+  findRoleForStep: (step: RequestStep) => { roleName: string; bundle: LoadedRoleBundle } | null,
+  roleExtras: Map<string, Record<string, unknown>> | undefined,
 ): string {
   const title = `${s.id} - ${escapeQuotes(s.name || 'scenario')}`;
   const body: string[] = [];
@@ -404,9 +439,9 @@ function renderScenarioTest(
   // sentinel.
   //
   // The local is only emitted when the scenario has at least one inline
-  // multipart step (i.e. a multipart step that is NOT routed through
-  // deploy()). deploy() steps pass strips as a JSON literal argument and
-  // never read the prologue local; omitting it for deploy-only scenarios
+  // multipart step (i.e. a multipart step that is NOT dispatched to a
+  // role). Role-bound steps pass strips as a JSON literal argument and
+  // never read the prologue local; omitting it for role-only scenarios
   // prevents an unused-variable error in the generated suite.
   //
   // Safety: `binding`, `fieldName`, `seedRule` are all required by the
@@ -416,14 +451,7 @@ function renderScenarioTest(
   // directly into emitted single-quoted TS string literals without an
   // escape pass.
   const hasInlineMultipartStep = (s.requestPlan ?? []).some(
-    (step) =>
-      step.bodyKind === 'multipart' &&
-      !!step.multipartTemplate &&
-      !(
-        !!deploymentGatewayOpId &&
-        step.operationId === deploymentGatewayOpId &&
-        step.expect.status === 200
-      ),
+    (step) => step.bodyKind === 'multipart' && !!step.multipartTemplate && !findRoleForStep(step),
   );
   const sentinelLocals = new Map<string, string>(); // fieldName -> local var name
   for (const seed of globalContextSeeds) {
@@ -468,47 +496,63 @@ function renderScenarioTest(
     // confined to the callback.
     body.push(`  await test.step(${JSON.stringify(step.operationId)}, async () => {`);
 
-    // Deployment-gateway multipart steps use the deploy() helper which
-    // encapsulates multipart body building, @@FILE: resolution, auth, HTTP
-    // POST, status assertion (throws on non-200), and extraction of all
-    // known deployment response fields into ctx. This keeps each deployment
-    // step as a single declarative call instead of ~35 lines of boilerplate.
-    // Only route 200-expected steps through deploy(): the helper hard-codes a
-    // 200 assertion, so a step with a declared non-200 expected status must
-    // fall through to the normal request path where step.expect.status is honoured.
-    // Lift 9 / #225: the operationId is sourced from the active config's
-    // artifact-kinds ABox role lookup, not a hard-coded literal.
-    const isDeploymentStep =
-      !!deploymentGatewayOpId &&
-      step.operationId === deploymentGatewayOpId &&
-      step.bodyKind === 'multipart' &&
-      !!step.multipartTemplate &&
-      step.expect.status === 200;
-    if (isDeploymentStep && step.multipartTemplate) {
-      const tpl = JSON.stringify(step.multipartTemplate, null, 2).replace(
-        /"\\?\$\{([^}]+)\}"/g,
-        (_, v) => `ctx["${v}"]`,
-      );
-      // Indent all lines after the first so the object literal aligns under
-      // the opening `{` in the deploy() call.
-      const tplIndented = tpl
+    // Lift 12 / #231: per-step role dispatch. When the step's opId is bound
+    // to a role in the active config's ABox AND the role's `match.json`
+    // gating permits the step's shape, render the role's `call-site.tmpl`
+    // with the per-step scope. Otherwise fall through to the generic
+    // per-method (inline) path. The role's helper encapsulates body
+    // building, auth, the HTTP request, status assertion, and any
+    // role-specific response extraction. See ROLES.md.
+    const roleMatch = findRoleForStep(step);
+    if (roleMatch) {
+      const tpl = JSON.stringify(
+        step.multipartTemplate ?? step.bodyTemplate ?? {},
+        null,
+        2,
+      ).replace(/"\\?\$\{([^}]+)\}"/g, (_, v) => `ctx["${v}"]`);
+      // Indent all lines after the first so the body literal aligns under
+      // its opening `{` in the helper call.
+      const bodyIndented = tpl
         .split('\n')
         .map((line: string, i: number) => (i === 0 ? line : `    ${line}`))
         .join('\n');
-      // Derive strip rules from globalContextSeeds so deploy() has no
+      // Derive strip rules from globalContextSeeds so the helper has no
       // hard-coded domain knowledge about sentinel values or field names.
       const strips = globalContextSeeds
         .filter((seed) => seed.stripFromMultipartWhenDefault && seed.defaultSentinel !== undefined)
         .map((seed) => ({ fieldName: seed.fieldName, sentinel: seed.defaultSentinel }));
-      const stripsArg = strips.length > 0 ? `, ${JSON.stringify(strips)}` : '';
-      body.push(
-        `    const ${varName} = await deploy(ctx, request, ${tplIndented}, baseUrl${stripsArg});`,
-      );
-      // Explicit status assertion mirrors the normal request path so the
-      // generated suite's assertion pattern is consistent across all steps.
-      // deploy() also throws on non-200 with the response body, but the
-      // expect() call keeps the declared expectation visible in the test.
-      body.push(`    expect(${varName}.status()).toBe(${step.expect.status});`);
+      const stripsLit = JSON.stringify(strips);
+      // Per-role data computed by the orchestrator (e.g. extracts derived
+      // from the role-bound op's responseSemanticLeaves for the
+      // deploymentGateway role). Roles that don't consume this simply
+      // ignore the scope variable in their template.
+      const extras = roleExtras?.get(roleMatch.roleName) ?? {};
+      const scope: PlaywrightRoleScope & Record<string, unknown> = {
+        respVar: varName,
+        pathTemplate: step.pathTemplate,
+        method: step.method.toUpperCase(),
+        operationId: step.operationId,
+        roleName: roleMatch.roleName,
+        defaultRender: '', // (#231 future: eager-rendered inline path; not consumed by deploymentGateway today)
+        ctx: 'ctx',
+        request: 'request',
+        baseUrl: 'baseUrl',
+        body: bodyIndented,
+        strips: stripsLit,
+        // `extracts` is a per-emitter scope variable (PlaywrightRoleScope):
+        // default to `[]` so a role bundle that hasn't been wired with
+        // per-role extras still renders. roleExtras may override.
+        extracts: '[]',
+        ...extras,
+        // Additional context vars used by the deploymentGateway template:
+        url: buildUrlExpression(step.pathTemplate),
+        expectedStatus: String(step.expect.status),
+      };
+      const rendered = renderRoleCallSite(roleMatch.bundle, scope);
+      // Indent each line to match the test-body depth (`    `).
+      for (const line of rendered.split('\n')) {
+        body.push(line ? `    ${line}` : '');
+      }
     } else {
       body.push(`    const url = baseUrl + ${urlExpr};`);
       const bodyVar = `body${idx + 1}`;
@@ -582,7 +626,7 @@ function renderScenarioTest(
       body.push(`    expect(${varName}.status()).toBe(${step.expect.status});`);
     }
     // Record observation for this step (best-effort). Only capture response shapes for 200 responses.
-    // For deploy() steps the helper throws on non-200, so __status is always 200 when this block runs.
+    // For role-bound steps the helper throws on non-200, so __status is always 200 when this block runs.
     if (recordResponses) {
       body.push(`    try {`);
       body.push(`      const __status = ${varName}.status();`);
@@ -628,15 +672,16 @@ function renderScenarioTest(
     // it skips the assignment when the value is `undefined` so seeded bindings
     // and earlier extracts in the same scenario aren't clobbered by a later step
     // whose response shape omits the field.
-    // deploy() steps: deploy() already extracts all known deployment response
-    // fields internally (processDefinitionKeyVar, deploymentKeyVar, tenantIdVar,
-    // etc.). Emitting those same extractInto() calls outside the helper would
-    // call resp.json() a second time and duplicate every assignment.
-    // Exception: placeholderAlias entries (note === 'placeholderAlias') bind to
-    // DIFFERENT ctx keys than deploy()'s hard-coded targets (e.g. an alias from
-    // processDefinitionKey → processDefinitionIdVar). deploy() has no knowledge
-    // of these aliases, so they must still be emitted here.
-    const effectiveExtracts = isDeploymentStep
+    // Role-bound steps: the role's helper handles its own response extraction
+    // internally (driven by per-role data threaded through roleExtras —
+    // e.g. the `extracts` list for deploymentGateway). Emitting the same
+    // extracts outside the helper would call resp.json() a second time and
+    // duplicate every assignment.
+    // Exception: placeholderAlias entries (note === 'placeholderAlias') bind
+    // to DIFFERENT ctx keys than the role helper's extracts (e.g. an alias
+    // from processDefinitionKey → processDefinitionIdVar). The role helper
+    // has no knowledge of these aliases, so they must still be emitted here.
+    const effectiveExtracts = roleMatch
       ? (step.extract ?? []).filter((ex) => ex.note === 'placeholderAlias')
       : (step.extract ?? []);
     if (effectiveExtracts.length) {

--- a/path-analyser/src/codegen/playwright/emitter.ts
+++ b/path-analyser/src/codegen/playwright/emitter.ts
@@ -503,6 +503,18 @@ function renderScenarioTest(
     // per-method (inline) path. The role's helper encapsulates body
     // building, auth, the HTTP request, status assertion, and any
     // role-specific response extraction. See ROLES.md.
+    // Pre-compute the generic inline lines so they are available as
+    // `defaultRender` in the role scope (wrap-pattern contract from ROLES.md)
+    // and as the body source for non-role steps.
+    const inlineLines = renderInlineStepLines({
+      step,
+      idx,
+      varName,
+      urlExpr,
+      method,
+      sentinelLocals,
+      awaitStepIndices,
+    });
     const roleMatch = findRoleForStep(step);
     if (roleMatch) {
       const tpl = JSON.stringify(
@@ -533,7 +545,9 @@ function renderScenarioTest(
         method: step.method.toUpperCase(),
         operationId: step.operationId,
         roleName: roleMatch.roleName,
-        defaultRender: '', // (#231 future: eager-rendered inline path; not consumed by deploymentGateway today)
+        // The eagerly-rendered inline path for this step so role templates
+        // can implement a wrap pattern via `{{{defaultRender}}}`.
+        defaultRender: inlineLines.join('\n'),
         ctx: 'ctx',
         request: 'request',
         baseUrl: 'baseUrl',
@@ -554,76 +568,7 @@ function renderScenarioTest(
         body.push(line ? `    ${line}` : '');
       }
     } else {
-      body.push(`    const url = baseUrl + ${urlExpr};`);
-      const bodyVar = `body${idx + 1}`;
-      if (step.bodyKind === 'json' && step.bodyTemplate) {
-        const json = JSON.stringify(step.bodyTemplate, null, 4).replace(
-          /"\\?\$\{([^}]+)\}"/g,
-          (_, v) => `ctx["${v}"]`,
-        );
-        body.push(`    const ${bodyVar} = ${json};`);
-      } else if (step.bodyKind === 'multipart' && step.multipartTemplate) {
-        // Non-createDeployment multipart template
-        const tpl = JSON.stringify(step.multipartTemplate, null, 4).replace(
-          /"\\?\$\{([^}]+)\}"/g,
-          (_, v) => `ctx["${v}"]`,
-        );
-        body.push(`    const ${bodyVar} = ${tpl};`);
-      }
-      const opts: string[] = [];
-      opts.push('headers: await authHeaders()');
-      if (step.bodyKind === 'json' && step.bodyTemplate) opts.push(`data: ${bodyVar}`);
-      if (step.bodyKind === 'multipart' && step.multipartTemplate) {
-        // Convert template to Playwright's expected multipart shape: a keyed object map.
-        // Field values are stringified (`String(v)`); file values are passed as
-        // `{ name, mimeType, buffer }`. The element type below mirrors the
-        // permissive subset of Playwright's `multipart` option that we actually
-        // emit, so the generated suite typechecks under `strict: true` when
-        // `request.post({ multipart })` is called.
-        body.push(
-          `    const multipart: Record<string, string | { name: string; mimeType: string; buffer: Buffer }> = {};`,
-        );
-        body.push(`    for (const [k,v] of Object.entries(${bodyVar}.fields||{})) {`);
-        // Emit a strip branch for every globalContextSeeds entry whose
-        // sentinel local was declared in the prologue. The emitter never
-        // hard-codes a field name here — the field name is the metadata key
-        // and the local was named after it.
-        for (const [fieldName, local] of sentinelLocals) {
-          body.push(`      if (k === '${fieldName}' && ${local}) continue;`);
-        }
-        body.push(`      if (v !== undefined && v !== null) multipart[k] = String(v);`);
-        body.push(`    }`);
-        body.push(`    for (const [k,v] of Object.entries(${bodyVar}.files||{})) {
-        if (typeof v === 'string' && v.startsWith('@@FILE:')) {
-          const p = v.slice('@@FILE:'.length);
-          const buf = await resolveFixture(p);
-          const name = p.split('/').pop() || 'file';
-          multipart[k] = { name, mimeType: 'application/octet-stream', buffer: buf };
-        } else {
-          multipart[k] = String(v);
-        }
-      }`);
-        opts.push('multipart: multipart');
-      }
-      // (#106) Eventually-consistent reads are wrapped with awaitEventually(),
-      // which retries the same request within a budget until the response is
-      // observably consistent (default predicate for POST .../search:
-      // `body.items.length > 0`; for GET: any 200) and returns the final
-      // APIResponse. Non-EC steps go straight through `request.${method}`.
-      if (awaitStepIndices.has(idx)) {
-        body.push(`    const ${varName} = await awaitEventually(`);
-        body.push(`      async () => request.${method}(url, { ${opts.join(', ')} }),`);
-        body.push(
-          `      { method: '${step.method.toUpperCase()}', operationId: '${step.operationId}' },`,
-        );
-        body.push(`    );`);
-      } else {
-        body.push(`    const ${varName} = await request.${method}(url, { ${opts.join(', ')} });`);
-      }
-      body.push(`    if (${varName}.status() !== ${step.expect.status}) {`);
-      body.push(`      try { console.error('Response body:', await ${varName}.text()); } catch {}`);
-      body.push(`    }`);
-      body.push(`    expect(${varName}.status()).toBe(${step.expect.status});`);
+      for (const line of inlineLines) body.push(line);
     }
     // Record observation for this step (best-effort). Only capture response shapes for 200 responses.
     // For role-bound steps the helper throws on non-200, so __status is always 200 when this block runs.
@@ -715,6 +660,104 @@ function buildUrlExpression(pathTemplate: string): string {
     pathTemplate.replace(/\{([^}]+)\}/g, (_, p) => `\${ctx.${camelCase(p)}Var || '\${${p}}'}`) +
     '`'
   );
+}
+
+/**
+ * Render the generic per-step inline code lines. Used both as the body
+ * source for non-role steps (pushed directly onto the scenario body array)
+ * and as `defaultRender` in the role scope so role templates can implement
+ * a wrap pattern via `{{{defaultRender}}}` (see ROLES.md).
+ */
+interface InlineStepRenderInput {
+  step: RequestStep;
+  idx: number;
+  varName: string;
+  urlExpr: string;
+  method: string;
+  sentinelLocals: Map<string, string>;
+  awaitStepIndices: Set<number>;
+}
+function renderInlineStepLines({
+  step,
+  idx,
+  varName,
+  urlExpr,
+  method,
+  sentinelLocals,
+  awaitStepIndices,
+}: InlineStepRenderInput): string[] {
+  const lines: string[] = [];
+  const bodyVar = `body${idx + 1}`;
+  lines.push(`    const url = baseUrl + ${urlExpr};`);
+  if (step.bodyKind === 'json' && step.bodyTemplate) {
+    const json = JSON.stringify(step.bodyTemplate, null, 4).replace(
+      /"\\?\$\{([^}]+)\}"/g,
+      (_, v) => `ctx["${v}"]`,
+    );
+    lines.push(`    const ${bodyVar} = ${json};`);
+  } else if (step.bodyKind === 'multipart' && step.multipartTemplate) {
+    // Non-createDeployment multipart template
+    const tpl = JSON.stringify(step.multipartTemplate, null, 4).replace(
+      /"\\?\$\{([^}]+)\}"/g,
+      (_, v) => `ctx["${v}"]`,
+    );
+    lines.push(`    const ${bodyVar} = ${tpl};`);
+  }
+  const opts: string[] = [];
+  opts.push('headers: await authHeaders()');
+  if (step.bodyKind === 'json' && step.bodyTemplate) opts.push(`data: ${bodyVar}`);
+  if (step.bodyKind === 'multipart' && step.multipartTemplate) {
+    // Convert template to Playwright's expected multipart shape: a keyed object map.
+    // Field values are stringified (`String(v)`); file values are passed as
+    // `{ name, mimeType, buffer }`. The element type below mirrors the
+    // permissive subset of Playwright's `multipart` option that we actually
+    // emit, so the generated suite typechecks under `strict: true` when
+    // `request.post({ multipart })` is called.
+    lines.push(
+      `    const multipart: Record<string, string | { name: string; mimeType: string; buffer: Buffer }> = {};`,
+    );
+    lines.push(`    for (const [k,v] of Object.entries(${bodyVar}.fields||{})) {`);
+    // Emit a strip branch for every globalContextSeeds entry whose
+    // sentinel local was declared in the prologue. The emitter never
+    // hard-codes a field name here — the field name is the metadata key
+    // and the local was named after it.
+    for (const [fieldName, local] of sentinelLocals) {
+      lines.push(`      if (k === '${fieldName}' && ${local}) continue;`);
+    }
+    lines.push(`      if (v !== undefined && v !== null) multipart[k] = String(v);`);
+    lines.push(`    }`);
+    lines.push(`    for (const [k,v] of Object.entries(${bodyVar}.files||{})) {
+        if (typeof v === 'string' && v.startsWith('@@FILE:')) {
+          const p = v.slice('@@FILE:'.length);
+          const buf = await resolveFixture(p);
+          const name = p.split('/').pop() || 'file';
+          multipart[k] = { name, mimeType: 'application/octet-stream', buffer: buf };
+        } else {
+          multipart[k] = String(v);
+        }
+      }`);
+    opts.push('multipart: multipart');
+  }
+  // (#106) Eventually-consistent reads are wrapped with awaitEventually(),
+  // which retries the same request within a budget until the response is
+  // observably consistent (default predicate for POST .../search:
+  // `body.items.length > 0`; for GET: any 200) and returns the final
+  // APIResponse. Non-EC steps go straight through `request.${method}`.
+  if (awaitStepIndices.has(idx)) {
+    lines.push(`    const ${varName} = await awaitEventually(`);
+    lines.push(`      async () => request.${method}(url, { ${opts.join(', ')} }),`);
+    lines.push(
+      `      { method: '${step.method.toUpperCase()}', operationId: '${step.operationId}' },`,
+    );
+    lines.push(`    );`);
+  } else {
+    lines.push(`    const ${varName} = await request.${method}(url, { ${opts.join(', ')} });`);
+  }
+  lines.push(`    if (${varName}.status() !== ${step.expect.status}) {`);
+  lines.push(`      try { console.error('Response body:', await ${varName}.text()); } catch {}`);
+  lines.push(`    }`);
+  lines.push(`    expect(${varName}.status()).toBe(${step.expect.status});`);
+  return lines;
 }
 
 function escapeQuotes(s: string): string {

--- a/path-analyser/src/codegen/playwright/materialize-support.ts
+++ b/path-analyser/src/codegen/playwright/materialize-support.ts
@@ -9,11 +9,15 @@
 //
 // Three sets of assets are copied:
 //   * support/ — runtime helpers (env.ts, recorder.ts, seeding.ts,
-//                fixtures.ts, seed-rules.json, await-eventually.ts,
-//                deployment.ts). Sources:
+//                fixtures.ts, seed-rules.json, await-eventually.ts).
+//                Sources:
 //                path-analyser/src/codegen/support/, staged into
 //                dist/src/codegen/playwright/support-templates/ at
 //                build time.
+//                PLUS per-role overlays from
+//                configs/<config>/codegen/playwright/roles/<role>/support.<ext>
+//                copied (renamed) to support/<role>.<ext>
+//                — see materializeRoleSupportFiles().
 //   * project root — package.json, playwright.config.ts, tsconfig.json,
 //                    .env.example, README.md.
 //                    Sources: path-analyser/templates/.
@@ -37,7 +41,6 @@ export const SUPPORT_TEMPLATE_FILES = [
   'fixtures.ts',
   'seed-rules.json',
   'await-eventually.ts',
-  'deployment.ts',
 ] as const;
 
 /** Files copied directly into <outDir>/ (project root scaffolding). */
@@ -169,6 +172,73 @@ export async function materializeSupport(
   }
 
   return destDir;
+}
+
+/**
+ * Vendor per-role helper files from the active config's role overlay
+ * (Lift 12 / #231) into `<outDir>/support/<role>.<ext>`.
+ *
+ * Walks `configs/<config>/codegen/playwright/roles/<role>/` directories
+ * via the role loader and, for each role whose directory contains a
+ * `support.<ext>` file, copies that file to the suite as `<role>.<ext>`.
+ * The rename collapses the per-role directory into a single suite-local
+ * file so role helpers cannot collide on basename and so the emitter's
+ * generated `import { ... } from './support/<role>'` line is stable.
+ *
+ * Raises when a role's helper basename (`<role>`) would collide with a
+ * built-in support file basename (e.g. a role named `env` or `seeding`),
+ * since the emitted suite imports built-ins as `./support/env`,
+ * `./support/seeding`, etc. and an overwrite would silently break the
+ * suite's imports. The error names both the role and the colliding
+ * built-in so the operator can rename the role.
+ *
+ * @param outDir       Same directory passed to {@link materializeSupport}.
+ * @param roleBundles  Loaded role bundles, as returned by
+ *                     `loadRoleBundlesForActiveConfig`. Decoupled from
+ *                     this module's loader so callers (codegen orchestrator
+ *                     + tests) construct the bundle map once and share it
+ *                     between the materializer and the renderer.
+ * @returns            The list of vendored file basenames (e.g.
+ *                     `['deploymentGateway.ts']`) for callers that want to
+ *                     assert what was copied.
+ */
+export async function materializeRoleSupportFiles(
+  outDir: string,
+  roleBundles: Map<string, { role: string; supportFilePath?: string }>,
+): Promise<string[]> {
+  const destDir = path.join(outDir, SUPPORT_DIR_NAME);
+  await fs.mkdir(destDir, { recursive: true });
+
+  // Build a quick lookup of built-in basenames (without extension) so we
+  // can detect role-vs-builtin collisions before any copy happens.
+  const builtInStems = new Set(
+    SUPPORT_TEMPLATE_FILES.map((f) => {
+      const dot = f.lastIndexOf('.');
+      return dot >= 0 ? f.slice(0, dot) : f;
+    }),
+  );
+
+  const copied: string[] = [];
+  for (const [roleName, bundle] of roleBundles) {
+    if (!bundle.supportFilePath) continue;
+    if (builtInStems.has(roleName)) {
+      throw new Error(
+        `materializeRoleSupportFiles: role '${roleName}' collides with a built-in support ` +
+          `file basename (${[...builtInStems].join(', ')}). Rename the role.`,
+      );
+    }
+    const ext = path.extname(bundle.supportFilePath);
+    const destName = `${roleName}${ext}`;
+    if (copied.includes(destName)) {
+      throw new Error(
+        `materializeRoleSupportFiles: role '${roleName}' produced duplicate destination ${destName}.`,
+      );
+    }
+    await fs.copyFile(bundle.supportFilePath, path.join(destDir, destName));
+    copied.push(destName);
+  }
+
+  return copied;
 }
 
 /** Subdirectory created under the emitter's outDir to hold BPMN/DMN/form

--- a/path-analyser/src/codegen/playwright/materialize-support.ts
+++ b/path-analyser/src/codegen/playwright/materialize-support.ts
@@ -223,8 +223,8 @@ export async function materializeRoleSupportFiles(
     if (!bundle.supportFilePath) continue;
     if (builtInStems.has(roleName)) {
       throw new Error(
-        `materializeRoleSupportFiles: role '${roleName}' collides with a built-in support ` +
-          `file basename (${[...builtInStems].join(', ')}). Rename the role.`,
+        `materializeRoleSupportFiles: role '${roleName}' collides with the built-in support ` +
+          `file '${roleName}.*'. Rename the role.`,
       );
     }
     const ext = path.extname(bundle.supportFilePath);

--- a/path-analyser/src/codegen/playwright/roleRenderer.ts
+++ b/path-analyser/src/codegen/playwright/roleRenderer.ts
@@ -28,8 +28,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 // Top-level import (vs. dynamic `await import`) — mustache is a small
-// CommonJS package with a default export carrying `render`. Cleanest at the
-// type system level is to use the namespace import.
+// CommonJS package with a default export carrying `render`.
 import Mustache from 'mustache';
 import { getActiveConfigDir } from '../../configResolver.js';
 import type { RequestStep } from '../../types.js';

--- a/path-analyser/src/codegen/playwright/roleRenderer.ts
+++ b/path-analyser/src/codegen/playwright/roleRenderer.ts
@@ -1,0 +1,201 @@
+// Per-config, per-role template renderer for the Playwright emitter
+// (Lift 12 / #231).
+//
+// The renderer is uniform: for every step the Playwright emitter looks up
+// the step's role via the ABox, asks the renderer for the call-site code,
+// and uses it. The generic per-method path is just the "no role bound to
+// this op" arm. Bound roles whose directory is missing OR whose
+// `call-site.tmpl` is missing raise a hard error — there is no silent
+// fallback (see ROLES.md).
+//
+// Roles live at `configs/<config>/codegen/playwright/roles/<role>/` and
+// each may contain:
+//   * `call-site.tmpl` (required) — Mustache template for the step's body
+//   * `imports.tmpl`   (optional) — Mustache template for the imports
+//                                    block contributions (rendered once
+//                                    per spec-file, per role used)
+//   * `support.<ext>`  (optional) — runtime helper vendored into the
+//                                    suite under `<outDir>/support/<role>.<ext>`
+//   * `match.json`     (optional) — gating conditions; without it the role
+//                                    matches every step whose opId carries
+//                                    the role binding in the ABox
+//
+// All templates are logic-free Mustache 4.x; authors must use triple-braces
+// (`{{{var}}}`) for code interpolation to avoid HTML-escaping of `/`, `<`,
+// `>` and `&` (which would corrupt TypeScript output).
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+// Top-level import (vs. dynamic `await import`) — mustache is a small
+// CommonJS package with a default export carrying `render`. Cleanest at the
+// type system level is to use the namespace import.
+import Mustache from 'mustache';
+import { getActiveConfigDir } from '../../configResolver.js';
+import type { RequestStep } from '../../types.js';
+import type { ImportsTemplateScope, PlaywrightRoleScope, RoleTemplateBundle } from '../roles.js';
+
+const ROLES_DIRNAME = 'roles';
+const EMITTER_DIRNAME = 'playwright';
+const CODEGEN_DIRNAME = 'codegen';
+
+/**
+ * Optional per-role gating rules (`match.json`) that constrain which steps
+ * with the role-bound opId actually dispatch through the role. An empty or
+ * omitted array on a field matches every value for that field.
+ */
+interface RoleMatchSpec {
+  bodyKinds?: string[];
+  expectedStatuses?: number[];
+}
+
+/**
+ * In-memory representation of a discovered role directory, with all
+ * templates eagerly loaded. Templates are tiny (under 1KB each) so the
+ * memory cost is negligible and avoids race conditions / repeated disk
+ * reads during the per-step render loop.
+ */
+export interface LoadedRoleBundle extends RoleTemplateBundle {
+  /** Eagerly-loaded contents of `call-site.tmpl`. */
+  callSiteTemplate: string;
+  /** Eagerly-loaded contents of `imports.tmpl`, when present. */
+  importsTemplate?: string;
+  /** Parsed `match.json`, when present. */
+  match?: RoleMatchSpec;
+}
+
+/**
+ * Locate the repo root (the directory containing `configs.json`) by
+ * walking up from this module's location. Robust across both tsx (source)
+ * and dist runtime modes so the role-template overlay works regardless of
+ * how the codegen entry point is invoked.
+ */
+function findRepoRoot(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  let dir = here;
+  for (let i = 0; i < 10; i++) {
+    if (existsSync(path.join(dir, 'configs.json'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(
+    `roleRenderer.findRepoRoot: could not locate a repo root (no configs.json found in any ancestor of ${here}).`,
+  );
+}
+
+/**
+ * Discover and load every role bundle defined under
+ * `configs/<active>/codegen/playwright/roles/`. Returns a `Map<roleName, LoadedRoleBundle>`.
+ *
+ * Roles whose directory contains no `call-site.tmpl` raise immediately —
+ * an empty role directory is an authoring mistake, not a "skip this role"
+ * signal. The materializer enforces the inverse direction
+ * (every ABox-bound role must have a directory) by reading from this same
+ * map.
+ */
+export function loadRoleBundlesForActiveConfig(repoRoot?: string): Map<string, LoadedRoleBundle> {
+  const root = repoRoot ?? findRepoRoot();
+  const rolesDir = path.join(
+    getActiveConfigDir(root),
+    CODEGEN_DIRNAME,
+    EMITTER_DIRNAME,
+    ROLES_DIRNAME,
+  );
+  const result = new Map<string, LoadedRoleBundle>();
+  if (!existsSync(rolesDir)) return result;
+
+  for (const entry of readdirSync(rolesDir)) {
+    const roleDir = path.join(rolesDir, entry);
+    if (!statSync(roleDir).isDirectory()) continue;
+
+    const callSitePath = path.join(roleDir, 'call-site.tmpl');
+    if (!existsSync(callSitePath)) {
+      throw new Error(
+        `roleRenderer: role directory ${roleDir} is missing required call-site.tmpl. ` +
+          `Either add the template or remove the directory.`,
+      );
+    }
+    const importsPath = path.join(roleDir, 'imports.tmpl');
+    // Discover support.<ext> by listing the directory — the role's helper
+    // language (ts/js/java/...) is the role's choice, not the renderer's.
+    let supportPath: string | undefined;
+    for (const f of readdirSync(roleDir)) {
+      if (f.startsWith('support.')) {
+        supportPath = path.join(roleDir, f);
+        break;
+      }
+    }
+    const matchPath = path.join(roleDir, 'match.json');
+    let match: RoleMatchSpec | undefined;
+    if (existsSync(matchPath)) {
+      const raw = readFileSync(matchPath, 'utf8');
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const parsed = JSON.parse(raw) as RoleMatchSpec & { _comment?: unknown };
+      match = {
+        bodyKinds: Array.isArray(parsed.bodyKinds) ? parsed.bodyKinds.map(String) : undefined,
+        expectedStatuses: Array.isArray(parsed.expectedStatuses)
+          ? parsed.expectedStatuses.map(Number)
+          : undefined,
+      };
+    }
+
+    result.set(entry, {
+      role: entry,
+      callSiteTemplatePath: callSitePath,
+      importsTemplatePath: existsSync(importsPath) ? importsPath : undefined,
+      supportFilePath: supportPath,
+      callSiteTemplate: readFileSync(callSitePath, 'utf8'),
+      importsTemplate: existsSync(importsPath) ? readFileSync(importsPath, 'utf8') : undefined,
+      match,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Decide whether a step should be dispatched to its bound role. Returns
+ * `true` when the role's `match.json` (if any) allows the step's
+ * `bodyKind` and declared `expect.status`. Roles without a `match.json`
+ * match every step that carries the role binding.
+ */
+export function stepMatchesRole(step: RequestStep, bundle: LoadedRoleBundle): boolean {
+  const m = bundle.match;
+  if (!m) return true;
+  if (m.bodyKinds && m.bodyKinds.length > 0) {
+    if (!step.bodyKind || !m.bodyKinds.includes(step.bodyKind)) return false;
+  }
+  if (
+    m.expectedStatuses &&
+    m.expectedStatuses.length > 0 &&
+    !m.expectedStatuses.includes(step.expect.status)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Render `call-site.tmpl` for a single step. Returns the raw multi-line
+ * template output; the caller indents lines to the desired depth.
+ *
+ * Templates MUST use triple-brace `{{{var}}}` interpolation for code; any
+ * value rendered through double-braces is HTML-escaped by Mustache and
+ * will corrupt TypeScript output. The renderer does not police this — it
+ * is an authoring contract documented in ROLES.md.
+ */
+export function renderRoleCallSite(bundle: LoadedRoleBundle, scope: PlaywrightRoleScope): string {
+  return Mustache.render(bundle.callSiteTemplate, scope);
+}
+
+/**
+ * Render `imports.tmpl` for a single role usage in a spec file. Returns
+ * the template output (possibly multi-line — each non-empty line becomes
+ * a distinct entry in the spec's import block, deduplicated by the
+ * caller). Returns `''` when the role has no imports template.
+ */
+export function renderRoleImports(bundle: LoadedRoleBundle, scope: ImportsTemplateScope): string {
+  if (!bundle.importsTemplate) return '';
+  return Mustache.render(bundle.importsTemplate, scope);
+}

--- a/path-analyser/src/codegen/playwright/roleRenderer.ts
+++ b/path-analyser/src/codegen/playwright/roleRenderer.ts
@@ -119,12 +119,22 @@ export function loadRoleBundlesForActiveConfig(repoRoot?: string): Map<string, L
     const importsPath = path.join(roleDir, 'imports.tmpl');
     // Discover support.<ext> by listing the directory — the role's helper
     // language (ts/js/java/...) is the role's choice, not the renderer's.
+    // Sort the entries for deterministic selection, and throw if more than
+    // one support.* file exists so the role directory has an unambiguous
+    // contract (non-deterministic filesystem ordering could silently select
+    // a different file across runs or machines).
+    const supportFiles = readdirSync(roleDir)
+      .filter((f) => f.startsWith('support.'))
+      .sort();
+    if (supportFiles.length > 1) {
+      throw new Error(
+        `roleRenderer: role directory ${roleDir} contains multiple support files: ` +
+          `${supportFiles.join(', ')}. Only one support.<ext> file is permitted per role.`,
+      );
+    }
     let supportPath: string | undefined;
-    for (const f of readdirSync(roleDir)) {
-      if (f.startsWith('support.')) {
-        supportPath = path.join(roleDir, f);
-        break;
-      }
+    if (supportFiles.length === 1) {
+      supportPath = path.join(roleDir, supportFiles[0]);
     }
     const matchPath = path.join(roleDir, 'match.json');
     let match: RoleMatchSpec | undefined;

--- a/tests/codegen/_helpers/roleDispatch.ts
+++ b/tests/codegen/_helpers/roleDispatch.ts
@@ -1,0 +1,74 @@
+// Test helper: load the active config's role bundles and produce the
+// EmitContext fields the Playwright emitter needs for role dispatch.
+// Replaces the pre-Lift-12 `deploymentGatewayOpId: 'createDeployment'`
+// shorthand with the role-aware plumbing.
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { computeDeploymentExtracts } from '../../../path-analyser/src/codegen/deploymentExtracts.ts';
+import {
+  type LoadedRoleBundle,
+  loadRoleBundlesForActiveConfig,
+} from '../../../path-analyser/src/codegen/playwright/roleRenderer.ts';
+import { deriveArtifactKindsViews } from '../../../path-analyser/src/ontology/loader.ts';
+import {
+  DEPLOYMENT_GATEWAY_ROLE,
+  getRoleForOperation,
+} from '../../../path-analyser/src/ontology/operationRoles.ts';
+import type { OperationNode } from '../../../path-analyser/src/types.ts';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+export interface RoleDispatchFixture {
+  getRoleForOperation: (opId: string) => string | undefined;
+  roleBundles: Map<string, LoadedRoleBundle>;
+  roleExtras: Map<string, Record<string, unknown>>;
+}
+
+/**
+ * Build a {getRoleForOperation, roleBundles, roleExtras} bundle mimicking the
+ * production codegen orchestrator, but with caller-supplied opId → role
+ * overrides and an optional deployment-gateway extracts list.
+ *
+ * Most tests just want "treat opId X as the deployment gateway with the
+ * default empty extracts list" — pass `{ [opId]: 'deploymentGateway' }`.
+ */
+export function buildRoleDispatch(
+  opIdToRole: Record<string, string>,
+  opts: { deployOp?: OperationNode } = {},
+): RoleDispatchFixture {
+  const roleBundles = loadRoleBundlesForActiveConfig(repoRoot);
+  const roleExtras = new Map<string, Record<string, unknown>>();
+  const extracts = computeDeploymentExtracts(opts.deployOp);
+  roleExtras.set(DEPLOYMENT_GATEWAY_ROLE, { extracts: JSON.stringify(extracts) });
+  return {
+    getRoleForOperation: (opId: string) => opIdToRole[opId],
+    roleBundles,
+    roleExtras,
+  };
+}
+
+/**
+ * Build a role-dispatch fixture that mirrors the real camunda-oca ABox —
+ * uses `getRoleForOperation(domain, opId)` over the production
+ * `artifact-kinds.json` rather than a caller-supplied map. Useful for
+ * tests that want the real `createDeployment → deploymentGateway` mapping
+ * without re-encoding it in the test.
+ */
+export function buildRoleDispatchFromActiveAbox(
+  opts: { deployOp?: OperationNode } = {},
+): RoleDispatchFixture {
+  const artifactViews = deriveArtifactKindsViews(repoRoot);
+  const domain = artifactViews
+    ? { operationArtifactRules: artifactViews.operationArtifactRules }
+    : undefined;
+  const roleBundles = loadRoleBundlesForActiveConfig(repoRoot);
+  const roleExtras = new Map<string, Record<string, unknown>>();
+  const extracts = computeDeploymentExtracts(opts.deployOp);
+  roleExtras.set(DEPLOYMENT_GATEWAY_ROLE, { extracts: JSON.stringify(extracts) });
+  return {
+    getRoleForOperation: (opId: string) => getRoleForOperation(domain, opId),
+    roleBundles,
+    roleExtras,
+  };
+}

--- a/tests/codegen/deploymentExtracts.test.ts
+++ b/tests/codegen/deploymentExtracts.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import {
-  computeDeploymentExtracts,
-  type DeploymentExtract,
-} from '../../path-analyser/src/codegen/deploymentExtracts.ts';
+import { computeDeploymentExtracts } from '../../path-analyser/src/codegen/deploymentExtracts.ts';
 import type { OperationNode } from '../../path-analyser/src/types.ts';
 
 function makeOp(
@@ -30,7 +27,12 @@ describe('computeDeploymentExtracts', () => {
 
   test('keeps leaves where provider === true', () => {
     const op = makeOp([
-      { semantic: 'ProcessDefinitionKey', fieldPath: 'deployments[].processDefinitionKey', status: '200', provider: true },
+      {
+        semantic: 'ProcessDefinitionKey',
+        fieldPath: 'deployments[].processDefinitionKey',
+        status: '200',
+        provider: true,
+      },
     ]);
     const result = computeDeploymentExtracts(op);
     expect(result).toHaveLength(1);
@@ -49,21 +51,36 @@ describe('computeDeploymentExtracts', () => {
 
   test('skips non-top-level leaves where provider === false', () => {
     const op = makeOp([
-      { semantic: 'ProcessDefinitionKey', fieldPath: 'deployments[].processDefinitionKey', status: '200', provider: false },
+      {
+        semantic: 'ProcessDefinitionKey',
+        fieldPath: 'deployments[].processDefinitionKey',
+        status: '200',
+        provider: false,
+      },
     ]);
     expect(computeDeploymentExtracts(op)).toEqual([]);
   });
 
   test('skips leaves with .resource. in the fieldPath', () => {
     const op = makeOp([
-      { semantic: 'ProcessDefinitionKey', fieldPath: 'deployments[].resource.processDefinitionKey', status: '200', provider: true },
+      {
+        semantic: 'ProcessDefinitionKey',
+        fieldPath: 'deployments[].resource.processDefinitionKey',
+        status: '200',
+        provider: true,
+      },
     ]);
     expect(computeDeploymentExtracts(op)).toEqual([]);
   });
 
   test('skips leaves where status !== "200"', () => {
     const op = makeOp([
-      { semantic: 'ProcessDefinitionKey', fieldPath: 'deployments[].processDefinitionKey', status: '400', provider: true },
+      {
+        semantic: 'ProcessDefinitionKey',
+        fieldPath: 'deployments[].processDefinitionKey',
+        status: '400',
+        provider: true,
+      },
     ]);
     expect(computeDeploymentExtracts(op)).toEqual([]);
   });
@@ -80,8 +97,18 @@ describe('computeDeploymentExtracts', () => {
     // Two leaves produce the same varName. The pre-dedup sort puts
     // the shorter segments path first, so that one should be kept.
     const op = makeOp([
-      { semantic: 'ProcessDefinitionKey', fieldPath: 'deployments[].processDefinitionKey', status: '200', provider: true },
-      { semantic: 'ProcessDefinitionKey', fieldPath: 'zzz[].processDefinitionKey', status: '200', provider: true },
+      {
+        semantic: 'ProcessDefinitionKey',
+        fieldPath: 'deployments[].processDefinitionKey',
+        status: '200',
+        provider: true,
+      },
+      {
+        semantic: 'ProcessDefinitionKey',
+        fieldPath: 'zzz[].processDefinitionKey',
+        status: '200',
+        provider: true,
+      },
     ]);
     const result = computeDeploymentExtracts(op);
     expect(result).toHaveLength(1);
@@ -116,11 +143,26 @@ describe('computeDeploymentExtracts', () => {
     const op = makeOp([
       { semantic: 'DeploymentKey', fieldPath: 'deploymentKey', status: '200', provider: false },
       { semantic: 'TenantId', fieldPath: 'tenantId', status: '200', provider: false },
-      { semantic: 'ProcessDefinitionKey', fieldPath: 'deployments[].processDefinition.processDefinitionKey', status: '200', provider: true },
+      {
+        semantic: 'ProcessDefinitionKey',
+        fieldPath: 'deployments[].processDefinition.processDefinitionKey',
+        status: '200',
+        provider: true,
+      },
       // .resource. path — should be skipped
-      { semantic: 'ProcessDefinitionKey', fieldPath: 'deployments[].resource.processDefinitionKey', status: '200', provider: true },
+      {
+        semantic: 'ProcessDefinitionKey',
+        fieldPath: 'deployments[].resource.processDefinitionKey',
+        status: '200',
+        provider: true,
+      },
       // non-provider nested — should be skipped
-      { semantic: 'InternalId', fieldPath: 'deployments[].internalId', status: '200', provider: false },
+      {
+        semantic: 'InternalId',
+        fieldPath: 'deployments[].internalId',
+        status: '200',
+        provider: false,
+      },
     ]);
     const result = computeDeploymentExtracts(op);
     const varNames = result.map((r) => r.varName);

--- a/tests/codegen/deploymentExtracts.test.ts
+++ b/tests/codegen/deploymentExtracts.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from 'vitest';
+import {
+  computeDeploymentExtracts,
+  type DeploymentExtract,
+} from '../../path-analyser/src/codegen/deploymentExtracts.ts';
+import type { OperationNode } from '../../path-analyser/src/types.ts';
+
+function makeOp(
+  leaves: Array<{ semantic: string; fieldPath: string; status: string; provider: boolean }>,
+): OperationNode {
+  return {
+    operationId: 'createDeployment',
+    method: 'POST',
+    path: '/deployments',
+    requires: { required: [], optional: [] },
+    produces: [],
+    responseSemanticLeaves: leaves,
+  };
+}
+
+describe('computeDeploymentExtracts', () => {
+  test('returns [] when op is undefined', () => {
+    expect(computeDeploymentExtracts(undefined)).toEqual([]);
+  });
+
+  test('returns [] when op has no responseSemanticLeaves', () => {
+    const op = makeOp([]);
+    expect(computeDeploymentExtracts(op)).toEqual([]);
+  });
+
+  test('keeps leaves where provider === true', () => {
+    const op = makeOp([
+      { semantic: 'ProcessDefinitionKey', fieldPath: 'deployments[].processDefinitionKey', status: '200', provider: true },
+    ]);
+    const result = computeDeploymentExtracts(op);
+    expect(result).toHaveLength(1);
+    expect(result[0].varName).toBe('processDefinitionKeyVar');
+    expect(result[0].segments).toEqual(['deployments', 0, 'processDefinitionKey']);
+  });
+
+  test('keeps top-level leaves (no . or [ in fieldPath) even when provider === false', () => {
+    const op = makeOp([
+      { semantic: 'DeploymentKey', fieldPath: 'deploymentKey', status: '200', provider: false },
+      { semantic: 'TenantId', fieldPath: 'tenantId', status: '200', provider: false },
+    ]);
+    const result = computeDeploymentExtracts(op);
+    expect(result.map((r) => r.varName).sort()).toEqual(['deploymentKeyVar', 'tenantIdVar'].sort());
+  });
+
+  test('skips non-top-level leaves where provider === false', () => {
+    const op = makeOp([
+      { semantic: 'ProcessDefinitionKey', fieldPath: 'deployments[].processDefinitionKey', status: '200', provider: false },
+    ]);
+    expect(computeDeploymentExtracts(op)).toEqual([]);
+  });
+
+  test('skips leaves with .resource. in the fieldPath', () => {
+    const op = makeOp([
+      { semantic: 'ProcessDefinitionKey', fieldPath: 'deployments[].resource.processDefinitionKey', status: '200', provider: true },
+    ]);
+    expect(computeDeploymentExtracts(op)).toEqual([]);
+  });
+
+  test('skips leaves where status !== "200"', () => {
+    const op = makeOp([
+      { semantic: 'ProcessDefinitionKey', fieldPath: 'deployments[].processDefinitionKey', status: '400', provider: true },
+    ]);
+    expect(computeDeploymentExtracts(op)).toEqual([]);
+  });
+
+  test('converts [] array markers to index 0 in segments', () => {
+    const op = makeOp([
+      { semantic: 'Foo', fieldPath: 'items[].value', status: '200', provider: true },
+    ]);
+    const result = computeDeploymentExtracts(op);
+    expect(result[0].segments).toEqual(['items', 0, 'value']);
+  });
+
+  test('deduplicates by varName, keeping the first occurrence under pre-dedup sort', () => {
+    // Two leaves produce the same varName. The pre-dedup sort puts
+    // the shorter segments path first, so that one should be kept.
+    const op = makeOp([
+      { semantic: 'ProcessDefinitionKey', fieldPath: 'deployments[].processDefinitionKey', status: '200', provider: true },
+      { semantic: 'ProcessDefinitionKey', fieldPath: 'zzz[].processDefinitionKey', status: '200', provider: true },
+    ]);
+    const result = computeDeploymentExtracts(op);
+    expect(result).toHaveLength(1);
+    // The pre-dedup sort is lexicographic on JSON.stringify(segments), so
+    // `["deployments",0,"processDefinitionKey"]` < `["zzz",0,"processDefinitionKey"]`.
+    expect(result[0].segments[0]).toBe('deployments');
+  });
+
+  test('final result is sorted by varName for byte-stable output', () => {
+    const op = makeOp([
+      { semantic: 'ZebraVar', fieldPath: 'zebraVar', status: '200', provider: false },
+      { semantic: 'AlphaKey', fieldPath: 'alphaKey', status: '200', provider: false },
+      { semantic: 'MidField', fieldPath: 'midField', status: '200', provider: false },
+    ]);
+    const result = computeDeploymentExtracts(op);
+    const names = result.map((r) => r.varName);
+    expect(names).toEqual([...names].sort());
+  });
+
+  test('handles op with no responseSemanticLeaves property', () => {
+    const op: OperationNode = {
+      operationId: 'createDeployment',
+      method: 'POST',
+      path: '/deployments',
+      requires: { required: [], optional: [] },
+      produces: [],
+    };
+    expect(computeDeploymentExtracts(op)).toEqual([]);
+  });
+
+  test('end-to-end: representative createDeployment leaves produce correct extracts', () => {
+    const op = makeOp([
+      { semantic: 'DeploymentKey', fieldPath: 'deploymentKey', status: '200', provider: false },
+      { semantic: 'TenantId', fieldPath: 'tenantId', status: '200', provider: false },
+      { semantic: 'ProcessDefinitionKey', fieldPath: 'deployments[].processDefinition.processDefinitionKey', status: '200', provider: true },
+      // .resource. path — should be skipped
+      { semantic: 'ProcessDefinitionKey', fieldPath: 'deployments[].resource.processDefinitionKey', status: '200', provider: true },
+      // non-provider nested — should be skipped
+      { semantic: 'InternalId', fieldPath: 'deployments[].internalId', status: '200', provider: false },
+    ]);
+    const result = computeDeploymentExtracts(op);
+    const varNames = result.map((r) => r.varName);
+    expect(varNames).toContain('deploymentKeyVar');
+    expect(varNames).toContain('tenantIdVar');
+    expect(varNames).toContain('processDefinitionKeyVar');
+    expect(varNames).not.toContain('internalIdVar');
+    // resource. path deduplicated/skipped — only one processDefinitionKeyVar
+    expect(varNames.filter((n) => n === 'processDefinitionKeyVar')).toHaveLength(1);
+    // Output is sorted by varName
+    expect(varNames).toEqual([...varNames].sort());
+  });
+});

--- a/tests/codegen/deploymentExtracts.test.ts
+++ b/tests/codegen/deploymentExtracts.test.ts
@@ -93,8 +93,8 @@ describe('computeDeploymentExtracts', () => {
     expect(result[0].segments).toEqual(['items', 0, 'value']);
   });
 
-  test('deduplicates by varName, keeping the first occurrence under pre-dedup sort', () => {
-    // Two leaves produce the same varName. The pre-dedup sort puts
+  test('deduplicates by varName, preferring the shorter segments path', () => {
+    // Two leaves produce the same varName. The pre-dedup sort prefers
     // the shorter segments path first, so that one should be kept.
     const op = makeOp([
       {
@@ -112,9 +112,36 @@ describe('computeDeploymentExtracts', () => {
     ]);
     const result = computeDeploymentExtracts(op);
     expect(result).toHaveLength(1);
-    // The pre-dedup sort is lexicographic on JSON.stringify(segments), so
-    // `["deployments",0,"processDefinitionKey"]` < `["zzz",0,"processDefinitionKey"]`.
+    // Same length → lexicographic JSON tie-break picks `deployments` < `zzz`.
     expect(result[0].segments[0]).toBe('deployments');
+  });
+
+  test('dedup prefers a strictly shorter path even when JSON.stringify ordering would invert it', () => {
+    // `["a",0,"b"]` < `["a",0]` lexicographically (because `,` < `]`), so
+    // an explicit length comparison is required for "shorter path wins"
+    // to hold. Use leaves whose varName collides but paths differ in
+    // length: provider-true ensures both survive the filter.
+    const op = makeOp([
+      {
+        semantic: 'ProcessDefinitionKey',
+        // top-level (after stripping resource. prefix is N/A here)
+        fieldPath: 'a.processDefinitionKey',
+        status: '200',
+        provider: true,
+      },
+      {
+        semantic: 'ProcessDefinitionKey',
+        fieldPath: 'a[].deeper.processDefinitionKey',
+        status: '200',
+        provider: true,
+      },
+    ]);
+    const result = computeDeploymentExtracts(op);
+    expect(result).toHaveLength(1);
+    // The 2-segment path must win over the 4-segment path even though
+    // ["a",0,"deeper","processDefinitionKey"] < ["a","processDefinitionKey"]
+    // lexicographically (because `,` < `]`).
+    expect(result[0].segments).toEqual(['a', 'processDefinitionKey']);
   });
 
   test('final result is sorted by varName for byte-stable output', () => {

--- a/tests/codegen/materialize-support.test.ts
+++ b/tests/codegen/materialize-support.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import {
   FIXTURES_DIR_NAME,
   materializeFixtures,
+  materializeRoleSupportFiles,
   materializeSupport,
   PROJECT_TEMPLATE_FILES,
   SUPPORT_DIR_NAME,
@@ -209,5 +210,83 @@ describe('materializeFixtures', () => {
     const candidate = path.resolve(supportDir, '..', 'fixtures', 'bpmn/service-task.bpmn');
     const buf = await fs.readFile(candidate);
     expect(buf.length).toBeGreaterThan(0);
+  });
+});
+
+describe('materializeRoleSupportFiles', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mat-role-support-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  test('copies a role support file into <outDir>/support/<role>.<ext>', async () => {
+    const srcDir = await fs.mkdtemp(path.join(os.tmpdir(), 'role-src-'));
+    try {
+      const supportFile = path.join(srcDir, 'support.ts');
+      await fs.writeFile(supportFile, '// role helper\n', 'utf8');
+      const bundles = new Map([['myRole', { role: 'myRole', supportFilePath: supportFile }]]);
+      const copied = await materializeRoleSupportFiles(tmp, bundles);
+      expect(copied).toEqual(['myRole.ts']);
+      const content = await fs.readFile(path.join(tmp, SUPPORT_DIR_NAME, 'myRole.ts'), 'utf8');
+      expect(content).toBe('// role helper\n');
+    } finally {
+      await fs.rm(srcDir, { recursive: true, force: true });
+    }
+  });
+
+  test('skips roles that have no support file', async () => {
+    const bundles = new Map([
+      ['noSupportRole', { role: 'noSupportRole', supportFilePath: undefined }],
+    ]);
+    const copied = await materializeRoleSupportFiles(tmp, bundles);
+    expect(copied).toEqual([]);
+  });
+
+  test('returns all copied basenames for multiple roles', async () => {
+    const srcDir = await fs.mkdtemp(path.join(os.tmpdir(), 'role-src-'));
+    try {
+      const supportA = path.join(srcDir, 'supportA.ts');
+      const supportB = path.join(srcDir, 'supportB.js');
+      await fs.writeFile(supportA, '// A\n', 'utf8');
+      await fs.writeFile(supportB, '// B\n', 'utf8');
+      const bundles = new Map([
+        ['roleA', { role: 'roleA', supportFilePath: supportA }],
+        ['roleB', { role: 'roleB', supportFilePath: supportB }],
+      ]);
+      const copied = await materializeRoleSupportFiles(tmp, bundles);
+      expect(copied.sort()).toEqual(['roleA.ts', 'roleB.js'].sort());
+      expect(existsSync(path.join(tmp, SUPPORT_DIR_NAME, 'roleA.ts'))).toBe(true);
+      expect(existsSync(path.join(tmp, SUPPORT_DIR_NAME, 'roleB.js'))).toBe(true);
+    } finally {
+      await fs.rm(srcDir, { recursive: true, force: true });
+    }
+  });
+
+  test('throws when a role name collides with a built-in support file basename', async () => {
+    const srcDir = await fs.mkdtemp(path.join(os.tmpdir(), 'role-src-'));
+    try {
+      const supportFile = path.join(srcDir, 'support.ts');
+      await fs.writeFile(supportFile, '// role helper\n', 'utf8');
+      // 'env' is the stem of the built-in 'env.ts'
+      const bundles = new Map([['env', { role: 'env', supportFilePath: supportFile }]]);
+      await expect(materializeRoleSupportFiles(tmp, bundles)).rejects.toThrow(
+        /collides with a built-in support file/,
+      );
+    } finally {
+      await fs.rm(srcDir, { recursive: true, force: true });
+    }
+  });
+
+  test('creates the support/ subdirectory when it does not exist', async () => {
+    const outDir = path.join(tmp, 'fresh');
+    await fs.mkdir(outDir);
+    const copied = await materializeRoleSupportFiles(outDir, new Map());
+    expect(existsSync(path.join(outDir, SUPPORT_DIR_NAME))).toBe(true);
+    expect(copied).toEqual([]);
   });
 });

--- a/tests/codegen/materialize-support.test.ts
+++ b/tests/codegen/materialize-support.test.ts
@@ -275,7 +275,7 @@ describe('materializeRoleSupportFiles', () => {
       // 'env' is the stem of the built-in 'env.ts'
       const bundles = new Map([['env', { role: 'env', supportFilePath: supportFile }]]);
       await expect(materializeRoleSupportFiles(tmp, bundles)).rejects.toThrow(
-        /collides with a built-in support file/,
+        /collides with the built-in support file/,
       );
     } finally {
       await fs.rm(srcDir, { recursive: true, force: true });

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -8,6 +8,7 @@ import type {
   EndpointScenarioCollection,
   GlobalContextSeed,
 } from '../../path-analyser/src/types.ts';
+import { buildRoleDispatch } from './_helpers/roleDispatch.ts';
 
 // The tenant-related tests below all derive the emitter's universal-seed
 // behaviour from this fixture, mirroring the entry shipped in
@@ -541,7 +542,7 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
       suiteName: 'createDeployment',
       mode: 'feature',
       globalContextSeeds: [TENANT_SEED],
-      deploymentGatewayOpId: 'createDeployment',
+      ...buildRoleDispatch({ createDeployment: 'deploymentGateway' }),
     });
     const c = file.content;
     // Seed assignment still emitted (always needed)
@@ -594,7 +595,7 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
       outDir: '/unused',
       suiteName: 'createDeployment',
       mode: 'feature',
-      deploymentGatewayOpId: 'createDeployment',
+      ...buildRoleDispatch({ createDeployment: 'deploymentGateway' }),
     });
     const c = file.content;
     // deploy() call must be present
@@ -1145,9 +1146,9 @@ describe('emitter: conditional import gating for deploy() and resolveFixture', (
       suiteName: 'createDeployment',
       mode: 'feature',
       recordResponses: false,
-      deploymentGatewayOpId: 'createDeployment',
+      ...buildRoleDispatch({ createDeployment: 'deploymentGateway' }),
     });
-    expect(src).toContain("import { deploy } from './support/deployment';");
+    expect(src).toContain("import { deploy } from './support/deploymentGateway';");
     expect(src).not.toContain('resolveFixture');
     // authHeaders is handled internally by deploy(); suite must not import it
     expect(src).not.toContain('authHeaders');
@@ -1165,7 +1166,7 @@ describe('emitter: conditional import gating for deploy() and resolveFixture', (
       suiteName: 'createDeployment',
       mode: 'feature',
       recordResponses: false,
-      deploymentGatewayOpId: 'createDeployment',
+      ...buildRoleDispatch({ createDeployment: 'deploymentGateway' }),
     });
     expect(src).toContain('expect(resp1.status()).toBe(200)');
   });
@@ -1270,10 +1271,10 @@ describe('emitter: conditional import gating for deploy() and resolveFixture', (
         suiteName: 'createDeployment',
         mode: 'feature',
         recordResponses: false,
-        deploymentGatewayOpId: 'createDeployment',
+        ...buildRoleDispatch({ createDeployment: 'deploymentGateway' }),
       },
     );
-    expect(src).toContain("import { deploy } from './support/deployment';");
+    expect(src).toContain("import { deploy } from './support/deploymentGateway';");
     expect(src).toContain("import { resolveFixture } from './support/fixtures';");
     // authHeaders is needed for the inline uploadDocument step
     expect(src).toContain('authHeaders');


### PR DESCRIPTION
Vertical slice landing Phases 2 (materializer overlay), 3 (renderer), and
4 (deployment-gateway reference implementation) of #231. Builds on the
templating contract and types merged in #232.

## What changes

The hard-coded \`isDeploymentStep\` branch and vendored
\`path-analyser/src/codegen/support/deployment.ts\` are gone. In their
place, the Playwright emitter does generic role dispatch: for each
step, look up its role via \`getRoleForOperation(domain, opId)\`; if a
role bundle exists at
\`configs/<config>/codegen/playwright/roles/<role>/\` and the step
satisfies the bundle's \`match.json\`, render via Mustache; otherwise
fall through to the generic inline path. Bound role without a bundle
is a hard error — no silent fallback.

### deploymentGateway reference implementation

Files under \`configs/camunda-oca/codegen/playwright/roles/deploymentGateway/\`:

- \`support.ts\` — relocated \`deploy()\`. Helper signature widened to
  take a fully-qualified URL and a caller-supplied extracts list, so
  the helper itself no longer encodes the \`/deployments\` path or the
  set of response field names.
- \`call-site.tmpl\` — 2-line Mustache template (deploy call + status
  assertion).
- \`imports.tmpl\` — 1-line import using renderer-computed
  \`{{{supportImportPath}}}\`.
- \`match.json\` — \`{ bodyKinds: [\"multipart\"], expectedStatuses: [200] }\`.

\`path-analyser/src/codegen/deploymentExtracts.ts\` derives the extracts
list from \`op.responseSemanticLeaves\` (absorbs #230's spec-derived
extracts as a scope variable. Filter rules: provider:true OR depth-1;
skip `resource.*` placeholders; `[]` → `0`; dedup; deterministic sort.
Result for createDeployment: 8 entries, dropping two dead vars the old
hand-written list carried (`formIdVar`, `decisionRequirementsIdVar`).

## Verification

- All 517 tests pass, including the 114 L3 invariants in
  `configs/camunda-oca/regression-invariants.test.ts`.
- Pipeline output is byte-identical to the pre-change baseline modulo
  the expected relocation diff (import path swap, URL + extracts added
  to deploy() call site, support file renamed).
- All four workspace typechecks pass; lint clean.

## Remaining work (separate PRs)

- **Phase 5** — L3 invariants asserting that every roleBinding in the
  ABox resolves to a renderable role directory, every active role's
  `support.<ext>` is referenced exactly once, and the extracts list
  covers every binding var consumed downstream of a deploy step.
- **Phase 6** — config-author guide for adding a new role and
  emitter-author guide for adding a new emitter.

Closes part of #231.
EOF
)