### PR TITLE
fix: encapsulate spec-derived `extracts` inside the `deploy()` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ These live under `configs/<active-config>/`:
 | `filter-providers.json` | Maps fields to value providers (`ctx`, `const`, `enumFirst`, etc.) |
 | `request-defaults.json` | Default values for request body fields per operation |
 | `fixtures/` | BPMN, DMN, and form files used by deployment tests, plus `deployment-artifacts.json` registry |
-| `codegen/playwright/roles/<role>/` | Per-role bundles consumed by the materializer (`call-site.tmpl`, optional `imports.tmpl`, `support.<ext>`, `match.json`) |
+| `codegen/playwright/roles/<role>/` | Per-role bundles consumed by the materializer (`call-site.tmpl`, optional `imports.tmpl`, `support.<ext>` or `support.<ext>.tmpl`, `match.json`) |
 
 ## Environment Variables
 

--- a/configs/camunda-oca/codegen/playwright/roles/deploymentGateway/call-site.tmpl
+++ b/configs/camunda-oca/codegen/playwright/roles/deploymentGateway/call-site.tmpl
@@ -1,2 +1,2 @@
-const {{{respVar}}} = await deploy({{{ctx}}}, {{{request}}}, {{{body}}}, {{{baseUrl}}} + {{{url}}}, {{{strips}}}, {{{extracts}}});
+const {{{respVar}}} = await deploy({{{ctx}}}, {{{request}}}, {{{body}}}, {{{baseUrl}}} + {{{url}}}, {{{strips}}});
 expect({{{respVar}}}.status()).toBe({{{expectedStatus}}});

--- a/configs/camunda-oca/codegen/playwright/roles/deploymentGateway/support.ts.tmpl
+++ b/configs/camunda-oca/codegen/playwright/roles/deploymentGateway/support.ts.tmpl
@@ -2,10 +2,11 @@
 //
 // Vendored into every emitted Playwright suite at
 // <outDir>/support/deploymentGateway.ts by the role-overlay materializer
-// (see path-analyser/src/codegen/playwright/materialize-support.ts). The
-// file is renamed on copy from this role directory's `support.ts` to
-// `deploymentGateway.ts` so role-owned helpers cannot collide with
-// built-in support files.
+// (see materializer/src/playwright/materialize-support.ts). This source
+// file ships as `support.ts.tmpl` and is rendered as a Mustache template
+// at codegen time so the spec-derived `EXTRACTS` constant is baked into
+// the vendored helper instead of being threaded through every call-site
+// literal (#243).
 //
 // Encapsulates the full deployment lifecycle in a single call:
 //   - resolve @@FILE: paths via resolveFixture()
@@ -13,10 +14,11 @@
 //     supplied by the emitter (from globalContextSeeds)
 //   - POST <baseUrl> + the role-bound op's path with auth headers
 //   - throw a descriptive Error on any non-200 response
-//   - walk the spec-derived `extracts` list and populate ctx via
+//   - walk the spec-derived `EXTRACTS` constant and populate ctx via
 //     extractInto() — the helper has no hard-coded knowledge of which
-//     response fields are extracted; the list comes from the
-//     extractor's responseSemanticLeaves at codegen time
+//     response fields are extracted; the list is generated at codegen
+//     time from the extractor's responseSemanticLeaves and templated
+//     into this file's `EXTRACTS` literal below.
 //
 // Keep this file free of npm package imports — only the co-vendored
 // ./env, ./fixtures, and ./seeding helpers (built-in support, sibling
