### PR TITLE
feat: generalise GeneratedModelSpec to { kind, bindings } (#253)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -5618,3 +5618,152 @@ describeForThisConfig(
     });
   },
 );
+
+// ---------------------------------------------------------------------------
+// Lift 13 (#253): generalised GeneratedModelSpec shape.
+//
+// Before Lift 13, the planner emitted closed-union `models[]` entries like
+// `{ kind: 'bpmn', processDefinitionIdVar: 'X' }` / `{ kind: 'form',
+// formKeyVar: 'X' }`. The closed union meant any ABox `modelKind` value
+// outside `'bpmn'` / `'form'` was silently dropped by the construction
+// branches in `ensureArtifactBindings`. Lift 13 generalises the type to
+// `{ kind: string; bindings: Record<string, string>; metadata?: ... }` and
+// replaces the per-kind arms with a single generic builder so any declared
+// `modelKind` produces a structured entry.
+//
+// These invariants pin the new shape on the emitted scenario JSON; they
+// were red on `main` (where the legacy union shape ships) and went green
+// after Lift 13 landed.
+// ---------------------------------------------------------------------------
+
+describe.skipIf(CONFIG_NAME !== 'camunda-oca')(
+  'bundled-spec invariants: GeneratedModelSpec generic shape (Lift 13 / #253)',
+  () => {
+    interface ModelSpecLite {
+      kind: string;
+      bindings?: Record<string, string>;
+      metadata?: Record<string, unknown>;
+      // Legacy fields that must NOT appear after Lift 13.
+      processDefinitionIdVar?: string;
+      formKeyVar?: string;
+      serviceTasks?: unknown;
+    }
+    interface ScenarioWithModels {
+      id?: string;
+      models?: ModelSpecLite[];
+    }
+    interface CollectionWithModels {
+      scenarios: ScenarioWithModels[];
+    }
+
+    function loadAllModelsEntries(): { file: string; scenarioId: string; spec: ModelSpecLite }[] {
+      if (!existsSync(SCENARIOS_DIR)) {
+        throw new Error(
+          `Scenarios directory not found at ${SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+        );
+      }
+      const out: { file: string; scenarioId: string; spec: ModelSpecLite }[] = [];
+      for (const f of readdirSync(SCENARIOS_DIR)) {
+        if (!f.endsWith('-scenarios.json')) continue;
+        // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+        const file = JSON.parse(
+          readFileSync(join(SCENARIOS_DIR, f), 'utf8'),
+        ) as CollectionWithModels;
+        for (const sc of file.scenarios) {
+          for (const m of sc.models ?? []) {
+            out.push({ file: f, scenarioId: sc.id ?? '?', spec: m });
+          }
+        }
+      }
+      return out;
+    }
+
+    it('every emitted models[] entry uses the generic { kind, bindings } shape (no legacy top-level fields)', () => {
+      const offenders: string[] = [];
+      for (const { file, scenarioId, spec } of loadAllModelsEntries()) {
+        if (typeof spec.kind !== 'string' || spec.kind.length === 0) {
+          offenders.push(`${file}::${scenarioId} — missing/empty 'kind'`);
+          continue;
+        }
+        if (!spec.bindings || typeof spec.bindings !== 'object') {
+          offenders.push(`${file}::${scenarioId} — missing 'bindings' map`);
+          continue;
+        }
+        if (spec.processDefinitionIdVar !== undefined) {
+          offenders.push(
+            `${file}::${scenarioId} — legacy top-level 'processDefinitionIdVar' still present (should live in bindings.processDefinitionId)`,
+          );
+        }
+        if (spec.formKeyVar !== undefined) {
+          offenders.push(
+            `${file}::${scenarioId} — legacy top-level 'formKeyVar' still present (should live in bindings.formKey)`,
+          );
+        }
+        if (spec.serviceTasks !== undefined) {
+          offenders.push(
+            `${file}::${scenarioId} — legacy top-level 'serviceTasks' still present (should live in metadata.serviceTasks)`,
+          );
+        }
+        for (const [role, varName] of Object.entries(spec.bindings)) {
+          if (typeof varName !== 'string' || varName.length === 0) {
+            offenders.push(
+              `${file}::${scenarioId} — bindings['${role}'] is not a non-empty string`,
+            );
+          }
+        }
+      }
+      expect(
+        offenders,
+        `Found ${offenders.length} models[] entries violating the Lift 13 generic shape:\n${offenders.slice(0, 20).join('\n')}`,
+      ).toEqual([]);
+    });
+
+    it('every realised models[] kind is declared in the ABox (no orphan kinds; the generic builder dispatches by ABox modelKind)', async () => {
+      const { loadGraph } = await import('../../path-analyser/src/graphLoader.js');
+      const graph = await loadGraph(join(REPO_ROOT, 'path-analyser'));
+      const kinds = graph.domain?.artifactKinds ?? {};
+      const declaredModelKinds = new Set<string>();
+      for (const k of Object.values(kinds)) {
+        if (k.modelKind) declaredModelKinds.add(k.modelKind);
+      }
+      // Sanity: the ABox declares at least one modelKind (otherwise this
+      // invariant is vacuous).
+      expect(declaredModelKinds.size).toBeGreaterThan(0);
+
+      const seenKinds = new Set<string>();
+      for (const { spec } of loadAllModelsEntries()) {
+        seenKinds.add(spec.kind);
+      }
+      // Every kind the planner actually emits to models[] must be a kind
+      // the ABox declares. Before Lift 13 this was a tautology: only the
+      // hard-coded `'bpmn'`/`'form'` arms could emit, and both were known
+      // ABox values. After Lift 13 the generic builder dispatches by
+      // whatever `modelKind` the ABox returns, so if a typo or stale entry
+      // ever sneaks a kind into models[] that nothing declares, the
+      // structural symmetry breaks — that's the regression this guards.
+      const orphans = [...seenKinds].filter((k) => !declaredModelKinds.has(k));
+      expect(
+        orphans,
+        `Emitted models[] entries reference kind(s) [${orphans.join(', ')}] not declared in artifact-kinds.json. ABox declares: [${[...declaredModelKinds].join(', ')}]`,
+      ).toEqual([]);
+    });
+
+    it('bpmn entries bind processDefinitionId; form entries bind formKey (planner-internal role conventions)', () => {
+      const offenders: string[] = [];
+      for (const { file, scenarioId, spec } of loadAllModelsEntries()) {
+        if (spec.kind === 'bpmn' && !spec.bindings?.processDefinitionId) {
+          offenders.push(
+            `${file}::${scenarioId} — bpmn entry missing bindings.processDefinitionId`,
+          );
+        }
+        if (spec.kind === 'form' && !spec.bindings?.formKey) {
+          offenders.push(`${file}::${scenarioId} — form entry missing bindings.formKey`);
+        }
+      }
+      expect(
+        offenders,
+        `Per-kind binding-role conventions violated:\n${offenders.slice(0, 20).join('\n')}`,
+      ).toEqual([]);
+    });
+  },
+);

--- a/ontology/vocabulary/artifact-kinds.schema.json
+++ b/ontology/vocabulary/artifact-kinds.schema.json
@@ -118,7 +118,7 @@
         "modelKind": {
           "type": "string",
           "minLength": 1,
-          "description": "Optional discriminator naming the `GeneratedModelSpec` variant the planner should construct when this kind is selected (Lift 10 / #227). Conventional values: `bpmn`, `form`. The planner consults this field via the ABox to pick the model-spec shape, replacing hard-coded semantic→kind comparisons in `ensureArtifactBindings`. Until the `GeneratedModelSpec` discriminated union is generalised (Lift 13), only the conventional values produce model-spec entries; other values are silently ignored by the model-spec construction step."
+          "description": "Optional discriminator naming the `GeneratedModelSpec` variant the planner should construct when this kind is selected (Lift 10 / #227). Conventional values: `bpmn`, `form`. The planner consults this field via the ABox to pick the model-spec shape, replacing hard-coded semantic→kind comparisons in `ensureArtifactBindings`. Lift 13 / #253: any value declared here produces a structured `models[]` entry of the form `{ kind, bindings: { <primary-role>: <varName> } }`; per-kind primary-binding-role names live in `path-analyser/src/modelSpecBuilders.ts` (`bpmn` → `processDefinitionId`, `form` → `formKey`, others default to `identifier`)."
         },
         "description": {
           "type": "string",

--- a/path-analyser/src/modelSpecBuilders.ts
+++ b/path-analyser/src/modelSpecBuilders.ts
@@ -1,0 +1,79 @@
+// Per-`modelKind` constructor helpers for `GeneratedModelSpec`.
+//
+// The planner needs to mint model-spec entries from two distinct sources:
+//   1. The ABox-driven `ensureArtifactBindings` path, which knows the
+//      semantic identifier var name minted for a given semantic type and
+//      the `modelKind` declared on the matching artifact-kind ABox entry.
+//   2. A small set of legacy heuristic fallbacks in `scenarioGenerator.ts`
+//      that fire when no ABox path produced models for the deployment-
+//      gateway operation (e.g. a chain that never asserted a
+//      `ProcessDefinitionKey` requirement but still needs a deployment).
+//
+// Both paths used to spell out `{ kind: 'bpmn', processDefinitionIdVar: …,
+// serviceTasks: … }` inline. After Lift 13 (#253) the shape lives behind
+// these helpers so:
+//   - the per-kind binding-role names (`processDefinitionId`, `formKey`)
+//     have a single declaration site, and
+//   - adding a new kind (e.g. `dmn`) is a one-line registry update rather
+//     than a new branch in `ensureArtifactBindings`.
+
+import type { GeneratedModelSpec } from './types.js';
+
+/**
+ * Per-kind primary binding-role name. The role is the key under
+ * `GeneratedModelSpec.bindings` that carries the "main" identifier var for
+ * that kind (the one downstream test code uses to refer to the deployed
+ * model). New kinds fall back to `'identifier'`.
+ */
+const PRIMARY_BINDING_ROLE: Record<string, string> = {
+  bpmn: 'processDefinitionId',
+  form: 'formKey',
+};
+
+/**
+ * Resolve the primary binding-role for a given `modelKind`. Used by the
+ * planner to find / dedupe an existing spec for that kind+var pair.
+ */
+export function primaryBindingRoleFor(kind: string): string {
+  return PRIMARY_BINDING_ROLE[kind] ?? 'identifier';
+}
+
+/**
+ * Build a generic `GeneratedModelSpec` for `kind` whose primary binding
+ * role maps to `varName`. Used by the ABox-driven path in
+ * `ensureArtifactBindings`.
+ */
+export function buildModelSpec(kind: string, varName: string): GeneratedModelSpec {
+  return { kind, bindings: { [primaryBindingRoleFor(kind)]: varName } };
+}
+
+/**
+ * Build a BPMN `GeneratedModelSpec` with optional `serviceTasks` metadata.
+ * Used by the legacy deployment-gateway fallback heuristics that mint a
+ * `processDefinitionIdVar1` placeholder when no ABox path drove model
+ * selection.
+ */
+export function buildBpmnModelSpec(
+  processDefinitionIdVar: string,
+  serviceTasks?: { id: string; typeVar: string }[],
+): GeneratedModelSpec {
+  const spec: GeneratedModelSpec = {
+    kind: 'bpmn',
+    bindings: { processDefinitionId: processDefinitionIdVar },
+  };
+  if (serviceTasks?.length) spec.metadata = { serviceTasks };
+  return spec;
+}
+
+/**
+ * Locate an existing spec in `drafts` whose `kind` and primary binding
+ * role's variable name match. Used to dedupe before appending.
+ */
+export function findModelSpec(
+  drafts: GeneratedModelSpec[],
+  kind: string,
+  varName: string,
+): GeneratedModelSpec | undefined {
+  const role = primaryBindingRoleFor(kind);
+  return drafts.find((m) => m.kind === kind && m.bindings[role] === varName);
+}

--- a/path-analyser/src/ontology/artifactKindsSchema.ts
+++ b/path-analyser/src/ontology/artifactKindsSchema.ts
@@ -151,7 +151,7 @@ export const artifactKindsSchema = {
           type: 'string',
           minLength: 1,
           description:
-            'Optional discriminator naming the `GeneratedModelSpec` variant the planner should construct when this kind is selected (Lift 10 / #227). Conventional values: `bpmn`, `form`. The planner consults this field via the ABox to pick the model-spec shape, replacing hard-coded semantic→kind comparisons in `ensureArtifactBindings`. Until the `GeneratedModelSpec` discriminated union is generalised (Lift 13), only the conventional values produce model-spec entries; other values are silently ignored by the model-spec construction step.',
+            'Optional discriminator naming the `GeneratedModelSpec` variant the planner should construct when this kind is selected (Lift 10 / #227). Conventional values: `bpmn`, `form`. The planner consults this field via the ABox to pick the model-spec shape, replacing hard-coded semantic→kind comparisons in `ensureArtifactBindings`. Lift 13 / #253: any value declared here produces a structured `models[]` entry of the form `{ kind, bindings: { <primary-role>: <varName> } }`; per-kind primary-binding-role names live in `path-analyser/src/modelSpecBuilders.ts` (`bpmn` → `processDefinitionId`, `form` → `formKey`, others default to `identifier`).',
         },
         description: {
           type: 'string',

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -1,5 +1,6 @@
 import { bindSemanticInput } from './bindSemanticInput.js';
 import { deterministicSuffix } from './deterministicSuffix.js';
+import { buildBpmnModelSpec, buildModelSpec, findModelSpec } from './modelSpecBuilders.js';
 import { getModelKindForSemantic } from './ontology/artifactModelKinds.js';
 import { findDeploymentGatewayOpId, isDeploymentGatewayOp } from './ontology/operationRoles.js';
 import type {
@@ -322,13 +323,12 @@ export function generateScenariosForEndpoint(
             // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder consumed by the test runtime
             bindings.jobTypeVar1 = 'jobType_${RANDOM}';
           models = [
-            {
-              kind: 'bpmn',
-              processDefinitionIdVar: 'processDefinitionIdVar1',
-              serviceTasks: state.ops.includes('activateJobs')
+            buildBpmnModelSpec(
+              'processDefinitionIdVar1',
+              state.ops.includes('activateJobs')
                 ? [{ id: 'task1', typeVar: 'jobTypeVar1' }]
                 : undefined,
-            },
+            ),
           ];
         }
         const scenario: EndpointScenario = {
@@ -698,7 +698,7 @@ export function generateScenariosForEndpoint(
       if (isDeploymentGatewayOp(graph.domain, producerOpId) && !modelsDraft) {
         // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder consumed by the test runtime
         bindingsDraft.processDefinitionIdVar1 = 'proc_${RANDOM}';
-        modelsDraft = [{ kind: 'bpmn', processDefinitionIdVar: 'processDefinitionIdVar1' }];
+        modelsDraft = [buildBpmnModelSpec('processDefinitionIdVar1')];
       }
       // Identifier heuristic: assign vars for newly added semantics ending with 'Key'.
       // Only applies to semantics that have no authoritative producer — producerBound
@@ -1200,7 +1200,7 @@ function deferForMissingDomainPrereqs(
     if (isDeploymentGatewayOp(graph.domain, candidateOpId) && !modelsDraft) {
       // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder consumed by the test runtime
       bindingsDraft.processDefinitionIdVar1 = 'proc_${RANDOM}';
-      modelsDraft = [{ kind: 'bpmn', processDefinitionIdVar: 'processDefinitionIdVar1' }];
+      modelsDraft = [buildBpmnModelSpec('processDefinitionIdVar1')];
     }
     const sig = signature(newOps, newProduced, newNeeded, nextCycle);
     if (seen.has(sig)) continue;
@@ -1485,19 +1485,15 @@ function ensureArtifactBindings(
         : `${camelLower(s)}_${deterministicSuffix(`sg:sem:${s}:${varName}`)}`;
     }
     // Resolve the GeneratedModelSpec variant for this semantic via the ABox
-    // (Lift 10 / #227): semantic → artifactKind → modelKind. The per-kind
-    // branches stay because the GeneratedModelSpec discriminated union still
-    // carries kind-specific fields (processDefinitionIdVar for bpmn,
-    // formKeyVar for form); generalising that union is Lift 13's concern.
+    // (Lift 10 / #227): semantic → artifactKind → modelKind. Lift 13 / #253:
+    // the per-kind arms collapsed into a single generic builder, so any
+    // ABox-declared `modelKind` value (not just `bpmn` / `form`) produces a
+    // model-spec entry. Per-kind primary-binding-role names live in
+    // `modelSpecBuilders.ts`; new kinds register there without editing this
+    // call site.
     const modelKind = getModelKindForSemantic(graph.domain, s);
-    if (modelKind === 'bpmn' && !state.modelsDraft.find((m) => m.kind === 'bpmn')) {
-      state.modelsDraft.push({ kind: 'bpmn', processDefinitionIdVar: varName });
-    }
-    if (
-      modelKind === 'form' &&
-      !state.modelsDraft.find((m) => m.kind === 'form' && m.formKeyVar === varName)
-    ) {
-      state.modelsDraft.push({ kind: 'form', formKeyVar: varName });
+    if (modelKind && !findModelSpec(state.modelsDraft, modelKind, varName)) {
+      state.modelsDraft.push(buildModelSpec(modelKind, varName));
     }
   }
 }

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -719,15 +719,39 @@ export interface ExtendedGenerationOpts {
   additionalNeeded?: string[];
 }
 
-export type GeneratedModelSpec = BpmnModelSpec | FormModelSpec;
-
-export interface BpmnModelSpec {
-  kind: 'bpmn';
-  processDefinitionIdVar: string;
-  serviceTasks?: { id: string; typeVar: string }[];
-}
-
-export interface FormModelSpec {
-  kind: 'form';
-  formKeyVar: string;
+/**
+ * A model-spec entry describing one synthesized model the planner needs to
+ * deploy as part of a scenario.
+ *
+ * The shape is intentionally **open** over `kind` so any ABox-declared
+ * `modelKind` value produces a structured entry, not just the hard-coded
+ * `bpmn` / `form` discriminants the planner originally hand-rolled. Per-kind
+ * extensions (e.g. BPMN's service-task metadata) live in `metadata`;
+ * consumers that care about a specific kind narrow via the `kind` tag and
+ * reach into `metadata` with their own decoder.
+ *
+ * Lift 13 / #253: the previous closed union `BpmnModelSpec | FormModelSpec`
+ * caused the planner to silently drop any ABox `modelKind` value outside
+ * those two literals (the caveat originally noted on `modelKind` in
+ * `artifactKindsSchema.ts`). Removing the union closes that gap and lets a
+ * new `modelKind` declared in the ABox flow end-to-end without editing
+ * `scenarioGenerator.ts`.
+ */
+export interface GeneratedModelSpec {
+  /** ABox-declared kind discriminator (e.g. `'bpmn'`, `'form'`). */
+  kind: string;
+  /**
+   * Map of binding-role → binding variable name. Role names are
+   * planner-internal conventions per kind (see
+   * `path-analyser/src/modelSpecBuilders.ts`): `bpmn` uses
+   * `processDefinitionId`; `form` uses `formKey`. Consumers that round-trip
+   * scenario JSON should treat unknown roles as opaque pass-through data.
+   */
+  bindings: Record<string, string>;
+  /**
+   * Optional per-kind structured extension. Currently used only by the
+   * `bpmn` kind to carry `serviceTasks` (id → job-type-binding pairs the
+   * runtime worker needs to honour). Consumers narrow via `kind`.
+   */
+  metadata?: Record<string, unknown>;
 }


### PR DESCRIPTION
Closes #253 (Lift 13).

## What

Replaces the closed discriminated union `GeneratedModelSpec = BpmnModelSpec | FormModelSpec` with a generic open shape:

```ts
export interface GeneratedModelSpec {
  kind: string;
  bindings: Record<string, string>;
  metadata?: Record<string, unknown>;
}
```

Per-kind primary-binding-role names (`bpmn → processDefinitionId`, `form → formKey`) live in one table in a new helper module `path-analyser/src/modelSpecBuilders.ts`. Adding a new modelKind to `artifact-kinds.json` is now a one-line registry update there — no new branch in `scenarioGenerator.ts`.

## Why

Before this PR, `ensureArtifactBindings` dispatched on the ABox-declared `modelKind` value with two hard-coded arms:

```ts
if (modelKind === 'bpmn' && !state.modelsDraft.find(m => m.kind === 'bpmn'))
  state.modelsDraft.push({ kind: 'bpmn', processDefinitionIdVar: varName });
if (modelKind === 'form' && !state.modelsDraft.find(m => m.kind === 'form' && m.formKeyVar === varName))
  state.modelsDraft.push({ kind: 'form', formKeyVar: varName });
```

Any third `modelKind` value declared in the ABox was silently dropped — the caveat the `artifactKindsSchema.ts` doc-comment explicitly called out. After this PR the dispatch is a single generic block:

```ts
const modelKind = getModelKindForSemantic(graph.domain, s);
if (modelKind && !findModelSpec(state.modelsDraft, modelKind, varName)) {
  state.modelsDraft.push(buildModelSpec(modelKind, varName));
}
```

## Behaviour change — scenario JSON shape

Scenario JSON `models[]` entries changed shape:

```jsonc
// before
{ "kind": "bpmn", "processDefinitionIdVar": "X" }
{ "kind": "form", "formKeyVar": "X" }

// after
{ "kind": "bpmn", "bindings": { "processDefinitionId": "X" } }
{ "kind": "form", "bindings": { "formKey": "X" } }
```

No consumer in this repo reads `scenario.models` (verified via grep across `path-analyser/`, `materializer/`, `tests/`, `emitter-sdk/`). The field is planner-internal scaffolding persisted in the scenario JSON for external SDK emitter consumers. **External emitters that consume this field must update to the new shape.**

BPMN's `serviceTasks` metadata moves from a closed top-level field to the generic `metadata?: Record<string, unknown>` escape hatch, accessed via the `buildBpmnModelSpec` helper.

## New L3 invariants

Three new invariants in `configs/camunda-oca/regression-invariants.test.ts`:

1. **every emitted `models[]` entry uses the generic `{ kind, bindings }` shape** (no legacy top-level fields)
2. **every realised `models[]` kind is declared in the ABox** (no orphan kinds; structural symmetry guard for the generic dispatcher)
3. **`bpmn` entries bind `processDefinitionId`; `form` entries bind `formKey`** (per-kind primary-binding-role conventions)

Per AGENTS.md green/green discipline: all three were **red on `main`** (where the legacy union shape ships) and went **green after this refactor**. The first invariant red against `main` listed every `bpmn` and `form` scenario file (~30+ offenders), confirming the assertion exercises the surface this PR changes.

## Other changes

- `ontology/vocabulary/artifact-kinds.schema.json` — regenerated via `npm run build:ontology` to pick up the updated `modelKind` description (caveat removed).
- `artifactKindsSchema.ts` `modelKind` doc-comment — updated to remove the "silently ignored" caveat and document the new generic shape + the location of per-kind binding-role conventions.

## Verification

- `npm run lint` — clean (5 pre-existing warnings, no errors).
- All 6 workspace tsconfigs typecheck (`path-analyser`, `emitter-sdk` builds emit `.d.ts` first; `materializer`, `request-validation`, `tests` typecheck after).
- `npm run testsuite:generate` + `npm run generate:request-validation` regen the full pipeline cleanly.
- `npm test` — 516 passed / 6 skipped / 0 failed.
