### PR TITLE
feat: extract Playwright project scaffolding via EmitterStrategy.scaffold() (#233 Step 7)

### DIFF
--- a/materializer/src/index.ts
+++ b/materializer/src/index.ts
@@ -25,7 +25,7 @@ import {
 import { getRoleForOperation } from 'path-analyser/ontology/operationRoles';
 import type { EndpointScenarioCollection, GlobalContextSeed } from 'path-analyser/types';
 import { parseCliArgs } from './cli-args.js';
-import { writeEmitted } from './orchestrator.js';
+import { writeEmitted, writeScaffolded } from './orchestrator.js';
 import { PlaywrightEmitter } from './playwright/emitter.js';
 import { DeploymentRoleHookProvider } from './playwright/hooks/deployment.js';
 import {
@@ -303,7 +303,7 @@ async function run() {
     const recordResponses =
       typeof emitterConfig.recordResponses === 'boolean' ? emitterConfig.recordResponses : false;
     const excludeSupportFiles = recordResponses ? undefined : ['recorder.ts'];
-    await materializeSupport(outDir, undefined, undefined, true, excludeSupportFiles);
+    await materializeSupport(outDir, undefined, excludeSupportFiles);
     // Lift 12 / #231: load per-role bundles and vendor their helper files
     // alongside the built-in support files. Roles bound in the ABox but
     // missing a bundle raise at render time (see roleRenderer.findRoleForStep
@@ -382,6 +382,16 @@ async function run() {
       roleExtras,
     };
   }
+
+  // #233 Step 7: one-shot project-root scaffolding via the SDK contract.
+  // Generic across emitters — Playwright today returns the five
+  // PROJECT_TEMPLATE_FILES; future SDK emitters (JS/C#/Python) return their
+  // own project framing. No-op when emitter.scaffold is omitted.
+  // Called once per CLI invocation, before any emit() call, per
+  // EmitterStrategy.scaffold's contract. suiteName/mode are unused by
+  // scaffold itself but are part of the shared EmitContext type; pass safe
+  // placeholders.
+  await writeScaffolded(emitter, buildCtx('', 'feature'));
 
   if (positional === '--all') {
     let count = 0;

--- a/materializer/src/orchestrator.ts
+++ b/materializer/src/orchestrator.ts
@@ -4,6 +4,28 @@ import type { EmitContext, EmitterStrategy } from '@camunda8/emitter-sdk';
 import type { EndpointScenarioCollection } from 'path-analyser/types';
 
 /**
+ * Invoke an emitter's optional {@link EmitterStrategy.scaffold} method and
+ * write its returned files into `ctx.outDir`. Centralised here so every
+ * emitter — Playwright today, JS/C#/Python OCA SDK emitters soon — uses
+ * the same write-path safety checks as {@link writeEmitted}: relative-path
+ * enforcement, escape-out-of-outDir rejection, and idempotent mkdir.
+ *
+ * No-op when the emitter does not implement `scaffold` (the SDK contract
+ * marks it optional for emitters that drop loose specs into an existing
+ * project).
+ *
+ * Returns the absolute paths of files written, in emit order.
+ */
+export async function writeScaffolded(
+  emitter: EmitterStrategy,
+  ctx: EmitContext,
+): Promise<string[]> {
+  if (!emitter.scaffold) return [];
+  const files = await emitter.scaffold(ctx);
+  return writeFiles(emitter, files, ctx.outDir, 'scaffold');
+}
+
+/**
  * Write all files emitted by an {@link Emitter} into `outDir`. Centralising
  * the write step lets emitters stay pure and lets us add cross-cutting
  * concerns (formatting, license headers, idempotency checks) in one place.
@@ -16,23 +38,32 @@ export async function writeEmitted(
   ctx: EmitContext,
 ): Promise<string[]> {
   const files = await emitter.emit(collection, ctx);
+  return writeFiles(emitter, files, ctx.outDir, 'emit');
+}
+
+async function writeFiles(
+  emitter: EmitterStrategy,
+  files: Awaited<ReturnType<EmitterStrategy['emit']>>,
+  outDir: string,
+  callSite: 'emit' | 'scaffold',
+): Promise<string[]> {
   const written: string[] = [];
   for (const f of files) {
     if (path.isAbsolute(f.relativePath)) {
       throw new Error(
-        `Emitter '${emitter.id}' returned absolute path '${f.relativePath}'. ` +
+        `Emitter '${emitter.id}' (${callSite}) returned absolute path '${f.relativePath}'. ` +
           'Emitted file paths must be relative to ctx.outDir.',
       );
     }
-    // Resolve and assert the destination stays within ctx.outDir. A naive
+    // Resolve and assert the destination stays within outDir. A naive
     // substring check on `..` would reject legitimate filenames like
     // `foo..bar.ts` and would not catch escapes hidden inside deeper segments.
-    const resolvedOutDir = path.resolve(ctx.outDir);
+    const resolvedOutDir = path.resolve(outDir);
     const abs = path.resolve(resolvedOutDir, f.relativePath);
     const rel = path.relative(resolvedOutDir, abs);
     if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
       throw new Error(
-        `Emitter '${emitter.id}' returned path '${f.relativePath}' that escapes ctx.outDir.`,
+        `Emitter '${emitter.id}' (${callSite}) returned path '${f.relativePath}' that escapes ctx.outDir.`,
       );
     }
     await fs.mkdir(path.dirname(abs), { recursive: true });

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -15,7 +15,11 @@ import type {
   RequestStep,
 } from 'path-analyser/types';
 import type { ImportsTemplateScope, PlaywrightRoleScope } from '../roles.js';
-import { materializeFixtures, materializeSupport } from './materialize-support.js';
+import {
+  loadProjectScaffoldingFiles,
+  materializeFixtures,
+  materializeSupport,
+} from './materialize-support.js';
 import { renderRoleCallSite, renderRoleImports, stepMatchesRole } from './roleRenderer.js';
 
 interface EmitOptions {
@@ -111,7 +115,15 @@ export async function emitPlaywrightSuite(
   // Default true (preserves pre-config behaviour, matching renderPlaywrightSuite).
   const recordResponses = opts.recordResponses ?? true;
   const excludeSupportFiles = recordResponses ? undefined : ['recorder.ts'];
-  await materializeSupport(opts.outDir, undefined, undefined, true, excludeSupportFiles);
+  await materializeSupport(opts.outDir, undefined, excludeSupportFiles);
+  // Project-root scaffolding (package.json, playwright.config.ts, …) is no
+  // longer copied by materializeSupport (#233 Step 7). The legacy entrypoint
+  // bypasses the orchestrator's generic scaffold-write path, so inline the
+  // equivalent here: load via the same source-of-truth helper and write each
+  // file relative to opts.outDir.
+  for (const file of await loadProjectScaffoldingFiles()) {
+    await fs.writeFile(path.join(opts.outDir, file.relativePath), file.content, 'utf8');
+  }
   await materializeFixtures(opts.outDir);
   const file = path.join(opts.outDir, playwrightSuiteFileName(collection, opts.mode || 'feature'));
   const code = renderPlaywrightSuite(collection, opts);
@@ -147,6 +159,17 @@ export const PlaywrightEmitter: EmitterStrategy = {
           'When true, every emitted scenario step appends a recordResponse({...}) call and the suite imports recordResponse/sanitizeBody from ./support/recorder. Defaults to false; recorder.ts is also vendored conditionally.',
       },
     },
+  },
+  async scaffold(_ctx: EmitContext): Promise<EmittedFile[]> {
+    // Project-root scaffolding for the Playwright/REST suite. Returned as
+    // {@link EmittedFile}s so the orchestrator's generic write path
+    // (`writeScaffolded`) owns the actual fs writes — keeping this method
+    // pure and trivially testable.
+    //
+    // PROJECT_TEMPLATE_FILES (re-exported alongside this helper) is the
+    // source of truth for which files ship in the scaffold; the loader
+    // returns them in that order.
+    return loadProjectScaffoldingFiles();
   },
   async emit(collection: EndpointScenarioCollection, ctx: EmitContext): Promise<EmittedFile[]> {
     const recordResponses =

--- a/materializer/src/playwright/materialize-support.ts
+++ b/materializer/src/playwright/materialize-support.ts
@@ -7,7 +7,16 @@
 //   npm install
 //   API_BASE_URL=http://localhost:8080/v2 npm test
 //
-// Three sets of assets are copied:
+// Three sets of assets are produced for an emitted suite:
+//   * Project scaffolding (package.json, playwright.config.ts, tsconfig.json,
+//                          .env.example, README.md): owned by the emitter's
+//                          SDK `scaffold()` method (see PlaywrightEmitter).
+//                          The orchestrator writes the returned EmittedFile
+//                          list into <outDir>/. This module exposes the
+//                          pure file-list builder via
+//                          `loadProjectScaffoldingFiles()` so PlaywrightEmitter.scaffold
+//                          and the legacy `emitPlaywrightSuite` entrypoint
+//                          share the same template-discovery logic.
 //   * support/ — runtime helpers (env.ts, recorder.ts, seeding.ts,
 //                fixtures.ts, seed-rules.json, await-eventually.ts).
 //                Sources:
@@ -18,9 +27,6 @@
 //                configs/<config>/codegen/playwright/roles/<role>/support.<ext>
 //                copied (renamed) to support/<role>.<ext>
 //                — see materializeRoleSupportFiles().
-//   * project root — package.json, playwright.config.ts, tsconfig.json,
-//                    .env.example, README.md.
-//                    Sources: materializer/templates/.
 //   * fixtures/ — BPMN/DMN/form files referenced by @@FILE:<rel-path>
 //                 markers in emitted tests. Sources:
 //                 configs/<config>/fixtures/ (per-config; #221 / Lift 11).
@@ -32,6 +38,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { EmittedFile } from '@camunda8/emitter-sdk';
 import { getActiveConfigDir, getSpecBundleDir } from 'path-analyser/configResolver';
 
 export const SUPPORT_TEMPLATE_FILES = [
@@ -94,27 +101,22 @@ function defaultProjectTemplatesDir(): string {
 }
 
 /**
- * Copy the runtime support templates AND project-root scaffolding into
- * `<outDir>/` so the emitted Playwright suite is self-contained and runnable
- * in place (`cd <outDir> && npm install && npm test`).
+ * Copy the runtime support templates into `<outDir>/support/` so the emitted
+ * Playwright suite has the helper modules it imports (env.ts, recorder.ts,
+ * seeding.ts, fixtures.ts, seed-rules.json, await-eventually.ts).
  *
- * Idempotent: safe to call multiple times per emit run.
+ * Idempotent: safe to call multiple times per emit run. Project-root
+ * scaffolding (package.json, playwright.config.ts, tsconfig.json,
+ * .env.example, README.md) is NOT written here — those files are produced
+ * by {@link PlaywrightEmitter.scaffold} and written by the orchestrator
+ * via the generic SDK scaffold path (#233 Step 7).
  *
  * @param outDir              Directory to materialize into (created if missing).
  * @param templatesDir        Optional override for the support-templates source
- *                            directory (env.ts, recorder.ts, seeding.ts,
- *                            seed-rules.json). Production callers should omit
- *                            this; it exists so tests can exercise the
+ *                            directory. Production callers should omit this;
+ *                            it exists so tests can exercise the
  *                            missing-template path without mutating
  *                            checked-in source files.
- * @param projectTemplatesDir Optional override for the project-root templates
- *                            (package.json, playwright.config.ts, tsconfig.json,
- *                            .env.example, README.md). Production callers
- *                            should omit this.
- * @param overwriteRoot       When false, root scaffolding files are only
- *                            written if they don't already exist. Support
- *                            files are always overwritten regardless.
- *                            Default: true.
  * @param excludeSupportFiles Optional list of support-template file names to
  *                            skip when copying into `<outDir>/support/`.
  *                            Used by callers that have configured the emitter
@@ -132,8 +134,6 @@ function defaultProjectTemplatesDir(): string {
 export async function materializeSupport(
   outDir: string,
   templatesDir?: string,
-  projectTemplatesDir?: string,
-  overwriteRoot: boolean = true,
   excludeSupportFiles?: readonly string[],
 ): Promise<string> {
   const srcDir = templatesDir ?? defaultTemplatesDir();
@@ -163,15 +163,32 @@ export async function materializeSupport(
     await fs.copyFile(path.join(srcDir, name), dest);
   }
 
-  // Project root scaffolding: overwritten by default; opt-out preserves user edits.
-  const projSrcDir = projectTemplatesDir ?? defaultProjectTemplatesDir();
-  for (const name of PROJECT_TEMPLATE_FILES) {
-    const dest = path.join(outDir, name);
-    if (!overwriteRoot && existsSync(dest)) continue;
-    await fs.copyFile(path.join(projSrcDir, name), dest);
-  }
-
   return destDir;
+}
+
+/**
+ * Read the Playwright project-root scaffolding templates into an in-memory
+ * {@link EmittedFile} list. Pure: no filesystem writes. Backs
+ * {@link PlaywrightEmitter.scaffold} so the orchestrator's generic
+ * scaffold-write path (see {@link writeScaffolded}) owns all actual writes.
+ *
+ * @param projectTemplatesDir Optional override for the source directory.
+ *                            Production callers should omit this; tests use
+ *                            it to point at a synthetic templates tree.
+ * @returns The five {@link PROJECT_TEMPLATE_FILES} as `EmittedFile`s, each
+ *          with `relativePath` equal to the file's basename (written into
+ *          `<ctx.outDir>/` directly).
+ */
+export async function loadProjectScaffoldingFiles(
+  projectTemplatesDir?: string,
+): Promise<EmittedFile[]> {
+  const srcDir = projectTemplatesDir ?? defaultProjectTemplatesDir();
+  const out: EmittedFile[] = [];
+  for (const name of PROJECT_TEMPLATE_FILES) {
+    const content = await fs.readFile(path.join(srcDir, name), 'utf8');
+    out.push({ relativePath: name, content });
+  }
+  return out;
 }
 
 /**

--- a/tests/codegen/materialize-support.test.ts
+++ b/tests/codegen/materialize-support.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import {
   FIXTURES_DIR_NAME,
+  loadProjectScaffoldingFiles,
   materializeFixtures,
   materializeRoleSupportFiles,
   materializeSupport,
@@ -37,24 +38,20 @@ describe('materializeSupport', () => {
     }
   });
 
-  test('writes project-root scaffolding files into <outDir>/', async () => {
+  test('does NOT write project-root scaffolding (delegated to PlaywrightEmitter.scaffold)', async () => {
+    // #233 Step 7: project-root files (package.json, playwright.config.ts,
+    // tsconfig.json, .env.example, README.md) moved off materializeSupport
+    // onto the EmitterStrategy.scaffold() SDK contract. The orchestrator now
+    // owns writing them via writeScaffolded(). Keep this assertion as a
+    // regression guard so a future refactor cannot silently re-introduce
+    // the project-template copy into materializeSupport.
     await materializeSupport(tmp);
     for (const name of PROJECT_TEMPLATE_FILES) {
-      const stat = await fs.stat(path.join(tmp, name));
-      expect(stat.size).toBeGreaterThan(0);
+      expect(
+        existsSync(path.join(tmp, name)),
+        `${name} must not be written by materializeSupport`,
+      ).toBe(false);
     }
-  });
-
-  test('emitted package.json declares a "test" script and @playwright/test devDep', async () => {
-    await materializeSupport(tmp);
-    const pkgRaw = await fs.readFile(path.join(tmp, 'package.json'), 'utf8');
-    // biome-ignore lint/plugin: test fixture parsing of known-good JSON
-    const pkg = JSON.parse(pkgRaw) as {
-      scripts?: Record<string, string>;
-      devDependencies?: Record<string, string>;
-    };
-    expect(pkg.scripts?.test).toMatch(/playwright/);
-    expect(pkg.devDependencies?.['@playwright/test']).toBeTruthy();
   });
 
   test('is idempotent: a second call overwrites without error', async () => {
@@ -62,25 +59,6 @@ describe('materializeSupport', () => {
     await expect(materializeSupport(tmp)).resolves.toBe(path.join(tmp, SUPPORT_DIR_NAME));
     const supportEntries = await fs.readdir(path.join(tmp, SUPPORT_DIR_NAME));
     expect(supportEntries.sort()).toEqual([...SUPPORT_TEMPLATE_FILES].sort());
-    for (const name of PROJECT_TEMPLATE_FILES) {
-      expect(existsSync(path.join(tmp, name))).toBe(true);
-    }
-  });
-
-  test('overwriteRoot=false preserves user-edited root files but refreshes support/', async () => {
-    await materializeSupport(tmp);
-    // Simulate a user edit to a root file.
-    const userPkg = '{"name":"user-edited"}';
-    await fs.writeFile(path.join(tmp, 'package.json'), userPkg, 'utf8');
-
-    await materializeSupport(tmp, undefined, undefined, false);
-
-    expect(await fs.readFile(path.join(tmp, 'package.json'), 'utf8')).toBe(userPkg);
-    // Support files are still part of the contract — refreshed regardless.
-    for (const name of SUPPORT_TEMPLATE_FILES) {
-      const stat = await fs.stat(path.join(tmp, SUPPORT_DIR_NAME, name));
-      expect(stat.size).toBeGreaterThan(0);
-    }
   });
 
   test('respects the templatesDir override and copies from a custom support source', async () => {
@@ -99,28 +77,12 @@ describe('materializeSupport', () => {
     }
   });
 
-  test('respects the projectTemplatesDir override', async () => {
-    const fakeProj = await fs.mkdtemp(path.join(os.tmpdir(), 'mat-proj-src-'));
-    try {
-      for (const name of PROJECT_TEMPLATE_FILES) {
-        await fs.writeFile(path.join(fakeProj, name), `fake-${name}`, 'utf8');
-      }
-      await materializeSupport(tmp, undefined, fakeProj);
-      for (const name of PROJECT_TEMPLATE_FILES) {
-        const content = await fs.readFile(path.join(tmp, name), 'utf8');
-        expect(content).toBe(`fake-${name}`);
-      }
-    } finally {
-      await fs.rm(fakeProj, { recursive: true, force: true });
-    }
-  });
-
   test('excludeSupportFiles skips listed files in support/ but keeps the rest', async () => {
-    // Exercises the gate behind configs.json#codegen.playwright.recordResponses=false:
+    // Exercises the gate behind codegen/playwright/config.json#recordResponses=false:
     // the call site drops recorder.ts when no recordResponse() call will be
     // emitted into the suite. Other support files must remain — they're part
     // of the suite's runtime contract regardless of the recorder option.
-    await materializeSupport(tmp, undefined, undefined, true, ['recorder.ts']);
+    await materializeSupport(tmp, undefined, ['recorder.ts']);
     const entries = (await fs.readdir(path.join(tmp, SUPPORT_DIR_NAME))).sort();
     const expected = SUPPORT_TEMPLATE_FILES.filter((f) => f !== 'recorder.ts').sort();
     expect(entries).toEqual(expected);
@@ -135,7 +97,7 @@ describe('materializeSupport', () => {
     // the stale recorder.ts is gone.
     await materializeSupport(tmp);
     expect(existsSync(path.join(tmp, SUPPORT_DIR_NAME, 'recorder.ts'))).toBe(true);
-    await materializeSupport(tmp, undefined, undefined, true, ['recorder.ts']);
+    await materializeSupport(tmp, undefined, ['recorder.ts']);
     expect(existsSync(path.join(tmp, SUPPORT_DIR_NAME, 'recorder.ts'))).toBe(false);
     // And the non-excluded files are still present.
     expect(existsSync(path.join(tmp, SUPPORT_DIR_NAME, 'seeding.ts'))).toBe(true);
@@ -146,9 +108,9 @@ describe('materializeSupport', () => {
     // would otherwise silently no-op and the caller would keep shipping
     // the helper they thought they were excluding. The validator surfaces
     // the bad name in the error message so the fix site is obvious.
-    await expect(
-      materializeSupport(tmp, undefined, undefined, true, ['no-such-file.ts']),
-    ).rejects.toThrow(/excludeSupportFiles contains unknown name "no-such-file\.ts"/);
+    await expect(materializeSupport(tmp, undefined, ['no-such-file.ts'])).rejects.toThrow(
+      /excludeSupportFiles contains unknown name "no-such-file\.ts"/,
+    );
   });
 
   test('fails with a clear filesystem error when a required support template is missing', async () => {
@@ -160,6 +122,44 @@ describe('materializeSupport', () => {
       await expect(materializeSupport(tmp, fakeSrc)).rejects.toThrow(/ENOENT|no such file/i);
     } finally {
       await fs.rm(fakeSrc, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('loadProjectScaffoldingFiles (#233 Step 7)', () => {
+  test('returns all PROJECT_TEMPLATE_FILES as in-memory EmittedFiles in declaration order', async () => {
+    const files = await loadProjectScaffoldingFiles();
+    expect(files.map((f) => f.relativePath)).toEqual([...PROJECT_TEMPLATE_FILES]);
+    for (const f of files) {
+      expect(f.content.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('package.json content declares a "test" script and @playwright/test devDep', async () => {
+    const files = await loadProjectScaffoldingFiles();
+    const pkgFile = files.find((f) => f.relativePath === 'package.json');
+    expect(pkgFile).toBeDefined();
+    // biome-ignore lint/plugin: test fixture parsing of known-good JSON
+    const pkg = JSON.parse(pkgFile?.content ?? '{}') as {
+      scripts?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    expect(pkg.scripts?.test).toMatch(/playwright/);
+    expect(pkg.devDependencies?.['@playwright/test']).toBeTruthy();
+  });
+
+  test('respects the projectTemplatesDir override', async () => {
+    const fakeProj = await fs.mkdtemp(path.join(os.tmpdir(), 'mat-proj-src-'));
+    try {
+      for (const name of PROJECT_TEMPLATE_FILES) {
+        await fs.writeFile(path.join(fakeProj, name), `fake-${name}`, 'utf8');
+      }
+      const files = await loadProjectScaffoldingFiles(fakeProj);
+      for (const f of files) {
+        expect(f.content).toBe(`fake-${f.relativePath}`);
+      }
+    } finally {
+      await fs.rm(fakeProj, { recursive: true, force: true });
     }
   });
 });

--- a/tests/codegen/playwright-scaffold.test.ts
+++ b/tests/codegen/playwright-scaffold.test.ts
@@ -1,0 +1,95 @@
+// #233 Step 7: lock in PlaywrightEmitter.scaffold() and the orchestrator's
+// generic writeScaffolded() write path. The scaffold method is the SDK
+// boundary for project-root framing files (package.json, playwright.config.ts,
+// tsconfig.json, .env.example, README.md); the orchestrator vendors the
+// returned EmittedFile[] into <ctx.outDir>/ via the same path-safety checks
+// used by writeEmitted().
+
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { EmitContext } from '@camunda8/emitter-sdk';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { writeScaffolded } from '../../materializer/src/orchestrator.ts';
+import { PlaywrightEmitter } from '../../materializer/src/playwright/emitter.ts';
+import { PROJECT_TEMPLATE_FILES } from '../../materializer/src/playwright/materialize-support.ts';
+
+function minimalCtx(outDir: string): EmitContext {
+  return {
+    outDir,
+    suiteName: '',
+    mode: 'feature',
+    configName: 'camunda-oca',
+    emitterConfig: {},
+    resolveConfigPath: (...parts: string[]) => path.join(outDir, ...parts),
+  };
+}
+
+describe('PlaywrightEmitter.scaffold', () => {
+  test('returns the five project-root templates as EmittedFiles in declaration order', async () => {
+    if (!PlaywrightEmitter.scaffold) throw new Error('scaffold must be defined');
+    const ctx = minimalCtx('/tmp/ignored-scaffold-pure');
+    const files = await PlaywrightEmitter.scaffold(ctx);
+    expect(files.map((f) => f.relativePath)).toEqual([...PROJECT_TEMPLATE_FILES]);
+    // Pure: no fs writes; verify nothing was created under the (non-existent)
+    // outDir. fs.stat throws ENOENT — that's the assertion.
+    await expect(fs.stat('/tmp/ignored-scaffold-pure')).rejects.toThrow(/ENOENT/);
+    for (const f of files) {
+      expect(f.content.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('writeScaffolded (orchestrator generic scaffold-write path)', () => {
+  let tmp: string;
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'scaffold-write-'));
+  });
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  test('writes every file returned by scaffold() into ctx.outDir', async () => {
+    const written = await writeScaffolded(PlaywrightEmitter, minimalCtx(tmp));
+    expect(written.length).toBe(PROJECT_TEMPLATE_FILES.length);
+    for (const name of PROJECT_TEMPLATE_FILES) {
+      const stat = await fs.stat(path.join(tmp, name));
+      expect(stat.size).toBeGreaterThan(0);
+    }
+  });
+
+  test('is a no-op for emitters that omit scaffold', async () => {
+    const noopEmitter = {
+      ...PlaywrightEmitter,
+      scaffold: undefined,
+    };
+    const written = await writeScaffolded(noopEmitter, minimalCtx(tmp));
+    expect(written).toEqual([]);
+    const entries = await fs.readdir(tmp);
+    expect(entries).toEqual([]);
+  });
+
+  test('rejects scaffold files that escape ctx.outDir', async () => {
+    const evilEmitter = {
+      ...PlaywrightEmitter,
+      async scaffold() {
+        return [{ relativePath: '../escaped.txt', content: 'pwn' }];
+      },
+    };
+    await expect(writeScaffolded(evilEmitter, minimalCtx(tmp))).rejects.toThrow(
+      /escapes ctx.outDir/,
+    );
+  });
+
+  test('rejects absolute paths returned by scaffold', async () => {
+    const evilEmitter = {
+      ...PlaywrightEmitter,
+      async scaffold() {
+        return [{ relativePath: '/etc/passwd', content: 'pwn' }];
+      },
+    };
+    await expect(writeScaffolded(evilEmitter, minimalCtx(tmp))).rejects.toThrow(
+      /returned absolute path/,
+    );
+  });
+});

--- a/tests/codegen/playwright-scaffold.test.ts
+++ b/tests/codegen/playwright-scaffold.test.ts
@@ -28,12 +28,17 @@ function minimalCtx(outDir: string): EmitContext {
 describe('PlaywrightEmitter.scaffold', () => {
   test('returns the five project-root templates as EmittedFiles in declaration order', async () => {
     if (!PlaywrightEmitter.scaffold) throw new Error('scaffold must be defined');
-    const ctx = minimalCtx('/tmp/ignored-scaffold-pure');
+    const outDir = path.join(
+      os.tmpdir(),
+      `ignored-scaffold-pure-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    );
+    await expect(fs.stat(outDir)).rejects.toThrow(/ENOENT/);
+    const ctx = minimalCtx(outDir);
     const files = await PlaywrightEmitter.scaffold(ctx);
     expect(files.map((f) => f.relativePath)).toEqual([...PROJECT_TEMPLATE_FILES]);
-    // Pure: no fs writes; verify nothing was created under the (non-existent)
-    // outDir. fs.stat throws ENOENT — that's the assertion.
-    await expect(fs.stat('/tmp/ignored-scaffold-pure')).rejects.toThrow(/ENOENT/);
+    // Pure: no fs writes; verify nothing was created under the generated
+    // outDir before or after calling scaffold().
+    await expect(fs.stat(outDir)).rejects.toThrow(/ENOENT/);
     for (const f of files) {
       expect(f.content.length).toBeGreaterThan(0);
     }


### PR DESCRIPTION
Closes the last deferred step from #233.

## What

Lifts the project-root framing files (`package.json`, `playwright.config.ts`, `tsconfig.json`, `.env.example`, `README.md`) out of `materializeSupport()` onto the SDK `EmitterStrategy.scaffold()` contract introduced in #237.

## Why

#237 landed the `EmitterStrategy` contract but deferred `scaffold()`. With `scaffold()` in place, the SDK contract is now complete: SDK contributors (JS / C# / Python OCA emitters) have a single, stable integration shape — `{ id, name, supportedConfigs, configSchema?, roleHooks?, scaffold?, emit }` — and the orchestrator owns all filesystem writes via uniform path-safety checks.

## Changes

- **`materializer/src/playwright/materialize-support.ts`**
  - `materializeSupport()` is now runtime-support-only: signature simplifies from `(outDir, templatesDir?, projectTemplatesDir?, overwriteRoot?, excludeSupportFiles?)` → `(outDir, templatesDir?, excludeSupportFiles?)`
  - New pure helper `loadProjectScaffoldingFiles(srcDir?): Promise<EmittedFile[]>` — the source-of-truth for project-root template discovery, shared by `PlaywrightEmitter.scaffold` and the legacy `emitPlaywrightSuite` entrypoint
- **`materializer/src/playwright/emitter.ts`**
  - `PlaywrightEmitter.scaffold(ctx)` implements the SDK contract, returning the five `PROJECT_TEMPLATE_FILES` as in-memory `EmittedFile[]`
  - `emitPlaywrightSuite()` inlines the equivalent load+write so the standalone entrypoint stays runnable without the orchestrator
- **`materializer/src/orchestrator.ts`**
  - Adds `writeScaffolded(emitter, ctx)` — the generic scaffold write path
  - Factors `writeFiles()` helper so absolute-path and `ctx.outDir`-escape checks apply uniformly to both `emit()` and `scaffold()` outputs
- **`materializer/src/index.ts`**
  - Orchestrator calls `writeScaffolded()` once per CLI invocation, before any `emit()`, per the SDK contract

## Tests

- **`tests/codegen/playwright-scaffold.test.ts`** (new, 5 tests)
  - `PlaywrightEmitter.scaffold` returns the five templates in declaration order with non-empty content
  - `scaffold` is pure (no fs writes)
  - `writeScaffolded` writes every returned file, is a no-op for emitters that omit `scaffold`, rejects `../`-escape, and rejects absolute paths
- **`tests/codegen/materialize-support.test.ts`**
  - Updated for the new 3-arg signature
  - Added a regression guard asserting `materializeSupport` must NOT write project-root files (so a future refactor cannot silently re-introduce the old behaviour)
  - Added a `loadProjectScaffoldingFiles` describe block

## Verification

- `npm run lint`: clean
- All five workspace typechecks (path-analyser, request-validation, semantic-graph-extractor, materializer, emitter-sdk): clean
- 534 passed + 6 skipped (was 535 + 6; net +5 new scaffold tests / -6 obsolete project-template tests reframed into the scaffold helper block)
- Pipeline output byte-identical to baseline aside from generation timestamps in `responses.json` and `scenarios/index.json`

Closes #233.