### PR TITLE
feat: split crossRefValidator into per-slice modules (Lift 15 / #255)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -5075,6 +5075,109 @@ describe.skipIf(CONFIG_NAME !== 'camunda-oca')(
   },
 );
 
+describeForThisConfig('bundled-spec invariants: cross-ref module coverage (Lift 15 / #255)', () => {
+  // Pre-Lift 15, `path-analyser/src/ontology/crossRefValidator.ts` hand-
+  // encoded the merged-domain shape as zod `.passthrough()` schemas — a
+  // parallel encoding of the per-slice TBoxes that silently drifted
+  // whenever a slice schema added a property. Lift 15 split the cross-
+  // reference invariants into one module per slice under
+  // `path-analyser/src/ontology/crossRef/<slice>CrossRef.ts`, registered
+  // in `CROSS_REF_MODULES`. This invariant is the build-time guard the
+  // issue called for: every `*Schema.ts` slice must have a corresponding
+  // cross-ref module registered, even if it ships zero checks (an
+  // explicit `noChecksRationale` is required in that case so the empty
+  // module is a deliberate declaration, not an oversight).
+  //
+  // Adding a new slice schema without a corresponding cross-ref module
+  // — or removing a slice's cross-ref module — fails this test with a
+  // named-slice message pointing at the property the author needs to
+  // restore. The class-scoped guard against the original drift defect.
+
+  it('every per-slice TBox under path-analyser/src/ontology/*Schema.ts has a corresponding cross-ref module registered in CROSS_REF_MODULES', async () => {
+    const ontologyDir = join(REPO_ROOT, 'path-analyser', 'src', 'ontology');
+    const sliceFiles = readdirSync(ontologyDir)
+      .filter((f) => f.endsWith('Schema.ts'))
+      .sort();
+    const sliceStems = sliceFiles.map((f) => f.replace(/Schema\.ts$/, ''));
+
+    // Sanity check that the per-slice TBoxes the issue references are
+    // discovered. If `*Schema.ts` is ever renamed (e.g. to `.tbox.ts`)
+    // this invariant must be updated or it would silently match nothing.
+    expect(
+      sliceStems.length,
+      'no `*Schema.ts` slice files discovered — the file-naming convention may have changed',
+    ).toBeGreaterThanOrEqual(6);
+    for (const required of [
+      'edge',
+      'entityKinds',
+      'artifactKinds',
+      'runtimeStates',
+      'semantics',
+      'globalContextSeeds',
+    ]) {
+      expect(sliceStems, `slice ${required}Schema.ts must exist`).toContain(required);
+    }
+
+    const { CROSS_REF_MODULES } = await import(
+      '../../path-analyser/src/ontology/crossRefValidator.js'
+    );
+    const registered = new Set(CROSS_REF_MODULES.map((m) => m.slice));
+
+    const missing: string[] = [];
+    for (const stem of sliceStems) {
+      if (!registered.has(stem)) {
+        missing.push(stem);
+      }
+    }
+    expect(
+      missing,
+      `slices missing a registered cross-ref module under path-analyser/src/ontology/crossRef/<slice>CrossRef.ts: ${missing.join(', ')}. ` +
+        'Adding a TBox slice without considering cross-reference invariants is the drift defect Lift 15 / #255 was filed to prevent. ' +
+        'Create the module (even a stub with `checks: []` and a `noChecksRationale` explaining why no cross-refs are needed) and register it in CROSS_REF_MODULES.',
+    ).toEqual([]);
+  });
+
+  it('every cross-ref module with no checks ships an explicit noChecksRationale', async () => {
+    const { CROSS_REF_MODULES } = await import(
+      '../../path-analyser/src/ontology/crossRefValidator.js'
+    );
+    const undocumentedEmpties: string[] = [];
+    for (const mod of CROSS_REF_MODULES) {
+      if (mod.checks.length === 0 && !mod.noChecksRationale?.trim()) {
+        undocumentedEmpties.push(mod.slice);
+      }
+    }
+    expect(
+      undocumentedEmpties,
+      `cross-ref modules with no checks must document why via a non-empty noChecksRationale: ${undocumentedEmpties.join(', ')}. ` +
+        'An empty module without a rationale is indistinguishable from an unfinished/forgotten cross-ref check.',
+    ).toEqual([]);
+  });
+
+  it('every registered cross-ref module corresponds to an actual *Schema.ts slice file', async () => {
+    const { CROSS_REF_MODULES } = await import(
+      '../../path-analyser/src/ontology/crossRefValidator.js'
+    );
+    const ontologyDir = join(REPO_ROOT, 'path-analyser', 'src', 'ontology');
+    const sliceStems = new Set(
+      readdirSync(ontologyDir)
+        .filter((f) => f.endsWith('Schema.ts'))
+        .map((f) => f.replace(/Schema\.ts$/, '')),
+    );
+    const orphans: string[] = [];
+    for (const mod of CROSS_REF_MODULES) {
+      if (!sliceStems.has(mod.slice)) {
+        orphans.push(mod.slice);
+      }
+    }
+    expect(
+      orphans,
+      `cross-ref modules registered for slice names with no matching path-analyser/src/ontology/<slice>Schema.ts file: ${orphans.join(', ')}. ` +
+        'Either the slice was removed (delete the cross-ref module too) or the slice stem was misspelt in the SliceCrossRefModule registration.',
+    ).toEqual([]);
+  });
+});
+
 describeForThisConfig(
   'bundled-spec invariants: role-template rendering contract (Lift 12 / #231 Phase 5)',
   () => {

--- a/path-analyser/src/ontology/crossRef/artifactKindsCrossRef.ts
+++ b/path-analyser/src/ontology/crossRef/artifactKindsCrossRef.ts
@@ -9,10 +9,7 @@
 
 import type { DomainSemantics } from '../../types.js';
 import type { CrossRefIssue, SliceCrossRefModule } from './types.js';
-
-function declaredStates(d: DomainSemantics): Set<string> {
-  return new Set([...Object.keys(d.runtimeStates ?? {}), ...Object.keys(d.capabilities ?? {})]);
-}
+import { declaredStates } from './util.js';
 
 export function checkArtifactKindStateDeclared(d: DomainSemantics): CrossRefIssue[] {
   const declared = declaredStates(d);

--- a/path-analyser/src/ontology/crossRef/artifactKindsCrossRef.ts
+++ b/path-analyser/src/ontology/crossRef/artifactKindsCrossRef.ts
@@ -1,0 +1,102 @@
+// Per-slice cross-reference module for `artifactKindsSchema.ts`
+// (Lift 5 / #212 + Lift 15 / #255).
+//
+// Owns invariants whose offending field is `artifactKinds[*].*` or
+// `operationArtifactRules[*].rules[*].*`. Both cross slices — they read
+// `runtimeStates` / `capabilities` and `semanticTypes` for resolution —
+// but the broken row lives in the artifact-kinds ABox, so the check
+// lives here.
+
+import type { DomainSemantics } from '../../types.js';
+import type { CrossRefIssue, SliceCrossRefModule } from './types.js';
+
+function declaredStates(d: DomainSemantics): Set<string> {
+  return new Set([...Object.keys(d.runtimeStates ?? {}), ...Object.keys(d.capabilities ?? {})]);
+}
+
+export function checkArtifactKindStateDeclared(d: DomainSemantics): CrossRefIssue[] {
+  const declared = declaredStates(d);
+  const issues: CrossRefIssue[] = [];
+  for (const [kind, spec] of Object.entries(d.artifactKinds ?? {})) {
+    for (const state of spec.producesStates ?? []) {
+      if (!declared.has(state)) {
+        issues.push({
+          code: 'artifactKindStateDeclared',
+          message: `artifactKinds.${kind}.producesStates references "${state}", which is not declared in runtimeStates or capabilities`,
+        });
+      }
+    }
+    // #159: producibleStates carries the same cross-reference invariant
+    // as producesStates — the planner's chain-feasibility BFS reads both,
+    // so an undeclared state name would silently break the BFS rather
+    // than surface as a config error at load time.
+    for (const state of spec.producibleStates ?? []) {
+      if (!declared.has(state)) {
+        issues.push({
+          code: 'artifactKindStateDeclared',
+          message: `artifactKinds.${kind}.producibleStates references "${state}", which is not declared in runtimeStates or capabilities`,
+        });
+      }
+    }
+  }
+  // Lift 5 / #212: rule-level overrides on operationArtifactRules carry the
+  // same cross-reference invariant as kind-level producesStates — the planner
+  // reads them via getEffectiveProducesStates() during chain-feasibility BFS.
+  // Without this check, an ABox-introduced (or hand-edited legacy) override
+  // pointing at an undeclared state silently breaks the BFS rather than
+  // surfacing as a load-time config error.
+  for (const [op, spec] of Object.entries(d.operationArtifactRules ?? {})) {
+    for (const rule of spec.rules ?? []) {
+      const ruleId = rule.id ?? '<unnamed>';
+      for (const state of rule.producesStates ?? []) {
+        if (!declared.has(state)) {
+          issues.push({
+            code: 'artifactKindStateDeclared',
+            message: `operationArtifactRules.${op}.rules['${ruleId}'].producesStates references "${state}", which is not declared in runtimeStates or capabilities`,
+          });
+        }
+      }
+    }
+  }
+  return issues;
+}
+
+export function checkArtifactKindWitnessDeclared(d: DomainSemantics): CrossRefIssue[] {
+  const declared = d.semanticTypes ?? {};
+  const issues: CrossRefIssue[] = [];
+  for (const [kind, spec] of Object.entries(d.artifactKinds ?? {})) {
+    for (const type of spec.producesSemantics ?? []) {
+      const entry = declared[type];
+      if (!entry || typeof entry.witnesses !== 'string' || entry.witnesses.length === 0) {
+        issues.push({
+          code: 'artifactKindWitnessDeclared',
+          message: `artifactKinds.${kind}.producesSemantics references "${type}", which has no semanticTypes.${type}.witnesses declaration`,
+        });
+      }
+    }
+  }
+  // Lift 5 / #212: same coverage extension as
+  // checkArtifactKindStateDeclared — rule-level producesSemantics
+  // overrides also reach the planner via getEffectiveProducesSemantics()
+  // and a stale/ABox-introduced typo would otherwise pass through.
+  for (const [op, spec] of Object.entries(d.operationArtifactRules ?? {})) {
+    for (const rule of spec.rules ?? []) {
+      const ruleId = rule.id ?? '<unnamed>';
+      for (const type of rule.producesSemantics ?? []) {
+        const entry = declared[type];
+        if (!entry || typeof entry.witnesses !== 'string' || entry.witnesses.length === 0) {
+          issues.push({
+            code: 'artifactKindWitnessDeclared',
+            message: `operationArtifactRules.${op}.rules['${ruleId}'].producesSemantics references "${type}", which has no semanticTypes.${type}.witnesses declaration`,
+          });
+        }
+      }
+    }
+  }
+  return issues;
+}
+
+export const ARTIFACT_KINDS_CROSS_REF: SliceCrossRefModule = {
+  slice: 'artifactKinds',
+  checks: [checkArtifactKindStateDeclared, checkArtifactKindWitnessDeclared],
+};

--- a/path-analyser/src/ontology/crossRef/edgeCrossRef.ts
+++ b/path-analyser/src/ontology/crossRef/edgeCrossRef.ts
@@ -1,0 +1,25 @@
+// Per-slice cross-reference module for `edgeSchema.ts`
+// (Lift 3 / #208 + Lift 15 / #255).
+//
+// The edges ABox declares typed dataflow / establishes / requires edges
+// between operations. Those references resolve against the operation
+// graph itself (operationId existence, semantic-type identity) and are
+// validated post-overlay in `graphLoader.ts` against `graph.operations`
+// — they cannot be checked from a `DomainSemantics`-only view because
+// `DomainSemantics` does not surface the edges sub-tree.
+//
+// This module is therefore an explicit "no cross-ref invariants need to
+// run during validateDomainSemantics" declaration, so the build-time
+// guard in regression-invariants.test.ts can confirm every slice is
+// accounted for. It is NOT a placeholder for future work — edges
+// invariants belong with the graph loader, not in the domain-semantics
+// composer.
+
+import type { SliceCrossRefModule } from './types.js';
+
+export const EDGES_CROSS_REF: SliceCrossRefModule = {
+  slice: 'edge',
+  checks: [],
+  noChecksRationale:
+    'Edge references resolve against the operation graph (operationId, semantic-type identity), not against DomainSemantics. Validation happens in graphLoader post-overlay; see graphLoader.ts validateEdgesAbox + the abox-vs-graph L3 invariants in configs/<config>/regression-invariants.test.ts.',
+};

--- a/path-analyser/src/ontology/crossRef/entityKindsCrossRef.ts
+++ b/path-analyser/src/ontology/crossRef/entityKindsCrossRef.ts
@@ -1,0 +1,24 @@
+// Per-slice cross-reference module for `entityKindsSchema.ts`
+// (Lift 4 / #210 + Lift 15 / #255).
+//
+// The entity-kinds ABox declares the external-entity identifier
+// vocabulary. Its sub-tree (`kinds`) is not surfaced on
+// `DomainSemantics` — the loader projects it into
+// `graph.externalEntityIdentifiers` directly. Cross-references against
+// the bundled spec (identifier types existing on operations) are
+// L3-invariant-enforced in regression-invariants.test.ts and not
+// reachable from a `DomainSemantics`-only view.
+//
+// This module is an explicit "no cross-ref invariants need to run
+// during validateDomainSemantics" declaration, so the build-time guard
+// in regression-invariants.test.ts can confirm every slice is
+// accounted for.
+
+import type { SliceCrossRefModule } from './types.js';
+
+export const ENTITY_KINDS_CROSS_REF: SliceCrossRefModule = {
+  slice: 'entityKinds',
+  checks: [],
+  noChecksRationale:
+    'Entity-kind references resolve against the operation graph (per-op kindRegistry alignment), not against DomainSemantics. Validation happens in graphLoader and the abox-vs-graph L3 invariants in configs/<config>/regression-invariants.test.ts.',
+};

--- a/path-analyser/src/ontology/crossRef/globalContextSeedsCrossRef.ts
+++ b/path-analyser/src/ontology/crossRef/globalContextSeedsCrossRef.ts
@@ -1,0 +1,100 @@
+// Per-slice cross-reference module for `globalContextSeedsSchema.ts`
+// (#87 + Lift 15 / #255).
+//
+// Owns invariants whose offending field is in `globalContextSeeds[*]`.
+// The structural `GlobalContextSeedSchema` zod definition lives in
+// `crossRefValidator.ts` because it is also consumed by the public
+// boundary-asserter `assertSafeGlobalContextSeeds`; importing it here
+// keeps a single source of truth.
+
+import type { DomainSemantics } from '../../types.js';
+import type { CrossRefIssue, SliceCrossRefModule } from './types.js';
+
+// JS/TS identifier syntax. Conservative — ASCII only — because the emitter
+// builds locals like `__<fieldName>IsDefault` and ctx keys like `<binding>`
+// from these strings; restricting them to identifier-safe ASCII rules out
+// accidental code injection (`'; DROP TABLE`-style) and ensures the emitted
+// TS compiles regardless of the surrounding generator's escape choices.
+function isSafeIdentifierName(name: string): boolean {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name);
+}
+
+// `defaultSentinel` is interpolated into a single-quoted TS string literal
+// (preserved verbatim from the pre-#87 emitter so generated suites stay
+// byte-identical). Reject characters that would break that literal: single
+// quotes, backslashes, line terminators, and other control characters.
+// Unicode line separators U+2028 / U+2029 also terminate string literals in
+// JS so they're rejected too. The current production sentinel `<default>`
+// passes; anything that would have required escaping fails fast at load.
+function sentinelHasUnsafeChars(sentinel: string): boolean {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars to reject them
+  return /['\\\r\n\t\u0000-\u001f\u2028\u2029]/.test(sentinel);
+}
+
+// #87: every globalContextSeeds entry must have a unique, identifier-safe
+// `binding` and `fieldName`. The emitter's sentinel local is
+// `__<fieldName>IsDefault`, the multipart strip branch keys off `fieldName`,
+// and ctx[<binding>] / seedBinding('<seedRule>') interpolate `binding` and
+// `seedRule` directly. Restricting these to safe identifiers (and rejecting
+// duplicates) means the emitter can interpolate them without an escape pass,
+// rules out config-driven code injection, and prevents two entries from
+// declaring the same `const __...IsDefault`. Also reject
+// `stripFromMultipartWhenDefault: true` without a `defaultSentinel` — the
+// strip branch needs something to compare against, otherwise the emitter
+// would have to choose a fallback sentinel itself (re-introducing the very
+// hard-coding this entry is meant to remove).
+export function checkGlobalContextSeedsCoherent(d: DomainSemantics): CrossRefIssue[] {
+  const issues: CrossRefIssue[] = [];
+  const seenBindings = new Set<string>();
+  const seenFieldNames = new Set<string>();
+  for (const seed of d.globalContextSeeds ?? []) {
+    if (seenBindings.has(seed.binding)) {
+      issues.push({
+        code: 'globalContextSeedBindingUnique',
+        message: `globalContextSeeds contains duplicate binding "${seed.binding}"`,
+      });
+    }
+    seenBindings.add(seed.binding);
+
+    if (seenFieldNames.has(seed.fieldName)) {
+      issues.push({
+        code: 'globalContextSeedFieldNameUnique',
+        message: `globalContextSeeds contains duplicate fieldName "${seed.fieldName}"`,
+      });
+    }
+    seenFieldNames.add(seed.fieldName);
+
+    for (const [key, value] of [
+      ['binding', seed.binding],
+      ['fieldName', seed.fieldName],
+      ['seedRule', seed.seedRule],
+    ] as const) {
+      if (!isSafeIdentifierName(value)) {
+        issues.push({
+          code: 'globalContextSeedSafeIdentifier',
+          message: `globalContextSeeds entry for binding "${seed.binding}" has ${key} "${value}", which is not a safe identifier (must match /^[A-Za-z_$][A-Za-z0-9_$]*$/)`,
+        });
+      }
+    }
+
+    if (seed.defaultSentinel !== undefined && sentinelHasUnsafeChars(seed.defaultSentinel)) {
+      issues.push({
+        code: 'globalContextSeedSentinelSafe',
+        message: `globalContextSeeds entry for binding "${seed.binding}" has defaultSentinel containing characters (single-quote, backslash, line terminator, or control char) that would break the emitted single-quoted string literal`,
+      });
+    }
+
+    if (seed.stripFromMultipartWhenDefault === true && seed.defaultSentinel === undefined) {
+      issues.push({
+        code: 'globalContextSeedStripRequiresSentinel',
+        message: `globalContextSeeds entry for binding "${seed.binding}" sets stripFromMultipartWhenDefault but has no defaultSentinel`,
+      });
+    }
+  }
+  return issues;
+}
+
+export const GLOBAL_CONTEXT_SEEDS_CROSS_REF: SliceCrossRefModule = {
+  slice: 'globalContextSeeds',
+  checks: [checkGlobalContextSeedsCoherent],
+};

--- a/path-analyser/src/ontology/crossRef/runtimeStatesCrossRef.ts
+++ b/path-analyser/src/ontology/crossRef/runtimeStatesCrossRef.ts
@@ -9,10 +9,7 @@
 
 import type { DomainSemantics } from '../../types.js';
 import type { CrossRefIssue, SliceCrossRefModule } from './types.js';
-
-function declaredStates(d: DomainSemantics): Set<string> {
-  return new Set([...Object.keys(d.runtimeStates ?? {}), ...Object.keys(d.capabilities ?? {})]);
-}
+import { declaredStates } from './util.js';
 
 function witnessOf(d: DomainSemantics): Map<string, string> {
   const m = new Map<string, string>();

--- a/path-analyser/src/ontology/crossRef/runtimeStatesCrossRef.ts
+++ b/path-analyser/src/ontology/crossRef/runtimeStatesCrossRef.ts
@@ -1,0 +1,116 @@
+// Per-slice cross-reference module for `runtimeStatesSchema.ts`
+// (Lift 6 / #214 + Lift 15 / #255).
+//
+// Owns invariants whose offending field is in `runtimeStates[*]` or
+// `operationRequirements[*]` — the two sub-trees the runtime-states
+// ABox publishes. Several invariants cross into `semanticTypes` /
+// `capabilities` for resolution; the broken row lives here, so the
+// check lives here.
+
+import type { DomainSemantics } from '../../types.js';
+import type { CrossRefIssue, SliceCrossRefModule } from './types.js';
+
+function declaredStates(d: DomainSemantics): Set<string> {
+  return new Set([...Object.keys(d.runtimeStates ?? {}), ...Object.keys(d.capabilities ?? {})]);
+}
+
+function witnessOf(d: DomainSemantics): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const [type, spec] of Object.entries(d.semanticTypes ?? {})) {
+    if (typeof spec.witnesses === 'string' && spec.witnesses.length > 0) {
+      m.set(type, spec.witnesses);
+    }
+  }
+  return m;
+}
+
+export function checkSemanticBindingTargetResolves(d: DomainSemantics): CrossRefIssue[] {
+  const declared = new Set(Object.keys(d.semanticTypes ?? {}));
+  const issues: CrossRefIssue[] = [];
+  for (const [op, req] of Object.entries(d.operationRequirements ?? {})) {
+    for (const [field, rhs] of Object.entries(req.valueBindings ?? {})) {
+      if (!rhs.startsWith('semantic:')) continue;
+      const ref = rhs.slice('semantic:'.length);
+      if (!declared.has(ref)) {
+        issues.push({
+          code: 'semanticBindingTargetResolves',
+          message: `operationRequirements.${op}.valueBindings["${field}"] references semantic type "${ref}", which is not declared in semanticTypes`,
+        });
+      }
+    }
+  }
+  return issues;
+}
+
+export function checkDisjunctionNotWitnessRedundant(d: DomainSemantics): CrossRefIssue[] {
+  const witness = witnessOf(d);
+  const issues: CrossRefIssue[] = [];
+  for (const [op, req] of Object.entries(d.operationRequirements ?? {})) {
+    for (const group of req.disjunctions ?? []) {
+      for (const member of group) {
+        const w = witness.get(member);
+        if (w && group.includes(w)) {
+          issues.push({
+            code: 'disjunctionNotWitnessRedundant',
+            message: `operationRequirements.${op}.disjunctions contains both semantic type "${member}" and its witnessed state "${w}" — collapse to requires: ["${w}"]`,
+          });
+        }
+      }
+    }
+  }
+  return issues;
+}
+
+export function checkDisjunctionMemberResolves(d: DomainSemantics): CrossRefIssue[] {
+  const declared = declaredStates(d);
+  const issues: CrossRefIssue[] = [];
+  for (const [op, req] of Object.entries(d.operationRequirements ?? {})) {
+    for (const group of req.disjunctions ?? []) {
+      for (const member of group) {
+        if (!declared.has(member)) {
+          issues.push({
+            code: 'disjunctionMemberResolves',
+            message: `operationRequirements.${op}.disjunctions references "${member}", which is not declared in runtimeStates or capabilities`,
+          });
+        }
+      }
+    }
+  }
+  return issues;
+}
+
+// #159 PR B: a runtimeState marked `eventual: true` must declare a
+// `witness` so the planner has something to wait on. Without this check,
+// flipping `eventual` true on a state without a witness would silently
+// produce a chain with no wait injected (and the consumer step would
+// still race the producer's projection lag).
+export function checkEventualStateWitnessShape(d: DomainSemantics): CrossRefIssue[] {
+  const issues: CrossRefIssue[] = [];
+  for (const [name, spec] of Object.entries(d.runtimeStates ?? {})) {
+    const eventual = spec.eventual === true;
+    const witness = spec.witness;
+    if (eventual && (witness === undefined || witness === null)) {
+      issues.push({
+        code: 'eventualStateWitnessShape',
+        message: `runtimeStates.${name} sets eventual: true but has no witness — the planner would inject no wait. Declare a witness { operationId, predicate } or unset eventual.`,
+      });
+    }
+    if (!eventual && witness !== undefined && witness !== null) {
+      issues.push({
+        code: 'eventualStateWitnessShape',
+        message: `runtimeStates.${name} declares a witness but eventual is not true — the witness will not be used. Set eventual: true or remove the witness.`,
+      });
+    }
+  }
+  return issues;
+}
+
+export const RUNTIME_STATES_CROSS_REF: SliceCrossRefModule = {
+  slice: 'runtimeStates',
+  checks: [
+    checkSemanticBindingTargetResolves,
+    checkDisjunctionNotWitnessRedundant,
+    checkDisjunctionMemberResolves,
+    checkEventualStateWitnessShape,
+  ],
+};

--- a/path-analyser/src/ontology/crossRef/semanticsCrossRef.ts
+++ b/path-analyser/src/ontology/crossRef/semanticsCrossRef.ts
@@ -1,0 +1,61 @@
+// Per-slice cross-reference module for `semanticsSchema.ts`
+// (Lift 7 / #216 + Lift 15 / #255).
+//
+// Owns invariants whose offending field is in `semanticTypes[*]`.
+
+import type { DomainSemantics } from '../../types.js';
+import type { CrossRefIssue, SliceCrossRefModule } from './types.js';
+
+function declaredStates(d: DomainSemantics): Set<string> {
+  return new Set([...Object.keys(d.runtimeStates ?? {}), ...Object.keys(d.capabilities ?? {})]);
+}
+
+export function checkSemanticTypeWitnessTargetResolves(d: DomainSemantics): CrossRefIssue[] {
+  const declared = declaredStates(d);
+  const issues: CrossRefIssue[] = [];
+  for (const [type, spec] of Object.entries(d.semanticTypes ?? {})) {
+    const w = spec.witnesses;
+    if (typeof w !== 'string' || w.length === 0) continue;
+    if (!declared.has(w)) {
+      issues.push({
+        code: 'semanticTypeWitnessTargetResolves',
+        message: `semanticTypes.${type}.witnesses targets "${w}", which is not declared in runtimeStates or capabilities`,
+      });
+    }
+  }
+  return issues;
+}
+
+// #162 PR 2: `kind: 'attribute'` and `clientMinted: true` are paired —
+// a `clientMinted: true` flag without `kind: 'attribute'` is dead config
+// (the planner only consults clientMinted on attribute-kind semantics),
+// and `kind: 'attribute'` without `clientMinted: true` is currently
+// undefined (PR 2's planner branch hard-requires clientMinted, since the
+// alternative interpretation — server-minted attributes — isn't part of
+// the classification vocabulary). Both directions get a load-time error
+// so a typo doesn't silently fall through.
+export function checkAttributeKindClientMintedPairing(d: DomainSemantics): CrossRefIssue[] {
+  const issues: CrossRefIssue[] = [];
+  for (const [name, spec] of Object.entries(d.semanticTypes ?? {})) {
+    const kind = spec.kind;
+    const clientMinted = spec.clientMinted === true;
+    if (kind === 'attribute' && !clientMinted) {
+      issues.push({
+        code: 'attributeKindClientMintedPairing',
+        message: `semanticTypes.${name} sets kind: 'attribute' but is missing clientMinted: true. PR 2 (#162) requires the pairing — declare clientMinted: true or change the kind.`,
+      });
+    }
+    if (clientMinted && kind !== 'attribute') {
+      issues.push({
+        code: 'attributeKindClientMintedPairing',
+        message: `semanticTypes.${name} sets clientMinted: true but kind is ${kind ? `'${kind}'` : 'absent'}. The planner only consults clientMinted on attribute-kind semantics.`,
+      });
+    }
+  }
+  return issues;
+}
+
+export const SEMANTICS_CROSS_REF: SliceCrossRefModule = {
+  slice: 'semantics',
+  checks: [checkSemanticTypeWitnessTargetResolves, checkAttributeKindClientMintedPairing],
+};

--- a/path-analyser/src/ontology/crossRef/semanticsCrossRef.ts
+++ b/path-analyser/src/ontology/crossRef/semanticsCrossRef.ts
@@ -5,10 +5,7 @@
 
 import type { DomainSemantics } from '../../types.js';
 import type { CrossRefIssue, SliceCrossRefModule } from './types.js';
-
-function declaredStates(d: DomainSemantics): Set<string> {
-  return new Set([...Object.keys(d.runtimeStates ?? {}), ...Object.keys(d.capabilities ?? {})]);
-}
+import { declaredStates } from './util.js';
 
 export function checkSemanticTypeWitnessTargetResolves(d: DomainSemantics): CrossRefIssue[] {
   const declared = declaredStates(d);

--- a/path-analyser/src/ontology/crossRef/types.ts
+++ b/path-analyser/src/ontology/crossRef/types.ts
@@ -1,0 +1,56 @@
+// Shared shapes for per-slice cross-reference modules.
+//
+// Lift 15 / #255 splits the cross-reference invariants out of the
+// monolithic `crossRefValidator.ts` into one module per per-slice TBox
+// under `path-analyser/src/ontology/*Schema.ts`. Each module exports a
+// `SliceCrossRefModule` describing which slice it owns, which check
+// functions it ships, and a `noChecksRationale` for slices with no
+// cross-references today (so an empty module is an explicit declaration,
+// not an oversight). The composer in `crossRefValidator.ts` enumerates
+// the registered modules and runs every check.
+//
+// The build-time guard in `configs/<config>/regression-invariants.test.ts`
+// asserts every `*Schema.ts` slice has a matching `crossRef/*CrossRef.ts`
+// registered in `CROSS_REF_MODULES`. Adding a new slice schema without a
+// corresponding module fails the test — the drift case Lift 15 / #255
+// was filed to prevent.
+
+import type { DomainSemantics } from '../../types.js';
+
+export interface CrossRefIssue {
+  /**
+   * Stable invariant code. Surfaced as the `invariant` field on
+   * `DomainSemanticsValidationError` so test assertions and CI grep
+   * patterns can target a specific class of violation regardless of
+   * which row triggered it.
+   */
+  code: string;
+  /**
+   * Human-readable message identifying the offending property. One
+   * check function may emit multiple issues — one per offending row —
+   * each carrying the same `code` but a distinct `message`.
+   */
+  message: string;
+}
+
+export type CrossRefCheck = (d: DomainSemantics) => CrossRefIssue[];
+
+export interface SliceCrossRefModule {
+  /**
+   * Stem of the slice's TBox source file (e.g. `runtimeStates` for
+   * `runtimeStatesSchema.ts`). The build-time guard pairs this against
+   * the discovered `*Schema.ts` files; a mismatch is a configuration
+   * error.
+   */
+  slice: string;
+  /**
+   * Cross-reference check functions owned by this slice. May be empty.
+   */
+  checks: CrossRefCheck[];
+  /**
+   * Required iff `checks.length === 0`. Documents why the slice has no
+   * cross-reference invariants today, so an empty module is an explicit
+   * "no checks needed" declaration rather than an oversight.
+   */
+  noChecksRationale?: string;
+}

--- a/path-analyser/src/ontology/crossRef/util.ts
+++ b/path-analyser/src/ontology/crossRef/util.ts
@@ -1,0 +1,18 @@
+// Shared helpers for per-slice cross-reference modules.
+//
+// Anything imported by more than one slice module lives here so the
+// resolution rules (e.g. what counts as a "declared state") cannot drift
+// between invariants — addresses the same anti-drift property the
+// per-slice split was filed to defend (Lift 15 / #255).
+
+import type { DomainSemantics } from '../../types.js';
+
+// The set of identifiers a witness/disjunction member is allowed to
+// resolve to. `runtimeStates` and `capabilities` are both treated as
+// declarable state names by the planner; any check that asks "does this
+// reference resolve?" must consult both. Centralised so a slice that
+// later widens the resolution set (e.g. adds a third sub-tree) updates
+// every invariant at once.
+export function declaredStates(d: DomainSemantics): Set<string> {
+  return new Set([...Object.keys(d.runtimeStates ?? {}), ...Object.keys(d.capabilities ?? {})]);
+}

--- a/path-analyser/src/ontology/crossRefValidator.ts
+++ b/path-analyser/src/ontology/crossRefValidator.ts
@@ -1,119 +1,76 @@
 import { z } from 'zod';
 import { classifySemantic } from '../bindSemanticInput.js';
-import type { OperationGraph } from '../types.js';
+import type { DomainSemantics, OperationGraph } from '../types.js';
+import { ARTIFACT_KINDS_CROSS_REF } from './crossRef/artifactKindsCrossRef.js';
+import { EDGES_CROSS_REF } from './crossRef/edgeCrossRef.js';
+import { ENTITY_KINDS_CROSS_REF } from './crossRef/entityKindsCrossRef.js';
+import {
+  checkGlobalContextSeedsCoherent,
+  GLOBAL_CONTEXT_SEEDS_CROSS_REF,
+} from './crossRef/globalContextSeedsCrossRef.js';
+import { RUNTIME_STATES_CROSS_REF } from './crossRef/runtimeStatesCrossRef.js';
+import { SEMANTICS_CROSS_REF } from './crossRef/semanticsCrossRef.js';
+import type { SliceCrossRefModule } from './crossRef/types.js';
 
 // ---------------------------------------------------------------------------
-// path-analyser/src/domainSemanticsValidator.ts
+// path-analyser/src/ontology/crossRefValidator.ts
 //
-// Load-time validator for the synthesized graph-domain view.
+// Composer for the per-slice cross-reference invariants that gate the
+// synthesized merged-domain view (`DomainSemantics`).
 //
-// The shape of `DomainSemantics` (in types.ts) describes *what* fields exist;
-// this module describes *which combinations of values are coherent* — the
-// cross-reference invariants between sections. Each invariant is reported
-// from `superRefine` via `ctx.addIssue(..., { params: { invariant } })` so
-// failures point directly at the broken property rather than at a structural diff.
+// History: pre-Lift 15 / #255 this module hand-encoded the merged-overlay
+// shape as zod schemas — a parallel encoding of the per-slice TBoxes
+// (`runtimeStatesSchema.ts`, `semanticsSchema.ts`, `artifactKindsSchema.ts`,
+// `globalContextSeedsSchema.ts`). Because the zod shapes used `passthrough`
+// they did not actually validate — they only narrowed types — and they
+// silently drifted whenever a slice TBox added a property. Lift 15 split
+// the cross-reference checks into per-slice modules under
+// `./crossRef/<slice>CrossRef.ts`, each registered in
+// {@link CROSS_REF_MODULES}. A build-time L3 invariant in
+// `configs/<config>/regression-invariants.test.ts` asserts every
+// `*Schema.ts` slice has a matching cross-ref module — adding a new slice
+// without considering cross-references now fails the build.
 //
-// Invariants encoded (all class-scoped — they reject the defect class, not
-// just one instance):
+// Structural validation of each per-slice ABox happens in
+// `./loader.ts` against the source-of-truth `*Schema.ts` TBoxes (ajv).
+// By the time `validateDomainSemantics` is called from
+// `graphLoader.ts` post-overlay re-validation, the merged-domain view
+// is already structurally well-formed; this module's job is purely
+// cross-reference invariants between sections.
 //
-//   1. artifactKindStateDeclared — every state in artifactKinds.*.producesStates
-//      is declared in runtimeStates ∪ capabilities.
-//   2. artifactKindWitnessDeclared — every key-shaped semantic type
-//      (artifactKinds.*.producesSemantics) declares a semanticTypes[T].witnesses
-//      edge.
-//   3. semanticTypeWitnessTargetResolves — every semanticTypes[T].witnesses
-//      target resolves to runtimeStates ∪ capabilities.
-//   4. semanticBindingTargetResolves — every valueBindings RHS of the form
-//      `semantic:X` references a declared semanticTypes entry.
-//   5. disjunctionNotWitnessRedundant — no disjunction group contains both a
-//      semantic type X and the state semanticTypes[X].witnesses.
-//   6. disjunctionMemberResolves — every disjunction member resolves to
-//      runtimeStates ∪ capabilities.
-//
-// The corresponding tests in tests/regression/ remain in place as
-// human-readable, hand-curated regression statements; this module promotes
-// them into a load-time gate inside graphLoader.
+// Each cross-reference issue is surfaced as a
+// {@link DomainSemanticsValidationError} carrying a stable `invariant`
+// code so test assertions and CI greps can target a specific class of
+// violation regardless of which row triggered it.
 // ---------------------------------------------------------------------------
 
-const SemanticTypeSpecSchema = z
-  .object({
-    witnesses: z.string().min(1).optional(),
-    // #162 PR 1 added `modelDerived`; PR 2 added `attribute`; PR 5 adds
-    // `serverEmergent` for server-minted lifecycle keys (e.g. IncidentKey,
-    // AuditLogKey) that no client API directly mints with a returned value.
-    // Strict enum so a typo (e.g. `attributes`) is rejected at load time
-    // rather than silently falling through to the default classification
-    // chain.
-    kind: z.enum(['modelDerived', 'attribute', 'serverEmergent']).optional(),
-    // #162 PR 2: only meaningful with `kind: 'attribute'`. Validator
-    // enforces the pairing in `checkAttributeKindClientMintedPairing`
-    // below.
-    clientMinted: z.boolean().optional(),
-  })
-  .passthrough();
+/**
+ * Registry of per-slice cross-reference modules. The composer iterates
+ * this list and runs every check; the build-time guard L3 invariant
+ * enumerates `path-analyser/src/ontology/*Schema.ts` and asserts every
+ * slice has an entry here (a module with `checks: []` and an explicit
+ * `noChecksRationale` is the way to declare "no cross-refs needed").
+ *
+ * Ordering is insertion order → issue order, kept stable so test
+ * snapshots and CI logs are reproducible across runs.
+ */
+export const CROSS_REF_MODULES: readonly SliceCrossRefModule[] = [
+  EDGES_CROSS_REF,
+  ENTITY_KINDS_CROSS_REF,
+  ARTIFACT_KINDS_CROSS_REF,
+  RUNTIME_STATES_CROSS_REF,
+  SEMANTICS_CROSS_REF,
+  GLOBAL_CONTEXT_SEEDS_CROSS_REF,
+];
 
-const ArtifactKindSpecSchema = z
-  .object({
-    producesStates: z.array(z.string()).optional(),
-    producibleStates: z.array(z.string()).optional(),
-    producesSemantics: z.array(z.string()).optional(),
-    modelKind: z.string().min(1).optional(),
-  })
-  .passthrough();
-
-// #159 PR B: structured predicate shape. `path` must be a safe identifier
-// because the emitter renders it as a TS bracket-access key (`b['<path>']`)
-// without an escape pass; `equals` is constrained to primitives so the
-// emitter can JSON.stringify it directly. `.strict()` aligns this runtime
-// schema with the on-disk JSON schema's `additionalProperties: false` —
-// extra keys are almost always a typo (e.g. `equal` for `equals`) and
-// silently dropping them would mask the typo until the emitted predicate
-// misbehaved at runtime.
-const WitnessPredicateSchema = z
-  .object({
-    path: z.string().regex(/^[A-Za-z_$][A-Za-z0-9_$]*$/, {
-      message: 'witness.predicate.path must match /^[A-Za-z_$][A-Za-z0-9_$]*$/',
-    }),
-    equals: z.union([z.string(), z.number(), z.boolean()]),
-  })
-  .strict();
-
-const WitnessSpecSchema = z
-  .object({
-    operationId: z.string().min(1),
-    predicate: WitnessPredicateSchema,
-    waitUpToMs: z.number().int().positive().optional(),
-    pollIntervalMs: z.number().int().positive().optional(),
-  })
-  .strict();
-
-const RuntimeStateSpecSchema = z
-  .object({
-    kind: z.literal('state').optional(),
-    producedBy: z.array(z.string()).optional(),
-    parameter: z.string().optional(),
-    parameters: z.array(z.string()).optional(),
-    requires: z.array(z.string()).optional(),
-    eventual: z.boolean().optional(),
-    witness: WitnessSpecSchema.optional(),
-  })
-  .passthrough();
-
-const OperationDomainRequirementsSchema = z
-  .object({
-    requires: z.array(z.string()).optional(),
-    disjunctions: z.array(z.array(z.string())).optional(),
-    implicitAdds: z.array(z.string()).optional(),
-    produces: z.array(z.string()).optional(),
-    chainCleanupRequires: z.array(z.string()).optional(),
-    valueBindings: z.record(z.string(), z.string()).optional(),
-  })
-  .passthrough();
-
-// Strict: mirrors `additionalProperties: false` in domain-semantics.schema.json
-// so runtime validation matches the published JSON Schema. Unknown keys are
-// almost always a typo (e.g. `seedRules` for `seedRule`) and silently
-// dropping them would mask the typo until the emitted suite misbehaves.
+// Public-boundary structural validator for `globalContextSeeds`. Kept
+// in this module (not the per-slice cross-ref module) because it is
+// also consumed by {@link assertSafeGlobalContextSeeds} below — the
+// public entry point for the Playwright emitter. Strict: mirrors
+// `additionalProperties: false` in `globalContextSeedsSchema.ts` so
+// runtime validation matches the published JSON Schema. Unknown keys
+// are almost always a typo and silently dropping them would mask the
+// typo until the emitted suite misbehaved.
 export const GlobalContextSeedSchema = z
   .object({
     binding: z.string().min(1),
@@ -125,407 +82,54 @@ export const GlobalContextSeedSchema = z
   })
   .strict();
 
-const ArtifactRuleSchema = z
-  .object({
-    id: z.string().optional(),
-    artifactKind: z.string(),
-    priority: z.number().optional(),
-    producesSemantics: z.array(z.string()).optional(),
-    producesStates: z.array(z.string()).optional(),
-  })
-  .passthrough();
-
-const OperationArtifactRuleSpecSchema = z
-  .object({
-    composable: z.boolean().optional(),
-    role: z.string().min(1).optional(),
-    rules: z.array(ArtifactRuleSchema).optional(),
-  })
-  .passthrough();
-
-// Top-level shape — `passthrough` so unrelated fields
-// (artifactFileKinds, semanticTypeToArtifactKind, identifiers, version,
-// $schema) flow through unmodified.
-const DomainSemanticsShape = z
-  .object({
-    runtimeStates: z.record(z.string(), RuntimeStateSpecSchema).optional(),
-    capabilities: z.record(z.string(), z.unknown()).optional(),
-    semanticTypes: z.record(z.string(), SemanticTypeSpecSchema).optional(),
-    artifactKinds: z.record(z.string(), ArtifactKindSpecSchema).optional(),
-    operationArtifactRules: z.record(z.string(), OperationArtifactRuleSpecSchema).optional(),
-    operationRequirements: z.record(z.string(), OperationDomainRequirementsSchema).optional(),
-    globalContextSeeds: z.array(GlobalContextSeedSchema).optional(),
-  })
-  .passthrough();
-
-type DomainSemanticsShape = z.infer<typeof DomainSemanticsShape>;
-
-interface CrossRefIssue {
-  code: string;
-  message: string;
-}
-
-// Helpers ---------------------------------------------------------------
-
-function declaredStates(d: DomainSemanticsShape): Set<string> {
-  return new Set([...Object.keys(d.runtimeStates ?? {}), ...Object.keys(d.capabilities ?? {})]);
-}
-
-function witnessOf(d: DomainSemanticsShape): Map<string, string> {
-  const m = new Map<string, string>();
-  for (const [type, spec] of Object.entries(d.semanticTypes ?? {})) {
-    if (typeof spec.witnesses === 'string' && spec.witnesses.length > 0) {
-      m.set(type, spec.witnesses);
-    }
-  }
-  return m;
-}
-
-// Cross-reference invariants -------------------------------------------
-
-function checkArtifactKindStateDeclared(d: DomainSemanticsShape): CrossRefIssue[] {
-  const declared = declaredStates(d);
-  const issues: CrossRefIssue[] = [];
-  for (const [kind, spec] of Object.entries(d.artifactKinds ?? {})) {
-    for (const state of spec.producesStates ?? []) {
-      if (!declared.has(state)) {
-        issues.push({
-          code: 'artifactKindStateDeclared',
-          message: `artifactKinds.${kind}.producesStates references "${state}", which is not declared in runtimeStates or capabilities`,
-        });
-      }
-    }
-    // #159: producibleStates carries the same cross-reference invariant
-    // as producesStates — the planner's chain-feasibility BFS reads both,
-    // so an undeclared state name would silently break the BFS rather
-    // than surface as a config error at load time.
-    for (const state of spec.producibleStates ?? []) {
-      if (!declared.has(state)) {
-        issues.push({
-          code: 'artifactKindStateDeclared',
-          message: `artifactKinds.${kind}.producibleStates references "${state}", which is not declared in runtimeStates or capabilities`,
-        });
-      }
-    }
-  }
-  // Lift 5 / #212: rule-level overrides on operationArtifactRules carry the
-  // same cross-reference invariant as kind-level producesStates — the planner
-  // reads them via getEffectiveProducesStates() during chain-feasibility BFS.
-  // Without this check, an ABox-introduced (or hand-edited legacy) override
-  // pointing at an undeclared state silently breaks the BFS rather than
-  // surfacing as a load-time config error.
-  for (const [op, spec] of Object.entries(d.operationArtifactRules ?? {})) {
-    for (const rule of spec.rules ?? []) {
-      const ruleId = rule.id ?? '<unnamed>';
-      for (const state of rule.producesStates ?? []) {
-        if (!declared.has(state)) {
-          issues.push({
-            code: 'artifactKindStateDeclared',
-            message: `operationArtifactRules.${op}.rules['${ruleId}'].producesStates references "${state}", which is not declared in runtimeStates or capabilities`,
-          });
-        }
-      }
-    }
-  }
-  return issues;
-}
-
-function checkArtifactKindWitnessDeclared(d: DomainSemanticsShape): CrossRefIssue[] {
-  const declared = d.semanticTypes ?? {};
-  const issues: CrossRefIssue[] = [];
-  for (const [kind, spec] of Object.entries(d.artifactKinds ?? {})) {
-    for (const type of spec.producesSemantics ?? []) {
-      const entry = declared[type];
-      if (!entry || typeof entry.witnesses !== 'string' || entry.witnesses.length === 0) {
-        issues.push({
-          code: 'artifactKindWitnessDeclared',
-          message: `artifactKinds.${kind}.producesSemantics references "${type}", which has no semanticTypes.${type}.witnesses declaration`,
-        });
-      }
-    }
-  }
-  // Lift 5 / #212: same coverage extension as
-  // checkArtifactKindStateDeclared — rule-level producesSemantics
-  // overrides also reach the planner via getEffectiveProducesSemantics()
-  // and a stale/ABox-introduced typo would otherwise pass through.
-  for (const [op, spec] of Object.entries(d.operationArtifactRules ?? {})) {
-    for (const rule of spec.rules ?? []) {
-      const ruleId = rule.id ?? '<unnamed>';
-      for (const type of rule.producesSemantics ?? []) {
-        const entry = declared[type];
-        if (!entry || typeof entry.witnesses !== 'string' || entry.witnesses.length === 0) {
-          issues.push({
-            code: 'artifactKindWitnessDeclared',
-            message: `operationArtifactRules.${op}.rules['${ruleId}'].producesSemantics references "${type}", which has no semanticTypes.${type}.witnesses declaration`,
-          });
-        }
-      }
-    }
-  }
-  return issues;
-}
-
-function checkSemanticTypeWitnessTargetResolves(d: DomainSemanticsShape): CrossRefIssue[] {
-  const declared = declaredStates(d);
-  const issues: CrossRefIssue[] = [];
-  for (const [type, spec] of Object.entries(d.semanticTypes ?? {})) {
-    const w = spec.witnesses;
-    if (typeof w !== 'string' || w.length === 0) continue;
-    if (!declared.has(w)) {
-      issues.push({
-        code: 'semanticTypeWitnessTargetResolves',
-        message: `semanticTypes.${type}.witnesses targets "${w}", which is not declared in runtimeStates or capabilities`,
-      });
-    }
-  }
-  return issues;
-}
-
-function checkSemanticBindingTargetResolves(d: DomainSemanticsShape): CrossRefIssue[] {
-  const declared = new Set(Object.keys(d.semanticTypes ?? {}));
-  const issues: CrossRefIssue[] = [];
-  for (const [op, req] of Object.entries(d.operationRequirements ?? {})) {
-    for (const [field, rhs] of Object.entries(req.valueBindings ?? {})) {
-      if (!rhs.startsWith('semantic:')) continue;
-      const ref = rhs.slice('semantic:'.length);
-      if (!declared.has(ref)) {
-        issues.push({
-          code: 'semanticBindingTargetResolves',
-          message: `operationRequirements.${op}.valueBindings["${field}"] references semantic type "${ref}", which is not declared in semanticTypes`,
-        });
-      }
-    }
-  }
-  return issues;
-}
-
-function checkDisjunctionNotWitnessRedundant(d: DomainSemanticsShape): CrossRefIssue[] {
-  const witness = witnessOf(d);
-  const issues: CrossRefIssue[] = [];
-  for (const [op, req] of Object.entries(d.operationRequirements ?? {})) {
-    for (const group of req.disjunctions ?? []) {
-      for (const member of group) {
-        const w = witness.get(member);
-        if (w && group.includes(w)) {
-          issues.push({
-            code: 'disjunctionNotWitnessRedundant',
-            message: `operationRequirements.${op}.disjunctions contains both semantic type "${member}" and its witnessed state "${w}" — collapse to requires: ["${w}"]`,
-          });
-        }
-      }
-    }
-  }
-  return issues;
-}
-
-function checkDisjunctionMemberResolves(d: DomainSemanticsShape): CrossRefIssue[] {
-  const declared = declaredStates(d);
-  const issues: CrossRefIssue[] = [];
-  for (const [op, req] of Object.entries(d.operationRequirements ?? {})) {
-    for (const group of req.disjunctions ?? []) {
-      for (const member of group) {
-        if (!declared.has(member)) {
-          issues.push({
-            code: 'disjunctionMemberResolves',
-            message: `operationRequirements.${op}.disjunctions references "${member}", which is not declared in runtimeStates or capabilities`,
-          });
-        }
-      }
-    }
-  }
-  return issues;
-}
-
-// JS/TS identifier syntax. Conservative — ASCII only — because the emitter
-// builds locals like `__<fieldName>IsDefault` and ctx keys like `<binding>`
-// from these strings; restricting them to identifier-safe ASCII rules out
-// accidental code injection (`'; DROP TABLE`-style) and ensures the emitted
-// TS compiles regardless of the surrounding generator's escape choices.
-function isSafeIdentifierName(name: string): boolean {
-  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name);
-}
-
-// `defaultSentinel` is interpolated into a single-quoted TS string literal
-// (preserved verbatim from the pre-#87 emitter so generated suites stay
-// byte-identical). Reject characters that would break that literal: single
-// quotes, backslashes, line terminators, and other control characters.
-// Unicode line separators U+2028 / U+2029 also terminate string literals in
-// JS so they're rejected too. The current production sentinel `<default>`
-// passes; anything that would have required escaping fails fast at load.
-function sentinelHasUnsafeChars(sentinel: string): boolean {
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars to reject them
-  return /['\\\r\n\t\u0000-\u001f\u2028\u2029]/.test(sentinel);
-}
-
-// #87: every globalContextSeeds entry must have a unique, identifier-safe
-// `binding` and `fieldName`. The emitter's sentinel local is
-// `__<fieldName>IsDefault`, the multipart strip branch keys off `fieldName`,
-// and ctx[<binding>] / seedBinding('<seedRule>') interpolate `binding` and
-// `seedRule` directly. Restricting these to safe identifiers (and rejecting
-// duplicates) means the emitter can interpolate them without an escape pass,
-// rules out config-driven code injection, and prevents two entries from
-// declaring the same `const __...IsDefault`. Also reject
-// `stripFromMultipartWhenDefault: true` without a `defaultSentinel` — the
-// strip branch needs something to compare against, otherwise the emitter
-// would have to choose a fallback sentinel itself (re-introducing the very
-// hard-coding this entry is meant to remove).
-function checkGlobalContextSeedsCoherent(d: DomainSemanticsShape): CrossRefIssue[] {
-  const issues: CrossRefIssue[] = [];
-  const seenBindings = new Set<string>();
-  const seenFieldNames = new Set<string>();
-  for (const seed of d.globalContextSeeds ?? []) {
-    if (seenBindings.has(seed.binding)) {
-      issues.push({
-        code: 'globalContextSeedBindingUnique',
-        message: `globalContextSeeds contains duplicate binding "${seed.binding}"`,
-      });
-    }
-    seenBindings.add(seed.binding);
-
-    if (seenFieldNames.has(seed.fieldName)) {
-      issues.push({
-        code: 'globalContextSeedFieldNameUnique',
-        message: `globalContextSeeds contains duplicate fieldName "${seed.fieldName}"`,
-      });
-    }
-    seenFieldNames.add(seed.fieldName);
-
-    for (const [key, value] of [
-      ['binding', seed.binding],
-      ['fieldName', seed.fieldName],
-      ['seedRule', seed.seedRule],
-    ] as const) {
-      if (!isSafeIdentifierName(value)) {
-        issues.push({
-          code: 'globalContextSeedSafeIdentifier',
-          message: `globalContextSeeds entry for binding "${seed.binding}" has ${key} "${value}", which is not a safe identifier (must match /^[A-Za-z_$][A-Za-z0-9_$]*$/)`,
-        });
-      }
-    }
-
-    if (seed.defaultSentinel !== undefined && sentinelHasUnsafeChars(seed.defaultSentinel)) {
-      issues.push({
-        code: 'globalContextSeedSentinelSafe',
-        message: `globalContextSeeds entry for binding "${seed.binding}" has defaultSentinel containing characters (single-quote, backslash, line terminator, or control char) that would break the emitted single-quoted string literal`,
-      });
-    }
-
-    if (seed.stripFromMultipartWhenDefault === true && seed.defaultSentinel === undefined) {
-      issues.push({
-        code: 'globalContextSeedStripRequiresSentinel',
-        message: `globalContextSeeds entry for binding "${seed.binding}" sets stripFromMultipartWhenDefault but has no defaultSentinel`,
-      });
-    }
-  }
-  return issues;
-}
-
-// #159 PR B: a runtimeState marked `eventual: true` must declare a
-// `witness` so the planner has something to wait on. Without this check,
-// flipping `eventual` true on a state without a witness would silently
-// produce a chain with no wait injected (and the consumer step would
-// still race the producer's projection lag).
-function checkEventualStateWitnessShape(d: DomainSemanticsShape): CrossRefIssue[] {
-  const issues: CrossRefIssue[] = [];
-  for (const [name, spec] of Object.entries(d.runtimeStates ?? {})) {
-    const eventual = spec.eventual === true;
-    const witness = spec.witness;
-    if (eventual && (witness === undefined || witness === null)) {
-      issues.push({
-        code: 'eventualStateWitnessShape',
-        message: `runtimeStates.${name} sets eventual: true but has no witness — the planner would inject no wait. Declare a witness { operationId, predicate } or unset eventual.`,
-      });
-    }
-    if (!eventual && witness !== undefined && witness !== null) {
-      issues.push({
-        code: 'eventualStateWitnessShape',
-        message: `runtimeStates.${name} declares a witness but eventual is not true — the witness will not be used. Set eventual: true or remove the witness.`,
-      });
-    }
-  }
-  return issues;
-}
-
-// #162 PR 2: `kind: 'attribute'` and `clientMinted: true` are paired —
-// a `clientMinted: true` flag without `kind: 'attribute'` is dead config
-// (the planner only consults clientMinted on attribute-kind semantics),
-// and `kind: 'attribute'` without `clientMinted: true` is currently
-// undefined (PR 2's planner branch hard-requires clientMinted, since the
-// alternative interpretation — server-minted attributes — isn't part of
-// the classification vocabulary). Both directions get a load-time error
-// so a typo doesn't silently fall through.
-function checkAttributeKindClientMintedPairing(d: DomainSemanticsShape): CrossRefIssue[] {
-  const issues: CrossRefIssue[] = [];
-  for (const [name, spec] of Object.entries(d.semanticTypes ?? {})) {
-    const kind = spec.kind;
-    const clientMinted = spec.clientMinted === true;
-    if (kind === 'attribute' && !clientMinted) {
-      issues.push({
-        code: 'attributeKindClientMintedPairing',
-        message: `semanticTypes.${name} sets kind: 'attribute' but is missing clientMinted: true. PR 2 (#162) requires the pairing — declare clientMinted: true or change the kind.`,
-      });
-    }
-    if (clientMinted && kind !== 'attribute') {
-      issues.push({
-        code: 'attributeKindClientMintedPairing',
-        message: `semanticTypes.${name} sets clientMinted: true but kind is ${kind ? `'${kind}'` : 'absent'}. The planner only consults clientMinted on attribute-kind semantics.`,
-      });
-    }
-  }
-  return issues;
-}
-
-const CROSS_REF_CHECKS = [
-  checkArtifactKindStateDeclared,
-  checkArtifactKindWitnessDeclared,
-  checkSemanticTypeWitnessTargetResolves,
-  checkSemanticBindingTargetResolves,
-  checkDisjunctionNotWitnessRedundant,
-  checkDisjunctionMemberResolves,
-  checkGlobalContextSeedsCoherent,
-  checkEventualStateWitnessShape,
-  checkAttributeKindClientMintedPairing,
-] as const;
-
-// Composed schema: structural shape + every cross-reference invariant.
-export const DomainSemanticsSchema = DomainSemanticsShape.superRefine((d, ctx) => {
-  for (const check of CROSS_REF_CHECKS) {
-    for (const issue of check(d)) {
-      ctx.addIssue({
-        code: 'custom',
-        message: issue.message,
-        params: { invariant: issue.code },
-      });
-    }
-  }
-});
-
 export interface DomainSemanticsValidationError {
   invariant: string;
   message: string;
 }
 
 /**
- * Run all structural and cross-reference checks against `raw`. Returns the
- * empty array on success; otherwise returns one entry per Zod issue — a
- * single invariant can produce multiple entries when several instances
- * violate it (each entry carries the same `invariant` name but a distinct
- * `message` identifying the offending property).
+ * Run every registered cross-reference invariant against `raw`. Returns
+ * the empty array on success; otherwise returns one entry per offending
+ * row — multiple instances of the same invariant produce multiple
+ * entries each carrying the same `invariant` code and a distinct
+ * `message` identifying the property.
  *
- * The graphLoader calls this immediately after JSON.parse and throws if any
- * issues are returned. Tests can call it directly against synthetic
- * minimal-domain objects to verify each invariant in isolation.
+ * `raw` is accepted as `unknown` so callers do not have to assert
+ * `DomainSemantics` at the call site, but in production it is always
+ * the loader-synthesized merged-domain view (already structurally
+ * validated by ajv against the per-slice TBoxes during ABox load).
+ * The only structural rejection done here is "is it an object" — if
+ * `raw` is `null`, an array, or a primitive, every cross-ref check
+ * would defensively no-op and the caller would silently get an empty
+ * result; the early rejection makes mis-use surface explicitly.
  */
 export function validateDomainSemantics(raw: unknown): DomainSemanticsValidationError[] {
-  const result = DomainSemanticsSchema.safeParse(raw);
-  if (result.success) return [];
-  return result.error.issues.map((issue) => {
-    const params = issue.code === 'custom' ? issue.params : undefined;
-    const invariantRaw =
-      params && typeof params === 'object' ? Reflect.get(params, 'invariant') : undefined;
-    const invariant = typeof invariantRaw === 'string' ? invariantRaw : 'shape';
-    return { invariant, message: issue.message };
-  });
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    return [
+      {
+        invariant: 'shape',
+        message: `validateDomainSemantics expected an object describing the merged DomainSemantics view; received ${
+          raw === null ? 'null' : Array.isArray(raw) ? 'array' : typeof raw
+        }.`,
+      },
+    ];
+  }
+  // The merged-domain view is structurally well-formed by construction —
+  // the loader builds it from per-slice ABoxes that have already been
+  // ajv-validated against their `*Schema.ts` TBoxes. Cross-ref checks
+  // tolerate any subset of sub-trees being absent (every `Object.entries(
+  // d.X ?? {})` access is defensive).
+  // biome-ignore lint/plugin: caller boundary; downstream check fns are defensive on every field access
+  const domain = raw as DomainSemantics;
+  const issues: DomainSemanticsValidationError[] = [];
+  for (const module_ of CROSS_REF_MODULES) {
+    for (const check of module_.checks) {
+      for (const issue of check(domain)) {
+        issues.push({ invariant: issue.code, message: issue.message });
+      }
+    }
+  }
+  return issues;
 }
 
 /**
@@ -541,13 +145,14 @@ export function validateDomainSemantics(raw: unknown): DomainSemanticsValidation
  * the loader's safety net and produce broken or injection-vulnerable
  * generated suites.
  *
- * Throws on any structural issue (Zod `.strict()` schema) or any
- * cross-seed coherence violation (uniqueness, identifier safety, sentinel
- * char safety, strip-requires-sentinel). Returns silently on success.
+ * Throws on any structural issue ({@link GlobalContextSeedSchema}'s
+ * `.strict()` schema) or any cross-seed coherence violation
+ * (uniqueness, identifier safety, sentinel char safety,
+ * strip-requires-sentinel). Returns silently on success.
  *
  * The validation is intentionally redundant with `validateDomainSemantics`
- * — both surfaces use the same `GlobalContextSeedSchema` and
- * `checkGlobalContextSeedsCoherent` so they cannot drift.
+ * — both surfaces use the same {@link GlobalContextSeedSchema} and the
+ * same {@link checkGlobalContextSeedsCoherent} so they cannot drift.
  */
 export function assertSafeGlobalContextSeeds(seeds: unknown): void {
   if (!Array.isArray(seeds)) {
@@ -562,7 +167,10 @@ export function assertSafeGlobalContextSeeds(seeds: unknown): void {
       .join('\n');
     throw new Error(`globalContextSeeds failed structural validation:\n${formatted}`);
   }
-  const issues = checkGlobalContextSeedsCoherent({ globalContextSeeds: arrayResult.data });
+  // biome-ignore lint/plugin: zod-validated entries narrow safely to the DomainSemantics shape
+  const issues = checkGlobalContextSeedsCoherent({
+    globalContextSeeds: arrayResult.data,
+  } as DomainSemantics);
   if (issues.length > 0) {
     const formatted = issues.map((i) => `  - [${i.code}] ${i.message}`).join('\n');
     throw new Error(`globalContextSeeds failed coherence validation:\n${formatted}`);


### PR DESCRIPTION
Closes #255.

## Summary

Splits the monolithic `path-analyser/src/ontology/crossRefValidator.ts`
(675 lines, hand-encoded merged-domain zod shapes that silently drifted
from the per-slice TBoxes) into per-slice cross-ref modules registered in
a `CROSS_REF_MODULES` array, plus a build-time L3 invariant that catches
the original drift defect.

Adopts option **(b)** from the issue's acceptance criterion.

## Approach

- New `path-analyser/src/ontology/crossRef/` directory, one module per
  `*Schema.ts` slice (`edge`, `entityKinds`, `artifactKinds`,
  `runtimeStates`, `semantics`, `globalContextSeeds`).
- `crossRefValidator.ts` slimmed from **675 → ~290 lines**: now a pure
  composer over `CROSS_REF_MODULES`. The hand-encoded `.passthrough()`
  zod shapes are gone — `DomainSemantics` from `types.ts` is the typed
  view, and structural validation already happens in `loader.ts` (ajv)
  against the source-of-truth `*Schema.ts` TBoxes.
- `GlobalContextSeedSchema` is preserved (still backs the public-boundary
  `assertSafeGlobalContextSeeds`).
- `edge` and `entityKinds` modules ship `checks: []` with an explicit
  `noChecksRationale` — their references resolve against the operation
  graph (not `DomainSemantics`), and that validation already lives in
  `graphLoader.ts` + L3 abox-vs-graph invariants.

## Behaviour preservation

- Every cross-ref check's `code` and `message` text is **verbatim** from
  the pre-refactor version.
- `validateDomainSemantics`, `assertSafeGlobalContextSeeds`,
  `validateRuntimeStateWitnessGraphRefs`, and
  `validateRequestBodySemanticsClassified` keep their existing signatures
  and observable behaviour.
- Pipeline output unchanged (**186 feature.specs + 67 variant.specs** —
  same as main).
- All **517 prior tests** still pass.

## Build-time guard (the L3 invariants that catch the drift defect)

Three new invariants under
`configs/camunda-oca/regression-invariants.test.ts`
→ `"bundled-spec invariants: cross-ref module coverage (Lift 15 / #255)"`:

1. **Every `*Schema.ts` slice has a registered cross-ref module.**
   Enumerates `path-analyser/src/ontology/*Schema.ts` and asserts each
   slice stem appears in `CROSS_REF_MODULES`. Fails with a named-slice
   message pointing the author at the property to restore — class-scoped
   against the drift defect, not the specific instance.
2. **Empty cross-ref modules must declare `noChecksRationale`.** Prevents
   an empty module from being indistinguishable from a forgotten /
   unfinished cross-ref.
3. **Every registered module corresponds to an actual slice file.**
   Catches the inverse (renamed or deleted slice).

### Red-proof

Verified locally: commenting out `RUNTIME_STATES_CROSS_REF` from the
registry fires invariant (1) with the named-slice message; restoring
returns to green.

## Validation

Full pre-push gate is clean:

- `npm run lint` — 0 errors, 5 pre-existing warnings
- All 6 tsc typechecks (semantic-graph-extractor, path-analyser,
  emitter-sdk, materializer, request-validation, tests)
- `TEST_SEED=snapshot-baseline npm run testsuite:generate &&
  npm run generate:request-validation`
- `npm test` → **520 passed | 6 skipped** (517 + 3 new invariants)

## Out of scope

- Re-running per-slice ajv validation inside the validator (already done
  in `loader.ts`; would be redundant).
- Generating zod from JSON Schema via `json-schema-to-zod` (option (a) in
  the issue) — option (b) is the lighter touch and the build-time guard
  achieves the same anti-drift property.
