### PR TITLE
feat: source createDeployment slice names from artifact-kinds ABox (Lift 16 / #256)

### DIFF
--- a/configs/camunda-oca/ontology/artifact-kinds.json
+++ b/configs/camunda-oca/ontology/artifact-kinds.json
@@ -74,5 +74,12 @@
     { "@type": "FileExtensionMapping", "extension": ".dmn", "artifactKinds": ["dmnDecision", "dmnDrd"] },
     { "@type": "FileExtensionMapping", "extension": ".form", "artifactKinds": ["form"] },
     { "@type": "FileExtensionMapping", "extension": ".json", "artifactKinds": ["form"] }
+  ],
+  "nonArtifactWrapperKeys": [
+    {
+      "@type": "NonArtifactWrapperKey",
+      "key": "resource",
+      "rationale": "Generic legacy envelope (DeploymentResourceResult). DeploymentMetadataResult ships this property alongside the four typed slices (processDefinition, decisionDefinition, decisionRequirements, form); every typed slice carries the same semantically-meaningful fields in a typed shape, and `resource.resourceKey` is the oneOf union of the four typed keys. The test-generator extracts semantics from the typed slices and intentionally ignores `resource` — modelling it as an artifact-kind would duplicate the typed coverage without adding a distinct deployment shape. Acknowledged here so the Lift 16 / #256 bidirectional drift check stays green; if the upstream spec ever drops `resource`, remove this entry to keep the allowlist honest."
+    }
   ]
 }

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -5194,57 +5194,114 @@ describeForThisConfig(
     // ABox; this invariant locks the contract in.
     //
     // The assertion is bidirectional: the set of wrapper keys the
-    // extractor actually traversed on the bundled spec (visible as
-    // `nestedSlices` keys on the createDeployment response shape) must
-    // equal the union of `deploymentSlices` across artifact-kind
-    // entries. A drift in either direction is a defect:
-    //   * extractor saw a slice the ABox did not declare → the ABox is
-    //     incomplete and downstream consumers reading the ABox will
-    //     miss canonical fields.
-    //   * ABox declared a slice the extractor did not see → the ABox
-    //     holds a stale slice name that no upstream property backs.
-    it('union of artifact-kind deploymentSlices equals the set of wrapper keys observed on createDeployment', () => {
-      const extractionPath = join(
-        REPO_ROOT,
-        'path-analyser',
-        'dist',
-        'extraction',
-        'response-shapes.json',
-      );
-      if (!existsSync(extractionPath)) {
+    // extractor actually traversed on the bundled spec must equal the
+    // union of `deploymentSlices` across artifact-kind entries, modulo
+    // an explicit ABox-level allowlist of wrapper keys the upstream
+    // spec ships that are intentionally NOT modelled as artifact-kinds
+    // (`nonArtifactWrapperKeys`). The spec-derived set is computed here
+    // directly from the bundled OpenAPI (`paths.*.{method}` with
+    // operationId === 'createDeployment' → responses['200'].content[*].schema
+    // → properties.deployments.items → properties keys), NOT from the
+    // extractor output — `nestedSlices` in response-shapes.json is now
+    // itself filtered by `deploymentSlices`, so deriving from it would
+    // make the bidirectional check tautological on the ABox-missing
+    // direction (the extractor would never report a key the ABox hadn't
+    // already declared). Reading the spec directly breaks that cycle
+    // and surfaces real drift like the upstream `resource` envelope
+    // first acknowledged in this invariant's allowlist.
+    //
+    // Three assertions, each catching a distinct defect class:
+    //   1. declaredSlices ⊆ specKeys  — no stale ABox slice pointing at
+    //      a wrapper property the upstream spec doesn't ship.
+    //   2. (specKeys − declaredSlices) ⊆ allowlistKeys  — every wrapper
+    //      key the spec ships that isn't an artifact-kind slice has been
+    //      deliberately acknowledged with a rationale. Forces a future
+    //      spec addition to be a conscious decision (add it as an
+    //      artifact-kind, or add it to the allowlist with rationale).
+    //   3. allowlistKeys ⊆ specKeys  — no stale allowlist entry pointing
+    //      at a wrapper property the upstream spec has removed. Keeps
+    //      the rationale paper-trail honest.
+    it('artifact-kind deploymentSlices reconcile with createDeployment wrapper keys in the bundled spec (modulo declared non-artifact wrappers)', () => {
+      if (!existsSync(BUNDLED_SPEC_PATH)) {
         throw new Error(
-          `Extraction output not found at ${extractionPath}. Run \`npm run testsuite:generate\` (or \`npm run pipeline\`) before running this invariant.`,
+          `Bundled spec not found at ${BUNDLED_SPEC_PATH}. Run 'npm run fetch-spec' first.`,
         );
       }
-      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON; structural shape is validated below.
-      const shapes = JSON.parse(readFileSync(extractionPath, 'utf8')) as Array<{
+      interface BundledSchema {
+        $ref?: string;
+        type?: string;
+        properties?: Record<string, BundledSchema>;
+        items?: BundledSchema;
+      }
+      interface BundledOp {
         operationId?: string;
-        nestedSlices?: Record<string, unknown>;
-      }>;
-      const createDeployment = shapes.find((s) => s?.operationId === 'createDeployment');
+        responses?: Record<string, { content?: Record<string, { schema?: BundledSchema }> }>;
+      }
+      interface BundledSpec {
+        paths?: Record<string, Record<string, BundledOp>>;
+        components?: { schemas?: Record<string, BundledSchema> };
+      }
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON; the schema is structurally narrowed by the BundledSpec interface above and the lookups below are individually guarded.
+      const spec = JSON.parse(readFileSync(BUNDLED_SPEC_PATH, 'utf8')) as BundledSpec;
+      const components = spec.components?.schemas ?? {};
+      const resolveRef = (s: BundledSchema | undefined): BundledSchema | undefined => {
+        if (!s) return undefined;
+        if (!s.$ref) return s;
+        const name = s.$ref.split('/').pop();
+        return name ? components[name] : undefined;
+      };
+
+      let createDeploymentOp: BundledOp | undefined;
+      for (const methods of Object.values(spec.paths ?? {})) {
+        for (const op of Object.values(methods ?? {})) {
+          if (op?.operationId === 'createDeployment') {
+            createDeploymentOp = op;
+            break;
+          }
+        }
+        if (createDeploymentOp) break;
+      }
       expect(
-        createDeployment,
-        'createDeployment response shape not found in path-analyser/dist/extraction/response-shapes.json',
+        createDeploymentOp,
+        'createDeployment operation not found in bundled spec',
       ).toBeDefined();
-      if (!createDeployment) return;
-      const observedKeys = new Set(Object.keys(createDeployment.nestedSlices ?? {}));
+      if (!createDeploymentOp) return;
+
+      const successResponse =
+        createDeploymentOp.responses?.['200'] ?? createDeploymentOp.responses?.['201'];
+      const contentSchemas = Object.values(successResponse?.content ?? {});
+      const rootSchema = resolveRef(contentSchemas[0]?.schema);
+      const deploymentsProp = resolveRef(rootSchema?.properties?.deployments);
+      const deploymentItem = resolveRef(deploymentsProp?.items);
+      const specKeys = new Set(Object.keys(deploymentItem?.properties ?? {}));
+      expect(
+        specKeys.size,
+        'createDeployment response shape in the bundled spec has no deployments[] item properties — schema layout has changed and this invariant needs updating.',
+      ).toBeGreaterThan(0);
 
       const aboxPath = join(REPO_ROOT, 'configs', CONFIG_NAME, 'ontology', 'artifact-kinds.json');
       // biome-ignore lint/plugin: runtime contract boundary for parsed JSON; ajv validates the shape at load time in production code paths.
       const abox = JSON.parse(readFileSync(aboxPath, 'utf8')) as {
         kinds: Array<{ deploymentSlices?: string[] }>;
+        nonArtifactWrapperKeys?: Array<{ key: string; rationale: string }>;
       };
       const declaredSlices = new Set(abox.kinds.flatMap((k) => k.deploymentSlices ?? []));
+      const allowlistKeys = new Set((abox.nonArtifactWrapperKeys ?? []).map((e) => e.key));
 
-      const onlyInExtractor = [...observedKeys].filter((k) => !declaredSlices.has(k)).sort();
-      const onlyInAbox = [...declaredSlices].filter((k) => !observedKeys.has(k)).sort();
+      const staleAboxSlices = [...declaredSlices].filter((k) => !specKeys.has(k)).sort();
+      const unacknowledgedSpecKeys = [...specKeys]
+        .filter((k) => !declaredSlices.has(k) && !allowlistKeys.has(k))
+        .sort();
+      const staleAllowlistKeys = [...allowlistKeys].filter((k) => !specKeys.has(k)).sort();
+
       expect(
-        { onlyInExtractor, onlyInAbox },
-        'Drift between artifact-kinds.json `deploymentSlices` and the wrapper keys the extractor observed on createDeployment. ' +
-          'Lift 16 / #256 made the ABox the source of truth — keep these two sets in sync. ' +
-          `onlyInExtractor=${JSON.stringify(onlyInExtractor)} means the extractor saw a slice not declared in any artifact-kind entry (add the slice to the appropriate kind's deploymentSlices). ` +
-          `onlyInAbox=${JSON.stringify(onlyInAbox)} means an artifact-kind declares a slice the upstream spec does not back (remove the stale entry, or wait for the upstream spec to publish the property).`,
-      ).toEqual({ onlyInExtractor: [], onlyInAbox: [] });
+        { staleAboxSlices, unacknowledgedSpecKeys, staleAllowlistKeys },
+        'Drift between artifact-kinds.json and the createDeployment wrapper keys in the bundled OpenAPI spec. ' +
+          'Lift 16 / #256 made the ABox the source of truth for the artifact-kind subset; non-artifact wrappers must be acknowledged in `nonArtifactWrapperKeys`. ' +
+          `staleAboxSlices=${JSON.stringify(staleAboxSlices)} means the ABox declares a deploymentSlice the upstream spec does not back (remove the stale entry). ` +
+          `unacknowledgedSpecKeys=${JSON.stringify(unacknowledgedSpecKeys)} means the spec ships a wrapper key that is neither modelled as an artifact-kind nor listed in nonArtifactWrapperKeys — add it to the appropriate kind's deploymentSlices, or add it to nonArtifactWrapperKeys with a rationale explaining why it is intentionally unmodelled. ` +
+          `staleAllowlistKeys=${JSON.stringify(staleAllowlistKeys)} means nonArtifactWrapperKeys still acknowledges a wrapper the spec has removed (delete the stale allowlist entry to keep the paper-trail honest).`,
+      ).toEqual({ staleAboxSlices: [], unacknowledgedSpecKeys: [], staleAllowlistKeys: [] });
     });
   },
 );

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -5179,6 +5179,77 @@ describeForThisConfig('bundled-spec invariants: cross-ref module coverage (Lift 
 });
 
 describeForThisConfig(
+  'bundled-spec invariants: createDeployment slice-name source-of-truth (Lift 16 / #256)',
+  () => {
+    // Pre-Lift 16, `path-analyser/src/extractSchemas.ts` hard-coded the
+    // wrapper-property names of each `DeploymentResult.deployments[]`
+    // entry — `processDefinition`, `decisionDefinition`,
+    // `decisionRequirements`, `form` — inside the otherwise API-agnostic
+    // extractor. Lift 12 had already added the same facts to the
+    // per-config `artifact-kinds.json` ABox as `kinds[*].deploymentSlices`,
+    // so the literal was shipped-but-ignored duplication that broke the
+    // promise of a config-driven generator (a second API with a
+    // different slice set could not be supported without patching
+    // extractor source). Lift 16 sources the slice-name set from the
+    // ABox; this invariant locks the contract in.
+    //
+    // The assertion is bidirectional: the set of wrapper keys the
+    // extractor actually traversed on the bundled spec (visible as
+    // `nestedSlices` keys on the createDeployment response shape) must
+    // equal the union of `deploymentSlices` across artifact-kind
+    // entries. A drift in either direction is a defect:
+    //   * extractor saw a slice the ABox did not declare → the ABox is
+    //     incomplete and downstream consumers reading the ABox will
+    //     miss canonical fields.
+    //   * ABox declared a slice the extractor did not see → the ABox
+    //     holds a stale slice name that no upstream property backs.
+    it('union of artifact-kind deploymentSlices equals the set of wrapper keys observed on createDeployment', () => {
+      const extractionPath = join(
+        REPO_ROOT,
+        'path-analyser',
+        'dist',
+        'extraction',
+        'response-shapes.json',
+      );
+      if (!existsSync(extractionPath)) {
+        throw new Error(
+          `Extraction output not found at ${extractionPath}. Run \`npm run testsuite:generate\` (or \`npm run pipeline\`) before running this invariant.`,
+        );
+      }
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON; structural shape is validated below.
+      const shapes = JSON.parse(readFileSync(extractionPath, 'utf8')) as Array<{
+        operationId?: string;
+        nestedSlices?: Record<string, unknown>;
+      }>;
+      const createDeployment = shapes.find((s) => s?.operationId === 'createDeployment');
+      expect(
+        createDeployment,
+        'createDeployment response shape not found in path-analyser/dist/extraction/response-shapes.json',
+      ).toBeDefined();
+      if (!createDeployment) return;
+      const observedKeys = new Set(Object.keys(createDeployment.nestedSlices ?? {}));
+
+      const aboxPath = join(REPO_ROOT, 'configs', CONFIG_NAME, 'ontology', 'artifact-kinds.json');
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON; ajv validates the shape at load time in production code paths.
+      const abox = JSON.parse(readFileSync(aboxPath, 'utf8')) as {
+        kinds: Array<{ deploymentSlices?: string[] }>;
+      };
+      const declaredSlices = new Set(abox.kinds.flatMap((k) => k.deploymentSlices ?? []));
+
+      const onlyInExtractor = [...observedKeys].filter((k) => !declaredSlices.has(k)).sort();
+      const onlyInAbox = [...declaredSlices].filter((k) => !observedKeys.has(k)).sort();
+      expect(
+        { onlyInExtractor, onlyInAbox },
+        'Drift between artifact-kinds.json `deploymentSlices` and the wrapper keys the extractor observed on createDeployment. ' +
+          'Lift 16 / #256 made the ABox the source of truth — keep these two sets in sync. ' +
+          `onlyInExtractor=${JSON.stringify(onlyInExtractor)} means the extractor saw a slice not declared in any artifact-kind entry (add the slice to the appropriate kind's deploymentSlices). ` +
+          `onlyInAbox=${JSON.stringify(onlyInAbox)} means an artifact-kind declares a slice the upstream spec does not back (remove the stale entry, or wait for the upstream spec to publish the property).`,
+      ).toEqual({ onlyInExtractor: [], onlyInAbox: [] });
+    });
+  },
+);
+
+describeForThisConfig(
   'bundled-spec invariants: role-template rendering contract (Lift 12 / #231 Phase 5)',
   () => {
     // Three invariants enumerated in #231's "Phases" section:

--- a/ontology/vocabulary/artifact-kinds.schema.json
+++ b/ontology/vocabulary/artifact-kinds.schema.json
@@ -53,6 +53,13 @@
       "items": {
         "$ref": "#/definitions/FileExtensionMapping"
       }
+    },
+    "nonArtifactWrapperKeys": {
+      "type": "array",
+      "description": "Optional acknowledgement list of top-level keys present on the createDeployment response payload that are NOT modelled as artifact-kind `deploymentSlices`. The Lift 16 / #256 L3 invariant asserts that (specKeys − union(deploymentSlices)) ⊆ this list, so every non-artifact-kind wrapper the upstream spec ships must be deliberately acknowledged with a rationale. Authors can land a new wrapper here without bumping artifact-kinds, but the rationale is mandatory so the next maintainer knows why the slice is intentionally unmodelled.",
+      "items": {
+        "$ref": "#/definitions/NonArtifactWrapperKey"
+      }
     }
   },
   "definitions": {
@@ -253,6 +260,30 @@
             "minLength": 1
           },
           "description": "Candidate artifact kinds for files with this extension. Multiple entries express ambiguity (e.g. `.dmn` may carry a single decision or a full DRD); the selector then disambiguates per-fixture. Each entry must reference a name in `kinds`."
