### PR TITLE
fix: feature base scenarios emit only required fields (#247)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -5332,3 +5332,160 @@ describeForThisConfig('bundled-spec invariants: emitter is API-agnostic (#207)',
     ).toEqual([]);
   });
 });
+
+describeForThisConfig(
+  'bundled-spec invariants: feature base scenario contains only required fields (#247)',
+  () => {
+    // #247: the feature suite's "base" scenario (`feature-1`,
+    // `variantKey: "base"`, `optionals: []`) must emit a request body
+    // populated with required leaves only. Optional sub-shapes and
+    // top-level optional scalars belong to the variant suite
+    // (`generateOptionalSubShapeVariants`); injecting them into the
+    // feature base re-creates the duplication that the #162 PR 4
+    // suite-partition cut explicitly removed.
+    //
+    // This is a class-scoped guard: for every feature-output file whose
+    // base scenario has a final JSON-body POST/PUT/PATCH step, every
+    // top-level field in that body must correspond to a REQUIRED leaf
+    // in the endpoint's `requestBodySemanticTypes` (or have no
+    // semantic-type annotation at all, in which case it's either a
+    // schema-required scalar or a buildRequestBodyFromCanonical
+    // fallback — those are out of scope here). Any top-level field
+    // backed by an OPTIONAL semantic-typed leaf is an offender.
+
+    if (!existsSync(FEATURE_SCENARIOS_DIR)) {
+      throw new Error(
+        `Feature-output directory not found at ${FEATURE_SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+      );
+    }
+
+    interface BodySemanticLeaf {
+      semanticType: string;
+      fieldPath: string;
+      required: boolean;
+    }
+    interface FeatureRequestStep {
+      operationId: string;
+      method: string;
+      bodyKind?: string;
+      bodyTemplate?: unknown;
+    }
+    interface FeatureScenario {
+      id: string;
+      variantKey?: string;
+      strategy?: string;
+      requestPlan?: FeatureRequestStep[];
+    }
+    interface FeatureScenarioFile {
+      endpoint: { operationId: string; method: string; path: string };
+      scenarios: FeatureScenario[];
+    }
+    interface GraphOp {
+      operationId: string;
+      method: string;
+      path: string;
+      requestBodySemanticTypes?: BodySemanticLeaf[];
+    }
+    interface GraphFile {
+      operations: GraphOp[];
+    }
+
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const graph = JSON.parse(readFileSync(GRAPH_PATH, 'utf8')) as GraphFile;
+    const opById = new Map<string, GraphOp>();
+    for (const op of graph.operations) opById.set(op.operationId, op);
+
+    interface Offender {
+      file: string;
+      scenarioId: string;
+      operationId: string;
+      field: string;
+      semantic: string;
+    }
+    const offenders: Offender[] = [];
+
+    for (const f of readdirSync(FEATURE_SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const collection = JSON.parse(
+        readFileSync(join(FEATURE_SCENARIOS_DIR, f), 'utf8'),
+      ) as FeatureScenarioFile;
+      const base = collection.scenarios.find(
+        (s) => s.strategy === 'featureCoverage' && s.variantKey === 'base',
+      );
+      if (!base) continue;
+      const steps = base.requestPlan ?? [];
+      if (steps.length === 0) continue;
+      const finalStep = steps[steps.length - 1];
+      if (finalStep.bodyKind !== 'json') continue;
+      const body = finalStep.bodyTemplate;
+      if (!body || typeof body !== 'object' || Array.isArray(body)) continue;
+
+      const op = opById.get(finalStep.operationId);
+      if (!op) continue;
+      const leaves = op.requestBodySemanticTypes ?? [];
+      // Build an index of top-level field → leaves that mention that
+      // top-level field. A field is an offender when EVERY semantic-typed
+      // occurrence of it is optional (i.e. no required leaf exists).
+      const topLevelLeaves = new Map<string, BodySemanticLeaf[]>();
+      for (const leaf of leaves) {
+        // First path segment, stripping `[]` array marker.
+        const top = (leaf.fieldPath.split('.')[0] ?? '').replace(/\[\]$/, '');
+        if (!top) continue;
+        const arr = topLevelLeaves.get(top) ?? [];
+        arr.push(leaf);
+        topLevelLeaves.set(top, arr);
+      }
+
+      for (const [field, value] of Object.entries(body)) {
+        const fieldLeaves = topLevelLeaves.get(field);
+        // No semantic-type annotation → not in scope (schema-required
+        // scalar or default-injection fallback).
+        if (!fieldLeaves || fieldLeaves.length === 0) continue;
+        // If ANY leaf under this top-level field is required, the
+        // field's presence in the body is justified.
+        if (fieldLeaves.some((l) => l.required)) continue;
+        // Empty scaffolding for schema-required object/array fields
+        // (`filter: {}`, `elements: []`) is the minimal-required body
+        // shape — every nested leaf is genuinely absent, so the
+        // optional-leakage we guard against here did not occur.
+        if (value === undefined || value === null) continue;
+        if (Array.isArray(value) && value.length === 0) continue;
+        if (
+          value !== null &&
+          typeof value === 'object' &&
+          !Array.isArray(value) &&
+          Object.keys(value).length === 0
+        ) {
+          continue;
+        }
+        // Otherwise every leaf under this field is optional AND the
+        // value is non-empty — the feature base scenario is leaking
+        // variant coverage.
+        offenders.push({
+          file: f,
+          scenarioId: base.id,
+          operationId: finalStep.operationId,
+          field,
+          semantic: fieldLeaves.map((l) => l.semanticType).join(','),
+        });
+      }
+    }
+
+    it('every feature `base` scenario emits a body containing only required-leaf top-level fields', () => {
+      expect(
+        offenders,
+        `Found ${offenders.length} feature base scenarios whose bodyTemplate ` +
+          `contains a top-level field backed only by OPTIONAL semantic-typed leaves. ` +
+          `This is the regression #247 guards against — optional population belongs in the ` +
+          `variant suite (\`generateOptionalSubShapeVariants\`), not the feature base. ` +
+          `Offenders:\n${offenders
+            .map(
+              (o) =>
+                `  - ${o.file} :: ${o.scenarioId} (${o.operationId}) :: field "${o.field}" backed by [${o.semantic}]`,
+            )
+            .join('\n')}`,
+      ).toEqual([]);
+    });
+  },
+);