@@ -79,21 +81,32 @@ export interface DeployStripRule {
 
 /**
  * A response-field extraction directive: navigate `segments` on the response
- * JSON and bind the value to `ctx[varName]` via `extractInto`. Computed at
- * codegen time from the role-bound op's `responseSemanticLeaves` so the
- * runtime helper carries zero spec-derived knowledge.
+ * JSON and bind the value to `ctx[varName]` via `extractInto`.
  *
  * `segments` mixes string property keys with number array indices. A `null`
  * or `undefined` encountered partway short-circuits the walk and the
  * variable is left untouched (extractInto skips undefined values).
  */
-export interface DeployExtract {
+interface DeployExtract {
   varName: string;
   segments: (string | number)[];
 }
 
 /**
- * Perform a multipart deploy call against `path` and walk `extracts` against
+ * Spec-derived response-extracts list. Baked into this file at codegen time
+ * from the role-bound operation's `responseSemanticLeaves` via the
+ * `DeploymentRoleHookProvider` (`materializer/src/playwright/hooks/deployment.ts`)
+ * and the templated-support-file rendering path in `materializeRoleSupportFiles`
+ * (`materializer/src/playwright/materialize-support.ts`).
+ *
+ * Keeping the list inside the helper (rather than at every `deploy(...)`
+ * call site in the emitted suite) is the encapsulation the helper was
+ * introduced for — see #243.
+ */
+const EXTRACTS: DeployExtract[] = {{{extracts}}};
+
+/**
+ * Perform a multipart deploy call against `path` and walk `EXTRACTS` against
  * the response JSON.
  *
  * - Resolves `@@FILE:<path>` entries in `body.files` via resolveFixture().
@@ -103,7 +116,7 @@ export interface DeployExtract {
  *   `globalContextSeeds` so no domain-specific knowledge is hard-coded here.
  * - Throws a descriptive Error on any non-200 response (includes the response
  *   body for diagnosis).
- * - Walks `extracts` against the parsed JSON and assigns each resolved value
+ * - Walks `EXTRACTS` against the parsed JSON and assigns each resolved value
  *   to `ctx[ex.varName]` via `extractInto`. The walker short-circuits to
  *   `undefined` on a null/missing segment; `extractInto` skips undefined
  *   values so pre-seeded ctx bindings are preserved.
@@ -115,7 +128,6 @@ export async function deploy(
   body: DeployBody,
   url: string,
   strips: DeployStripRule[],
-  extracts: DeployExtract[],
 ): Promise<ApiResponseLike> {
   const multipart: Record<string, string | { name: string; mimeType: string; buffer: Buffer }> = {};
 
@@ -147,7 +159,7 @@ export async function deploy(
 
   const json = await resp.json();
 
-  for (const ex of extracts) {
+  for (const ex of EXTRACTS) {
     let v: unknown = json;
     for (const seg of ex.segments) {
       if (v === null || v === undefined) {

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -5326,28 +5326,36 @@ describeForThisConfig(
       ).toEqual([]);
     });
 
-    it('spec-derived deploymentGateway extracts cover every downstream binding consumer', async () => {
-      // The deploy() helper receives an extracts list at materialise
-      // time and writes `ctx[<varName>] = ...` for each entry. If a
-      // downstream step references a binding the extracts list does
-      // not produce, the suite runs against an undefined ctx slot —
-      // a silent test-time regression.
+    it('spec-derived deploymentGateway EXTRACTS cover every downstream binding consumer', async () => {
+      // #243: the deploy() helper bakes the spec-derived response-extracts
+      // list into a module-level `const EXTRACTS = [...]` at codegen time
+      // (see materializer/src/playwright/materialize-support.ts —
+      // materializeRoleSupportFiles renders the role's
+      // `support.ts.tmpl` against the role's roleExtras entry). The
+      // helper itself owns extraction; call sites are extract-agnostic.
       //
-      // Two-part check, both phrased over the actual emitted specs
-      // (the materialised contract — not the scenario JSON, which
-      // doesn't carry the extracts literal):
-      //   (a) Drift detector: every emitted `deploy(...)` call's
-      //       extracts list literal has the same varName set as
+      // If a downstream step references a binding that EXTRACTS does not
+      // produce, the suite runs against an undefined ctx slot — a silent
+      // test-time regression.
+      //
+      // Three-part check:
+      //   (a) Drift detector: parse the materialised
+      //       <outDir>/support/deploymentGateway.ts and assert its
+      //       EXTRACTS literal's varName set equals
       //       computeDeploymentExtracts(createDeployment). Catches a
-      //       regression where the emitter inlines a stale subset or
-      //       where the spec gains/loses an annotation without the
-      //       extract list following.
-      //   (b) Coverage: for every emitted spec whose chain is exactly
-      //       `[createDeployment, <consumer>]`, every `ctx.<...>Var`
-      //       reference in the consumer step body must be produced
-      //       either by computeDeploymentExtracts or by a
-      //       `seedBinding('<...>Var')` / `ctx.<...>Var = …`
-      //       assignment earlier in the same spec.
+      //       regression where the materializer fails to render the
+      //       template, where the hook provider returns a stale subset,
+      //       or where the spec gains/loses an annotation without the
+      //       extract filter following.
+      //   (b) No-call-site-leakage detector: no emitted spec contains a
+      //       `varName:` literal inside a `deploy(` argument list. Catches
+      //       a regression where the call-site template starts inlining
+      //       extracts again, defeating the encapsulation #243 introduced.
+      //   (c) Coverage: every `ctx.<...>Var` read in a spec that uses
+      //       deploy() must be produced either by EXTRACTS, by a
+      //       `seedBinding('<...>Var')`, by a `ctx.<...>Var = …`
+      //       assignment, or by an explicit `extractInto(ctx, '...Var', …)`
+      //       earlier in the same spec.
       const { loadGraph } = await import('../../path-analyser/src/graphLoader.js');
       const { computeDeploymentExtracts } = await import(
         '../../materializer/src/deploymentExtracts.js'
@@ -5361,26 +5369,53 @@ describeForThisConfig(
       const extracts = computeDeploymentExtracts(opNode);
       const producedVars = new Set(extracts.map((e) => e.varName));
 
+      // (a) Drift detector against the single materialised helper.
+      const helperPath = join(GENERATED_TESTS_DIR, 'support', 'deploymentGateway.ts');
+      const helperSrc = readFileSync(helperPath, 'utf8');
+      // Locate the `const EXTRACTS: DeployExtract[] = [...]` literal and
+      // scope varName extraction to its contents. The literal is the only
+      // place in the helper where `varName:` appears.
+      const extractsLiteralMatch = helperSrc.match(
+        /const\s+EXTRACTS\s*:\s*DeployExtract\[\]\s*=\s*(\[[\s\S]*?\]);/,
+      );
+      const helperVars = new Set<string>();
+      if (extractsLiteralMatch) {
+        const varNameInLiteralPattern = /varName:\s*['"]([A-Za-z_$][\w$]*)['"]/g;
+        let m: RegExpExecArray | null;
+        // biome-ignore lint/suspicious/noAssignInExpressions: standard regex-exec loop
+        while ((m = varNameInLiteralPattern.exec(extractsLiteralMatch[1])) !== null) {
+          helperVars.add(m[1]);
+        }
+      }
+      const missingInHelper = [...producedVars].filter((v) => !helperVars.has(v)).sort();
+      const extraInHelper = [...helperVars].filter((v) => !producedVars.has(v)).sort();
+      expect(
+        { missing: missingInHelper, extra: extraInHelper },
+        `Materialised <outDir>/support/deploymentGateway.ts EXTRACTS literal drifted from computeDeploymentExtracts(createDeployment). ` +
+          `Either the spec gained/lost an x-semantic-type / x-semantic-provider annotation on createDeployment and the extract filter needs adjusting, ` +
+          `the materializer failed to render support.ts.tmpl against roleExtras, or the DeploymentRoleHookProvider returned a stale subset. ` +
+          `Helper path: ${helperPath}`,
+      ).toEqual({ missing: [], extra: [] });
+
+      // (b) + (c) walk emitted spec files.
       const specFiles = readdirSync(GENERATED_TESTS_DIR).filter((f) => f.endsWith('.spec.ts'));
-      const driftFailures: string[] = [];
+      const leakageFailures: string[] = [];
       const coverageFailures: string[] = [];
 
-      // Match a `deploy(` call and capture everything up to its matching
-      // closing paren followed by `;`. The emitted form is stable: the
-      // extracts list is the only arg containing `varName:` literals.
-      const varNameInLiteralPattern = /varName:\s*['"]([A-Za-z_$][\w$]*)['"]/g;
       const ctxReadPattern = /\bctx\.([A-Za-z_$][\w$]*Var)\b/g;
       const ctxSeedPattern = /\bctx\.([A-Za-z_$][\w$]*Var)\s*=/g;
       const seedBindingPattern = /\bseedBinding\(\s*['"]([A-Za-z_$][\w$]*Var)['"]/g;
+      const extractIntoPattern = /\bextractInto\(\s*ctx\s*,\s*['"]([A-Za-z_$][\w$]*Var)['"]/g;
+      const varNameInLiteralPattern = /varName:\s*['"]([A-Za-z_$][\w$]*)['"]/g;
 
       for (const spec of specFiles) {
         const content = readFileSync(join(GENERATED_TESTS_DIR, spec), 'utf8');
         if (!content.includes('deploy(')) continue;
 
-        // (a) Drift detector.
-        // Each `deploy(...)` call contains exactly the extracts literal —
-        // capture the substring from `deploy(` to the matching `);` at
-        // depth 0 to scope varName extraction per call.
+        // (b) No-call-site-leakage. Walk every `deploy(...);` argument
+        // list and assert it carries no `varName:` literal. The helper
+        // owns extraction (#243); a varName literal here means the
+        // call-site template has started inlining extracts again.
         let idx = 0;
         while ((idx = content.indexOf('deploy(', idx)) !== -1) {
           let depth = 0;
@@ -5398,44 +5433,28 @@ describeForThisConfig(
           }
           if (end < 0) break;
           const call = content.slice(idx, end + 1);
-          const callVars = new Set<string>();
-          let m: RegExpExecArray | null;
-          while ((m = varNameInLiteralPattern.exec(call)) !== null) {
-            callVars.add(m[1]);
-          }
-          if (callVars.size > 0) {
-            // Compare set-equality against producedVars.
-            const missing = [...producedVars].filter((v) => !callVars.has(v)).sort();
-            const extra = [...callVars].filter((v) => !producedVars.has(v)).sort();
-            if (missing.length || extra.length) {
-              driftFailures.push(
-                `${spec}: deploy() extracts drift — missing=[${missing.join(',')}] extra=[${extra.join(',')}]`,
-              );
-            }
-          } else {
-            // No varName entries found — the extracts literal is empty or absent.
-            // A regression that wires an empty `[]` or an unwired roleExtra would
-            // produce zero varNames, silently skipping the comparison. Fail here so
-            // it is reported as drift rather than silently ignored.
-            driftFailures.push(
-              `${spec}: deploy() call contains no varName entries (extracts literal empty or missing) — expected [${[...producedVars].sort().join(',')}]`,
+          if (varNameInLiteralPattern.test(call)) {
+            leakageFailures.push(
+              `${spec}: deploy(...) call contains a varName: literal — extracts have leaked back into the call site, defeating the helper encapsulation (#243).`,
             );
           }
+          varNameInLiteralPattern.lastIndex = 0;
           idx = end + 1;
         }
 
-        // (b) Coverage: collect everything the spec can produce
-        // (deploy() extracts ∪ seedBinding ∪ ctx.X = …) and verify
-        // every ctx.X read is producible.
+        // (c) Coverage: producible set = EXTRACTS (baked into helper) ∪
+        // seedBinding ∪ ctx.X = … ∪ extractInto(ctx, 'xVar', …).
         const produced = new Set<string>(producedVars);
         let s: RegExpExecArray | null;
+        // biome-ignore lint/suspicious/noAssignInExpressions: standard regex-exec loop
         while ((s = ctxSeedPattern.exec(content)) !== null) produced.add(s[1]);
+        // biome-ignore lint/suspicious/noAssignInExpressions: standard regex-exec loop
         while ((s = seedBindingPattern.exec(content)) !== null) produced.add(s[1]);
-        // Also count `extractInto(ctx, 'xVar', …)` as a producer.
-        const extractIntoPattern = /\bextractInto\(\s*ctx\s*,\s*['"]([A-Za-z_$][\w$]*Var)['"]/g;
+        // biome-ignore lint/suspicious/noAssignInExpressions: standard regex-exec loop
         while ((s = extractIntoPattern.exec(content)) !== null) produced.add(s[1]);
 
         const reads = new Set<string>();
+        // biome-ignore lint/suspicious/noAssignInExpressions: standard regex-exec loop
         while ((s = ctxReadPattern.exec(content)) !== null) reads.add(s[1]);
         const unproduced = [...reads].filter((v) => !produced.has(v)).sort();
         if (unproduced.length > 0) {
@@ -5444,14 +5463,13 @@ describeForThisConfig(
       }
 
       expect(
-        driftFailures,
-        `Emitted deploy() extracts literal drifted from computeDeploymentExtracts(createDeployment) output. ` +
-          `Either the spec gained/lost an x-semantic-type / x-semantic-provider annotation on createDeployment and the ` +
-          `extract filter needs adjusting, or the emitter is hard-coding a stale subset.`,
+        leakageFailures,
+        `Emitted spec(s) inline an extracts literal at a deploy() call site. The encapsulation introduced in #243 moved the spec-derived EXTRACTS list into the materialised helper; ` +
+          `if the call-site template starts inlining them again, the duplication regresses.`,
       ).toEqual([]);
       expect(
         coverageFailures,
-        `Emitted spec(s) reference ctx binding var(s) with no producer (no deploy() extract, no seedBinding, no ctx.X = …, no extractInto). ` +
+        `Emitted spec(s) reference ctx binding var(s) with no producer (not in helper's EXTRACTS, no seedBinding, no ctx.X = …, no extractInto). ` +
           `Either a downstream extractor is missing, or the consumer step is reading a binding that was never set.`,
       ).toEqual([]);
     });

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -5375,12 +5375,19 @@ describeForThisConfig(
       // Locate the `const EXTRACTS: DeployExtract[] = [...]` literal and
       // scope varName extraction to its contents. The literal is the only
       // place in the helper where `varName:` appears.
+      //
+      // The hook serialises the list via JSON.stringify, which produces
+      // quoted keys (`"varName":"foo"`). Biome's post-codegen format pass
+      // (`biome:fix-generated:codegen`) rewrites them to unquoted
+      // (`varName: 'foo'`). Accept both forms so this invariant doesn't
+      // silently report every var as missing if the formatter is skipped
+      // or its output style changes.
       const extractsLiteralMatch = helperSrc.match(
         /const\s+EXTRACTS\s*:\s*DeployExtract\[\]\s*=\s*(\[[\s\S]*?\]);/,
       );
       const helperVars = new Set<string>();
       if (extractsLiteralMatch) {
-        const varNameInLiteralPattern = /varName:\s*['"]([A-Za-z_$][\w$]*)['"]/g;
+        const varNameInLiteralPattern = /(?:"varName"|varName)\s*:\s*['"]([A-Za-z_$][\w$]*)['"]/g;
         let m: RegExpExecArray | null;
         // biome-ignore lint/suspicious/noAssignInExpressions: standard regex-exec loop
         while ((m = varNameInLiteralPattern.exec(extractsLiteralMatch[1])) !== null) {
@@ -5406,7 +5413,7 @@ describeForThisConfig(
       const ctxSeedPattern = /\bctx\.([A-Za-z_$][\w$]*Var)\s*=/g;
       const seedBindingPattern = /\bseedBinding\(\s*['"]([A-Za-z_$][\w$]*Var)['"]/g;
       const extractIntoPattern = /\bextractInto\(\s*ctx\s*,\s*['"]([A-Za-z_$][\w$]*Var)['"]/g;
-      const varNameInLiteralPattern = /varName:\s*['"]([A-Za-z_$][\w$]*)['"]/g;
+      const varNameInLiteralPattern = /(?:"varName"|varName)\s*:\s*['"]([A-Za-z_$][\w$]*)['"]/g;
 
       for (const spec of specFiles) {
         const content = readFileSync(join(GENERATED_TESTS_DIR, spec), 'utf8');

--- a/emitter-sdk/README.md
+++ b/emitter-sdk/README.md
@@ -253,19 +253,32 @@ Playwright emitter's role-dispatch loop is at
 If your emitter declares `roleHooks: ['deployment']` (etc.), the
 orchestrator will invoke registered `RoleHookProvider`s before any
 `emit` call and populate `ctx.roleExtras.get('<role>')` with the
-provider's output. Spread it into your role-template scope:
+provider's output. Two places can consume the extras:
 
-```ts
-const extras = ctx.roleExtras?.get(role) ?? {};
-const rendered = mustache.render(bundle.callSiteTemplate, {
-  ...stepScope,
-  ...extras,        // e.g. { extracts: '[{varName: "deploymentKeyVar", ...}]' }
-});
-```
+1. **Call-site template scope.** Spread the extras into your
+   `call-site.tmpl` Mustache scope so per-step rendering can read them:
 
-The canonical example is the deployment role's `extracts` variable,
-computed once per CLI invocation by `DeploymentRoleHookProvider` at
-[`materializer/src/playwright/hooks/deployment.ts`](../materializer/src/playwright/hooks/deployment.ts).
+   ```ts
+   const extras = ctx.roleExtras?.get(role) ?? {};
+   const rendered = mustache.render(bundle.callSiteTemplate, {
+     ...stepScope,
+     ...extras,
+   });
+   ```
+
+2. **Templated support file (`support.<ext>.tmpl`).** If the extras are
+   constant across the whole CLI run (e.g. derived from the OpenAPI
+   graph, not from the individual step), prefer baking them into the
+   support file once instead of threading them through every call site.
+   The materializer renders the role's `support.<ext>.tmpl` against the
+   same extras map and writes the result to `support/<role>.<ext>`.
+
+   This is what the deployment role does: `extracts` is a spec-derived
+   constant, so `support.ts.tmpl` interpolates it as
+   `const EXTRACTS = {{{extracts}}};` and the call-site template never
+   sees it. See
+   [`materializer/src/playwright/hooks/deployment.ts`](../materializer/src/playwright/hooks/deployment.ts)
+   for the provider and #243 for the rationale.
 
 ### Step 6 — Implement `scaffold` (optional)
 

--- a/materializer/README.md
+++ b/materializer/README.md
@@ -118,6 +118,7 @@ Per-config role bundles live under
 | `call-site.tmpl` | yes | Mustache template rendered into the spec |
 | `imports.tmpl` | no | Additional imports prepended to the spec |
 | `support.<ext>` | no | Helper file vendored into the emitted suite as `support/<role>.<ext>` and imported by the call-site template |
+| `support.<ext>.tmpl` | no | Mustache template variant of the helper file. Rendered against the role's `roleExtras` entry at codegen time before being written as `support/<role>.<ext>`. Mutually exclusive with `support.<ext>`. Use this when the helper needs to bake in spec-derived constants (see the `deploymentGateway` `EXTRACTS` list). |
 | `match.json` | no | Match rules selecting which operations resolve to this role |
 
 See [`src/ROLES.md`](src/ROLES.md) for the resolution algorithm and
@@ -142,8 +143,11 @@ config-specific helper (e.g. the OCA deployment helper).
    any `roleExtras` your role consumes (see below). The
    [`deploymentGateway` bundle](../configs/camunda-oca/codegen/playwright/roles/deploymentGateway/)
    is a complete worked example.
-5. Optionally ship `support.<ext>` (vendored helper file),
-   `imports.tmpl` (extra imports), and `match.json` (gating rules).
+5. Optionally ship `support.<ext>` or `support.<ext>.tmpl` (vendored
+   helper file; the `.tmpl` form is rendered as Mustache against the
+   role's `roleExtras` at codegen time and is mutually exclusive with
+   the verbatim form), `imports.tmpl` (extra imports), and
+   `match.json` (gating rules).
 6. If your role needs spec-derived data (e.g. response-extracts
    computed from the OpenAPI graph), implement a `RoleHookProvider`
    per [`@camunda8/emitter-sdk`](../emitter-sdk/README.md), declare

--- a/materializer/src/ROLES.md
+++ b/materializer/src/ROLES.md
@@ -85,10 +85,22 @@ The renderer caches the lookup per step.
 
 ```
 configs/<config>/codegen/<emitter>/roles/<role>/
-  support.<ext>      # vendored verbatim into the emitted suite's support/ tree
-  call-site.tmpl     # Mustache template rendered at each step bound to this role
-  imports.tmpl       # optional; Mustache template producing import lines to inject
+  support.<ext>          # vendored verbatim into the emitted suite's support/ tree
+  support.<ext>.tmpl     # OR: Mustache template rendered against the role's roleExtras
+                         #     at codegen time, then written to support/<role>.<ext>
+                         #     (mutually exclusive with the verbatim form)
+  call-site.tmpl         # Mustache template rendered at each step bound to this role
+  imports.tmpl           # optional; Mustache template producing import lines to inject
 ```
+
+A role directory carries **either** `support.<ext>` (copied verbatim) **or**
+`support.<ext>.tmpl` (rendered as Mustache against the role's
+`roleExtras` entry before being written). The loader rejects a directory
+that contains both. The templated form is the right choice when the
+helper needs to bake in spec-derived constants that would otherwise have
+to be threaded through every call site — the `deploymentGateway` role's
+`EXTRACTS` list is the canonical example (see "Deployment-gateway
+reference implementation" below).
 
 All three files are **per emitter** because they encode emitter-specific
 syntax (TypeScript helpers for Playwright; Java classes for the future
@@ -149,22 +161,30 @@ Source layout (in the repo):
 
 ```
 configs/camunda-oca/codegen/playwright/roles/deploymentGateway/
-  support.ts        # contains `export async function deploy(...)`
+  support.ts.tmpl   # Mustache template; bakes EXTRACTS in via {{{extracts}}}
   call-site.tmpl
   imports.tmpl
 ```
 
-The helper itself imports built-in support as siblings:
+The templated helper imports built-in support as siblings and reads the
+baked-in `EXTRACTS` constant directly:
 
 ```ts
-// configs/camunda-oca/codegen/playwright/roles/deploymentGateway/support.ts
+// configs/camunda-oca/codegen/playwright/roles/deploymentGateway/support.ts.tmpl
 import { extractInto } from './seeding.js';
 import { resolveFile } from './fixtures.js';
 
+const EXTRACTS: DeployExtract[] = {{{extracts}}};
+
 export async function deploy(
-  ctx, request, body, baseUrl, strips, extracts,
-) { /* ... */ }
+  ctx, request, body, baseUrl, strips,
+) { /* loops EXTRACTS internally */ }
 ```
+
+`{{{extracts}}}` is interpolated once at codegen time from the
+deployment role's `roleExtras` entry (see "Deployment-gateway reference
+implementation" below). The emitted `support/deploymentGateway.ts`
+contains a literal array; no template syntax leaks into the suite.
 
 Note the `./seeding.js` and `./fixtures.js` imports — these resolve in
 the emitted suite because the file lands next to those built-ins
@@ -202,7 +222,7 @@ HTML-escaped.
 `call-site.tmpl` for the role:
 
 ```hbs
