### PR TITLE
feat: hoist '__PENDING__' magic-string sentinel into PENDING_BINDING const (Lift 18 / #258)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -6109,3 +6109,73 @@ describe.skipIf(CONFIG_NAME !== 'camunda-oca')(
     });
   },
 );
+
+describeForThisConfig(
+  'bundled-spec invariants: PENDING_BINDING sentinel hygiene (Lift 18 / #258)',
+  () => {
+    // Lift 18 / #258 hoisted the previously-duplicated `'__PENDING__'`
+    // string literal into a single `PENDING_BINDING` const in
+    // path-analyser/src/types.ts. The sentinel is the planner's
+    // internal placeholder for "binding declared but not yet produced
+    // — a later step's response extraction, a seed-rule literal, or a
+    // runtime-seeded value will fill it in before the materializer
+    // emits a request that reads it".
+    //
+    // Its presence in scenario JSON IS contractual: the materializer
+    // reads `scenario.bindings[v] === PENDING_BINDING` to skip emitting
+    // a literal `ctx.set(v, '__PENDING__')` line, and
+    // `computeSeedBindings` (path-analyser/src/seedBindings.ts) returns
+    // exactly the still-PENDING bindings as the per-scenario runtime
+    // seed list (#136). Scanning scenario JSON for the sentinel would
+    // therefore be the wrong leak detector — it'd fire constantly on
+    // legitimate planner output.
+    //
+    // The real contract: NO emitted Playwright suite file ever contains
+    // the literal sentinel. If the materializer's skip guard regresses
+    // (or a future emitter omits the analogous skip), the sentinel will
+    // leak into a generated `.spec.ts` as either a `ctx.set('foo',
+    // '__PENDING__')` line or a request-body field — either way the
+    // literal string flows into a live API call and produces a
+    // baffling test failure. This invariant locks the post-emit
+    // hygiene in across the entire generated suite.
+    it('no emitted Playwright suite file contains the PENDING_BINDING sentinel string', () => {
+      const playwrightDir = getPlaywrightSuiteDir(REPO_ROOT);
+      if (!existsSync(playwrightDir)) {
+        throw new Error(
+          `Playwright suite directory not found at ${playwrightDir}. Run 'npm run pipeline' first.`,
+        );
+      }
+      const walk = (dir: string): string[] => {
+        const out: string[] = [];
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+          const full = join(dir, entry.name);
+          if (entry.isDirectory()) out.push(...walk(full));
+          else if (entry.isFile() && (entry.name.endsWith('.ts') || entry.name.endsWith('.js'))) {
+            out.push(full);
+          }
+        }
+        return out;
+      };
+      const offenders: Array<{ file: string; line: number; snippet: string }> = [];
+      for (const file of walk(playwrightDir)) {
+        const lines = readFileSync(file, 'utf8').split('\n');
+        for (let i = 0; i < lines.length; i++) {
+          if (lines[i].includes('__PENDING__')) {
+            offenders.push({
+              file: relative(REPO_ROOT, file),
+              line: i + 1,
+              snippet: lines[i].trim().slice(0, 200),
+            });
+          }
+        }
+      }
+      expect(
+        offenders,
+        `Emitted Playwright suite file(s) contain the PENDING_BINDING sentinel ('__PENDING__'). ` +
+          `The materializer must skip every binding whose value is still PENDING_BINDING — that guard lives in materializer/src/playwright/emitter.ts (the \`if (v === PENDING_BINDING) continue\` inside the "Seed scenario bindings" loop) and the per-scenario runtime seed list comes from computeSeedBindings in path-analyser/src/seedBindings.ts. ` +
+          `A leak here means one of those guards regressed and the literal sentinel string will end up in a live API call. ` +
+          `Offenders: ${JSON.stringify(offenders.slice(0, 10))}${offenders.length > 10 ? ` (and ${offenders.length - 10} more)` : ''}`,
+      ).toEqual([]);
+    });
+  },
+);

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -14,6 +14,7 @@ import type {
   GlobalContextSeed,
   RequestStep,
 } from 'path-analyser/types';