--- a/path-analyser/src/bindSemanticInput.ts
+++ b/path-analyser/src/bindSemanticInput.ts
@@ -5,17 +5,18 @@ import type { ArtifactRegistryEntry, OperationGraph } from './types.js';
  * Unified classification + value-resolution dispatch (#162 PR 3).
  *
  * Single chokepoint for "where does the value of this semantic come
- * from?" reasoning. Both `bindModelDerivedFromFixture` and
- * `bindClientMintedAttribute` route through this module so the
+ * from?" reasoning. The variant suite
+ * (`generateOptionalSubShapeVariants`) routes through this module so
  * classification rules and per-classification value derivation live in
- * one place rather than being scattered across helper-specific
- * filters in `path-analyser/src/index.ts`.
+ * one place. (Issue #247 retired the dedicated feature-suite helpers
+ * `bindClientMintedAttribute` / `bindModelDerivedFromFixture` — they
+ * duplicated the variant-suite optional-population path and contaminated
+ * the feature `base` scenario.)
  *
  * Scope of PR 3 (refactor only, no behaviour change):
  *
  *   - Classifications 3 (`clientMintedAttribute`) and 5 (`modelDerived`)
  *     return a concrete `value` ready to bind into `scenario.bindings`.
- *     These were the two cases the existing helpers handled inline.
  *
  *   - Classifications 1 (`producerBound`), 2 (`clientMintedIdentifier`)
  *     and 4 (`externalBoundary`) are recognised but have no value
@@ -23,10 +24,6 @@ import type { ArtifactRegistryEntry, OperationGraph } from './types.js';
  *     for these classifications return only the `varName` so callers
  *     can verify "this is owned by another path" and bail out without
  *     overwriting the BFS-driven binding.
- *
- *   - PR 4 will extend the variant planner to call this module so
- *     populated optional sub-shapes flow through the same dispatch as
- *     feature-coverage scenarios.
  *
  *   - PR 5 will turn `'unclassified'` into a load-time diagnostic.
  */
@@ -118,9 +115,7 @@ export function classifySemantic(semantic: string, graph: OperationGraph): Seman
  *
  *   - `clientMintedAttribute`: produces a deterministic
  *     `fc:cma:<sem>:<suffix>` token using
- *     ``deterministicSuffix(`fc:cma:${operationId}:${semantic}`)``,
- *     matching the byte-stable mint formula from
- *     `bindClientMintedAttribute` PR 2.
+ *     ``deterministicSuffix(`fc:cma:${operationId}:${semantic}`)``.
  *
  *   - producerBound / clientMintedIdentifier / externalBoundary: returned
  *     with `varName` only. Callers should treat these as "owned by BFS"

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -2,7 +2,6 @@ import fsSync from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { bindSemanticInput } from './bindSemanticInput.js';
 import { buildCanonicalShapes } from './canonicalSchemas.js';
 import {
   getActiveConfigDir,
@@ -13,7 +12,7 @@ import {
 import { writeExtractionOutputs } from './extractSchemas.js';
 import { generateFeatureCoverageForEndpoint } from './featureCoverageGenerator.js';
 import { loadGraph, loadOpenApiSemanticHints } from './graphLoader.js';
-import { findDeploymentGatewayOpId, isDeploymentGatewayOp } from './ontology/operationRoles.js';
+import { isDeploymentGatewayOp } from './ontology/operationRoles.js';
 import {
   generateOptionalSubShapeVariants,
   generateScenariosForEndpoint,
@@ -435,12 +434,11 @@ async function main() {
 
 // Only auto-invoke main() when this module is executed directly as a
 // CLI (e.g. `node path-analyser/dist/src/index.js`), not when imported
-// by another module. Tests in tests/fixtures/planner/ import the
-// exported `bindModelDerivedFromFixture` / `bindClientMintedAttribute`
-// helpers from this file under Vitest; without the guard, importing
-// would kick off the generator pipeline (filesystem writes against
-// `generated/`) inside the test process. Standard ESM CLI idiom: the
-// module's own URL matches the file URL of `process.argv[1]`.
+// by another module. Without the guard, importing exported helpers
+// under Vitest would kick off the generator pipeline (filesystem
+// writes against `generated/`) inside the test process. Standard ESM
+// CLI idiom: the module's own URL matches the file URL of
+// `process.argv[1]`.
 if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
   main().catch((err) => {
     console.error(err);
@@ -581,18 +579,6 @@ function buildRequestPlan(
       steps.push(dup);
     }
   }
-  // #162 PR 1: bind modelDerived semantics from the chain's deploy fixture
-  // BEFORE merging populatesSubShape, so that the merge sees the
-  // populatesSubShape entry the helper plants for nested-path values
-  // (and so the binding has the fixture value rather than the
-  // synthetic placeholder featureCoverageGenerator stamped earlier).
-  bindModelDerivedFromFixture(scenario, steps, graph);
-  // #162 PR 2: bind clientMintedAttribute semantics with a deterministic
-  // minted value at setter sites in the same window (before the
-  // populatesSubShape merge). Independent of bindModelDerivedFromFixture
-  // — different value source (planner, not fixture) — but co-located so
-  // both feed the same downstream materialization.
-  bindClientMintedAttribute(scenario, steps, graph);
   // Issue #105 (Phase 3): for variant scenarios, deep-merge the populated
   // sub-shape into the FINAL step's bodyTemplate. The planner stamps
   // `populatesSubShape` on each variant scenario; the emitter expects the
@@ -685,276 +671,6 @@ function annotateEventualWaits(steps: RequestStep[], graph: OperationGraph): voi
       });
     }
   }
-}
-
-/**
- * #162 PR 1: bind modelDerived semantic values from the chain's
- * createDeployment fixture and annotate `populatesSubShape` so the final
- * step's body materializes the value.
- *
- * "modelDerived" means the value comes from inside the deployment
- * artifact itself (e.g. an ElementId encoded in the BPMN), not from a
- * Camunda API response. The fixture registry's `providesValues` entry
- * declares which concrete values each fixture supplies.
- *
- * Scope (PR 1):
- *
- *   - Runs ONLY for feature-coverage scenarios. Variant scenarios
- *     continue using their producer-chain logic (see
- *     `generateOptionalSubShapeVariants`); PR 4 of #162 unifies them.
- *
- *   - Single-deploy chains only — the helper picks the FIRST
- *     `createDeployment` step's fixture as the value source. Multi-deploy
- *     chains (source + target models, e.g. migrateProcessInstance) need
- *     per-deploy-step fixture selection and are a follow-up.
- *
- *   - Index 0 of `providesValues[semantic]` is used unconditionally.
- *     A future per-consumer-site preference vocabulary can pick a
- *     specific entry; not load-bearing today.
- *
- * Side effects:
- *
- *   - For modelDerived semantics on nested optional sub-shape leaves from
- *     `endpoint.optionalSubShapes` (i.e. the leaves computed via
- *     `subShapeRootOf`), overrides any pre-existing binding (synthetic or
- *     otherwise) with the fixture value. The override is intentional:
- *     modelDerived values are authoritative over the `fc:pos:...`
- *     synthetic placeholder stamped by featureCoverageGenerator.
- *
- *   - For nested-array semantics (`fieldPath` containing `[]`), adds a
- *     `populatesSubShape` entry so `mergePopulatesSubShapeIntoFinalBody`
- *     materializes the nested structure. Top-level scalar semantics are
- *     handled by the existing flat-optional fill loop in
- *     `buildRequestBodyFromCanonical` and do not need a populatesSubShape
- *     annotation.
- */
-export function bindModelDerivedFromFixture(
-  scenario: EndpointScenario,
-  steps: RequestStep[],
-  graph: OperationGraph,
-): void {
-  if (scenario.strategy !== 'featureCoverage') return;
-  if (!steps.length) return;
-  const finalStep = steps[steps.length - 1];
-  const endpoint = graph.operations[finalStep.operationId];
-  // optionalSubShapes already filters to nested optional semantic leaves
-  // (the graphLoader pre-computes this via `subShapeRootOf`). PR 1's
-  // scope is exactly that subset — nested ElementId at consumer sites
-  // like `startInstructions[].elementId`. Top-level scalar modelDerived
-  // semantics (e.g. JobType) go through a different binding path and
-  // are out of scope here.
-  const subShapes = endpoint?.optionalSubShapes ?? [];
-  if (!subShapes.length) return;
-  // Find the first deployment-gateway step in the chain — single-deploy
-  // only in PR 1; multi-deploy is a follow-up. The op is identified via
-  // the active config's artifact-kinds ABox role lookup
-  // (Lift 9 / #225) instead of a hard-coded `createDeployment` literal.
-  const deploymentGatewayOpId = findDeploymentGatewayOpId(graph.domain);
-  const deployStep = deploymentGatewayOpId
-    ? steps.find((s) => s.operationId === deploymentGatewayOpId)
-    : undefined;
-  if (!deployStep) return;
-  const fixture = fixtureFromDeployStep(deployStep);
-  if (!fixture?.providesValues) return;
-
-  for (const subShape of subShapes) {
-    for (const leaf of subShape.leaves) {
-      // #162 PR 3: route classification + value derivation through the
-      // unified chokepoint. The helper still owns its scope filter
-      // (subShape leaves only) and its mutation (binding + populatesSubShape
-      // entry); the chokepoint owns "is this a modelDerived semantic and
-      // what value does it resolve to?".
-      const result = bindSemanticInput({
-        semantic: leaf.semantic,
-        operationId: finalStep.operationId,
-        graph,
-        fixture,
-      });
-      if (result.classification !== 'modelDerived') continue;
-      // Per #162 PR 3 reviewer note: the chokepoint reports modelDerived
-      // even when no fixture value is resolvable, so PR 5 can tell
-      // "unclassified semantic" apart from "modelDerived semantic with
-      // missing fixture data". The caller is responsible for skipping
-      // the unresolved case here — mirrors the pre-PR3 `if (!values?.length) continue`.
-      if (result.value === undefined) continue;
-
-      scenario.bindings ||= {};
-      // Authoritative override: a featureCoverageGenerator synthetic
-      // would otherwise shadow the real fixture value.
-      scenario.bindings[result.varName] = result.value;
-
-      const sub = scenario.populatesSubShape ?? {
-        rootPath: subShape.rootPath,
-        leafPaths: [],
-        leafSemantics: [],
-      };
-      if (!sub.leafPaths.includes(leaf.fieldPath)) {
-        sub.leafPaths.push(leaf.fieldPath);
-        sub.leafSemantics ||= [];
-        sub.leafSemantics.push(leaf.semantic);
-      }
-      if (!sub.rootPath) sub.rootPath = subShape.rootPath;
-      scenario.populatesSubShape = sub;
-    }
-  }
-}
-
-/**
- * Find the fixture registry entry referenced by a `createDeployment`
- * step's multipart `resources` template. Multi-deploy steps carry
- * multiple file references; PR 1 returns the entry for the FIRST one
- * (single-deploy scope).
- */
-function fixtureFromDeployStep(step: RequestStep): ArtifactRegistryEntry | undefined {
-  const tpl = step.multipartTemplate;
-  if (!isPlainRecord(tpl)) return undefined;
-  const files = isPlainRecord(tpl.files) ? tpl.files : undefined;
-  if (!files) return undefined;
-  for (const v of Object.values(files)) {
-    if (typeof v === 'string' && v.startsWith('@@FILE:')) {
-      const path = v.slice('@@FILE:'.length);
-      return getArtifactsRegistry().find((e) => e.path === path);
-    }
-  }
-  return undefined;
-}
-
-/**
- * #162 PR 2: bind values for `kind: 'attribute'` + `clientMinted: true`
- * semantic types at SETTER sites in the chain. A setter site is an
- * operation whose request body declares the semantic — the value
- * originates from the planner (a deterministic minted token), not from
- * any producer endpoint, and gets stamped into the body via the
- * standard `populatesSubShape` materializer.
- *
- * Scope (PR 2):
- *
- *   - Runs ONLY for feature-coverage scenarios. Variant scenarios are
- *     handled by their own dedicated planner path; the unified-dispatch
- *     refactor is #162 PR 3.
- *
- *   - Setter-site only. If the endpoint accepts the semantic in its
- *     request body, we mint + populate here. Filter-consumer endpoints
- *     (search/batch ops where a tag is matched against existing
- *     entities) need setter-chain reuse — insert a setter step BEFORE
- *     the consumer step and thread the same minted value through — and
- *     are deferred to a follow-up issue. Without that work, filter
- *     scenarios would search for a non-existent value and return empty
- *     results, failing the non-empty assertion.
- *
- *   - Walks `endpoint.requestBodySemantics` (the inclusive index added
- *     in PR 2 for exactly this purpose) so scalar-array paths (`tags[]`)
- *     and top-level scalars (`businessId`) are visible alongside
- *     nested-object leaves. `optionalSubShapes` would miss them.
- *
- *   - The `fc:cma:<sem>:` prefix on the minted value tags the source
- *     (`fc` = feature coverage, `cma` = client-minted attribute) so
- *     a grep of the emitted output can distinguish it from
- *     `fc:pos:<sem>:` (the pre-#162 synthetic) and from
- *     producer-bound values.
- *
- * Side effects:
- *
- *   - Overrides any pre-existing binding (synthetic from
- *     featureCoverageGenerator) with the new minted value. Override is
- *     intentional — clientMintedAttribute values are authoritative over
- *     the pre-classification synthetic.
- *
- *   - Adds a `populatesSubShape` entry for the leaf (even when the path
- *     is top-level scalar or scalar-array) so the existing
- *     `mergePopulatesSubShapeIntoFinalBody` materializer fills the body.
- *     `setLeafPlaceholder` already handles scalar-array `[]` leaves
- *     correctly — building `tags: ['${tagVar}']` for top-level
- *     `tags[]` and `filter.tags: ['${tagVar}']` for nested
- *     `filter.tags[]`.
- */
-export function bindClientMintedAttribute(
-  scenario: EndpointScenario,
-  steps: RequestStep[],
-  graph: OperationGraph,
-): void {
-  if (scenario.strategy !== 'featureCoverage') return;
-  if (!steps.length) return;
-  const finalStep = steps[steps.length - 1];
-  const endpoint = graph.operations[finalStep.operationId];
-  const bodySems = endpoint?.requestBodySemantics ?? [];
-  if (!bodySems.length) return;
-
-  for (const bodySem of bodySems) {
-    // PR 2 narrowed scope: only fill at the endpoint that IS the setter
-    // (the final-step body accepts the semantic). Filter-consumer sites
-    // also have the semantic in their bodySemantics but need a separate
-    // setter-chain pass to make the value meaningful — deferred.
-    //
-    // Heuristic for "this is a setter site" vs "this is a filter
-    // consumer": filter consumers have the semantic under a path
-    // beginning with `filter.` or `filter[` (the bundled spec uses
-    // `filter.tags[]` and `filter.$or[].tags[]`); setters have the
-    // semantic at top-level or under a non-filter parent. This is a
-    // pragmatic shortcut for PR 2; the follow-up issue (#168) will use
-    // the requestSettersByType index to discover setters generically
-    // and prepend a setter step before each filter consumer.
-    if (bodySem.fieldPath.startsWith('filter.') || bodySem.fieldPath.startsWith('filter[')) {
-      continue;
-    }
-
-    // #162 PR 3: route classification + mint through the unified
-    // chokepoint. The helper still owns its scope filter (setter-site
-    // bodySemantics only) and its mutation (binding + populatesSubShape
-    // entry); the chokepoint owns "is this a clientMintedAttribute and
-    // what deterministic value does it mint?".
-    const result = bindSemanticInput({
-      semantic: bodySem.semantic,
-      operationId: finalStep.operationId,
-      graph,
-    });
-    if (result.classification !== 'clientMintedAttribute') continue;
-
-    scenario.bindings ||= {};
-    scenario.bindings[result.varName] = result.value;
-
-    // Always plant a populatesSubShape entry so the body is filled by
-    // the existing materializer. setLeafPlaceholder handles all three
-    // shapes the planner emits: top-level scalar (`businessId`),
-    // top-level scalar array (`tags[]`), and nested scalar array
-    // (`filter.tags[]`, when setter-chain support lands).
-    const sub = scenario.populatesSubShape ?? {
-      rootPath: subShapeRootForFieldPath(bodySem.fieldPath),
-      leafPaths: [],
-      leafSemantics: [],
-    };
-    if (!sub.leafPaths.includes(bodySem.fieldPath)) {
-      sub.leafPaths.push(bodySem.fieldPath);
-      sub.leafSemantics ||= [];
-      sub.leafSemantics.push(bodySem.semantic);
-    }
-    if (!sub.rootPath) sub.rootPath = subShapeRootForFieldPath(bodySem.fieldPath);
-    scenario.populatesSubShape = sub;
-  }
-}
-
-/**
- * Compute the sub-shape root for a fieldPath. Used by the
- * clientMintedAttribute helper to seed `populatesSubShape.rootPath` for
- * top-level scalar / scalar-array leaves where the graphLoader's
- * `subShapeRootOf` returns null. Mirrors the simpler cases:
- *
- *   "tags[]"           → "tags[]"
- *   "businessId"       → "businessId"
- *   "filter.tags[]"    → "filter"  (deepest object/array-of-object
- *                                   ancestor — but PR 2 skips this
- *                                   branch since filter sites are
- *                                   deferred)
- *
- * Single-segment paths return the segment itself rather than the empty
- * string the graphLoader's stricter rule would yield — the rootPath
- * is informational metadata on populatesSubShape and the merge logic
- * doesn't actually read it.
- */
-function subShapeRootForFieldPath(fieldPath: string): string {
-  const segments = fieldPath.split('.');
-  if (segments.length === 1) return segments[0];
-  return segments.slice(0, -1).join('.');
 }
 
 function mergePopulatesSubShapeIntoFinalBody(
@@ -1220,7 +936,10 @@ function buildRequestBodyFromCanonical(
     if (bindingMap[entry.fieldPath]) continue;
     // Only auto-derive when the graph has a response-producer for this semantic type.
     // This excludes clientMintedAttribute semantics (Tag, BusinessId) which have no
-    // graph-level response producer and are handled separately by bindClientMintedAttribute.
+    // graph-level response producer — those used to be populated by the dedicated
+    // bindClientMintedAttribute helper in the feature suite, which was removed in
+    // issue #247 because the optional-population scenarios now live exclusively in
+    // the variant suite (`generateOptionalSubShapeVariants`).
     if (!graph.producersByType[entry.semantic]?.length) continue;
     semanticFallback[entry.fieldPath] = camelCase(entry.semantic);
   }

--- a/tests/fixtures/loader/graphloader-request-setters.test.ts
+++ b/tests/fixtures/loader/graphloader-request-setters.test.ts
@@ -9,11 +9,12 @@
  * semantic in its body, dedup'd, with no entries when no operation
  * declares a body semantic.
  *
- * These properties are what the planner's `bindClientMintedAttribute`
- * helper and the future setter-chain reuse pass consume; if either
- * regresses, attribute-classification scenarios silently revert to the
- * pre-PR-2 synthetic placeholder. The fixture is the smallest spec
- * that exercises each shape independently.
+ * These properties are what the variant suite's
+ * `generateOptionalSubShapeVariants` consumes via the `bindSemanticInput`
+ * chokepoint (and what the future setter-chain reuse pass will
+ * consume); if either regresses, attribute-classification variant
+ * scenarios silently revert to a synthetic placeholder. The fixture is
+ * the smallest spec that exercises each shape independently.
  */
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/tests/fixtures/planner/classification-dispatch.test.ts
+++ b/tests/fixtures/planner/classification-dispatch.test.ts
@@ -3,463 +3,57 @@ import {
   bindSemanticInput,
   classifySemantic,
 } from '../../../path-analyser/src/bindSemanticInput.ts';
-import {
-  bindClientMintedAttribute,
-  bindModelDerivedFromFixture,
-} from '../../../path-analyser/src/index.ts';
-import type {
-  DomainSemantics,
-  EndpointScenario,
-  OperationGraph,
-  OperationNode,
-  RequestStep,
-} from '../../../path-analyser/src/types.ts';
+import type { OperationGraph } from '../../../path-analyser/src/types.ts';
 
 /**
  * Classification-dispatch fixtures — Layer 2 of the layered test
- * strategy, for issue #162 PR 3 (unified `bindSemanticInput` chokepoint).
- *
- * Today the 5 value-source classifications described in #162 are
- * dispatched by separate code paths:
+ * strategy, for the `bindSemanticInput` chokepoint that routes all
+ * five #162 value-source classifications through a single helper.
  *
  *   1. producer-bound          → BFS in scenarioGenerator.ts
  *   2. client-minted identifier → BFS via `establishersByType`
- *   3. client-minted attribute  → bindClientMintedAttribute (#162 PR 2)
+ *   3. client-minted attribute  → variant suite (`generateOptionalSubShapeVariants`)
  *   4. external boundary        → BFS via `externalEntityIdentifiers`
- *   5. model-derived            → bindModelDerivedFromFixture (#162 PR 1)
+ *   5. model-derived            → variant suite (`generateOptionalSubShapeVariants`)
  *
- * PR 3 will route all five through a single `bindSemanticInput` helper
- * with NO behaviour change. This file is the green/green guard step
- * (per AGENTS.md "Coverage analysis before a behaviour-preserving
- * refactor") — synthetic-graph-driven assertions on the dispatch output
- * that pass against current `main` and must continue passing after the
- * refactor.
+ * Issue #247 (suite-partition cut follow-up) removed the dedicated
+ * feature-suite helpers `bindClientMintedAttribute` and
+ * `bindModelDerivedFromFixture`. Optional-population for the
+ * `clientMintedAttribute` (Tag, BusinessId) and `modelDerived`
+ * (ElementId) classifications now lives exclusively in the variant
+ * suite, which routes through `bindSemanticInput` the same way every
+ * other classification does. The chokepoint's classification and
+ * value-resolution contracts are guarded here.
  *
  * Coverage map for the five classifications:
  *
  *   1. producer-bound          → planner-contracts.test.ts (fixtures
- *                                A, F, G, H) covers chain-shape selection;
- *                                see also planner-establishes.test.ts
+ *                                A, F, G, H); planner-establishes.test.ts
  *                                for binding-name discipline.
- *   2. client-minted identifier → planner-establishes.test.ts (fixtures
- *                                for `x-semantic-establishes`).
- *   3. client-minted attribute  → THIS FILE.
+ *   2. client-minted identifier → planner-establishes.test.ts.
+ *   3. client-minted attribute  → variant-suite L3 invariants in
+ *                                configs/<config>/regression-invariants.test.ts.
  *   4. external boundary        → planner-establishes.test.ts (ClientId
- *                                fixture asserting `externalEntitySites`
- *                                tagging).
- *   5. model-derived            → THIS FILE.
+ *                                fixture).
+ *   5. model-derived            → variant-suite L3 invariants in
+ *                                configs/<config>/regression-invariants.test.ts.
  *
- * (3) and (5) had no L2 guard before this file because their helpers
- * live in index.ts post-BFS, outside the scenarioGenerator entry point
- * the rest of the planner suite calls. Exposing them and pinning their
- * observable behaviour with synthetic inputs lets the PR 3 refactor land
- * with a single, readable diff at the chokepoint instead of having to
- * read the L3 bundled-spec invariants to know what each helper did.
+ * What stays here is the classification + value-resolution contract on
+ * `bindSemanticInput` itself, because the chokepoint is a thin
+ * synthetic surface that PR 5 (load-time diagnostic on `unclassified`)
+ * will build on.
  */
-
-interface NodeOpts {
-  required?: string[];
-  optional?: string[];
-  produces?: string[];
-  optionalSubShapes?: OperationNode['optionalSubShapes'];
-  requestBodySemantics?: OperationNode['requestBodySemantics'];
-}
-
-function makeOp(operationId: string, opts: NodeOpts = {}): OperationNode {
-  return {
-    operationId,
-    method: 'POST',
-    path: `/${operationId}`,
-    requires: {
-      required: opts.required ?? [],
-      optional: opts.optional ?? [],
-    },
-    produces: opts.produces ?? [],
-    optionalSubShapes: opts.optionalSubShapes,
-    requestBodySemantics: opts.requestBodySemantics,
-  };
-}
-
-function makeGraph(opts: {
-  operations: OperationNode[];
-  domain?: DomainSemantics;
-}): OperationGraph {
-  const operations: Record<string, OperationNode> = {};
-  for (const node of opts.operations) operations[node.operationId] = node;
-  return {
-    operations,
-    producersByType: {},
-    domain: opts.domain,
-  };
-}
-
-function makeDeployStep(fixturePath: string): RequestStep {
-  return {
-    operationId: 'createDeployment',
-    method: 'POST',
-    pathTemplate: '/deployments',
-    bodyKind: 'multipart',
-    multipartTemplate: {
-      files: { resources: `@@FILE:${fixturePath}` },
-    },
-    expect: { status: 200 },
-  };
-}
-
-function makeEndpointStep(operationId: string): RequestStep {
-  return {
-    operationId,
-    method: 'POST',
-    pathTemplate: `/${operationId}`,
-    expect: { status: 200 },
-  };
-}
-
-function makeFeatureScenario(overrides: Partial<EndpointScenario> = {}): EndpointScenario {
-  return {
-    id: 'feature-1',
-    operations: [],
-    producedSemanticTypes: [],
-    satisfiedSemanticTypes: [],
-    strategy: 'featureCoverage',
-    ...overrides,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Classification 5 — model-derived (bindModelDerivedFromFixture, #162 PR 1)
-// ---------------------------------------------------------------------------
-//
-// The helper binds a semantic value out-of-band from a deployment
-// artifact's `providesValues` map when:
-//
-//   - scenario.strategy === 'featureCoverage'
-//   - domain.semanticTypes[<sem>].kind === 'modelDerived'
-//   - the endpoint declares an optional sub-shape whose leaf semantic
-//     is <sem>
-//   - the chain includes a createDeployment step whose multipart
-//     template references a registry entry with providesValues[<sem>]
-//
-// These tests use `bpmn/service-task.bpmn`, which is a real entry in
-// path-analyser/fixtures/deployment-artifacts.json (now
-// configs/<config>/fixtures/deployment-artifacts.json) with both ElementId
-// and JobType providesValues. The registry contents are themselves
-// guarded by the L3 invariants in regression-invariants.test.ts; this
-// L2 layer locks in the dispatch behaviour given a known-good registry.
-
-const modelDerivedDomain: DomainSemantics = {
-  version: 1,
-  semanticTypes: {
-    ElementId: { kind: 'modelDerived' },
-  },
-  operationArtifactRules: {
-    createDeployment: { role: 'deploymentGateway' },
-  },
-};
-
-const endpointWithElementIdSubShape: OperationNode = makeOp('createProcessInstance', {
-  required: ['ProcessDefinitionKey'],
-  optionalSubShapes: [
-    {
-      rootPath: 'startInstructions[]',
-      leaves: [{ fieldPath: 'startInstructions[].elementId', semantic: 'ElementId' }],
-    },
-  ],
-});
-
-describe('classification 5: model-derived dispatch (#162 PR 1)', () => {
-  it('binds <sem>Var from fixture.providesValues[0] when leaf is modelDerived', () => {
-    const scenario = makeFeatureScenario();
-    const steps: RequestStep[] = [
-      makeDeployStep('bpmn/service-task.bpmn'),
-      makeEndpointStep('createProcessInstance'),
-    ];
-    const graph = makeGraph({
-      operations: [endpointWithElementIdSubShape],
-      domain: modelDerivedDomain,
-    });
-
-    bindModelDerivedFromFixture(scenario, steps, graph);
-
-    // service-task.bpmn declares providesValues.ElementId =
-    // ['StartEvent_1', 'Activity_06kuv4r', 'Event_0tll3bk']. The helper
-    // takes the first entry unconditionally.
-    expect(scenario.bindings?.elementIdVar).toBe('StartEvent_1');
-    expect(scenario.populatesSubShape?.rootPath).toBe('startInstructions[]');
-    expect(scenario.populatesSubShape?.leafPaths).toEqual(['startInstructions[].elementId']);
-    expect(scenario.populatesSubShape?.leafSemantics).toEqual(['ElementId']);
-  });
-
-  it('is a no-op for non-featureCoverage scenarios (variant suite untouched)', () => {
-    // Locks in the suite-scoping contract that #162 PR 4 will lift; PR 3
-    // must preserve it.
-    const scenario = makeFeatureScenario({ strategy: 'optionalSubShapeVariant' });
-    const steps: RequestStep[] = [
-      makeDeployStep('bpmn/service-task.bpmn'),
-      makeEndpointStep('createProcessInstance'),
-    ];
-    const graph = makeGraph({
-      operations: [endpointWithElementIdSubShape],
-      domain: modelDerivedDomain,
-    });
-
-    bindModelDerivedFromFixture(scenario, steps, graph);
-
-    expect(scenario.bindings).toBeUndefined();
-    expect(scenario.populatesSubShape).toBeUndefined();
-  });
-
-  it('is a no-op when the chain has no createDeployment step', () => {
-    const scenario = makeFeatureScenario();
-    const steps: RequestStep[] = [makeEndpointStep('createProcessInstance')];
-    const graph = makeGraph({
-      operations: [endpointWithElementIdSubShape],
-      domain: modelDerivedDomain,
-    });
-
-    bindModelDerivedFromFixture(scenario, steps, graph);
-
-    expect(scenario.bindings).toBeUndefined();
-  });
-
-  it('is a no-op when the deployment fixture has no providesValues for the semantic', () => {
-    const scenario = makeFeatureScenario();
-    const steps: RequestStep[] = [
-      // forms/simple.form is a real registry entry with no providesValues
-      makeDeployStep('forms/simple.form'),
-      makeEndpointStep('createProcessInstance'),
-    ];
-    const graph = makeGraph({
-      operations: [endpointWithElementIdSubShape],
-      domain: modelDerivedDomain,
-    });
-
-    bindModelDerivedFromFixture(scenario, steps, graph);
-
-    expect(scenario.bindings).toBeUndefined();
-  });
-
-  it('is a no-op when the deploy step references an unknown registry path', () => {
-    const scenario = makeFeatureScenario();
-    const steps: RequestStep[] = [
-      makeDeployStep('bpmn/does-not-exist.bpmn'),
-      makeEndpointStep('createProcessInstance'),
-    ];
-    const graph = makeGraph({
-      operations: [endpointWithElementIdSubShape],
-      domain: modelDerivedDomain,
-    });
-
-    bindModelDerivedFromFixture(scenario, steps, graph);
-
-    expect(scenario.bindings).toBeUndefined();
-  });
-
-  it('overrides any pre-existing synthetic binding (authoritative)', () => {
-    // The featureCoverageGenerator may have stamped a synthetic
-    // `fc:pos:elementId:...` placeholder before this helper runs.
-    // The modelDerived value wins.
-    const scenario = makeFeatureScenario({
-      bindings: { elementIdVar: 'fc:pos:elementId:SYNTHETIC' },
-    });
-    const steps: RequestStep[] = [
-      makeDeployStep('bpmn/service-task.bpmn'),
-      makeEndpointStep('createProcessInstance'),
-    ];
-    const graph = makeGraph({
-      operations: [endpointWithElementIdSubShape],
-      domain: modelDerivedDomain,
-    });
-
-    bindModelDerivedFromFixture(scenario, steps, graph);
-
-    expect(scenario.bindings?.elementIdVar).toBe('StartEvent_1');
-  });
-
-  it('is a no-op when domain.semanticTypes does not declare the leaf as modelDerived', () => {
-    // Class-scoped: leaves declared with other `kind` values (e.g.
-    // 'attribute') OR with no kind at all must not be touched. The
-    // helper is exclusive to classification 5.
-    const scenario = makeFeatureScenario();
-    const steps: RequestStep[] = [
-      makeDeployStep('bpmn/service-task.bpmn'),
-      makeEndpointStep('createProcessInstance'),
-    ];
-    const graph = makeGraph({
-      operations: [endpointWithElementIdSubShape],
-      // No kind on ElementId — falls back to producer/establisher chain.
-      domain: { version: 1, semanticTypes: { ElementId: {} } },
-    });
-
-    bindModelDerivedFromFixture(scenario, steps, graph);
-
-    expect(scenario.bindings).toBeUndefined();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Classification 3 — client-minted attribute (bindClientMintedAttribute,
-// #162 PR 2)
-// ---------------------------------------------------------------------------
-//
-// The helper mints a deterministic `fc:cma:<sem>:<suffix>` value and
-// stamps a populatesSubShape entry when:
-//
-//   - scenario.strategy === 'featureCoverage'
-//   - domain.semanticTypes[<sem>].kind === 'attribute'
-//     && clientMinted === true
-//   - the endpoint declares the semantic in requestBodySemantics with a
-//     setter-site path (NOT starting with `filter.` / `filter[`)
-//
-// Setter-site is a pragmatic PR 2 narrowing — filter consumers are
-// deferred to #168. PR 3 must preserve that narrowing.
-
-const attributeDomain: DomainSemantics = {
-  version: 1,
-  semanticTypes: {
-    Tag: { kind: 'attribute', clientMinted: true },
-  },
-};
-
-const setterEndpoint: OperationNode = makeOp('createProcessInstance', {
-  requestBodySemantics: [{ semantic: 'Tag', fieldPath: 'tags[]', required: false }],
-});
-
-const filterConsumerEndpoint: OperationNode = makeOp('searchProcessInstances', {
-  requestBodySemantics: [{ semantic: 'Tag', fieldPath: 'filter.tags[]', required: false }],
-});
-
-describe('classification 3: client-minted attribute dispatch (#162 PR 2)', () => {
-  it('mints fc:cma:<sem>:<suffix> and populates the sub-shape at a setter site', () => {
-    const scenario = makeFeatureScenario();
-    const steps: RequestStep[] = [makeEndpointStep('createProcessInstance')];
-    const graph = makeGraph({
-      operations: [setterEndpoint],
-      domain: attributeDomain,
-    });
-
-    bindClientMintedAttribute(scenario, steps, graph);
-
-    const tagVar = scenario.bindings?.tagVar;
-    expect(tagVar, 'tagVar must be minted').toBeDefined();
-    // The prefix is the load-bearing classification marker. The suffix
-    // is a deterministicSuffix() of (opId, semantic) — content tested
-    // by the L3 invariants; here we only assert the contract shape.
-    expect(tagVar).toMatch(/^fc:cma:tag:/);
-    expect(scenario.populatesSubShape?.leafPaths).toEqual(['tags[]']);
-    expect(scenario.populatesSubShape?.leafSemantics).toEqual(['Tag']);
-  });
-
-  it('is deterministic across runs for the same (opId, semantic)', () => {
-    // The minted value uses deterministicSuffix to keep snapshot output
-    // byte-stable. Two calls with identical inputs must produce
-    // identical bindings.
-    const sa = makeFeatureScenario();
-    const sb = makeFeatureScenario();
-    const steps: RequestStep[] = [makeEndpointStep('createProcessInstance')];
-    const graph = makeGraph({
-      operations: [setterEndpoint],
-      domain: attributeDomain,
-    });
-
-    bindClientMintedAttribute(sa, steps, graph);
-    bindClientMintedAttribute(sb, steps, graph);
-
-    expect(sa.bindings?.tagVar).toBe(sb.bindings?.tagVar);
-  });
-
-  it('is a no-op at filter-consumer sites (setter-only scope of PR 2)', () => {
-    // Class-scoped: every fieldPath beginning with `filter.` or
-    // `filter[` must be skipped. PR 3 must preserve this narrowing
-    // because #168's setter-chain-reuse pass has not landed.
-    const scenario = makeFeatureScenario();
-    const steps: RequestStep[] = [makeEndpointStep('searchProcessInstances')];
-    const graph = makeGraph({
-      operations: [filterConsumerEndpoint],
-      domain: attributeDomain,
-    });
-
-    bindClientMintedAttribute(scenario, steps, graph);
-
-    expect(scenario.bindings).toBeUndefined();
-    expect(scenario.populatesSubShape).toBeUndefined();
-  });
-
-  it('is a no-op for non-featureCoverage scenarios (variant suite untouched)', () => {
-    const scenario = makeFeatureScenario({ strategy: 'optionalSubShapeVariant' });
-    const steps: RequestStep[] = [makeEndpointStep('createProcessInstance')];
-    const graph = makeGraph({
-      operations: [setterEndpoint],
-      domain: attributeDomain,
-    });
-
-    bindClientMintedAttribute(scenario, steps, graph);
-
-    expect(scenario.bindings).toBeUndefined();
-  });
-
-  it('is a no-op when kind:attribute but clientMinted is not true', () => {
-    // Class-scoped: `kind: 'attribute'` is necessary but not sufficient
-    // — clientMinted must be explicitly true. A future server-derived
-    // attribute type must not get minted.
-    const scenario = makeFeatureScenario();
-    const steps: RequestStep[] = [makeEndpointStep('createProcessInstance')];
-    const graph = makeGraph({
-      operations: [setterEndpoint],
-      domain: {
-        version: 1,
-        semanticTypes: { Tag: { kind: 'attribute' } },
-      },
-    });
-
-    bindClientMintedAttribute(scenario, steps, graph);
-
-    expect(scenario.bindings).toBeUndefined();
-  });
-
-  it('is a no-op when the endpoint has no requestBodySemantics for the type', () => {
-    const scenario = makeFeatureScenario();
-    const steps: RequestStep[] = [makeEndpointStep('createProcessInstance')];
-    const graph = makeGraph({
-      // setter endpoint with NO requestBodySemantics array.
-      operations: [makeOp('createProcessInstance')],
-      domain: attributeDomain,
-    });
-
-    bindClientMintedAttribute(scenario, steps, graph);
-
-    expect(scenario.bindings).toBeUndefined();
-  });
-
-  it('is a no-op when domain.semanticTypes is undefined', () => {
-    const scenario = makeFeatureScenario();
-    const steps: RequestStep[] = [makeEndpointStep('createProcessInstance')];
-    const graph = makeGraph({
-      operations: [setterEndpoint],
-      domain: { version: 1 },
-    });
-
-    bindClientMintedAttribute(scenario, steps, graph);
-
-    expect(scenario.bindings).toBeUndefined();
-  });
-});
 
 // ---------------------------------------------------------------------------
 // classifySemantic precedence (#162 PR 3)
 // ---------------------------------------------------------------------------
 //
-// The unified chokepoint resolves a semantic to ONE classification using
-// a documented precedence: explicit `domain.semanticTypes[T].kind`
-// declarations win over graph-index inferences. This block locks the
-// precedence in directly so PR 5 (load-time diagnostic on `unclassified`)
-// can build on a contract instead of an accident of code order.
-//
-// Today the bundled spec has no real collisions — every modelDerived /
-// clientMintedAttribute semantic is also absent from the producer /
-// establisher / external-entity indices. These synthetic tests assert
-// the precedence anyway, because the contract matters even if it is
-// today unobservable.
+// `classifySemantic` walks declarations + graph indices in a fixed
+// order. The bundled spec today has no real collisions — every
+// modelDerived / clientMintedAttribute semantic is also absent from the
+// producer / establisher / external-entity indices. These synthetic
+// tests assert the precedence anyway, because the contract matters
+// even if it is today unobservable.
 
 describe('classifySemantic precedence (#162 PR 3)', () => {
   function graphWithProducer(semantic: string): OperationGraph {
@@ -536,8 +130,8 @@ describe('classifySemantic precedence (#162 PR 3)', () => {
   it('attribute declaration without clientMinted does NOT short-circuit producerBound', () => {
     // A declaration of `kind: 'attribute'` without `clientMinted: true`
     // must NOT be treated as clientMintedAttribute — only the explicit
-    // `clientMinted === true` flag promotes the semantic into PR 2's
-    // chokepoint scope.
+    // `clientMinted === true` flag promotes the semantic into the
+    // clientMintedAttribute branch.
     const graph: OperationGraph = {
       ...graphWithProducer('SomeAttr'),
       domain: {
@@ -554,10 +148,9 @@ describe('classifySemantic precedence (#162 PR 3)', () => {
 // bindSemanticInput modelDerived value-resolution contract (#162 PR 3)
 // ---------------------------------------------------------------------------
 //
-// Reviewer note on PR 179 (copilot-pull-request-reviewer): the chokepoint
-// must NOT collapse "modelDerived semantic with missing fixture data" to
-// `unclassified`, because PR 5 needs to tell the two cases apart in
-// load-time diagnostics. The classification is a property of the
+// The chokepoint must NOT collapse "modelDerived semantic with missing
+// fixture data" to `unclassified` — PR 5 (load-time diagnostic) needs
+// to tell the two cases apart. Classification is a property of the
 // semantic + graph; the value is a separate question of whether the
 // active fixture happens to provide it.
 
@@ -593,10 +186,6 @@ describe('bindSemanticInput modelDerived value-resolution (#162 PR 3)', () => {
   });
 
   it('returns modelDerived (NOT unclassified) when the fixture lacks providesValues', () => {
-    // Defect-class guard for the reviewer note: stable classification
-    // even when the value can't be resolved. PR 5 will use this to
-    // distinguish "semantic not declared anywhere" from "semantic
-    // declared modelDerived but the selected fixture is the wrong file".
     const fixture = {
       kind: 'form',
       path: 'forms/simple.form',


### PR DESCRIPTION
Closes #247.

## What

Removes two helpers in `path-analyser/src/index.ts` that were re-injecting
`clientMintedAttribute` (Tag, BusinessId) and `modelDerived` (ElementId)
optional leaves into every `featureCoverage` scenario — including the
"base" scenario whose contract is required-only:

- `bindModelDerivedFromFixture` (#162 PR 1)
- `bindClientMintedAttribute` (#162 PR 2)

Both predated the #162 PR 4 suite-partition cut, which moved
optional-population scenarios into the variant suite
(`generateOptionalSubShapeVariants`). After PR 4 these helpers
duplicated coverage that already lives in the variant suite and
contaminated the feature `base` shape.

## Before / after

Before (`createProcessInstance.feature.spec.ts`, base scenario):

```ts
const body = {
  processDefinitionKey: ctx.processDefinitionKeyVar,
  startInstructions: [{ elementId: ctx.elementIdVar }],
  runtimeInstructions: [{ afterElementId: ctx.elementIdVar }],
  tags: [ctx.tagVar],
  businessId: ctx.businessIdVar,
};
```

After:

```ts
const body = {
  processDefinitionKey: ctx.processDefinitionKeyVar,
};
```

The four optional fields are still exercised — they live in
`createProcessInstance.variant.spec.ts` (one variant per
`<rootPath>::<fieldPath>`), populated via the `bindSemanticInput`
chokepoint with values resolved from the deployed BPMN fixture's
`providesValues` (for `modelDerived`) or deterministic mint (for
`clientMintedAttribute`).

## Why this is safe

The variant suite never used either removed helper. Both gated on
`scenario.strategy === 'featureCoverage'`; variants are tagged
`strategy: 'optionalSubShapeVariant'` (`scenarioGenerator.ts:1730`).
The variant suite has its own per-leaf `populatesSubShape` pass
(`scenarioGenerator.ts:1732-1736`) routed through the unified
`bindSemanticInput` chokepoint — the same ontology-driven binding the
helpers were trying to replicate one level too late.

Existing L3 invariants under `configs/camunda-oca/regression-invariants.test.ts`
(lines ~2741, ~2943, ~2988) target the **variant** suite for ElementId / Tag /
BusinessId population and continue to pass.

## Tests

- Updated `tests/fixtures/planner/classification-dispatch.test.ts` —
  the L2 guard that exercised the two removed helpers is replaced
  with retained `classifySemantic` precedence + `bindSemanticInput`
  value-resolution contracts (still the chokepoint contract the
  variant suite uses).
- Added L3 invariant: every feature `base` scenario's `bodyTemplate`
  contains only top-level fields backed by required semantic-typed
  leaves (or by no semantic-typed leaf at all). Empty scaffolding
  (`{}` / `[]`) for schema-required object/array fields is exempt —
  those are the minimal-required body shape, not leakage.
- Local pipeline regenerated + `npm test`: **511 passed | 6 skipped**.
- Lint clean (5 pre-existing warnings unrelated to this change).

## Out of scope

Richening synthetic values for `Tag` / `BusinessId` (today
`fc:cma:tag:1iom`-style) to business-meaningful values like
`customer-onboarding` is a separate enhancement to
`bindSemanticInput` / `resolveFallbackValue`. Orthogonal to
base-vs-variant separation.
