### PR TITLE
refactor: retire response.* valueBindings; auto-derive from graph (#251)

### DIFF
--- a/configs/camunda-oca/ontology/runtime-states.json
+++ b/configs/camunda-oca/ontology/runtime-states.json
@@ -87,9 +87,7 @@
         "ProcessInstanceCompleted"
       ],
       "valueBindings": {
-        "request.processDefinitionId": "ProcessDefinitionDeployed.processDefinitionId",
-        "request.processDefinitionKey": "semantic:ProcessDefinitionKey",
-        "response.processInstanceKey": "semantic:ProcessInstanceKey"
+        "request.processDefinitionId": "ProcessDefinitionDeployed.processDefinitionId"
       }
     },
     {
@@ -141,14 +139,6 @@
       "requires": [
         "ProcessInstanceCompleted"
       ]
-    },
-    {
-      "operationId": "createDeployment",
-      "valueBindings": {
-        "response.deployments[].processDefinition.processDefinitionId": "ProcessDefinitionDeployed.processDefinitionId",
-        "response.deployments[].processDefinition.processDefinitionKey": "semantic:ProcessDefinitionKey",
-        "response.deployments[].form.formKey": "FormDeployed.formKey"
-      }
     },
     {
       "operationId": "searchProcessDefinitions",

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -5515,3 +5515,106 @@ describeForThisConfig(
     });
   },
 );
