### PR TITLE
fix: encode post-condition hygiene state for createProcessInstance (#249)

### DIFF
--- a/configs/camunda-oca/ontology/runtime-states.json
+++ b/configs/camunda-oca/ontology/runtime-states.json
@@ -83,11 +83,26 @@
       "implicitAdds": [
         "ProcessInstanceExists"
       ],
+      "chainCleanupRequires": [
+        "ProcessInstanceCompleted"
+      ],
       "valueBindings": {
         "request.processDefinitionId": "ProcessDefinitionDeployed.processDefinitionId",
         "request.processDefinitionKey": "semantic:ProcessDefinitionKey",
         "response.processInstanceKey": "semantic:ProcessInstanceKey"
       }
+    },
+    {
+      "operationId": "completeJob",
+      "produces": [
+        "ProcessInstanceCompleted"
+      ]
+    },
+    {
+      "operationId": "cancelProcessInstance",
+      "produces": [
+        "ProcessInstanceCompleted"
+      ]
     },
     {
       "operationId": "activateJobs",

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1464,6 +1464,32 @@ describeForThisConfig('bundled-spec invariants: fixture selection by required st
     );
   });
 
+  it('createProcessInstance.feature.spec.ts deploys bpmn/simple.bpmn (chainCleanupRequires ProcessInstanceCompleted, #249)', () => {
+    // #249: createProcessInstance declares
+    // `chainCleanupRequires: ["ProcessInstanceCompleted"]` so the
+    // base-feature chain (createDeployment → createProcessInstance) picks a
+    // self-completing fixture. Without the hygiene declaration the tie-break
+    // between bpmn/simple.bpmn and bpmn/service-task.bpmn falls through to
+    // registry-array order — both have providesStates.length === 1 — and
+    // service-task wins, stranding a running instance the test never
+    // completes. The invariant fails closed: any fixture other than
+    // simple.bpmn means the hygiene encoding broke (or the residual logic
+    // in `computeDeploymentRequiredStates` dropped chainCleanupRequires
+    // from the union).
+    const spec = join(GENERATED_TESTS_DIR, 'createProcessInstance.feature.spec.ts');
+    if (!existsSync(spec)) {
+      throw new Error(`expected emitted spec ${spec} not found — run 'npm run testsuite:generate'`);
+    }
+    const src = readFileSync(spec, 'utf8');
+    expect(src, 'createProcessInstance base must deploy the self-completing fixture').toContain(
+      '@@FILE:bpmn/simple.bpmn',
+    );
+    expect(
+      src,
+      'createProcessInstance base must NOT deploy service-task.bpmn (would leave a hanging instance)',
+    ).not.toContain('@@FILE:bpmn/service-task.bpmn');
+  });
+
   it('deleteProcessInstance.feature.spec.ts injects an awaitEventually wait between createProcessInstance and deleteProcessInstance (#159 PR B)', () => {
     // PR B of #159: ProcessInstanceCompleted is declared `eventual: true`
     // with a `witness` shape that polls getProcessInstance until

--- a/ontology/vocabulary/runtime-states.schema.json
+++ b/ontology/vocabulary/runtime-states.schema.json
@@ -201,6 +201,14 @@
           },
           "description": "Explicit producer override (rare — used when a state is produced by an op that does not appear in the state's `producedBy`). Each entry must reference a state in `states`."
         },
