### PR TITLE
feat: source artifact-kind default fixtures from ABox (Lift 17 / #257)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -5513,18 +5513,36 @@ describeForThisConfig(
       const fixtureKinds = new Set(registry.artifacts.map((a) => a.kind));
 
       const orphans: Array<{ operationId: string; kind: string }> = [];
+      const malformedRules: Array<{ operationId: string; ruleIndex: number }> = [];
       for (const opRule of abox.operationRules ?? []) {
-        for (const r of opRule.rules ?? []) {
-          if (r.artifactKind && !fixtureKinds.has(r.artifactKind)) {
+        const rules = opRule.rules ?? [];
+        for (let i = 0; i < rules.length; i++) {
+          const r = rules[i];
+          if (!r?.artifactKind) {
+            // The TBox declares `artifactKind` required on every
+            // ArtifactRule entry (ajv-validated by loadArtifactKindsAbox),
+            // so reaching here means the ABox was loaded through a path
+            // that bypassed schema validation. Treat it as a defect:
+            // a silently-skipped malformed rule will fail at runtime
+            // with the much less actionable "no fixture" error from
+            // path-analyser/src/index.ts.
+            malformedRules.push({ operationId: opRule.operationId, ruleIndex: i });
+            continue;
+          }
+          if (!fixtureKinds.has(r.artifactKind)) {
             orphans.push({ operationId: opRule.operationId, kind: r.artifactKind });
           }
         }
       }
       expect(
+        malformedRules,
+        `ABox operationRules contain entries with a missing/empty \`artifactKind\` — the TBox declares this field required (ajv-validated at load time), so its absence here means the file was loaded outside the validated path. Restore the \`artifactKind\` field on each malformed rule. Malformed: ${JSON.stringify(malformedRules)}`,
+      ).toEqual([]);
+      expect(
         orphans,
-        `Artifact-kind(s) referenced by an ABox operationArtifactRules entry have no fixture of that kind in fixtures/deployment-artifacts.json. ` +
+        `Artifact-kind(s) referenced by an ABox operationRules entry have no fixture of that kind in fixtures/deployment-artifacts.json. ` +
           `Lift 17 / #257 retired the silent OCA-flavoured default-fixtures map, so a missing fixture now throws at pipeline time. ` +
-          `Either add a fixture of the named kind, or remove the rule from operationArtifactRules. ` +
+          `Either add a fixture of the named kind, or remove the rule from operationRules. ` +
           `Orphans: ${JSON.stringify(orphans)}`,
       ).toEqual([]);
     });

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -5468,6 +5468,70 @@ describeForThisConfig('bundled-spec invariants: emitter is API-agnostic (#207)',
 });
 
 describeForThisConfig(
+  'bundled-spec invariants: artifact-kind fixture resolvability (Lift 17 / #257)',
+  () => {
+    // Pre-Lift 17, `path-analyser/src/index.ts` carried a hard-coded
+    //   const defaultFixtures: Record<string, string> = {
+    //     bpmnProcess: '@@FILE:bpmn/simple.bpmn',
+    //     form:        '@@FILE:forms/simple.form',
+    //     dmnDecision: '@@FILE:dmn/decision.dmn',
+    //     dmnDrd:      '@@FILE:dmn/drd.dmn',
+    //   };
+    // map plus a `'@@FILE:bpmn/simple.bpmn'` second-fallback that masked
+    // any registry miss. Both were OCA-flavoured and would silently
+    // coerce a second-API config's deployment to a BPMN file. Lift 17
+    // retired both — `chooseFixtureFromRegistry` now throws on a miss.
+    //
+    // This invariant fails the build *before* anyone runs the pipeline
+    // against a misconfigured ABox: every artifact-kind named by an
+    // `operationArtifactRules[op].rules[*].artifactKind` (which includes
+    // the ABox-derived default for a deployment-gateway op,
+    // `rules[0].artifactKind`) must resolve to at least one entry of
+    // that kind in the per-config `fixtures/deployment-artifacts.json`.
+    // The recurring shape of the defect was "kind referenced but no
+    // fixture of that kind exists"; this is the class-scoped guard.
+    it('every artifact-kind referenced by operationArtifactRules has at least one fixture in deployment-artifacts.json', () => {
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON; ajv validates the shape at load time in production code paths.
+      const abox = JSON.parse(
+        readFileSync(
+          join(REPO_ROOT, 'configs', CONFIG_NAME, 'ontology', 'artifact-kinds.json'),
+          'utf8',
+        ),
+      ) as {
+        operationRules: Array<{
+          operationId: string;
+          rules?: Array<{ artifactKind?: string }>;
+        }>;
+      };
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON; the planner's own loader narrows the same payload.
+      const registry = JSON.parse(
+        readFileSync(
+          join(REPO_ROOT, 'configs', CONFIG_NAME, 'fixtures', 'deployment-artifacts.json'),
+          'utf8',
+        ),
+      ) as { artifacts: Array<{ kind: string }> };
+      const fixtureKinds = new Set(registry.artifacts.map((a) => a.kind));
+
+      const orphans: Array<{ operationId: string; kind: string }> = [];
+      for (const opRule of abox.operationRules ?? []) {
+        for (const r of opRule.rules ?? []) {
+          if (r.artifactKind && !fixtureKinds.has(r.artifactKind)) {
+            orphans.push({ operationId: opRule.operationId, kind: r.artifactKind });
+          }
+        }
+      }
+      expect(
+        orphans,
+        `Artifact-kind(s) referenced by an ABox operationArtifactRules entry have no fixture of that kind in fixtures/deployment-artifacts.json. ` +
+          `Lift 17 / #257 retired the silent OCA-flavoured default-fixtures map, so a missing fixture now throws at pipeline time. ` +
+          `Either add a fixture of the named kind, or remove the rule from operationArtifactRules. ` +
+          `Orphans: ${JSON.stringify(orphans)}`,
+      ).toEqual([]);
+    });
+  },
+);
+
+describeForThisConfig(
   'bundled-spec invariants: feature base scenario contains only required fields (#247)',
   () => {
     // #247: the feature suite's "base" scenario (`feature-1`,

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1181,21 +1181,17 @@ function buildRequestBodyFromCanonical(
       const domainRules = graph.domain?.operationArtifactRules?.[opId]?.rules || [];
       const rule = ruleId ? domainRules.find((r) => r.id === ruleId) : undefined;
       let kind = rule?.artifactKind;
-      if (!kind) {
-        // Default to BPMN process for the deployment-gateway op when
-        // unspecified. Lift 9 / #225: the op is now resolved against the
-        // ABox role mapping; the bpmnProcess default for that op stays
-        // hard-coded here pending Lift 10 (#225 follow-up: derive the
-        // default from operationRules[op].rules[0].artifactKind).
-        if (isDeploymentGatewayOp(graph.domain, opId)) kind = 'bpmnProcess';
+      if (!kind && isDeploymentGatewayOp(graph.domain, opId)) {
+        // Lift 17 / #257: derive the deployment-gateway's default
+        // artifact kind from the ABox
+        // (`operationArtifactRules[op].rules[0].artifactKind`) instead
+        // of a hard-coded `'bpmnProcess'`. Lift 9 / #225 routed the
+        // *operation lookup* through the ABox; this completes the chain
+        // so the *kind* is also ABox-sourced. A second-API config whose
+        // deployment-gateway op produces a different default artifact
+        // kind no longer silently coerces to BPMN.
+        kind = graph.domain?.operationArtifactRules?.[opId]?.rules?.[0]?.artifactKind;
       }
-      // Map artifact kind -> default fixture path
-      const defaultFixtures: Record<string, string> = {
-        bpmnProcess: '@@FILE:bpmn/simple.bpmn',
-        form: '@@FILE:forms/simple.form',
-        dmnDecision: '@@FILE:dmn/decision.dmn',
-        dmnDrd: '@@FILE:dmn/drd.dmn',
-      };
       // Pick the registry entry whose effective providesStates covers the
       // states this createDeployment step must produce for the chain (#159).
       // requiredStates is derived from operationRequirements.<op>.requires
@@ -1210,7 +1206,20 @@ function buildRequestBodyFromCanonical(
         kind ? (graph.domain?.artifactKinds?.[kind]?.producesStates ?? []) : [],
       );
       const regHit = chooseFixtureFromRegistry(kind, requiredStates, kindLevelProvides);
-      const fileRef = regHit?.ref || defaultFixtures[kind || ''] || '@@FILE:bpmn/simple.bpmn';
+      if (!regHit) {
+        // Lift 17 / #257 retired the hard-coded `defaultFixtures` map
+        // and the `'@@FILE:bpmn/simple.bpmn'` second-fallback that
+        // previously masked this misconfiguration. The L3 invariant
+        // "every artifact-kind referenced by an operationArtifactRule
+        // resolves to at least one registry fixture" catches the
+        // recurring shape of this defect at build time.
+        throw new Error(
+          `No deployment fixture available for operationId="${opId}", artifactKind="${kind ?? '(unresolved — declare operationArtifactRules.' + opId + '.rules[0].artifactKind in the ABox)'}". ` +
+            `Add a fixture entry of kind "${kind ?? '<kind>'}" to the active config's fixtures/deployment-artifacts.json, or declare a default ABox rule under operationArtifactRules.${opId}.rules. ` +
+            `Lift 17 / #257 removed the silent OCA-flavoured fallback (@@FILE:bpmn/simple.bpmn) that previously masked this case.`,
+        );
+      }
+      const fileRef = regHit.ref;
       // Bind jobType from the chosen fixture for later use in the request
       // body (`activateJobs.type`, `completeJob`/`failJob`/`throwJobError`
       // path params, etc.). After #164 the SOLE source is

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1214,8 +1214,8 @@ function buildRequestBodyFromCanonical(
         // resolves to at least one registry fixture" catches the
         // recurring shape of this defect at build time.
         throw new Error(
-          `No deployment fixture available for operationId="${opId}", artifactKind="${kind ?? '(unresolved — declare operationArtifactRules.' + opId + '.rules[0].artifactKind in the ABox)'}". ` +
-            `Add a fixture entry of kind "${kind ?? '<kind>'}" to the active config's fixtures/deployment-artifacts.json, or declare a default ABox rule under operationArtifactRules.${opId}.rules. ` +
+          `No deployment fixture available for operationId="${opId}", artifactKind="${kind ?? '(unresolved — declare operationRules[operationId="' + opId + '"].rules[0].artifactKind in the active config\'s ontology/artifact-kinds.json ABox)'}". ` +
+            `Add a fixture entry of kind "${kind ?? '<kind>'}" to the active config's fixtures/deployment-artifacts.json, or declare a default ABox rule under operationRules[operationId="${opId}"].rules. ` +
             `Lift 17 / #257 removed the silent OCA-flavoured fallback (@@FILE:bpmn/simple.bpmn) that previously masked this case.`,
         );
       }


### PR DESCRIPTION
Closes #257.

## Summary

`path-analyser/src/index.ts` previously carried three independent
hard-coded OCA assumptions inside an otherwise API-agnostic generator:

1. **`kind` for an unspecified rule on a deployment-gateway op**
   defaulted to literal `'bpmnProcess'`.
2. **Per-kind default-fixtures map**
   (`bpmnProcess→bpmn/simple.bpmn`, `form→forms/simple.form`,
   `dmnDecision→dmn/decision.dmn`, `dmnDrd→dmn/drd.dmn`).
3. **Cross-kind second-fallback**
   (`'@@FILE:bpmn/simple.bpmn'`) on registry miss.

A second-API config whose deployment-gateway op produced a different
default artifact kind would silently coerce to BPMN. The inline comment
explicitly flagged (1) as a Lift-10 follow-up (#225); (2) and (3) were
never tracked.

Lift 17 retires all three:

- `kind` is now derived from
  `operationArtifactRules[opId].rules[0]?.artifactKind` — the same ABox
  the *operation* lookup already consults (Lift 9 / #225).
- The `defaultFixtures` map is removed.
- The `'@@FILE:bpmn/simple.bpmn'` second-fallback is removed; on a
  registry miss the analyser throws with a named operationId,
  named artifactKind, and a pointer at the two ABox files that must
  be reconciled.

## Behaviour preservation

- For camunda-oca, `operationArtifactRules.createDeployment.rules[0].artifactKind`
  is `"bpmnProcess"` — identical to the retired literal.
- `chooseFixtureFromRegistry` already had a "first matching kind"
  fallback when no entry covers `requiredStates`, so the per-kind
  `defaultFixtures` map was redundant for any kind already in the
  fixture registry; every OCA kind (`bpmnProcess`, `dmnDecision`,
  `dmnDrd`, `form`) is registered.
- Pipeline counts unchanged: **186 feature.specs + 67 variant.specs**.
- Spec-emitted file references unchanged:
  - 73× `bpmn/simple.bpmn`
  - 16× `dmn/decision.dmn`
  - 6× `dmn/drd.dmn`
  - 2× `forms/simple.form`
- All **520 prior tests** still pass; **+1 new L3 invariant** (521 total).

## L3 invariant

`configs/camunda-oca/regression-invariants.test.ts` →
`'bundled-spec invariants: artifact-kind fixture resolvability (Lift 17 / #257)'`:

> Every artifact-kind named by `operationArtifactRules[*].rules[*].artifactKind`
> has at least one entry of that kind in
> `configs/<config>/fixtures/deployment-artifacts.json`.

Class-scoped against the recurring defect "kind referenced but no
fixture of that kind exists" — fails the build *before* the pipeline
runs and triggers the runtime throw.

### Red-proof

Removing all `kind: "form"` entries from the fixture registry fires the
invariant with the named orphan
`{operationId: "createDeployment", kind: "form"}`; reverting returns to
green.

## Validation

Full pre-push gate clean:
- `npm run lint` — 0 errors, 5 pre-existing warnings
- All 6 tsc typechecks (semantic-graph-extractor, path-analyser,
  emitter-sdk, materializer, request-validation, tests)
- `TEST_SEED=snapshot-baseline npm run testsuite:generate &&
  npm run generate:request-validation`
- `npm test` → **521 passed | 6 skipped**

## Sequencing

Independent of #253/#254/#255/#256. Stacks cleanly on top of #263
(Lift 16 / #256), which is currently in review on a separate branch.