-const {{respVar}} = await deploy({{{ctx}}}, {{{request}}}, {{{body}}}, {{{baseUrl}}}, {{{strips}}}, {{{extracts}}});
+const {{respVar}} = await deploy({{{ctx}}}, {{{request}}}, {{{body}}}, {{{baseUrl}}}, {{{strips}}});
 ```
 
 Rendered spec file (excerpt):
@@ -215,15 +235,18 @@ import { deploy } from './support/deploymentGateway';
 
 test('publish a process and start an instance', async ({ request, baseUrl }, ctx) => {
   // ... earlier steps ...
-  const resp7 = await deploy(ctx, request, body7, baseUrl, STRIPS, EXTRACTS_7);
+  const resp7 = await deploy(ctx, request, body7, baseUrl, STRIPS);
   // ... later steps consume ctx.processDefinitionKeyVar ...
 });
 ```
 
+The extracts list does not appear at the call site — it is baked into
+`support/deploymentGateway.ts` once, by the templated support file.
+
 ### Scope variables for `imports.tmpl`
 
 `imports.tmpl` is rendered **once per `(spec-file, role)` pair** —
-not once per step. Per-step values like `respVar`, `body`, `extracts`,
+not once per step. Per-step values like `respVar`, `body`,
 `operationId`, `pathTemplate` would be ambiguous in that scope (which
 step's value would they hold?) and step-dependent imports are not a
 use case the contract supports: if a template's import block needs to
@@ -241,7 +264,7 @@ spec file:
 | `roleName` | string | The role identifier (e.g. `deploymentGateway`). |
 | `supportImportPath` | string | Renderer-computed relative path from the current spec file to `playwright/support/<role>` (no extension; Playwright/TypeScript resolves both `.ts` and `.js` per the suite's `tsconfig`). Typically `./support/<role>` for spec files at the suite root, `../support/<role>` for spec files in subdirectories. Authors should always interpolate this with triple-braces. |
 
-Per-step variables (`respVar`, `body`, `extracts`, `operationId`,
+Per-step variables (`respVar`, `body`, `operationId`,
 `pathTemplate`, `method`, `request`, `baseUrl`, `strips`, `ctx`,
 `defaultRender`) are **not** in `imports.tmpl` scope. Referencing
 them is a template-render error so that mistakes fail at codegen time
@@ -310,7 +333,12 @@ extensions are documented in this file under the per-emitter section.
 | `baseUrl` | string | Name of the base-URL variable in scope (typically `baseUrl`). |
 | `body` | string | TypeScript expression evaluating to the request body for this step. JSON literal, multipart builder call, or `undefined`. |
 | `strips` | string | JSON literal expression for the strip-on-sentinel rules derived from `globalContextSeeds`. |
-| `extracts` | string | JSON literal expression for the response-extracts list (see "Wrap-or-replace"; for `deploymentGateway`, computed by [`DeploymentRoleHookProvider`](playwright/hooks/deployment.ts) per #233 Step 6). |
+
+`roleExtras` populated by registered `RoleHookProvider`s is also spread
+into both the call-site scope and the support-file template scope (see
+"Deployment-gateway reference implementation" for the canonical
+example: `extracts` is consumed by the support-file template, not by
+the call-site template).
 
 The exact scope contract for the Java SDK and any future emitter is
 defined when that emitter lands; this file is the canonical reference
@@ -328,7 +356,7 @@ one — e.g. the OCA `deploymentGateway` role wraps a multipart upload
 with response-field extraction and an OCA-specific error envelope.
 
 ```hbs
-const {{respVar}} = await deploy({{{ctx}}}, {{{request}}}, {{{body}}}, {{{baseUrl}}}, {{{strips}}}, {{{extracts}}});
+const {{respVar}} = await deploy({{{ctx}}}, {{{request}}}, {{{body}}}, {{{baseUrl}}}, {{{strips}}});
 ```
 
 ### Wrap
@@ -373,16 +401,23 @@ The Playwright materializer copies the built-in support tree from
    [`materializer/README.md`](../README.md).
 2. For every role bundle loaded via
    [`loadRoleBundlesForActiveConfig`](playwright/roleRenderer.ts)
-   whose directory carries a `support.<ext>` file, that file is
-   copied to `playwright/support/<role>.<ext>` — **renamed on copy**
-   so role names (not the literal `support`) become the emitted
-   filenames.
+   whose directory carries a support file, that file lands at
+   `playwright/support/<role>.<ext>` — **renamed on copy** so role
+   names (not the literal `support`) become the emitted filenames.
+   - A bundle whose source is `support.<ext>` is copied byte-for-byte.
+   - A bundle whose source is `support.<ext>.tmpl` is rendered with
+     Mustache against `ctx.roleExtras.get(<role>) ?? {}` and the
+     result is written under the stripped basename. The orchestrator
+     defers this materialisation until **after** all
+     `RoleHookProvider`s have run, so spec-derived extras are visible
+     to the template.
 3. Collisions error. A role name that matches a built-in support file's
    stem (`env`, `seeding`, `fixtures`, `recorder`, `await-eventually`)
    raises with the colliding name surfaced in the error message.
 
 `configs/camunda-oca/codegen/playwright/roles/deploymentGateway/
-support.ts` materialises as `playwright/support/deploymentGateway.ts`.
+support.ts.tmpl` materialises as `playwright/support/deploymentGateway.ts`
+(the `.tmpl` suffix is stripped on render).
 The built-in support tree retains only files that are generic across
 configs (`env.ts`, `fixtures.ts`, `seeding.ts`, `recorder.ts`,
 `await-eventually.ts`, `seed-rules.json`).
@@ -410,23 +445,28 @@ The `deploymentGateway` role at
 `configs/camunda-oca/codegen/playwright/roles/deploymentGateway/`
 exercises every phase end-to-end:
 
-- `support.ts` ships the `deploy()` helper that all `createDeployment`
-  call sites invoke.
+- `support.ts.tmpl` ships the `deploy()` helper that all
+  `createDeployment` call sites invoke. The Mustache template bakes a
+  module-level `const EXTRACTS: DeployExtract[] = {{{extracts}}};` at
+  codegen time; `deploy()` reads `EXTRACTS` directly so call sites
+  don't carry the list.
 - `call-site.tmpl` renders the `deploy(...)` call with the per-step
-  scope.
+  scope (no `extracts` argument).
 - `imports.tmpl` injects `import { deploy } from '<supportImportPath>'`
   at the top of each spec that contains a deployment step.
 - `match.json` constrains the role to multipart-body `createDeployment`
   calls with the expected response status set.
 
-The `extracts` argument to each `deploy()` call is computed once per
-CLI invocation by
+The `extracts` value interpolated into `support.ts.tmpl` is computed
+once per CLI invocation by
 [`DeploymentRoleHookProvider`](playwright/hooks/deployment.ts)
 (`#233` Step 6 / #237). The provider walks
 `graph.operations[createDeployment].responseSemanticLeaves`, filters by
-provider/depth rules, dedupes, and threads the resulting list into
-`ctx.roleExtras['deploymentGateway']`. The renderer reads it back via
-the Mustache scope. No per-field knowledge lives in the emitter.
+provider/depth rules, dedupes, and writes the JSON literal into
+`ctx.roleExtras['deploymentGateway'].extracts`. The materializer reads
+it back when rendering the templated support file. No per-field
+knowledge lives in the emitter, and no per-field literal leaks into the
+call site (#243).
 
 ## L3 invariants (Phase 5, landed)
 
@@ -445,11 +485,15 @@ under the describe block **"role-template rendering contract (Lift 12 /
    (delete them) and unwired role dispatch (the planner is no longer
    binding any operation to the role).
 3. **Spec-derived deploymentGateway extracts cover every downstream
-   binding consumer.** Two checks: a drift detector that every emitted
-   `deploy(...)` call's extracts list literal matches
-   `computeDeploymentExtracts(createDeployment)`, and a coverage check
-   that every `ctx.<...>Var` reference in a deployment-using spec has
-   a producer (deploy extract, `seedBinding`, `extractInto`, or direct
+   binding consumer.** Three checks against the materialised
+   `support/deploymentGateway.ts` and the emitted specs: (a) a drift
+   detector that the helper's baked `EXTRACTS` constant's varName set
+   equals `computeDeploymentExtracts(createDeployment)`; (b) a
+   no-leakage assertion that no emitted spec contains a `varName:`
+   literal inside a `deploy(` argument list (catches a regression that
+   re-introduces the inlining — see #243); (c) a coverage check that
+   every `ctx.<...>Var` reference in a deployment-using spec has a
+   producer (deploy extract, `seedBinding`, `extractInto`, or direct
    `ctx.<...>Var = …` assignment).
 
 The originally-drafted fourth invariant (a grep-ban over emitter source

--- a/materializer/src/index.ts
+++ b/materializer/src/index.ts
@@ -304,15 +304,14 @@ async function run() {
       typeof emitterConfig.recordResponses === 'boolean' ? emitterConfig.recordResponses : false;
     const excludeSupportFiles = recordResponses ? undefined : ['recorder.ts'];
     await materializeSupport(outDir, undefined, excludeSupportFiles);
-    // Lift 12 / #231: load per-role bundles and vendor their helper files
-    // alongside the built-in support files. Roles bound in the ABox but
-    // missing a bundle raise at render time (see roleRenderer.findRoleForStep
-    // in playwright/emitter.ts). The wider materializer LoadedRoleBundle
-    // (which carries `supportFilePath`) is structurally a superset of the
-    // SDK shape, so we feed it straight into `materializeRoleSupportFiles`
-    // and assign the same map into ctx.roleBundles below.
+    // Lift 12 / #231: load per-role bundles. Vendoring the role helper
+    // files into <outDir>/support/ is deferred until after the role-hook
+    // loop below populates `roleExtras` — templated helpers
+    // (`support.<ext>.tmpl`, #243) are rendered against those extras at
+    // codegen time so spec-derived constants (e.g. the deployment-gateway
+    // `EXTRACTS` list) live inside the helper instead of being threaded
+    // through every call-site literal.
     roleBundles = loadRoleBundlesForActiveConfig(repoRoot);
-    await materializeRoleSupportFiles(outDir, roleBundles);
     // Copy BPMN/DMN/form fixture files into <outDir>/fixtures/ so the suite
     // is self-contained: @@FILE:<rel-path> markers in emitted tests resolve
     // via support/fixtures.ts regardless of process.cwd().
@@ -366,6 +365,18 @@ async function run() {
       process.exit(1);
     }
     roleExtras.set(provider.role, extras);
+  }
+
+  // #243: Vendor per-role helper files now that `roleExtras` is populated,
+  // so templated helpers (`support.<ext>.tmpl`) render against the same
+  // per-role data the call-site renderer sees. Roles bound in the ABox but
+  // missing a bundle raise at render time (see roleRenderer.findRoleForStep
+  // in playwright/emitter.ts). The wider materializer LoadedRoleBundle
+  // (which carries `supportFilePath` and `supportIsTemplated`) is
+  // structurally a superset of the SDK shape, so we feed it straight into
+  // `materializeRoleSupportFiles` and the same map into ctx.roleBundles.
+  if (emitter.id === 'playwright' && roleBundles) {
+    await materializeRoleSupportFiles(outDir, roleBundles, roleExtras);
   }
 
   function buildCtx(suiteName: string, mode: 'feature' | 'variant'): EmitContext {

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -576,10 +576,11 @@ function renderScenarioTest(
         .filter((seed) => seed.stripFromMultipartWhenDefault && seed.defaultSentinel !== undefined)
         .map((seed) => ({ fieldName: seed.fieldName, sentinel: seed.defaultSentinel }));
       const stripsLit = JSON.stringify(strips);
-      // Per-role data computed by the orchestrator (e.g. extracts derived
-      // from the role-bound op's responseSemanticLeaves for the
-      // deploymentGateway role). Roles that don't consume this simply
-      // ignore the scope variable in their template.
+      // Per-role data computed by the orchestrator. The deployment-gateway
+      // hook's `extracts` payload is consumed by `materializeRoleSupportFiles`
+      // when rendering the templated helper (#243), so it is also threaded
+      // here for any future role template that wants to interpolate it
+      // directly. Roles that consume neither simply ignore the scope.
       const extras = roleExtras?.get(roleMatch.roleName) ?? {};
       const scope: PlaywrightRoleScope & Record<string, unknown> = {
         respVar: varName,
@@ -595,10 +596,6 @@ function renderScenarioTest(
         baseUrl: 'baseUrl',
         body: bodyIndented,
         strips: stripsLit,
-        // `extracts` is a per-emitter scope variable (PlaywrightRoleScope):
-        // default to `[]` so a role bundle that hasn't been wired with
-        // per-role extras still renders. roleExtras may override.
-        extracts: '[]',
         ...extras,
         // Additional context vars used by the deploymentGateway template:
         url: buildUrlExpression(step.pathTemplate),

--- a/materializer/src/playwright/hooks/deployment.ts
+++ b/materializer/src/playwright/hooks/deployment.ts
@@ -5,6 +5,14 @@
 // for that hook, and the generic hook loop in the orchestrator pulls
 // `extracts` into `ctx.roleExtras[DEPLOYMENT_GATEWAY_ROLE]`.
 //
+// The `extracts` payload is consumed by `materializeRoleSupportFiles`
+// (`materializer/src/playwright/materialize-support.ts`) when it renders
+// the role's `support.ts.tmpl` against this provider's extras map — the
+// spec-derived `EXTRACTS` list is baked into the vendored
+// `<outDir>/support/deploymentGateway.ts` once per codegen run instead
+// of being threaded through every `deploy(...)` call-site literal
+// (#243).
+//
 // Lift 12 Phase 5 grep-invariant unblocker: with this extraction, the
 // only references to `computeDeploymentExtracts` and to the
 // `DEPLOYMENT_GATEWAY_ROLE` literal in the orchestrator surface live

--- a/materializer/src/playwright/materialize-support.ts
+++ b/materializer/src/playwright/materialize-support.ts
@@ -227,15 +227,90 @@ export async function loadProjectScaffoldingFiles(
  * @param roleExtras   Per-role data computed by role-hook providers (e.g.
  *                     `{ extracts: '[…]' }` from `DeploymentRoleHookProvider`).
  *                     Used as the Mustache scope when rendering templated
- *                     support files. Verbatim helpers ignore it. May be
- *                     omitted when no hook providers are registered; a role
- *                     whose support file is templated but has no extras
- *                     entry renders against an empty scope (Mustache emits
- *                     empty strings for unresolved variables).
+ *                     support files. Verbatim helpers ignore it. For
+ *                     templated helpers, **every Mustache variable
+ *                     referenced by the template must resolve to a
+ *                     non-`undefined` value in this map's entry for the
+ *                     role** — otherwise the renderer would silently
+ *                     emit a syntactically broken helper (e.g.
+ *                     `const EXTRACTS = ;` when `extracts` is missing),
+ *                     and downstream TypeScript would report a parse
+ *                     error far from the root cause. Unresolved variables
+ *                     raise immediately with the template path, the
+ *                     missing names, and the role name.
  * @returns            The list of vendored file basenames (e.g.
  *                     `['deploymentGateway.ts']`) for callers that want to
  *                     assert what was copied.
  */
+/**
+ * Walk a parsed Mustache token tree and collect the names of every
+ * variable referenced (`{{name}}`, `{{{name}}}`, `{{&name}}`), descending
+ * into section bodies (`{{#x}}…{{/x}}` and `{{^x}}…{{/x}}`). Used by
+ * {@link materializeRoleSupportFiles} to fail fast when a templated
+ * support helper references a variable that the role's `roleExtras`
+ * entry doesn't supply.
+ *
+ * Bracketed paths like `{{a.b}}` are reported as the top-level segment
+ * (`a`) since that is what must exist on the scope object.
+ */
+function collectTemplateVariableNames(template: string): Set<string> {
+  // Mustache.parse returns a nested token tree; each token is a tuple
+  // [type, name, start, end, children?, ...]. We only care about types
+  // 'name' (escaped interpolation), '&' (unescaped), '#' (section),
+  // '^' (inverted section). Recurse into children to catch nested usage.
+  // biome-ignore lint/plugin: parsed Mustache token shape is library-internal
+  const tokens = Mustache.parse(template) as unknown as Array<
+    [string, string, number, number, unknown[]?]
+  >;
+  const names = new Set<string>();
+  const VARIABLE_TYPES = new Set(['name', '&', '#', '^']);
+  const visit = (toks: Array<[string, string, number, number, unknown[]?]>): void => {
+    for (const t of toks) {
+      const type = t[0];
+      const name = t[1];
+      if (VARIABLE_TYPES.has(type) && typeof name === 'string' && name !== '.') {
+        const top = name.split('.')[0];
+        if (top) names.add(top);
+      }
+      const children = t[4];
+      if (Array.isArray(children)) {
+        // biome-ignore lint/plugin: parsed Mustache token shape is library-internal
+        visit(children as Array<[string, string, number, number, unknown[]?]>);
+      }
+    }
+  };
+  visit(tokens);
+  return names;
+}
+
+/**
+ * Throw if any Mustache variable referenced by `template` is missing
+ * (or `undefined`) in `scope`. Prevents silently emitting broken
+ * helpers like `const EXTRACTS = ;` when a hook provider forgot to
+ * populate `roleExtras`.
+ */
+function assertTemplateVariablesResolved(
+  template: string,
+  scope: Record<string, unknown>,
+  roleName: string,
+  templatePath: string,
+): void {
+  const required = collectTemplateVariableNames(template);
+  const missing: string[] = [];
+  for (const name of required) {
+    if (!(name in scope) || scope[name] === undefined) missing.push(name);
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `materializeRoleSupportFiles: templated support file ${templatePath} for role ` +
+        `'${roleName}' references Mustache variable(s) [${missing
+          .map((n) => `'${n}'`)
+          .join(', ')}] that are not present in roleExtras['${roleName}']. ` +
+        `Ensure a RoleHookProvider populates them, or rewrite the template to omit them.`,
+    );
+  }
+}
+
 export async function materializeRoleSupportFiles(
   outDir: string,
   roleBundles: Map<
@@ -314,6 +389,7 @@ export async function materializeRoleSupportFiles(
     if (bundle.supportIsTemplated) {
       const tmplSrc = await fs.readFile(sourcePath, 'utf8');
       const scope = roleExtras?.get(roleName) ?? {};
+      assertTemplateVariablesResolved(tmplSrc, scope, roleName, sourcePath);
       const rendered = Mustache.render(tmplSrc, scope);
       await fs.writeFile(path.join(destDir, destName), rendered, 'utf8');
     } else {

--- a/materializer/src/playwright/materialize-support.ts
+++ b/materializer/src/playwright/materialize-support.ts
@@ -39,6 +39,7 @@ import { existsSync, promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { EmittedFile } from '@camunda8/emitter-sdk';
+import Mustache from 'mustache';
 import { getActiveConfigDir, getSpecBundleDir } from 'path-analyser/configResolver';
 
 export const SUPPORT_TEMPLATE_FILES = [
@@ -202,6 +203,14 @@ export async function loadProjectScaffoldingFiles(
  * file so role helpers cannot collide on basename and so the emitter's
  * generated `import { ... } from './support/<role>'` line is stable.
  *
+ * When a role's source helper is named `support.<ext>.tmpl`, it is treated
+ * as a Mustache template (logic-free, triple-brace interpolation) and
+ * rendered against the role's entry in `roleExtras` before write. The
+ * destination filename drops the `.tmpl` suffix. Templated helpers let the
+ * generator bake spec-derived constants (e.g. the deployment-gateway
+ * `EXTRACTS` list) into the vendored file at codegen time, instead of
+ * threading them through every call-site literal — see #243.
+ *
  * Raises when a role's helper basename (`<role>`) would collide with a
  * built-in support file basename (e.g. a role named `env` or `seeding`),
  * since the emitted suite imports built-ins as `./support/env`,
@@ -215,13 +224,30 @@ export async function loadProjectScaffoldingFiles(
  *                     this module's loader so callers (codegen orchestrator
  *                     + tests) construct the bundle map once and share it
  *                     between the materializer and the renderer.
+ * @param roleExtras   Per-role data computed by role-hook providers (e.g.
+ *                     `{ extracts: '[…]' }` from `DeploymentRoleHookProvider`).
+ *                     Used as the Mustache scope when rendering templated
+ *                     support files. Verbatim helpers ignore it. May be
+ *                     omitted when no hook providers are registered; a role
+ *                     whose support file is templated but has no extras
+ *                     entry renders against an empty scope (Mustache emits
+ *                     empty strings for unresolved variables).
  * @returns            The list of vendored file basenames (e.g.
  *                     `['deploymentGateway.ts']`) for callers that want to
  *                     assert what was copied.
  */
 export async function materializeRoleSupportFiles(
   outDir: string,
-  roleBundles: Map<string, { dir: string; supportBasename?: string }>,
+  roleBundles: Map<
+    string,
+    {
+      dir: string;
+      supportBasename?: string;
+      supportIsTemplated?: boolean;
+      supportFilePath?: string;
+    }
+  >,
+  roleExtras?: Map<string, Record<string, unknown>>,
 ): Promise<string[]> {
   const destDir = path.join(outDir, SUPPORT_DIR_NAME);
   await fs.mkdir(destDir, { recursive: true });
@@ -245,6 +271,16 @@ export async function materializeRoleSupportFiles(
       );
     }
     const sourceBasename = bundle.supportBasename;
+    // The on-disk source filename may carry an extra `.tmpl` suffix when
+    // the role ships a templated helper (see roleRenderer: supportBasename
+    // is the *emitted* basename, stripped of `.tmpl`; supportFilePath is
+    // the *source* path on disk). Prefer the loader-provided source path
+    // for the read; fall back to reconstructing it from the role dir and
+    // the emitted basename + suffix for callers that hand-build bundles
+    // without supportFilePath.
+    const sourceFilename = bundle.supportFilePath
+      ? path.basename(bundle.supportFilePath)
+      : `${sourceBasename}${bundle.supportIsTemplated ? '.tmpl' : ''}`;
     // Defensive: the loader produces a pure basename, but this function is
     // exported from the package and could be called with hand-built bundles.
     // Reject anything containing a path separator or `..` to prevent
@@ -254,15 +290,20 @@ export async function materializeRoleSupportFiles(
       sourceBasename.includes('\\') ||
       sourceBasename.includes('\0') ||
       sourceBasename.split(/[\\/]/).includes('..') ||
-      path.basename(sourceBasename) !== sourceBasename
+      path.basename(sourceBasename) !== sourceBasename ||
+      sourceFilename.includes('/') ||
+      sourceFilename.includes('\\') ||
+      sourceFilename.includes('\0') ||
+      sourceFilename.split(/[\\/]/).includes('..') ||
+      path.basename(sourceFilename) !== sourceFilename
     ) {
       throw new Error(
         `materializeRoleSupportFiles: role '${roleName}' supportBasename ${JSON.stringify(
           sourceBasename,
-        )} is not a pure basename.`,
+        )} (source filename ${JSON.stringify(sourceFilename)}) is not a pure basename.`,
       );
     }
-    const sourcePath = path.join(bundle.dir, sourceBasename);
+    const sourcePath = path.join(bundle.dir, sourceFilename);
     const ext = path.extname(sourceBasename);
     const destName = `${roleName}${ext}`;
     if (copied.includes(destName)) {
@@ -270,7 +311,14 @@ export async function materializeRoleSupportFiles(
         `materializeRoleSupportFiles: role '${roleName}' produced duplicate destination ${destName}.`,
       );
     }
-    await fs.copyFile(sourcePath, path.join(destDir, destName));
+    if (bundle.supportIsTemplated) {
+      const tmplSrc = await fs.readFile(sourcePath, 'utf8');
+      const scope = roleExtras?.get(roleName) ?? {};
+      const rendered = Mustache.render(tmplSrc, scope);
+      await fs.writeFile(path.join(destDir, destName), rendered, 'utf8');
+    } else {
+      await fs.copyFile(sourcePath, path.join(destDir, destName));
+    }
     copied.push(destName);
   }
 

--- a/materializer/src/playwright/materialize-support.ts
+++ b/materializer/src/playwright/materialize-support.ts
@@ -284,10 +284,11 @@ function collectTemplateVariableNames(template: string): Set<string> {
 }
 
 /**
- * Throw if any Mustache variable referenced by `template` is missing
- * (or `undefined`) in `scope`. Prevents silently emitting broken
- * helpers like `const EXTRACTS = ;` when a hook provider forgot to
- * populate `roleExtras`.
+ * Throw if any Mustache variable referenced by `template` is missing,
+ * `undefined`, or `null` in `scope`. Mustache renders all three the same
+ * way — as an empty string — so accepting `null` here would let a
+ * provider that returned `null` silently produce a broken helper like
+ * `const EXTRACTS = ;`.
  */
 function assertTemplateVariablesResolved(
   template: string,
@@ -298,7 +299,7 @@ function assertTemplateVariablesResolved(
   const required = collectTemplateVariableNames(template);
   const missing: string[] = [];
   for (const name of required) {
-    if (!(name in scope) || scope[name] === undefined) missing.push(name);
+    if (!(name in scope) || scope[name] === undefined || scope[name] === null) missing.push(name);
   }
   if (missing.length > 0) {
     throw new Error(

--- a/materializer/src/playwright/materialize-support.ts
+++ b/materializer/src/playwright/materialize-support.ts
@@ -348,12 +348,15 @@ export async function materializeRoleSupportFiles(
     }
     const sourceBasename = bundle.supportBasename;
     // The on-disk source filename may carry an extra `.tmpl` suffix when
-    // the role ships a templated helper (see roleRenderer: supportBasename
-    // is the *emitted* basename, stripped of `.tmpl`; supportFilePath is
-    // the *source* path on disk). Prefer the loader-provided source path
-    // for the read; fall back to reconstructing it from the role dir and
-    // the emitted basename + suffix for callers that hand-build bundles
-    // without supportFilePath.
+    // the role ships a templated helper. `supportBasename` is the SOURCE
+    // basename with any trailing `.tmpl` stripped (e.g. `'support.ts'`
+    // for both `support.ts` and `support.ts.tmpl`); `supportFilePath` is
+    // the full source path on disk including the `.tmpl` suffix.
+    // Prefer the loader-provided source path for the read; fall back to
+    // reconstructing it from the role dir and the source basename
+    // (+ `.tmpl`) for callers that hand-build bundles without
+    // supportFilePath. The emitted destination filename (`<roleName><ext>`)
+    // is constructed below at `destName`; neither field carries it.
     const sourceFilename = bundle.supportFilePath
       ? path.basename(bundle.supportFilePath)
       : `${sourceBasename}${bundle.supportIsTemplated ? '.tmpl' : ''}`;

--- a/materializer/src/playwright/roleRenderer.ts
+++ b/materializer/src/playwright/roleRenderer.ts
@@ -191,10 +191,12 @@ export function loadRoleBundlesForActiveConfig(repoRoot?: string): Map<string, L
       callSiteTemplatePath: callSitePath,
       importsTemplatePath: existsSync(importsPath) ? importsPath : undefined,
       supportFilePath: supportPath,
-      // `supportBasename` is the FINAL emitted basename — strip the `.tmpl`
-      // suffix when the source is a template so downstream consumers
-      // (materializer, drift-detector invariants) see the same name a
-      // verbatim helper would have.
+      // `supportBasename` is the SOURCE helper basename with any
+      // trailing `.tmpl` suffix stripped (e.g. `'support.ts'` for both
+      // `support.ts` and `support.ts.tmpl`). The materializer reads it
+      // only to derive the file extension; the emitted destination is
+      // `<roleName><ext>` (e.g. `'deploymentGateway.ts'`) and is not
+      // stored on the bundle.
       supportBasename: supportPath ? path.basename(supportPath).replace(/\.tmpl$/, '') : undefined,
       supportIsTemplated,
       callSiteTemplate: readFileSync(callSitePath, 'utf8'),

--- a/materializer/src/playwright/roleRenderer.ts
+++ b/materializer/src/playwright/roleRenderer.ts
@@ -74,6 +74,15 @@ export interface LoadedRoleBundle extends RoleTemplateBundle {
   match?: RoleMatchSpec;
   /** Basename of the vendored support file (e.g. `'deploymentGateway.ts'`), when present. */
   supportBasename?: string;
+  /**
+   * When true, the source file on disk is `support.<ext>.tmpl` (a Mustache
+   * template) and the materializer must render it against the role's
+   * {@link EmitContext.roleExtras} entry before writing it to the suite.
+   * When false (the default), the source is `support.<ext>` and is copied
+   * verbatim. Mutually exclusive — the loader rejects role directories
+   * that contain both forms.
+   */
+  supportIsTemplated?: boolean;
 }
 
 /**
@@ -129,24 +138,29 @@ export function loadRoleBundlesForActiveConfig(repoRoot?: string): Map<string, L
       );
     }
     const importsPath = path.join(roleDir, 'imports.tmpl');
-    // Discover support.<ext> by listing the directory — the role's helper
-    // language (ts/js/java/...) is the role's choice, not the renderer's.
-    // Sort the entries for deterministic selection, and throw if more than
-    // one support.* file exists so the role directory has an unambiguous
-    // contract (non-deterministic filesystem ordering could silently select
-    // a different file across runs or machines).
+    // Discover support.<ext> (verbatim) or support.<ext>.tmpl (Mustache
+    // template) by listing the directory — the role's helper language
+    // (ts/js/java/...) is the role's choice, not the renderer's. Sort the
+    // entries for deterministic selection, and throw if more than one
+    // support file exists so the role directory has an unambiguous
+    // contract (non-deterministic filesystem ordering could silently
+    // select a different file across runs or machines). The two forms
+    // are mutually exclusive: a role ships either a verbatim helper or a
+    // templated helper, not both.
     const supportFiles = readdirSync(roleDir)
       .filter((f) => f.startsWith('support.'))
       .sort();
     if (supportFiles.length > 1) {
       throw new Error(
         `roleRenderer: role directory ${roleDir} contains multiple support files: ` +
-          `${supportFiles.join(', ')}. Only one support.<ext> file is permitted per role.`,
+          `${supportFiles.join(', ')}. Only one support.<ext>[.tmpl] file is permitted per role.`,
       );
     }
     let supportPath: string | undefined;
+    let supportIsTemplated = false;
     if (supportFiles.length === 1) {
       supportPath = path.join(roleDir, supportFiles[0]);
+      supportIsTemplated = supportFiles[0].endsWith('.tmpl');
     }
     const matchPath = path.join(roleDir, 'match.json');
     let match: RoleMatchSpec | undefined;
@@ -169,7 +183,12 @@ export function loadRoleBundlesForActiveConfig(repoRoot?: string): Map<string, L
       callSiteTemplatePath: callSitePath,
       importsTemplatePath: existsSync(importsPath) ? importsPath : undefined,
       supportFilePath: supportPath,
-      supportBasename: supportPath ? path.basename(supportPath) : undefined,
+      // `supportBasename` is the FINAL emitted basename — strip the `.tmpl`
+      // suffix when the source is a template so downstream consumers
+      // (materializer, drift-detector invariants) see the same name a
+      // verbatim helper would have.
+      supportBasename: supportPath ? path.basename(supportPath).replace(/\.tmpl$/, '') : undefined,
+      supportIsTemplated,
       callSiteTemplate: readFileSync(callSitePath, 'utf8'),
       importsTemplate: existsSync(importsPath) ? readFileSync(importsPath, 'utf8') : undefined,
       match,

--- a/materializer/src/playwright/roleRenderer.ts
+++ b/materializer/src/playwright/roleRenderer.ts
@@ -72,7 +72,15 @@ export interface LoadedRoleBundle extends RoleTemplateBundle {
   importsTemplate?: string;
   /** Parsed `match.json`, when present. */
   match?: RoleMatchSpec;
-  /** Basename of the vendored support file (e.g. `'deploymentGateway.ts'`), when present. */
+  /**
+   * Basename of the **source** helper file on disk, with any trailing
+   * `.tmpl` suffix stripped (e.g. `'support.ts'`; for a templated source
+   * `support.ts.tmpl` this is still `'support.ts'`). Used by
+   * {@link materializeRoleSupportFiles} only to derive the file extension
+   * via `path.extname` — the **emitted destination filename** is always
+   * `<roleName><ext>` (e.g. `'deploymentGateway.ts'`) and is not stored
+   * on the bundle. Treat this as the source basename, not the destination.
+   */
   supportBasename?: string;
   /**
    * When true, the source file on disk is `support.<ext>.tmpl` (a Mustache

--- a/materializer/src/roles.ts
+++ b/materializer/src/roles.ts
@@ -51,20 +51,13 @@ export interface PlaywrightRoleScope extends CommonRoleScope {
    * `globalContextSeeds`.
    */
   strips: string;
-  /**
-   * JSON literal expression for the spec-derived response-extracts list.
-   * Computed at codegen time from the role-bound operation's
-   * `responseSemanticLeaves` (Phase 4 / absorbs the original #230 scope).
-   * Roles that do not consume extracts simply ignore this in their template.
-   */
-  extracts: string;
 }
 
 /**
  * Scope provided to `imports.tmpl`. Rendered **once per (spec-file, role)
  * pair**, not once per step — therefore receives only the role-static
  * subset of `CommonRoleScope` / per-emitter scopes, never per-step values
- * (`respVar`, `body`, `extracts`, `operationId`, `pathTemplate`, etc.).
+ * (`respVar`, `body`, `operationId`, `pathTemplate`, etc.).
  *
  * Step-dependent imports are not a use case the contract supports: if a
  * template's import block needs to differ between two steps of the same

--- a/tests/codegen/materialize-support.test.ts
+++ b/tests/codegen/materialize-support.test.ts
@@ -287,4 +287,71 @@ describe('materializeRoleSupportFiles', () => {
     expect(existsSync(path.join(outDir, SUPPORT_DIR_NAME))).toBe(true);
     expect(copied).toEqual([]);
   });
+
+  test('renders a templated support file with roleExtras and writes the result (#243)', async () => {
+    const srcDir = await fs.mkdtemp(path.join(os.tmpdir(), 'role-src-'));
+    try {
+      const supportFile = path.join(srcDir, 'support.ts.tmpl');
+      await fs.writeFile(
+        supportFile,
+        'const EXTRACTS = {{{extracts}}};\nexport const N = {{count}};\n',
+        'utf8',
+      );
+      const bundles = new Map([
+        [
+          'templatedRole',
+          {
+            dir: srcDir,
+            supportBasename: 'support.ts',
+            supportIsTemplated: true,
+            supportFilePath: supportFile,
+          },
+        ],
+      ]);
+      const extras = new Map<string, Record<string, unknown>>([
+        ['templatedRole', { extracts: "[{name: 'foo'}]", count: 7 }],
+      ]);
+      const copied = await materializeRoleSupportFiles(tmp, bundles, extras);
+      expect(copied).toEqual(['templatedRole.ts']);
+      const content = await fs.readFile(
+        path.join(tmp, SUPPORT_DIR_NAME, 'templatedRole.ts'),
+        'utf8',
+      );
+      expect(content).toBe("const EXTRACTS = [{name: 'foo'}];\nexport const N = 7;\n");
+    } finally {
+      await fs.rm(srcDir, { recursive: true, force: true });
+    }
+  });
+
+  test('fails fast when a templated support file references variables missing from roleExtras (#243)', async () => {
+    const srcDir = await fs.mkdtemp(path.join(os.tmpdir(), 'role-src-'));
+    try {
+      const supportFile = path.join(srcDir, 'support.ts.tmpl');
+      await fs.writeFile(supportFile, 'const EXTRACTS = {{{extracts}}};\n', 'utf8');
+      const bundles = new Map([
+        [
+          'templatedRole',
+          {
+            dir: srcDir,
+            supportBasename: 'support.ts',
+            supportIsTemplated: true,
+            supportFilePath: supportFile,
+          },
+        ],
+      ]);
+      // No roleExtras at all — missing.
+      await expect(materializeRoleSupportFiles(tmp, bundles)).rejects.toThrow(
+        /references Mustache variable\(s\) \['extracts'\] that are not present in roleExtras\['templatedRole'\]/,
+      );
+      // Extras present but the specific variable is missing.
+      const extras = new Map<string, Record<string, unknown>>([
+        ['templatedRole', { unrelated: 'value' }],
+      ]);
+      await expect(materializeRoleSupportFiles(tmp, bundles, extras)).rejects.toThrow(
+        /\['extracts'\]/,
+      );
+    } finally {
+      await fs.rm(srcDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/codegen/materialize-support.test.ts
+++ b/tests/codegen/materialize-support.test.ts
@@ -350,6 +350,14 @@ describe('materializeRoleSupportFiles', () => {
       await expect(materializeRoleSupportFiles(tmp, bundles, extras)).rejects.toThrow(
         /\['extracts'\]/,
       );
+      // Extras present but the variable is `null` (Mustache renders
+      // null as empty string, same as undefined — must also raise).
+      const nullExtras = new Map<string, Record<string, unknown>>([
+        ['templatedRole', { extracts: null }],
+      ]);
+      await expect(materializeRoleSupportFiles(tmp, bundles, nullExtras)).rejects.toThrow(
+        /\['extracts'\]/,
+      );
     } finally {
       await fs.rm(srcDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Closes #243.

## What

Encapsulates the spec-derived response-extracts list inside the `deploy()` helper, so it lives in **one** place (the materialised `support/deploymentGateway.ts`) instead of being duplicated as a ~13-line literal at every emitted `deploy(...)` call site across hundreds of spec files.

Before:
```ts
const resp1 = await deploy(
  ctx, request, body,
  `${baseUrl}/deployments`,
  [{ fieldName: 'tenantId', sentinel: '<default>' }],
  [
    { varName: 'decisionDefinitionIdVar', segments: ['deployments', 0, 'decisionDefinition', 'decisionDefinitionId'] },
    { varName: 'decisionDefinitionKeyVar', segments: [...] },
    // ... ~7 more entries, repeated in every deploy() call in every spec
  ],
);
```

After:
```ts
const resp1 = await deploy(
  ctx, request, body,
  `${baseUrl}/deployments`,
  [{ fieldName: 'tenantId', sentinel: '<default>' }],
);
```

The extracts list is now baked once into `<outDir>/support/deploymentGateway.ts` as a module-level `const EXTRACTS = [...]`. `deploy()` reads it directly; the parameter is gone.

## How

New convention in the SDK role bundle contract: a role may ship either `support.<ext>` (copied verbatim, status quo) **or** `support.<ext>.tmpl` (treated as a Mustache template, rendered at codegen time against the role's `roleExtras` entry). Mutually exclusive — the loader rejects role directories that contain both forms. Existing role authors are unaffected; opt in by renaming.

Threading:
1. `roleRenderer.loadRoleBundlesForActiveConfig` discovers `support.<ext>.tmpl`, sets `supportIsTemplated`, and exposes the **emitted** basename (stripped of `.tmpl`) via `supportBasename`.
2. `materializeRoleSupportFiles` accepts the existing `roleExtras` map and, for templated bundles, runs `Mustache.render(content, extras)` then writes `<outDir>/support/<role>.<ext>`.
3. The orchestrator defers `materializeRoleSupportFiles` until **after** the role-hook loop populates `roleExtras` — so templated helpers and call-site renderers see the same per-role data.
4. The deploymentGateway role's helper becomes `support.ts.tmpl` with `const EXTRACTS: DeployExtract[] = {{{extracts}}};` at module scope. `deploy()` drops its `extracts` parameter and loops `EXTRACTS`. `call-site.tmpl` drops the corresponding argument.

## L3 invariant

`configs/camunda-oca/regression-invariants.test.ts:5329-…` is refocused onto the single materialised helper:
- **(a) Drift detector** — parses `<outDir>/support/deploymentGateway.ts` and asserts its `EXTRACTS` literal's varName set equals `computeDeploymentExtracts(createDeployment)`. Catches a stale render, an unwired hook, or an upstream-spec annotation gain/loss.
- **(b) No-call-site-leakage detector** — asserts no emitted spec contains a `varName:` literal inside a `deploy(` argument list. Catches a regression that re-introduces the inlined literal (e.g. someone re-templates `{{{extracts}}}` back into `call-site.tmpl`).
- **(c) Coverage** — unchanged. Every `ctx.<...>Var` read in a `deploy()`-using spec must be producible by `EXTRACTS`, `seedBinding`, `ctx.X = …`, or `extractInto`.

## Out of scope (follow-up)

`strips` (the field-strip rules derived from `globalContextSeeds`) is the other per-config constant inlined at every `deploy()` call site. Same fix shape applies — left for a follow-up to keep this PR focused.

## Verification

- `npm run lint` — clean (5 pre-existing warnings unrelated to this change).
- Per-workspace `tsc --noEmit` for all workspaces + `tests/tsconfig.json` — pass.
- `TEST_SEED=snapshot-baseline npm run testsuite:generate` + `npm run generate:request-validation` regenerate cleanly.
- `npm test` — 538 passed, 6 skipped, 55 test files. Includes `tests/regression/generated-suites-typecheck.test.ts` which tsc-typechecks the emitted suite.
- Spot-checked an emitted spec: every `deploy(...)` call is now 5 args; `support/deploymentGateway.ts` contains the EXTRACTS constant once.