+import { PENDING_BINDING } from 'path-analyser/types';
 import type { ImportsTemplateScope, PlaywrightRoleScope } from '../roles.js';
 import {
   loadProjectScaffoldingFiles,
@@ -447,7 +448,7 @@ function renderScenarioTest(
   if (s.bindings && Object.keys(s.bindings).length) {
     body.push('  // Seed scenario bindings');
     for (const [k, v] of Object.entries(s.bindings)) {
-      if (v === '__PENDING__') continue; // handled by seedBindings below
+      if (v === PENDING_BINDING) continue; // handled by seedBindings below
       // Literal bindings flow into ctx unconditionally so any later
       // step (or the same step's body) can read the planner-minted
       // value before any extract overwrites it. The seedBindings list

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -31,6 +31,7 @@ import type {
   RequestStep,
   ResponseShapeSummary,
 } from './types.js';
+import { PENDING_BINDING } from './types.js';
 import { normalizeEndpointFileName } from './utils.js';
 
 function isPlainRecord(v: unknown): v is Record<string, unknown> {
@@ -717,7 +718,7 @@ function mergePopulatesSubShapeIntoFinalBody(
     const bind = `${camelCase(semantic)}Var`;
     setLeafPlaceholder(body, leafPath, `\${${bind}}`);
     scenario.bindings ||= {};
-    if (!scenario.bindings[bind]) scenario.bindings[bind] = '__PENDING__';
+    if (!scenario.bindings[bind]) scenario.bindings[bind] = PENDING_BINDING;
   }
   finalStep.bodyTemplate = body;
 }
@@ -814,7 +815,7 @@ function aliasProducerExtractsToPlaceholders(
         note: 'placeholderAlias',
       });
       scenario.bindings ||= {};
-      if (!scenario.bindings[placeholderVar]) scenario.bindings[placeholderVar] = '__PENDING__';
+      if (!scenario.bindings[placeholderVar]) scenario.bindings[placeholderVar] = PENDING_BINDING;
       break;
     }
   }
@@ -1021,7 +1022,7 @@ function buildRequestBodyFromCanonical(
           const hasBinding = !!(bindingMap[mappedName] || semanticParam);
           if (hasBinding) {
             scenario.bindings ||= {};
-            if (!scenario.bindings[varName]) scenario.bindings[varName] = '__PENDING__';
+            if (!scenario.bindings[varName]) scenario.bindings[varName] = PENDING_BINDING;
             template[name] = `${'${'}${varName}}`;
           } else if (defaults && Object.hasOwn(defaults, name)) {
             template[name] = defaults[name];
@@ -1034,7 +1035,7 @@ function buildRequestBodyFromCanonical(
             template[name] = [];
           } else {
             scenario.bindings ||= {};
-            if (!scenario.bindings[varName]) scenario.bindings[varName] = '__PENDING__';
+            if (!scenario.bindings[varName]) scenario.bindings[varName] = PENDING_BINDING;
             template[name] = `${'${'}${varName}}`;
             if (!bindingMap[mappedName]) missing.push(name);
           }
@@ -1065,7 +1066,7 @@ function buildRequestBodyFromCanonical(
           : !!(bindingMap[normalizedPath] || semanticParam);
         if (hasBinding) {
           scenario.bindings ||= {};
-          if (!scenario.bindings[varName]) scenario.bindings[varName] = '__PENDING__';
+          if (!scenario.bindings[varName]) scenario.bindings[varName] = PENDING_BINDING;
           template[leaf] = `${'${'}${varName}}`;
         } else if (defaults && Object.hasOwn(defaults, leaf)) {
           template[leaf] = defaults[leaf];
@@ -1078,7 +1079,7 @@ function buildRequestBodyFromCanonical(
           template[leaf] = [];
         } else {
           scenario.bindings ||= {};
-          if (!scenario.bindings[varName]) scenario.bindings[varName] = '__PENDING__';
+          if (!scenario.bindings[varName]) scenario.bindings[varName] = PENDING_BINDING;
           template[leaf] = `${'${'}${varName}}`;
           if (!bindingMap[normalizedPath]) missing.push(normalizedPath);
         }
@@ -1121,7 +1122,7 @@ function buildRequestBodyFromCanonical(
       if (allowedFields && !allowedFields.has(leaf)) continue;
       const varName = `${camelCase(param)}Var`;
       scenario.bindings ||= {};
-      if (!scenario.bindings[varName]) scenario.bindings[varName] = '__PENDING__';
+      if (!scenario.bindings[varName]) scenario.bindings[varName] = PENDING_BINDING;
       if (template[leaf] === undefined) {
         template[leaf] = `${'${'}${varName}}`;
       }
@@ -1155,7 +1156,7 @@ function buildRequestBodyFromCanonical(
       template.requestTimeout = shortTimeout;
       // Seed binding for completeness, though template uses a literal
       scenario.bindings ||= {};
-      if (!scenario.bindings.jobTypeVar || scenario.bindings.jobTypeVar === '__PENDING__') {
+      if (!scenario.bindings.jobTypeVar || scenario.bindings.jobTypeVar === PENDING_BINDING) {
         scenario.bindings.jobTypeVar = nonExistentType;
       }
     }
@@ -1253,7 +1254,7 @@ function buildRequestBodyFromCanonical(
       const node = nodes.find((n) => n.path === seed.fieldName);
       if (!node) continue;
       scenario.bindings ||= {};
-      if (!scenario.bindings[seed.binding]) scenario.bindings[seed.binding] = '__PENDING__';
+      if (!scenario.bindings[seed.binding]) scenario.bindings[seed.binding] = PENDING_BINDING;
       template.fields[seed.fieldName] = `\${${seed.binding}}`;
     }
     // Derive expected deployment slices using domain sidecar mapping (explicit). Fallback to heuristic later in emitter.

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -17,6 +17,7 @@ import type {
   OperationNode,
   OperationRef,
 } from './types.js';
+import { PENDING_BINDING } from './types.js';
 
 // Back-compat generation options
 interface GenerationOpts {
@@ -721,7 +722,7 @@ export function generateScenariosForEndpoint(
           if (!bindingsDraft[varName]) {
             const isProducerBound = (graph.producersByType[s]?.length ?? 0) > 0;
             bindingsDraft[varName] = isProducerBound
-              ? '__PENDING__'
+              ? PENDING_BINDING
               : `${camelLower(s)}_${deterministicSuffix(`sg:key:${s}:${varName}`)}`;
           }
         }
@@ -1491,7 +1492,7 @@ function ensureArtifactBindings(
       // client-minted) get a deterministic literal for pre-seeding.
       const isProducerBound = (graph.producersByType[s]?.length ?? 0) > 0;
       state.bindingsDraft[varName] = isProducerBound
-        ? '__PENDING__'
+        ? PENDING_BINDING
         : `${camelLower(s)}_${deterministicSuffix(`sg:sem:${s}:${varName}`)}`;
     }
     // Resolve the GeneratedModelSpec variant for this semantic via the ABox

--- a/path-analyser/src/seedBindings.ts
+++ b/path-analyser/src/seedBindings.ts
@@ -24,7 +24,9 @@
  *
  * The returned list is ordered by first-read for stable output.
  */
+
 import type { EndpointScenario, RequestStep } from './types.js';
+import { PENDING_BINDING } from './types.js';
 
 const PLACEHOLDER_RE = /\$\{([^}]+)\}/g;
 const PATH_PLACEHOLDER_RE = /\{([^}]+)\}/g;
@@ -96,7 +98,7 @@ export function computeSeedBindings(scenario: EndpointScenario): string[] {
     // else is a literal value the emitter writes as
     // `ctx['k'] = "<literal>";`, so it is already satisfied at scenario
     // start without a seedBinding() call.
-    if (v !== '__PENDING__') literalBindings.add(k);
+    if (v !== PENDING_BINDING) literalBindings.add(k);
   }
 
   const need = new Set<string>();

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -1,3 +1,22 @@
+/**
+ * Sentinel value the planner writes into `EndpointScenario.bindings[v]`
+ * when a binding is declared but not yet produced — a placeholder until
+ * an upstream producer (a prior step's response extraction, a seed-rule
+ * literal, or a fixture-provided value) fills it in. Comparisons against
+ * this value happen in the materializer (skip emitting literal request
+ * fields whose value is still pending) and in `seedBindings` (skip
+ * promoting `__PENDING__` placeholders to literal-seed bindings).
+ *
+ * Lift 18 / #258 hoisted the previously-duplicated `'__PENDING__'`
+ * literal into this single declaration. A planner-side L3 invariant
+ * asserts no scenario JSON ever ships this sentinel as a binding value
+ * (it is internal-only; presence in emitted output would be a bug).
+ *
+ * Imported by the materializer via the `path-analyser/types` subpath
+ * export so the two workspaces share one source of truth.
+ */
+export const PENDING_BINDING = '__PENDING__';
+
 export interface OperationRef {
   operationId: string;
   method: string;

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -1,16 +1,24 @@
 /**
  * Sentinel value the planner writes into `EndpointScenario.bindings[v]`
- * when a binding is declared but not yet produced — a placeholder until
- * an upstream producer (a prior step's response extraction, a seed-rule
- * literal, or a fixture-provided value) fills it in. Comparisons against
- * this value happen in the materializer (skip emitting literal request
- * fields whose value is still pending) and in `seedBindings` (skip
- * promoting `__PENDING__` placeholders to literal-seed bindings).
+ * when a binding is declared but not yet produced — a placeholder
+ * meaning "a later step's response extraction, a seed-rule literal, or
+ * a runtime-seeded value will fill this in before any step that reads
+ * it is emitted".
  *
- * Lift 18 / #258 hoisted the previously-duplicated `'__PENDING__'`
- * literal into this single declaration. A planner-side L3 invariant
- * asserts no scenario JSON ever ships this sentinel as a binding value
- * (it is internal-only; presence in emitted output would be a bug).
+ * The sentinel IS contractual in scenario JSON: the materializer reads
+ * `scenario.bindings[v] === PENDING_BINDING` to skip emitting a literal
+ * `ctx.set(v, '__PENDING__')` line, and `computeSeedBindings`
+ * (`path-analyser/src/seedBindings.ts`) returns exactly the still-PENDING
+ * bindings as the per-scenario runtime seed list (#136). Stripping the
+ * sentinel from scenario output would break both contracts.
+ *
+ * What MUST stay free of the sentinel is the *emitted* output (a
+ * generated Playwright `.spec.ts` containing `'__PENDING__'` means the
+ * materializer's skip guard or the seedBindings filter regressed and
+ * the string will flow into a live API call). Lift 18 / #258 added an
+ * L3 invariant that scans `generated/<config>/playwright/` for the
+ * literal — see "PENDING_BINDING sentinel hygiene" in
+ * `configs/<config>/regression-invariants.test.ts`.
  *
  * Imported by the materializer via the `path-analyser/types` subpath
  * export so the two workspaces share one source of truth.


### PR DESCRIPTION
Closes #258.

## Problem

The literal `'__PENDING__'` was used at 12 sites across the planner (`path-analyser/src/{index,scenarioGenerator,seedBindings}.ts`) plus one site in `materializer/src/playwright/emitter.ts` with no canonical declaration. A misspelling at any single site silently degrades to the literal leaking into emitted output and then into a live API call. Audit Pass 2 (#199) row 3.x flagged this as the last unrescued magic-string sentinel in the planner.

Same defect family as the `<default>` tenant sentinel that Lift 8 / #219 hoisted into the global-context-seeds ABox.

## Approach

TS-level const only. The sentinel is a planner-internal contract between the planner (writes), the materializer (reads via the existing `path-analyser/types` subpath export), and `computeSeedBindings` (reads). No external workspace beyond these consumes it, so no TBox lift is justified.

## Changes

- **`path-analyser/src/types.ts`**: `export const PENDING_BINDING = '__PENDING__'` with a docstring explaining the contract.
- All 12 path-analyser sites and the 1 materializer site switched to the symbol.
- Tests retain the literal string by design — they assert the contract value, not the import.

## L3 invariant

`configs/camunda-oca/regression-invariants.test.ts` gains "no emitted Playwright suite file contains the PENDING_BINDING sentinel string". It walks every `.ts`/`.js` under `generated/<config>/playwright/` and fails on any occurrence of the literal — the actual leak class (a sentinel appearing in a generated suite means the materializer skip guard or the `seedBindings` filter regressed and the string will flow into a live API call).

> Note: scanning planner **scenario JSON** for the sentinel would be the wrong detector — `PENDING_BINDING` shipping in `scenario.bindings` is contractual (the materializer reads it to skip emitting a literal `ctx.set` line, and `computeSeedBindings` returns exactly the still-PENDING bindings as the runtime seed list per #136). My first attempt at the invariant did that and surfaced 123 spurious 'leaks' — I rewrote it to scan emitted suites instead.

## Red-proof

Verified by injecting `// __PENDING__ leak` into one emitted spec — the invariant fires with file/line/snippet of the offender.

## Pre-push gate

- Lint: ✅
- All 6 `tsc --noEmit` typechecks: ✅
- `build:analyser` + `build:emitter-sdk`: ✅
- Pipeline regen (`testsuite:generate` + `generate:request-validation`): ✅
- Full vitest run: **523 passed | 6 skipped**