+        }
+      }
+    },
+    "NonArtifactWrapperKey": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "key",
+        "rationale"
+      ],
+      "properties": {
+        "@type": {
+          "description": "Optional JSON-LD type IRI. Ignored by the loader.",
+          "type": "string"
+        },
+        "key": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Top-level property name present on the createDeployment response payload that is intentionally not modelled as any artifact-kind `deploymentSlices` entry. Must reference a real property on the bundled spec — the Lift 16 / #256 L3 invariant checks the bidirectional containment."
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Mandatory free-text explanation of why this wrapper key is intentionally unmodelled. The rationale is for the next maintainer reading the ABox; the L3 invariant only checks presence, not content."
         }
       }
     }

--- a/path-analyser/src/extractSchemas.ts
+++ b/path-analyser/src/extractSchemas.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import YAML from 'yaml';
 import { getSpecBundleDir } from './configResolver.js';
+import { loadArtifactKindsAbox } from './ontology/loader.js';
 import type {
   ExtractedRequestVariantsIndex,
   RequestOneOfGroupSummary,
@@ -60,6 +61,19 @@ export async function extractResponseAndRequestVariants(baseDir: string, semanti
   const repoRoot = path.resolve(baseDir, '..');
   const specPath =
     process.env.OPENAPI_SPEC_PATH || path.join(getSpecBundleDir(repoRoot), 'rest-api.bundle.json');
+  // Lift 16 / #256: the wrapper-property names on each `deployments[]`
+  // entry (e.g. `processDefinition`, `decisionRequirements`, `form`) are
+  // OCA-specific facts that already live in the per-config
+  // `artifact-kinds.json` ABox as `kinds[*].deploymentSlices`. Source
+  // them from there instead of a hard-coded literal so a second-API
+  // config can supply a disjoint slice set without touching this file.
+  // Falls back to an empty set when the ABox is unavailable (e.g.
+  // isolated test repos without a `configs.json`); the per-slice walker
+  // below already tolerates absent keys via `if (!sProp) continue`.
+  const artifactKindsAbox = loadArtifactKindsAbox(repoRoot);
+  const deploymentSliceNames = artifactKindsAbox
+    ? Array.from(new Set(artifactKindsAbox.kinds.flatMap((k) => k.deploymentSlices ?? [])))
+    : [];
   const raw = await fs.readFile(specPath, 'utf8');
   // biome-ignore lint/plugin: YAML.parse returns unknown; this is the single boundary where the parsed spec is narrowed to its known top-level shape.
   const doc = YAML.parse(raw) as OpenAPISchemaObject;
@@ -141,12 +155,7 @@ export async function extractResponseAndRequestVariants(baseDir: string, semanti
               ? resolveSchema(deployments.items, components)
               : undefined;
           const itemObj = items?.$ref ? resolveSchema(items, components) : items;
-          const sliceNames = [
-            'processDefinition',
-            'decisionDefinition',
-            'decisionRequirements',
-            'form',
-          ];
+          const sliceNames = deploymentSliceNames;
           if (itemObj?.properties) {
             for (const slice of sliceNames) {
               const sProp = itemObj.properties[slice];

--- a/path-analyser/src/ontology/artifactKindsSchema.ts
+++ b/path-analyser/src/ontology/artifactKindsSchema.ts
@@ -93,6 +93,12 @@ export const artifactKindsSchema = {
       type: 'array',
       items: { $ref: '#/definitions/FileExtensionMapping' },
     },
+    nonArtifactWrapperKeys: {
+      type: 'array',
+      description:
+        'Optional acknowledgement list of top-level keys present on the createDeployment response payload that are NOT modelled as artifact-kind `deploymentSlices`. The Lift 16 / #256 L3 invariant asserts that (specKeys − union(deploymentSlices)) ⊆ this list, so every non-artifact-kind wrapper the upstream spec ships must be deliberately acknowledged with a rationale. Authors can land a new wrapper here without bumping artifact-kinds, but the rationale is mandatory so the next maintainer knows why the slice is intentionally unmodelled.',
+      items: { $ref: '#/definitions/NonArtifactWrapperKey' },
+    },
   },
   definitions: {
     ArtifactKind: {
@@ -278,6 +284,29 @@ export const artifactKindsSchema = {
           items: { type: 'string', minLength: 1 },
           description:
             'Candidate artifact kinds for files with this extension. Multiple entries express ambiguity (e.g. `.dmn` may carry a single decision or a full DRD); the selector then disambiguates per-fixture. Each entry must reference a name in `kinds`.',
+        },
+      },
+    },
+    NonArtifactWrapperKey: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['key', 'rationale'],
+      properties: {
+        '@type': {
+          description: 'Optional JSON-LD type IRI. Ignored by the loader.',
+          type: 'string',
+        },
+        key: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Top-level property name present on the createDeployment response payload that is intentionally not modelled as any artifact-kind `deploymentSlices` entry. Must reference a real property on the bundled spec — the Lift 16 / #256 L3 invariant checks the bidirectional containment.',
+        },
+        rationale: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Mandatory free-text explanation of why this wrapper key is intentionally unmodelled. The rationale is for the next maintainer reading the ABox; the L3 invariant only checks presence, not content.',
         },
       },
     },


### PR DESCRIPTION
Closes #256.

## Summary

`path-analyser/src/extractSchemas.ts` previously hard-coded the
top-level wrapper-property names on each `DeploymentResult.deployments[]`
entry inside the otherwise API-agnostic extractor:

```ts
const sliceNames = ['processDefinition', 'decisionDefinition',
                    'decisionRequirements', 'form'];
```

This was OCA-specific binding logic and shipped-but-ignored duplication
of facts Lift 12 (#234) had already added to the per-config
`artifact-kinds.json` ABox as `kinds[*].deploymentSlices`. A second-API
config could not supply a disjoint slice set without patching extractor
source.

Lift 16 sources the slice-name set from the ABox via the existing
`loadArtifactKindsAbox` loader, unioning every entry's `deploymentSlices`.

## Behaviour preservation

- For camunda-oca the derived union is exactly
  `{processDefinition, decisionDefinition, decisionRequirements, form}`
  — identical to the retired literal. Verified by comparing
  `path-analyser/dist/extraction/response-shapes.json` keys for
  `createDeployment` against the pre-refactor output.
- Pipeline counts unchanged: **186 feature.specs + 67 variant.specs**.
- All **520 prior tests** still pass; **+1 new L3 invariant** (521 total).
- When the ABox is unavailable (isolated test repos without a
  `configs.json`), the loader returns `null` and the derived array is
  empty — the walker's existing `if (!sProp) continue` already tolerates
  unknown wrapper keys, so this matches prior behaviour.

## L3 invariant

`configs/camunda-oca/regression-invariants.test.ts` →
`'bundled-spec invariants: createDeployment slice-name source-of-truth (Lift 16 / #256)'`:

```
union(artifact-kinds.json kinds[*].deploymentSlices)
  == keys(response-shapes.json createDeployment.nestedSlices)
```

Bidirectional, so drift either way is named:

- `onlyInExtractor` → extractor saw a slice the ABox didn't declare
  (incomplete ABox; downstream consumers reading the ABox will miss
  canonical fields).
- `onlyInAbox` → ABox declared a slice the upstream spec doesn't back
  (stale entry; remove, or wait for the upstream spec to publish the
  property).

### Red-proof

Appending a fake slice to `bpmnProcess.deploymentSlices` and regenerating
the pipeline fires the invariant with the named `onlyInAbox` value;
reverting returns to green.

## Validation

Full pre-push gate clean:

- `npm run lint` — 0 errors, 5 pre-existing warnings
- All 6 tsc typechecks (semantic-graph-extractor, path-analyser,
  emitter-sdk, materializer, request-validation, tests)
- `TEST_SEED=snapshot-baseline npm run testsuite:generate &&
  npm run generate:request-validation`
- `npm test` → **521 passed | 6 skipped**

## Out of scope

- The issue body calls the ABox field `responseTopLevelKeys`; the actual
  field added in Lift 12 is `deploymentSlices`. Same concept, different
  name — used the real field.