+        "chainCleanupRequires": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Post-condition hygiene states the chain should leave in place after this op runs, but which are NOT preconditions to invoking it (#249). Distinct from `requires` because the BFS scenario planner deliberately ignores this field — it never gates feasibility, never schedules a producer op, and never filters the op out. The fixture selector unions these states into the deployment-gateway requirement set so a fixture that provides them is preferred; subsequent ops in the chain whose `produces` / `implicitAdds` cover the state discharge the hygiene requirement. Encodes 'this op creates a resource that should be driven to a terminal state by test end' — e.g. `createProcessInstance.chainCleanupRequires: [\"ProcessInstanceCompleted\"]` makes the base scenario deploy a self-completing fixture instead of leaving an orphan running instance."
+        },
         "valueBindings": {
           "type": "object",
           "additionalProperties": {

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1495,11 +1495,21 @@ function chooseFixtureFromRegistry(
 /**
  * Compute the set of runtime states the deployment-gateway step in a chain
  * must provide. Walks every operation in the scenario chain, accumulating
- * required states from `operationRequirements.<op>.requires`, then subtracts
+ * required states from `operationRequirements.<op>.requires` and from the
+ * post-condition hygiene set `chainCleanupRequires` (#249), then subtracts
  * states produced by any non-deployment-gateway op in the chain (those are
  * satisfied by their own producer step, not by the deployment gateway). The
  * chain is BFS-ordered with producers before their consumers, so a simple
  * unordered subtraction is equivalent to a left-to-right walk here.
+ *
+ * `chainCleanupRequires` differs from `requires` in that it is INVISIBLE to
+ * the BFS scenario planner — it never gates feasibility, never schedules a
+ * producer op, and never filters the consumer op out of the scenario set.
+ * It exists solely to bias fixture selection toward fixtures that leave the
+ * broker in the desired terminal state (e.g. a self-completing BPMN process
+ * for `createProcessInstance`'s base scenario, so the test doesn't strand
+ * a running instance). Subsequent ops in the chain whose `produces` /
+ * `implicitAdds` cover the state discharge the hygiene requirement.
  *
  * The deployment-gateway op is identified via `isDeploymentGatewayOp`
  * (Lift 9 / #225 — see `ontology/operationRoles.ts`), not by a hard-coded
@@ -1520,6 +1530,7 @@ function computeDeploymentRequiredStates(
     const req = opReqs[opRef.operationId];
     if (!req) continue;
     for (const s of req.requires ?? []) result.add(s);
+    for (const s of req.chainCleanupRequires ?? []) result.add(s);
   }
   // States produced by non-deployment-gateway ops earlier in the chain are
   // satisfied by their own producer step; the deployment gateway doesn't

--- a/path-analyser/src/ontology/crossRefValidator.ts
+++ b/path-analyser/src/ontology/crossRefValidator.ts
@@ -105,6 +105,7 @@ const OperationDomainRequirementsSchema = z
     disjunctions: z.array(z.array(z.string())).optional(),
     implicitAdds: z.array(z.string()).optional(),
     produces: z.array(z.string()).optional(),
+    chainCleanupRequires: z.array(z.string()).optional(),
     valueBindings: z.record(z.string(), z.string()).optional(),
   })
   .passthrough();

--- a/path-analyser/src/ontology/loader.ts
+++ b/path-analyser/src/ontology/loader.ts
@@ -550,6 +550,7 @@ export interface RuntimeStatesViews {
       disjunctions?: string[][];
       implicitAdds?: string[];
       produces?: string[];
+      chainCleanupRequires?: string[];
       valueBindings?: Record<string, string>;
     }
   >;
@@ -584,6 +585,8 @@ export function deriveRuntimeStatesViews(repoRoot: string): RuntimeStatesViews |
     if (r.disjunctions !== undefined) entry.disjunctions = r.disjunctions.map((d) => [...d]);
     if (r.implicitAdds !== undefined) entry.implicitAdds = [...r.implicitAdds];
     if (r.produces !== undefined) entry.produces = [...r.produces];
+    if (r.chainCleanupRequires !== undefined)
+      entry.chainCleanupRequires = [...r.chainCleanupRequires];
     if (r.valueBindings !== undefined) entry.valueBindings = { ...r.valueBindings };
     operationRequirements[r.operationId] = entry;
   }

--- a/path-analyser/src/ontology/runtimeStatesSchema.ts
+++ b/path-analyser/src/ontology/runtimeStatesSchema.ts
@@ -224,6 +224,12 @@ export const runtimeStatesSchema = {
           description:
             "Explicit producer override (rare — used when a state is produced by an op that does not appear in the state's `producedBy`). Each entry must reference a state in `states`.",
         },
+        chainCleanupRequires: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description:
+            'Post-condition hygiene states the chain should leave in place after this op runs, but which are NOT preconditions to invoking it (#249). Distinct from `requires` because the BFS scenario planner deliberately ignores this field — it never gates feasibility, never schedules a producer op, and never filters the op out. The fixture selector unions these states into the deployment-gateway requirement set so a fixture that provides them is preferred; subsequent ops in the chain whose `produces` / `implicitAdds` cover the state discharge the hygiene requirement. Encodes \'this op creates a resource that should be driven to a terminal state by test end\' — e.g. `createProcessInstance.chainCleanupRequires: ["ProcessInstanceCompleted"]` makes the base scenario deploy a self-completing fixture instead of leaving an orphan running instance.',
+        },
         valueBindings: {
           type: 'object',
           additionalProperties: { type: 'string', minLength: 1 },

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -579,6 +579,24 @@ export interface OperationDomainRequirements {
   disjunctions?: string[][]; // sets where one of each required
   implicitAdds?: string[]; // states produced implicitly on success
   produces?: string[]; // produced states (override)
+  /**
+   * Post-condition hygiene states the chain SHOULD leave in place after
+   * this op runs, but which are NOT preconditions to the op (#249). Unlike
+   * `requires`, this field is invisible to the BFS scenario planner — it
+   * never gates feasibility, never schedules producer ops, and never
+   * filters the op out. Its sole consumer is the fixture selector
+   * (`computeDeploymentRequiredStates`), which unions these states into
+   * the deployment-gateway requirement set so a fixture that provides them
+   * is preferred. Subsequent ops in the chain whose `produces` /
+   * `implicitAdds` include the state discharge the hygiene requirement.
+   *
+   * Used to encode "this op creates a resource that should be driven to a
+   * terminal state by the end of the test" — e.g. `createProcessInstance`
+   * declares `chainCleanupRequires: ["ProcessInstanceCompleted"]` so the
+   * base scenario deploys a self-completing fixture instead of leaving an
+   * orphan running instance.
+   */
+  chainCleanupRequires?: string[];
   valueBindings?: Record<string, string>; // request field -> state.parameter mapping
 }
 


### PR DESCRIPTION
Closes #249.

## Summary

`createProcessInstance`'s base feature test deployed `bpmn/service-task.bpmn` — a blocking fixture whose process waits indefinitely for a client to activate + complete its job. The chain never drove the instance to completion, leaving an orphan in the broker after every run.

Root cause: `createProcessInstance.requires` only listed `ProcessDefinitionDeployed`, so the residual fixture-requirement set was empty and tie-break fell through to registry-array order. service-task.bpmn happened to be first.

## Approach

Adds a new ontology field, `operationRequirements.<op>.chainCleanupRequires`, for post-condition hygiene states that should hold after the op runs but are NOT preconditions to invoking it. Encoded:

```json
"createProcessInstance": { "chainCleanupRequires": ["ProcessInstanceCompleted"], ... }
"completeJob":           { "produces": ["ProcessInstanceCompleted"] }
"cancelProcessInstance": { "produces": ["ProcessInstanceCompleted"] }
```

### Why not just overload `requires`

`operationRequirements.<op>.requires` doubles as a **hard BFS gate** in `path-analyser/src/scenarioGenerator.ts:297-302`. Adding `ProcessInstanceCompleted` there would either:
- filter `createProcessInstance` out of the scenario suite entirely (no producer ahead of the endpoint), or
- force BFS to schedule a discharger op (e.g. `completeJob`) *before* `createProcessInstance` — a nonsensical cycle (`completeJob` needs a job → a process instance → `createProcessInstance` must run first).

`chainCleanupRequires` is invisible to the BFS planner — it never gates feasibility, never schedules producer ops, never filters operations out. Its sole consumer is `computeDeploymentRequiredStates`, which unions it into the deployment-gateway requirement set and applies the same discharge subtraction (`produces` / `implicitAdds`) as `requires`.

## Fixture selection per chain after the change

| Chain | Residual at gateway | Picked fixture |
|---|---|---|
| `createDeployment → createProcessInstance` | `{ProcessInstanceCompleted}` | `bpmn/simple.bpmn` ✅ (was service-task) |
| `→ ... → completeJob` | `{ModelHasServiceTaskType}` | `bpmn/service-task.bpmn` (unchanged) |
| `→ ... → cancelProcessInstance` | `{ModelHasServiceTaskType}` | `bpmn/service-task.bpmn` (unchanged) |
| `→ ... → deleteProcessInstance` | `{ProcessInstanceCompleted}` | `bpmn/simple.bpmn` (unchanged) |
| `→ activateJobs` (no completion) | `{ModelHasServiceTaskType}` | `bpmn/service-task.bpmn` (unchanged) |

## Changes

**Schema / loader / types**:
- `path-analyser/src/types.ts` — add `chainCleanupRequires?: string[]` to `OperationDomainRequirements`.
- `path-analyser/src/ontology/runtimeStatesSchema.ts` — add to JSON Schema source-of-truth.
- `path-analyser/src/ontology/loader.ts` — extend view interface + derivation.
- `path-analyser/src/ontology/crossRefValidator.ts` — extend zod schema.
- `ontology/vocabulary/runtime-states.schema.json` — regenerated via `npm run build:ontology`.

**Logic** (2-line change):
- `path-analyser/src/index.ts` — `computeDeploymentRequiredStates` now unions `chainCleanupRequires` alongside `requires`. Same subtraction logic for produces/implicitAdds discharge.

**Data**:
- `configs/camunda-oca/ontology/runtime-states.json` — declare the field on createProcessInstance + add operationRequirements entries for completeJob and cancelProcessInstance.

**L3 invariant**:
- `configs/camunda-oca/regression-invariants.test.ts` — new test asserts `createProcessInstance.feature.spec.ts` deploys `bpmn/simple.bpmn` and not `bpmn/service-task.bpmn`. Existing fixture-selection invariants for deleteProcessInstance/activateJobs continue to pass.

## Verification

Full pre-push gate ran clean:
- biome lint
- 5 workspace typechecks + tests/tsconfig
- `npm run build:analyser`, `npm run build:emitter-sdk`, `npm run build:ontology`
- `TEST_SEED=snapshot-baseline npm run testsuite:generate` + `npm run generate:request-validation`
- `npm test` — **512 passed**, 6 skipped (was 511; +1 for the new L3 invariant)

Spot-checked the regenerated `createProcessInstance.feature.spec.ts` — all three deploy call sites reference `bpmn/simple.bpmn`.

## Follow-up (out of scope)

The fixture-selector fallback path (`path-analyser/src/index.ts:1477-1483`) silently picks the first registered candidate when no fixture covers the residual — e.g. a chain `createDeployment → createProcessInstance → activateJobs → searchJobs` (no completer) now has residual `{ProcessInstanceCompleted, ModelHasServiceTaskType}` which neither fixture provides. The fallback hides this misconfiguration. Tightening it into a planner-emitted `missingFixture` annotation guarded by an L3 invariant is a separate cleanup tracked in the issue body.