+
+describeForThisConfig(
+  'bundled-spec invariants: response extract autoderivation parity (#251)',
+  () => {
+    // Class-scoped invariant pinning the refactor in #251.
+    //
+    // Defect class avoided: when the planner drops the ABox-declared
+    // `response.*` valueBindings (which the spec already encodes via
+    // `x-semantic-provider: [...]` on the response container schemas,
+    // surfaced into the graph as `responseSemanticLeaves[].provider`),
+    // the emitted `step.extract` blocks must still bind every
+    // identifier-shaped semantic that earlier steps need to satisfy
+    // downstream URL placeholders and request bodies. Forgetting any
+    // of these pairs reintroduces the "${...Var}" leak class that
+    // motivated the original ABox entries.
+    //
+    // The invariant lists the specific (operationId, fieldPath, bind)
+    // triples the ABox used to encode. Each triple must appear on the
+    // matching prerequisite step in at least one emitted feature
+    // scenario. Asserting per-triple (rather than over the full
+    // extract list per step) keeps the guard stable across legitimate
+    // planner changes that add or reorder unrelated extracts.
+    interface ExtractLite {
+      fieldPath: string;
+      bind: string;
+    }
+    interface RequestStepLite {
+      operationId: string;
+      extract?: ExtractLite[];
+    }
+    interface ScenarioLite {
+      requestPlan?: RequestStepLite[];
+    }
+    interface CollectionLite {
+      scenarios: ScenarioLite[];
+    }
+
+    const requiredTriples: { operationId: string; fieldPath: string; bind: string }[] = [
+      // createDeployment — formerly declared in
+      // configs/camunda-oca/ontology/runtime-states.json valueBindings.
+      // `[0]` matches the planner's `[]` -> `[0]` first-element
+      // normalisation (path-analyser/src/index.ts).
+      {
+        operationId: 'createDeployment',
+        fieldPath: 'deployments[0].processDefinition.processDefinitionId',
+        bind: 'processDefinitionIdVar',
+      },
+      {
+        operationId: 'createDeployment',
+        fieldPath: 'deployments[0].processDefinition.processDefinitionKey',
+        bind: 'processDefinitionKeyVar',
+      },
+      {
+        operationId: 'createDeployment',
+        fieldPath: 'deployments[0].form.formKey',
+        bind: 'formKeyVar',
+      },
+      // createProcessInstance — formerly `response.processInstanceKey`.
+      {
+        operationId: 'createProcessInstance',
+        fieldPath: 'processInstanceKey',
+        bind: 'processInstanceKeyVar',
+      },
+    ];
+
+    it('every triple from the retired ABox response.* valueBindings is still emitted by some scenario', () => {
+      if (!existsSync(FEATURE_SCENARIOS_DIR)) {
+        throw new Error(
+          `Feature-output directory not found at ${FEATURE_SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+        );
+      }
+      const seenTriples = new Set<string>();
+      for (const f of readdirSync(FEATURE_SCENARIOS_DIR)) {
+        if (!f.endsWith('-scenarios.json')) continue;
+        // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+        const file = JSON.parse(
+          readFileSync(join(FEATURE_SCENARIOS_DIR, f), 'utf8'),
+        ) as CollectionLite;
+        for (const sc of file.scenarios) {
+          for (const step of sc.requestPlan ?? []) {
+            for (const ex of step.extract ?? []) {
+              seenTriples.add(`${step.operationId}::${ex.fieldPath}::${ex.bind}`);
+            }
+          }
+        }
+      }
+      const missing = requiredTriples.filter(
+        (t) => !seenTriples.has(`${t.operationId}::${t.fieldPath}::${t.bind}`),
+      );
+      expect(
+        missing,
+        `Missing ${missing.length} (operationId, fieldPath, bind) triple(s) ` +
+          `that the retired ABox response.* valueBindings used to encode. ` +
+          `If the planner's responseSemanticTypes-driven extract emission ` +
+          `(path-analyser/src/index.ts ~540-565) regresses, these binds ` +
+          `disappear from the prereq step and downstream URL/body templates ` +
+          `leak unresolved \`\${...Var}\` literals. Missing:\n${missing
+            .map((t) => `  - ${t.operationId} :: ${t.fieldPath} -> ${t.bind}`)
+            .join('\n')}`,
+      ).toEqual([]);
+    });
+  },
+);

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -64,18 +64,33 @@ async function main() {
   const graph = await loadGraph(baseDir);
   // Build canonical deep schema shapes (requests + responses)
   const canonical = await buildCanonicalShapes(path.resolve(baseDir, '../'));
-  // Validate domain valueBindings against canonical response paths (fail-hard soon; warn now)
+  // Drift guard: every response-side semantic leaf reported by the
+  // extractor must resolve in the canonical response shape produced by
+  // the bundler. Mismatch points at an extractor↔bundler divergence
+  // (e.g. one walked through an allOf branch the other didn't), which
+  // would silently produce response extracts whose fieldPath cannot be
+  // navigated at runtime.
+  //
+  // Pre-#251 this guard validated `domain.operationRequirements[*].valueBindings['response.*']`
+  // LHSs against the canonical shape. Those entries were retired in
+  // #251 once the planner began auto-deriving response extracts from
+  // `responseSemanticLeaves` (sourced from `x-semantic-provider` on
+  // the spec), so the guard now reads from the same source the planner
+  // uses — the graph — instead of from the ABox.
   const validationErrors: string[] = [];
-  const opReqs = graph.domain?.operationRequirements || {};
-  for (const [opId, req] of Object.entries(opReqs)) {
-    if (!req.valueBindings) continue;
+  for (const [opId, op] of Object.entries(graph.operations)) {
+    const leaves = op.responseSemanticLeaves;
+    if (!leaves?.length) continue;
     const shape = canonical[opId];
-    const respSet = new Set((shape?.response || []).map((n) => n.path));
-    for (const key of Object.keys(req.valueBindings)) {
-      if (!key.startsWith('response.')) continue;
-      const raw = key.slice('response.'.length).replace(/\[\]/g, '[]');
-      if (!respSet.has(raw)) {
-        validationErrors.push(`${opId}: '${raw}' not in canonical response shape`);
+    if (!shape) continue;
+    const respSet = new Set((shape.response || []).map((n) => n.path));
+    const seen = new Set<string>();
+    for (const leaf of leaves) {
+      if (!leaf.provider) continue;
+      if (seen.has(leaf.fieldPath)) continue;
+      seen.add(leaf.fieldPath);
+      if (!respSet.has(leaf.fieldPath)) {
+        validationErrors.push(`${opId}: '${leaf.fieldPath}' not in canonical response shape`);
       }
     }
   }
@@ -472,34 +487,12 @@ function buildRequestPlan(
         ),
       },
     };
-    // Domain valueBindings driven response extraction (non-final steps included)
-    const opDom = graph.domain?.operationRequirements?.[opRef.operationId];
-    if (opDom?.valueBindings) {
-      const extracts: { fieldPath: string; bind: string; note?: string }[] = [];
-      for (const [k, v] of Object.entries(opDom.valueBindings)) {
-        if (!k.startsWith('response.')) continue; // only handle response mappings here
-        const fieldPathRaw = k.slice('response.'.length); // canonical path with [] markers
-        const norm = fieldPathRaw.replace(/\[\]/g, '[0]'); // first element access for arrays
-        // #70: under the new grammar `semantic:<SemanticType>`, the binding
-        // variable is derived from the LHS field-path leaf instead of from
-        // the RHS state.parameter pair (which the typed-dataflow lens replaces).
-        const mapping = v;
-        const isSemantic = mapping.startsWith('semantic:');
-        const paramPart = isSemantic
-          ? (fieldPathRaw.split('.').pop() ?? '')
-          : (mapping.split('.').pop() ?? '');
-        let bind = `${camelCase(paramPart)}Var`;
-        if (k.endsWith('$key')) {
-          // explicit key semantic mapping
-          bind = `${camelCase(paramPart.replace(/Id$/, 'Key'))}Var`;
-        }
-        // Ensure binding variable exists in scenario.bindings placeholder if not set
-        scenario.bindings ||= {};
-        if (!scenario.bindings[bind]) scenario.bindings[bind] = `__PENDING__`;
-        extracts.push({ fieldPath: norm, bind, note: 'domainBinding' });
-      }
-      if (extracts.length) step.extract = extracts;
-    }
+    // The legacy `response.*` valueBindings-driven extract block was
+    // retired in #251 — the ABox no longer carries `response.*` entries
+    // because the planner now auto-derives the equivalent extracts from
+    // `graph.operations[opId].responseSemanticTypes` (sourced from
+    // `x-semantic-provider` on the spec). See the producer-step block
+    // further down.
     // Canonical request body synthesis for POST/PUT/PATCH using requestByMediaType
     if (['POST', 'PUT', 'PATCH'].includes(opRef.method)) {
       const plan = buildRequestBodyFromCanonical(
@@ -537,6 +530,25 @@ function buildRequestPlan(
     // Without this, a grafted prerequisite chain could exist but never
     // populate the URL var, leaving `${...Var}` literally in the emitted
     // URL.
+    // Producer-step auto-derive: emit semantic-labeled extracts from
+    // the dependency graph's `responseSemanticTypes` (which captures
+    // nested fieldPaths like `metadata.processInstanceKey`, unlike
+    // `extractSchemas.flattenTopLevelFields` which only sees top-level).
+    // Without this, a grafted prerequisite chain could exist but never
+    // populate the URL var, leaving `${...Var}` literally in the
+    // emitted URL.
+    //
+    // Pre-#251 the equivalent extracts on FINAL steps were also seeded
+    // by the now-retired ABox `response.*` valueBindings (see the block
+    // higher up in this function). Final-step behaviour is preserved
+    // by `resp.fields` (top-level leaves) above; nested leaves on a
+    // final step were extracted into ctx vars that no later step
+    // consumes, so dropping them is behaviour-preserving for runtime
+    // semantics. The L3 invariant in
+    // configs/camunda-oca/regression-invariants.test.ts pins the
+    // specific (op, fieldPath, bind) triples that downstream URL and
+    // body templates rely on (each of which appears as a non-final
+    // prereq in some scenario, where this block emits it).
     if (!isFinal) {
       const stepNode = graph.operations[opRef.operationId];
       const stepSuccess = successStatusByOp[opRef.operationId];
@@ -550,8 +562,7 @@ function buildRequestPlan(
           // semantic-graph-extractor emits array item paths with `[]`
           // markers (schema-analyzer.ts: `${fieldPath}[]`). The Playwright
           // emitter's accessor builder expects numeric indices, so
-          // normalise to first-element access — same convention used for
-          // domainBinding extracts above.
+          // normalise to first-element access.
           const fieldPath = entry.fieldPath.replace(/\[\]/g, '[0]');
           extract.push({
             fieldPath,

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -74,19 +74,32 @@ async function main() {
   // Pre-#251 this guard validated `domain.operationRequirements[*].valueBindings['response.*']`
   // LHSs against the canonical shape. Those entries were retired in
   // #251 once the planner began auto-deriving response extracts from
-  // `responseSemanticLeaves` (sourced from `x-semantic-provider` on
-  // the spec), so the guard now reads from the same source the planner
-  // uses — the graph — instead of from the ABox.
+  // the dependency graph (`responseSemanticTypes` / `responseSemanticLeaves`,
+  // both populated from `x-semantic-type` on response fields; the
+  // `provider` flag tracked here is the authoritative-producer signal
+  // sourced from the container's `x-semantic-provider: [...]` array).
+  // The guard now reads from the same source the planner uses — the
+  // graph — instead of from the ABox.
   const validationErrors: string[] = [];
   for (const [opId, op] of Object.entries(graph.operations)) {
     const leaves = op.responseSemanticLeaves;
     if (!leaves?.length) continue;
+    const providerLeaves = leaves.filter((l) => l.provider);
+    if (providerLeaves.length === 0) continue;
     const shape = canonical[opId];
-    if (!shape) continue;
+    if (!shape) {
+      // An op with `provider:true` response leaves MUST have a 2xx
+      // JSON response shape; otherwise the extractor lifted a leaf
+      // from a response the bundler didn't materialise — a true
+      // extractor↔bundler divergence. Fail loud rather than skip.
+      validationErrors.push(
+        `${opId}: extractor reported ${providerLeaves.length} provider:true response leaf(s) but bundler produced no canonical response shape`,
+      );
+      continue;
+    }
     const respSet = new Set((shape.response || []).map((n) => n.path));
     const seen = new Set<string>();
-    for (const leaf of leaves) {
-      if (!leaf.provider) continue;
+    for (const leaf of providerLeaves) {
       if (seen.has(leaf.fieldPath)) continue;
       seen.add(leaf.fieldPath);
       if (!respSet.has(leaf.fieldPath)) {
@@ -490,9 +503,15 @@ function buildRequestPlan(
     // The legacy `response.*` valueBindings-driven extract block was
     // retired in #251 — the ABox no longer carries `response.*` entries
     // because the planner now auto-derives the equivalent extracts from
-    // `graph.operations[opId].responseSemanticTypes` (sourced from
-    // `x-semantic-provider` on the spec). See the producer-step block
-    // further down.
+    // `graph.operations[opId].responseSemanticTypes` (populated from
+    // `x-semantic-type` on response field schemas). See the producer-
+    // step block further down. (The authoritative-producer signal
+    // sourced from `x-semantic-provider: [...]` lives on
+    // `responseSemanticLeaves[].provider`, not on
+    // `responseSemanticTypes` entries; the auto-derive intentionally
+    // emits an extract for every annotated leaf, not just
+    // provider:true ones, because some scenarios consume non-provider
+    // identifier echoes for downstream filters.)
     // Canonical request body synthesis for POST/PUT/PATCH using requestByMediaType
     if (['POST', 'PUT', 'PATCH'].includes(opRef.method)) {
       const plan = buildRequestBodyFromCanonical(
@@ -523,28 +542,22 @@ function buildRequestPlan(
       }
       if (extract.length) step.extract = (step.extract || []).concat(extract);
     }
-    // Non-final producer steps: emit semantic-labeled extracts using the
-    // dependency graph's `responseSemanticTypes` (which captures nested
-    // fieldPaths like `metadata.processInstanceKey`, unlike
-    // `extractSchemas.flattenTopLevelFields` which only sees top-level).
-    // Without this, a grafted prerequisite chain could exist but never
-    // populate the URL var, leaving `${...Var}` literally in the emitted
-    // URL.
     // Producer-step auto-derive: emit semantic-labeled extracts from
-    // the dependency graph's `responseSemanticTypes` (which captures
-    // nested fieldPaths like `metadata.processInstanceKey`, unlike
-    // `extractSchemas.flattenTopLevelFields` which only sees top-level).
-    // Without this, a grafted prerequisite chain could exist but never
-    // populate the URL var, leaving `${...Var}` literally in the
-    // emitted URL.
+    // the dependency graph's `responseSemanticTypes` (populated from
+    // `x-semantic-type` on response field schemas, including nested
+    // paths like `metadata.processInstanceKey` — unlike
+    // `extractSchemas.flattenTopLevelFields`, which only sees
+    // top-level). Without this, a grafted prerequisite chain could
+    // exist but never populate the URL var, leaving `${...Var}`
+    // literally in the emitted URL.
     //
     // Pre-#251 the equivalent extracts on FINAL steps were also seeded
-    // by the now-retired ABox `response.*` valueBindings (see the block
-    // higher up in this function). Final-step behaviour is preserved
-    // by `resp.fields` (top-level leaves) above; nested leaves on a
-    // final step were extracted into ctx vars that no later step
-    // consumes, so dropping them is behaviour-preserving for runtime
-    // semantics. The L3 invariant in
+    // by the now-retired ABox `response.*` valueBindings (see the
+    // comment higher up in this function). Final-step behaviour is
+    // preserved by `resp.fields` (top-level leaves) above; nested
+    // leaves on a final step were extracted into ctx vars that no
+    // later step consumes, so dropping them is behaviour-preserving
+    // for runtime semantics. The L3 invariant in
     // configs/camunda-oca/regression-invariants.test.ts pins the
     // specific (op, fieldPath, bind) triples that downstream URL and
     // body templates rely on (each of which appears as a non-final


### PR DESCRIPTION
Closes #251.

## What

Retires the `response.*` entries in `configs/camunda-oca/ontology/runtime-states.json` `valueBindings`. Those entries were duplicating information the dependency graph already carries via `responseSemanticLeaves[].provider:true` (sourced from `x-semantic-provider: [...]` on the spec's response container schemas).

Also retires the redundant `request.processDefinitionKey: semantic:ProcessDefinitionKey` entry on `createProcessInstance` — the request-side `semanticFallback` auto-derive in `6b79d5b` already covers the `semantic:T` request grammar.

Legacy `request.X: State.parameter` entries (e.g. `createProcessInstance.request.processDefinitionId: ProcessDefinitionDeployed.processDefinitionId`, `activateJobs.request.jobType: ModelHasServiceTaskType.jobType`) stay — those encode the state→parameter projection and are not yet derivable from the graph.

## How

1. **New L3 invariant** (`configs/camunda-oca/regression-invariants.test.ts`) — `response extract autoderivation parity (#251)` — pins the specific `(operationId, fieldPath, bind)` triples that the retired ABox entries used to encode. Added and proven green against the **pre-refactor** pipeline output (AGENTS.md green/green).

2. **Drift guard rewrite** (`path-analyser/src/index.ts:67-89`) — pre-#251 the canonical-path validator iterated `domain.operationRequirements[*].valueBindings['response.*']` LHSs. Now it iterates `graph.operations[*].responseSemanticLeaves` filtered to `provider:true` — same drift signal (extractor↔bundler), sourced from the graph instead of the ABox.

3. **Dead-code removal** — the `domainBinding` response-extract loop (formerly at `index.ts:475-502`) is replaced by a short comment pointing to the producer-step block that already handles it.

4. **ABox cleanup** (`configs/camunda-oca/ontology/runtime-states.json`) — three `response.*` entries removed, one redundant `request.*: semantic:T` entry removed, the bare `createDeployment` entry dropped.

## Behavioural diff

Captured baseline `step.extract` blocks across all 1100+ scenarios in `generated/camunda-oca/feature-output/` before the refactor and re-diffed after. Only two changes, both behaviour-preserving:

- **4 dead extracts dropped** on `createDeployment`-as-final-step scenarios. The lost binds (`processDefinitionIdVar`, `processDefinitionKeyVar`, `formKeyVar`) are extracted into ctx vars that no later step consumes — `createDeployment` IS the endpoint in those scenarios. Same `createDeployment` op appears as a non-final prereq in many other scenarios, where the auto-derive block emits the equivalents (verified by the new L3 invariant).
- **3 duplicate `processInstanceKey → processInstanceKeyVar` extracts deduped** on final `createProcessInstance`. The legacy block was emitting the same extract that the final-step `resp.fields` block also emitted — strict improvement.

No bindings consumed by any URL or body template are lost. The new L3 invariant pins the runtime-relevant triples directly.

## Verification

- `npm run lint` — passes (5 pre-existing warnings, no errors).
- `npx tsc --noEmit` across all 6 workspace tsconfigs — passes.
- `TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation` — pipeline regenerates cleanly.
- `npm test` — **513 tests pass**, 6 pre-existing skipped.
