### PR TITLE
feat: scenario-template TBox + EdgeLifecycle ABox (#269)

### DIFF
--- a/configs/camunda-oca/ontology/scenario-templates.json
+++ b/configs/camunda-oca/ontology/scenario-templates.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "../../../ontology/vocabulary/scenario-template.schema.json",
+  "@context": {
+    "@vocab": "https://camunda.github.io/api-test-generator/ns/v1/",
+    "templates": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/templates",
+      "@container": "@set"
+    },
+    "appliesTo": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/appliesTo"
+    },
+    "steps": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/steps",
+      "@container": "@list"
+    },
+    "kind": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/kind"
+    },
+    "op": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/op"
+    },
+    "for": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/for"
+    },
+    "expect": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/expect"
+    }
+  },
+  "version": 1,
+  "templates": [
+    {
+      "@type": "ScenarioTemplate",
+      "name": "EdgeLifecycle",
+      "appliesTo": { "kind": "Edge" },
+      "description": "Establish an edge instance, verify it is observable via the edge's observableVia operation, revoke the edge instance, verify it is no longer observable. Applies to every edge in the edges ABox; consumes establishedBy, revokedBy, and observableVia (all required on the Edge TBox since #224). The high-level present/absent expectations compile down to toContain / not.toContain assertions on the membership identifier (per the #268 walkthrough): the planner uses the scenario binding context to source the value and the response-extraction graph to locate the array path inside the observation op's 200 response.",
+      "steps": [
+        { "kind": "PrereqChain", "for": "establishedBy" },
+        { "kind": "Invoke", "op": "establishedBy" },
+        { "kind": "Observe", "op": "observableVia", "expect": "present" },
+        { "kind": "Invoke", "op": "revokedBy" },
+        { "kind": "Observe", "op": "observableVia", "expect": "absent" }
+      ]
+    }
+  ]
+}

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -6395,3 +6395,198 @@ describeForThisConfig(
     });
   },
 );
+
+// ---------------------------------------------------------------------------
+// Scenario templates ABox (#268 Phase 1 / #269) — encoding only.
+//
+// ABox at `configs/<active>/ontology/scenario-templates.json`, validated
+// by the TBox authored as a TS const in
+// `path-analyser/src/ontology/scenarioTemplateSchema.ts`, loaded by
+// `path-analyser/src/ontology/loader.ts` (single source of truth: ajv
+// runtime validation + json-schema-to-ts type inference both consume
+// the same TS literal). The matching
+// `ontology/vocabulary/scenario-template.schema.json` is generated from
+// the TS const by `scripts/build-ontology.ts` for external
+// SPARQL/SHACL/OWL consumers.
+//
+// The dependency graph encodes data-flow (which ops, in what order);
+// templates encode temporal/modal assertions (what to assert between
+// or after those ops). Phase 1 ships the TBox + EdgeLifecycle template
+// for all 12 OCA edges as encoding only — there is no planner consumer
+// yet (#270 follows up). The invariants below pin that the encoding is
+// well-formed and that the observation-feasibility precondition holds
+// for every edge × Observe-step pair, so the #270 planner work lands
+// against a validated surface.
+describeForThisConfig(
+  'bundled-spec invariants: scenario-templates ABox (#268 Phase 1 / #269)',
+  () => {
+    it('loads the scenario-templates ABox via the generic loader (proves the load path)', async () => {
+      const { loadScenarioTemplatesAbox } = await import(
+        '../../path-analyser/src/ontology/loader.js'
+      );
+      const abox = loadScenarioTemplatesAbox(REPO_ROOT);
+      expect(
+        abox,
+        'scenario-templates ABox must exist for the camunda-oca config (Phase 1 / #269)',
+      ).not.toBeNull();
+      expect(abox?.templates.length).toBeGreaterThan(0);
+    });
+
+    it('every template Step references a known role on its appliesTo subject ABox', async () => {
+      // Templates reference subject roles (e.g. `establishedBy`,
+      // `revokedBy`, `observableVia`) symbolically, not by raw
+      // operationId. The planner resolves them at instantiation time
+      // against the subject's ABox entry. This invariant catches a
+      // typo or a renamed role at encoding time, before the planner
+      // (#270) ever runs.
+      const { loadScenarioTemplatesAbox, loadEdgesAbox } = await import(
+        '../../path-analyser/src/ontology/loader.js'
+      );
+      const templates = loadScenarioTemplatesAbox(REPO_ROOT);
+      if (!templates) throw new Error('scenario-templates ABox missing');
+      // Known subject-role fields per `appliesTo.kind`. Extending the
+      // template TBox with a new subject ABox requires extending this
+      // map AND the union in `AppliesTo.kind`.
+      const EDGE_ROLES = new Set(['establishedBy', 'revokedBy', 'observableVia']);
+      const offenders: string[] = [];
+      for (const tpl of templates.templates) {
+        const validRoles = tpl.appliesTo.kind === 'Edge' ? EDGE_ROLES : new Set<string>();
+        for (let i = 0; i < tpl.steps.length; i++) {
+          const step = tpl.steps[i];
+          const ref = step.kind === 'PrereqChain' ? step.for : step.op;
+          if (!validRoles.has(ref)) {
+            offenders.push(
+              `${tpl.name}.steps[${i}] (kind=${step.kind}) references role '${ref}' which is not a known field on '${tpl.appliesTo.kind}' subjects (known: ${[...validRoles].join(', ')})`,
+            );
+          }
+        }
+      }
+      expect(
+        offenders,
+        `Every template step's role reference must resolve to a known field on its appliesTo subject ABox. ` +
+          `For 'Edge' subjects, valid roles are: establishedBy, revokedBy, observableVia.`,
+      ).toEqual([]);
+    });
+
+    it('every edge in the edges ABox is covered by at least one EdgeLifecycle template (no edge silently unscoped)', async () => {
+      // Phase 1 has exactly one template (`EdgeLifecycle`) and it
+      // applies uniformly to all edges. The coverage check pins that
+      // intent so a future edge can't slip in without a corresponding
+      // template scope decision (either it is covered, or a new
+      // template / explicit opt-out is introduced).
+      const { loadScenarioTemplatesAbox, loadEdgesAbox } = await import(
+        '../../path-analyser/src/ontology/loader.js'
+      );
+      const templates = loadScenarioTemplatesAbox(REPO_ROOT);
+      const edges = loadEdgesAbox(REPO_ROOT);
+      if (!templates) throw new Error('scenario-templates ABox missing');
+      if (!edges) throw new Error('edges ABox missing');
+      const edgeTemplates = templates.templates.filter((t) => t.appliesTo.kind === 'Edge');
+      expect(edgeTemplates.length, 'at least one Edge-scoped template must exist').toBeGreaterThan(
+        0,
+      );
+      // Phase 1 templates apply uniformly to every edge — there is no
+      // per-edge filter expression in the TBox. A future per-edge
+      // selector would refine this invariant rather than replace it.
+      expect(edges.edges.length).toBeGreaterThan(0);
+    });
+
+    it('every edge × Observe step is feasible: the observation op response carries the membership identifier inside an array (#268 walkthrough)', async () => {
+      // The #268 walkthrough showed that high-level present/absent
+      // predicates compile down to `expect(items.map(...))
+      // .[not.]toContain(value)` — but only if the observation op's
+      // 200 response actually carries the *membership* identifier
+      // (= edge.identifiedBy minus the observation op's input
+      // semantic types) inside an array. The response-extraction
+      // graph already encodes that as a `responseSemanticTypes['200']`
+      // entry with a `fieldPath` containing `[]`.
+      //
+      // This invariant is the gate for #270: if every (edge,
+      // ObserveStep) pair passes here, the planner can rely on the
+      // type-match heuristic (option 1 in the walkthrough) without
+      // needing the `observableVia.itemsAt` escape hatch.
+      const { loadScenarioTemplatesAbox, loadEdgesAbox } = await import(
+        '../../path-analyser/src/ontology/loader.js'
+      );
+      const templates = loadScenarioTemplatesAbox(REPO_ROOT);
+      const edges = loadEdgesAbox(REPO_ROOT);
+      if (!templates) throw new Error('scenario-templates ABox missing');
+      if (!edges) throw new Error('edges ABox missing');
+      loadGraph();
+      const opById = cachedOperationById;
+      if (!opById) throw new Error('graph not loaded');
+      const offenders: string[] = [];
+      const edgeTemplates = templates.templates.filter((t) => t.appliesTo.kind === 'Edge');
+      for (const tpl of edgeTemplates) {
+        for (const edge of edges.edges) {
+          for (let i = 0; i < tpl.steps.length; i++) {
+            const step = tpl.steps[i];
+            if (step.kind !== 'Observe') continue;
+            // Resolve the observation operationId via the edge.
+            // The TBox restricts Edge ObserveStep.op to one of the
+            // edge roles; in practice it's `observableVia` for
+            // Phase 1 but we look up via a narrowing switch so the
+            // edge field access remains type-safe (no `as` cast).
+            const role = step.op;
+            let opId: string;
+            switch (role) {
+              case 'establishedBy':
+                opId = edge.establishedBy;
+                break;
+              case 'revokedBy':
+                opId = edge.revokedBy;
+                break;
+              case 'observableVia':
+                opId = edge.observableVia;
+                break;
+              default:
+                offenders.push(
+                  `${tpl.name} × ${edge.name}: Observe step references unknown edge role '${role}'`,
+                );
+                continue;
+            }
+            const op = opById.get(opId);
+            if (!op) {
+              offenders.push(`${tpl.name} × ${edge.name}: operationId '${opId}' not in graph`);
+              continue;
+            }
+            // Feasibility check: for every membership-candidate
+            // identifiedBy type, the observation op's 200 response
+            // must carry it as a field inside an array (i.e. `[]`
+            // in the fieldPath). This is what compiles to
+            // `expect(items.map(...)).toContain(value)` at #270.
+            //
+            // Note we deliberately do NOT exclude identifiedBy
+            // types that also appear as request-body filter inputs
+            // (e.g. `searchMappingRulesForRole` accepts
+            // `filter.mappingRuleId` AND returns
+            // `items[].mappingRuleId` — the filter is optional and
+            // doesn't disqualify the response field from being the
+            // membership locator). The actually-load-bearing
+            // property is "appears in an array-nested response
+            // field"; the scoping/membership split is a #270
+            // planner concern at instantiation time.
+            const responses = op.responseSemanticTypes?.['200'] ?? [];
+            const arrayNestedSemanticTypes = new Set(
+              responses.filter((r) => r.fieldPath.includes('[]')).map((r) => r.semanticType),
+            );
+            const observable = edge.identifiedBy.filter((s) => arrayNestedSemanticTypes.has(s));
+            if (observable.length === 0) {
+              offenders.push(
+                `${tpl.name} × ${edge.name}: observation op '${opId}' 200 response has no array-nested field carrying any identifiedBy type (${edge.identifiedBy.join(', ')}); got: ${responses
+                  .map((r) => `${r.semanticType}@${r.fieldPath}`)
+                  .join(', ')}`,
+              );
+            }
+          }
+        }
+      }
+      expect(
+        offenders,
+        `Every (edge × Observe step) pair must be feasible at the response-shape level. ` +
+          `This is the gate for #270 — if it fails for any pair, the planner cannot compile present/absent ` +
+          `to a concrete assertion without an explicit array-locator escape hatch on the edge.`,
+      ).toEqual([]);
+    });
+  },
+);

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -6439,7 +6439,7 @@ describeForThisConfig(
       // against the subject's ABox entry. This invariant catches a
       // typo or a renamed role at encoding time, before the planner
       // (#270) ever runs.
-      const { loadScenarioTemplatesAbox, loadEdgesAbox } = await import(
+      const { loadScenarioTemplatesAbox } = await import(
         '../../path-analyser/src/ontology/loader.js'
       );
       const templates = loadScenarioTemplatesAbox(REPO_ROOT);
@@ -6481,13 +6481,26 @@ describeForThisConfig(
       const edges = loadEdgesAbox(REPO_ROOT);
       if (!templates) throw new Error('scenario-templates ABox missing');
       if (!edges) throw new Error('edges ABox missing');
+      // Phase 1 pins exactly one Edge-scoped template named
+      // `EdgeLifecycle` that applies uniformly to every edge. Pinning
+      // the name + sole-Edge-template shape catches a rename, an
+      // accidental scope change to a non-Edge kind, or a silent
+      // removal — any of which would otherwise pass a "≥ 1 Edge
+      // template" check while breaking #270's planner consumption.
       const edgeTemplates = templates.templates.filter((t) => t.appliesTo.kind === 'Edge');
-      expect(edgeTemplates.length, 'at least one Edge-scoped template must exist').toBeGreaterThan(
-        0,
-      );
-      // Phase 1 templates apply uniformly to every edge — there is no
-      // per-edge filter expression in the TBox. A future per-edge
-      // selector would refine this invariant rather than replace it.
+      expect(
+        edgeTemplates.length,
+        'Phase 1 expects exactly one Edge-scoped template; a future per-edge selector would refine this invariant rather than replace it',
+      ).toBe(1);
+      expect(
+        edgeTemplates[0].name,
+        "the sole Edge-scoped template must be named 'EdgeLifecycle' (Phase 1 / #269); rename requires updating planner consumption in #270",
+      ).toBe('EdgeLifecycle');
+      // Coverage is structural in Phase 1: templates apply uniformly
+      // to every edge — there is no per-edge filter expression in the
+      // TBox. Asserting the edge ABox is non-empty pins the "every
+      // edge is covered" intent against a future regression where
+      // edges.json gets accidentally cleared.
       expect(edges.edges.length).toBeGreaterThan(0);
     });
 

--- a/ontology/vocabulary/scenario-template.schema.json
+++ b/ontology/vocabulary/scenario-template.schema.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://camunda.github.io/api-test-generator/ns/v1/scenario-template.schema.json",
+  "title": "ScenarioTemplatesAbox",
+  "description": "TBox JSON Schema for an ABox file describing scenario templates — declarative ordered lists of test steps the planner instantiates against subjects from another ABox (currently: edges). Each template asserts: a unique name; an `appliesTo` discriminator naming the subject ABox; a non-empty step list. Steps are a tagged union of PrereqChain (graph-derived prereqs targeted at a named subject role), Invoke (invocation of an operation named by a subject role), and Observe (invocation of an observation operation + a high-level expectation that an edge instance is present in or absent from the result set). The schema is intentionally agnostic to which subjects exist — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/scenario-templates.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references (subject-role names actually being fields on the referenced subject ABox; observation ops actually carrying the membership semantic type inside an array of their response) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "templates"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "@context": {
+      "description": "Optional JSON-LD context. Ignored by the loader; preserved verbatim so external RDF tooling can resolve term IRIs without modification.",
+      "type": [
+        "object",
+        "string",
+        "array"
+      ]
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Schema version of this ABox file. Bumped only when the TBox shape changes incompatibly."
+    },
+    "templates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/ScenarioTemplate"
+      }
+    }
+  },
+  "definitions": {
+    "ScenarioTemplate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "appliesTo",
+        "steps",
+        "description"
+      ],
+      "properties": {
+        "@type": {
+          "description": "Optional JSON-LD type IRI. Ignored by the loader.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Za-z0-9]+$",
+          "description": "PascalCase singular noun naming the template. Must be unique within the ABox (checked by the loader; Draft-07 cannot express uniqueness)."
+        },
+        "appliesTo": {
+          "$ref": "#/definitions/AppliesTo"
+        },
+        "steps": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/Step"
+          },
+          "description": "Ordered list of steps. Executed top-to-bottom by the planner / emitter at instantiation time."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Maintainer-facing prose explaining what behaviour this template asserts and why it is encoded as a template (vs. baked into the planner)."
+        }
+      }
+    },
+    "AppliesTo": {
+      "description": "Discriminator naming the subject ABox the template is instantiated against. Currently only `Edge` is recognised (#269 Phase 1); extending the union is how future subject ABoxes (resources, state-transitions, …) opt in to template-driven scenario emission.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "Edge"
+          ]
+        }
+      }
+    },
+    "Step": {
+      "description": "A single step in a scenario template. Tagged union on `kind`; each variant declares only the fields it consumes.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/PrereqChainStep"
+        },
+        {
+          "$ref": "#/definitions/InvokeStep"
+        },
+        {
+          "$ref": "#/definitions/ObserveStep"
+        }
+      ]
+    },
+    "PrereqChainStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "for"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "const": "PrereqChain"
+        },
+        "for": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Subject-role name (e.g. `establishedBy`). At instantiation time the planner resolves this to the subject's operationId and runs its existing BFS targeted at that operation, materializing all upstream producers as preceding steps."
+        }
+      }
+    },
+    "InvokeStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "op"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "const": "Invoke"
+        },
+        "op": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Subject-role name (e.g. `establishedBy` or `revokedBy`). At instantiation time the planner resolves this to the subject's operationId and emits an invocation whose inputs are drawn from the scenario binding context built up by any preceding PrereqChain step."
+        }
+      }
+    },
+    "ObserveStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "op",
+        "expect"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "const": "Observe"
+        },
+        "op": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Subject-role name (e.g. `observableVia`). At instantiation time the planner resolves this to the subject's observation operationId, invokes it, and asserts on the response per `expect`."
+        },
+        "expect": {
+          "type": "string",
+          "enum": [
+            "present",
+            "absent"
+          ],
+          "description": "High-level membership predicate. `present` asserts the subject instance (identified by the subject's `identifiedBy` tuple) appears in the response; `absent` asserts it does not. The planner compiles this to a concrete `toContain` / `not.toContain` assertion at instantiation time, using the binding context to source the lookup value and the response-extraction graph to locate the array path. Lower-level predicates (e.g. raw `status: 404`) are deliberately NOT in scope for Phase 1 — they belong on future template kinds applicable to non-edge subjects (resource lifecycle, etc.)."
+        }
+      }
+    }
+  }
+}

--- a/ontology/vocabulary/scenario-template.schema.json
+++ b/ontology/vocabulary/scenario-template.schema.json
@@ -41,8 +41,7 @@
       "required": [
         "name",
         "appliesTo",
-        "steps",
-        "description"
+        "steps"
       ],
       "properties": {
         "@type": {

--- a/path-analyser/src/ontology/crossRef/scenarioTemplateCrossRef.ts
+++ b/path-analyser/src/ontology/crossRef/scenarioTemplateCrossRef.ts
@@ -1,0 +1,35 @@
+// Per-slice cross-reference module for `scenarioTemplateSchema.ts`
+// (#268 Phase 1 / #269).
+//
+// Phase 1 ships templates as **encoding only** — no planner consumer
+// yet (#270 follows up). Cross-reference invariants between scenario
+// templates and other slices of `DomainSemantics` are therefore
+// deliberately deferred to Phase 2, where they live in
+// `configs/<config>/regression-invariants.test.ts` alongside the new
+// planner / emitter behaviours they guard (template-derived scenario
+// output, ObserveStep response-array locator feasibility, etc.).
+//
+// One Phase-1-shaped cross-ref invariant *does* exist today — the
+// per-edge × per-Observe-step observability check landed in
+// `configs/camunda-oca/regression-invariants.test.ts` under the
+// `'scenario-templates ABox (#268 Phase 1 / #269)'` describe block.
+// That check ranges over the dependency graph, not the merged
+// `DomainSemantics` view, so it lives at the L3 layer rather than in
+// this composer pipeline.
+//
+// This stub exists so the Lift 15 / #255 build-time guard ("every
+// `*Schema.ts` slice has a matching `crossRef/*CrossRef.ts`
+// registered in `CROSS_REF_MODULES`") passes. Without it, the guard
+// fires on every TBox addition — exactly the drift it was filed to
+// prevent. Promoting any cross-slice invariant to this module is the
+// natural way to fold a #270-introduced check into the merged-domain
+// validator if one materialises.
+
+import type { SliceCrossRefModule } from './types.js';
+
+export const SCENARIO_TEMPLATE_CROSS_REF: SliceCrossRefModule = {
+  slice: 'scenarioTemplate',
+  checks: [],
+  noChecksRationale:
+    'Phase 1 ships scenario templates as encoding only — no planner consumer yet (#270 follows up). The one currently-needed cross-reference invariant (edge × Observe-step observability feasibility against the dependency graph) lives as an L3 invariant in configs/<config>/regression-invariants.test.ts because it ranges over OperationGraph, not over the merged DomainSemantics view this composer validates. Promote a check here only when #270 introduces a cross-slice invariant naturally expressed over DomainSemantics.',
+};

--- a/path-analyser/src/ontology/crossRefValidator.ts
+++ b/path-analyser/src/ontology/crossRefValidator.ts
@@ -9,6 +9,7 @@ import {
   GLOBAL_CONTEXT_SEEDS_CROSS_REF,
 } from './crossRef/globalContextSeedsCrossRef.js';
 import { RUNTIME_STATES_CROSS_REF } from './crossRef/runtimeStatesCrossRef.js';
+import { SCENARIO_TEMPLATE_CROSS_REF } from './crossRef/scenarioTemplateCrossRef.js';
 import { SEMANTICS_CROSS_REF } from './crossRef/semanticsCrossRef.js';
 import type { SliceCrossRefModule } from './crossRef/types.js';
 
@@ -61,6 +62,7 @@ export const CROSS_REF_MODULES: readonly SliceCrossRefModule[] = [
   RUNTIME_STATES_CROSS_REF,
   SEMANTICS_CROSS_REF,
   GLOBAL_CONTEXT_SEEDS_CROSS_REF,
+  SCENARIO_TEMPLATE_CROSS_REF,
 ];
 
 // Public-boundary structural validator for `globalContextSeeds`. Kept

--- a/path-analyser/src/ontology/loader.ts
+++ b/path-analyser/src/ontology/loader.ts
@@ -8,6 +8,7 @@ import { edgeSchema } from './edgeSchema.js';
 import { entityKindsSchema } from './entityKindsSchema.js';
 import { globalContextSeedsSchema } from './globalContextSeedsSchema.js';
 import { runtimeStatesSchema } from './runtimeStatesSchema.js';
+import { scenarioTemplateSchema } from './scenarioTemplateSchema.js';
 import { semanticsSchema } from './semanticsSchema.js';
 
 // ---------------------------------------------------------------------------
@@ -61,6 +62,10 @@ export type IdentifierEntry = NonNullable<SemanticsAbox['identifiers']>[number];
 export type GlobalContextSeedsAbox = FromSchema<typeof globalContextSeedsSchema>;
 export type GlobalContextSeedEntry = GlobalContextSeedsAbox['seeds'][number];
 
+export type ScenarioTemplatesAbox = FromSchema<typeof scenarioTemplateSchema>;
+export type ScenarioTemplate = ScenarioTemplatesAbox['templates'][number];
+export type ScenarioTemplateStep = ScenarioTemplate['steps'][number];
+
 // `Ajv` is the named export pointing at the constructor; the namespace
 // also has a self-referential default but the named export is the
 // least error-prone form under module=nodenext.
@@ -72,6 +77,7 @@ const validateRuntimeStatesAbox = ajv.compile<RuntimeStatesAbox>(runtimeStatesSc
 const validateSemanticsAbox = ajv.compile<SemanticsAbox>(semanticsSchema);
 const validateGlobalContextSeedsAbox =
   ajv.compile<GlobalContextSeedsAbox>(globalContextSeedsSchema);
+const validateScenarioTemplatesAbox = ajv.compile<ScenarioTemplatesAbox>(scenarioTemplateSchema);
 
 function formatErrors(errors: ErrorObject[] | null | undefined): string {
   return (errors ?? [])
@@ -906,4 +912,61 @@ export function assertSafeGlobalContextSeeds(seeds: unknown): void {
       );
     }
   }
+}
+
+/**
+ * Load and validate the scenario-templates ABox file for the active
+ * config (#268 Phase 1 / #269).
+ *
+ * The ABox describes declarative test-step templates the planner
+ * instantiates against subjects from other ABoxes (currently only
+ * `Edge`). The dependency graph encodes data-flow (which ops, in what
+ * order); templates encode temporal/modal assertions (what to assert
+ * between or after those ops) — a property the graph fundamentally
+ * cannot express.
+ *
+ * @returns the parsed ABox, or `null` if no `scenario-templates.json`
+ *   ships under `configs/<active>/ontology/`. A missing file is
+ *   non-fatal: callers should treat it as "no template-derived
+ *   scenarios". There is no planner consumer in #269 — this loader
+ *   exists so #270 can land without further loader work.
+ * @throws if the file exists but does not validate against the TBox or
+ *   contains duplicate template names.
+ */
+export function loadScenarioTemplatesAbox(repoRoot: string): ScenarioTemplatesAbox | null {
+  let aboxPath: string;
+  try {
+    aboxPath = path.join(getActiveConfigDir(repoRoot), 'ontology', 'scenario-templates.json');
+  } catch {
+    return null;
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(aboxPath, 'utf8');
+  } catch (err) {
+    if (err !== null && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+      return null;
+    }
+    throw err;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse scenario-templates ABox at ${aboxPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!validateScenarioTemplatesAbox(parsed)) {
+    throw new Error(
+      `Scenario-templates ABox at ${aboxPath} failed TBox validation:\n${formatErrors(validateScenarioTemplatesAbox.errors)}`,
+    );
+  }
+  const dupeNames = duplicates(parsed.templates.map((t) => t.name));
+  if (dupeNames.length > 0) {
+    throw new Error(
+      `Scenario-templates ABox at ${aboxPath} has duplicate template name(s): ${dupeNames.join(', ')}`,
+    );
+  }
+  return parsed;
 }

--- a/path-analyser/src/ontology/scenarioTemplateSchema.ts
+++ b/path-analyser/src/ontology/scenarioTemplateSchema.ts
@@ -1,0 +1,181 @@
+// Source of truth for the scenario-template ABox TBox
+// (api-test-generator ontology, v1).
+//
+// Mirrors the pattern established by `edgeSchema.ts` (Lift 3 / #208) and
+// the other Lift-N TBox sources: this TypeScript module is the
+// authoritative declaration; the matching
+// `ontology/vocabulary/scenario-template.schema.json` file is generated
+// from it by `scripts/build-ontology.ts` (run via `npm run
+// build:ontology`) and committed solely so external SPARQL/SHACL/OWL
+// consumers can fetch a plain JSON Schema by URL. A regression
+// invariant in `configs/<config>/regression-invariants.test.ts` asserts
+// the two are in sync.
+//
+// What this ABox encodes (#268 Phase 1 / #269): scenario *templates* —
+// declarative, ordered lists of test steps that the planner instantiates
+// against subjects from another ABox (initially: edges, from #224 +
+// #208). The dependency graph encodes which operations belong in a
+// scenario and in what order (a data-flow property); templates encode
+// what to assert between or after those operations (a temporal/modal
+// property the graph fundamentally cannot express).
+//
+// Initial template surface (Phase 1, encoding only — no planner
+// consumption yet, see follow-up #270):
+//   - `PrereqChain { for: <edge-op-role> }`  — graph-derived; planner
+//     fills this in by running its existing BFS targeted at the edge's
+//     named operation role.
+//   - `Invoke { op: <edge-op-role> }`        — invoke the operation
+//     named by the edge role (`establishedBy` or `revokedBy`).
+//   - `Observe { op: <edge-op-role>,         — invoke the observation
+//        expect: present | absent }`           operation and assert the
+//                                              edge instance is (still)
+//                                              present in / absent from
+//                                              the result set.
+//
+// `op` and `for` are *role* references, not raw operationIds. The role
+// is a field name on the subject ABox entry (`establishedBy`,
+// `revokedBy`, `observableVia` for edges). The planner resolves the
+// role against the subject ABox at instantiation time. This keeps
+// templates portable across edges within a config and across configs.
+//
+// Cross-references against the spec / other ABoxes (does the role
+// resolve, does the observation op's response actually carry the
+// membership semantic type inside an array, etc) are encoded as L3
+// invariants in `configs/<name>/regression-invariants.test.ts` — same
+// design as #224. Draft-07 cannot express them, and a generic schema
+// error wouldn't point at the broken edge × template pair anyway.
+
+export const scenarioTemplateSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'https://camunda.github.io/api-test-generator/ns/v1/scenario-template.schema.json',
+  title: 'ScenarioTemplatesAbox',
+  description:
+    'TBox JSON Schema for an ABox file describing scenario templates — declarative ordered lists of test steps the planner instantiates against subjects from another ABox (currently: edges). Each template asserts: a unique name; an `appliesTo` discriminator naming the subject ABox; a non-empty step list. Steps are a tagged union of PrereqChain (graph-derived prereqs targeted at a named subject role), Invoke (invocation of an operation named by a subject role), and Observe (invocation of an observation operation + a high-level expectation that an edge instance is present in or absent from the result set). The schema is intentionally agnostic to which subjects exist — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/scenario-templates.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references (subject-role names actually being fields on the referenced subject ABox; observation ops actually carrying the membership semantic type inside an array of their response) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them.',
+  type: 'object',
+  additionalProperties: false,
+  required: ['version', 'templates'],
+  properties: {
+    $schema: { type: 'string' },
+    '@context': {
+      description:
+        'Optional JSON-LD context. Ignored by the loader; preserved verbatim so external RDF tooling can resolve term IRIs without modification.',
+      type: ['object', 'string', 'array'],
+    },
+    version: {
+      type: 'integer',
+      minimum: 1,
+      description:
+        'Schema version of this ABox file. Bumped only when the TBox shape changes incompatibly.',
+    },
+    templates: {
+      type: 'array',
+      minItems: 1,
+      items: { $ref: '#/definitions/ScenarioTemplate' },
+    },
+  },
+  definitions: {
+    ScenarioTemplate: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['name', 'appliesTo', 'steps', 'description'],
+      properties: {
+        '@type': {
+          description: 'Optional JSON-LD type IRI. Ignored by the loader.',
+          type: 'string',
+        },
+        name: {
+          type: 'string',
+          pattern: '^[A-Z][A-Za-z0-9]+$',
+          description:
+            'PascalCase singular noun naming the template. Must be unique within the ABox (checked by the loader; Draft-07 cannot express uniqueness).',
+        },
+        appliesTo: {
+          $ref: '#/definitions/AppliesTo',
+        },
+        steps: {
+          type: 'array',
+          minItems: 1,
+          items: { $ref: '#/definitions/Step' },
+          description:
+            'Ordered list of steps. Executed top-to-bottom by the planner / emitter at instantiation time.',
+        },
+        description: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Maintainer-facing prose explaining what behaviour this template asserts and why it is encoded as a template (vs. baked into the planner).',
+        },
+      },
+    },
+    AppliesTo: {
+      description:
+        'Discriminator naming the subject ABox the template is instantiated against. Currently only `Edge` is recognised (#269 Phase 1); extending the union is how future subject ABoxes (resources, state-transitions, …) opt in to template-driven scenario emission.',
+      type: 'object',
+      additionalProperties: false,
+      required: ['kind'],
+      properties: {
+        kind: {
+          type: 'string',
+          enum: ['Edge'],
+        },
+      },
+    },
+    Step: {
+      description:
+        'A single step in a scenario template. Tagged union on `kind`; each variant declares only the fields it consumes.',
+      oneOf: [
+        { $ref: '#/definitions/PrereqChainStep' },
+        { $ref: '#/definitions/InvokeStep' },
+        { $ref: '#/definitions/ObserveStep' },
+      ],
+    },
+    PrereqChainStep: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['kind', 'for'],
+      properties: {
+        kind: { type: 'string', const: 'PrereqChain' },
+        for: {
+          type: 'string',
+          minLength: 1,
+          description:
+            "Subject-role name (e.g. `establishedBy`). At instantiation time the planner resolves this to the subject's operationId and runs its existing BFS targeted at that operation, materializing all upstream producers as preceding steps.",
+        },
+      },
+    },
+    InvokeStep: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['kind', 'op'],
+      properties: {
+        kind: { type: 'string', const: 'Invoke' },
+        op: {
+          type: 'string',
+          minLength: 1,
+          description:
+            "Subject-role name (e.g. `establishedBy` or `revokedBy`). At instantiation time the planner resolves this to the subject's operationId and emits an invocation whose inputs are drawn from the scenario binding context built up by any preceding PrereqChain step.",
+        },
+      },
+    },
+    ObserveStep: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['kind', 'op', 'expect'],
+      properties: {
+        kind: { type: 'string', const: 'Observe' },
+        op: {
+          type: 'string',
+          minLength: 1,
+          description:
+            "Subject-role name (e.g. `observableVia`). At instantiation time the planner resolves this to the subject's observation operationId, invokes it, and asserts on the response per `expect`.",
+        },
+        expect: {
+          type: 'string',
+          enum: ['present', 'absent'],
+          description:
+            "High-level membership predicate. `present` asserts the subject instance (identified by the subject's `identifiedBy` tuple) appears in the response; `absent` asserts it does not. The planner compiles this to a concrete `toContain` / `not.toContain` assertion at instantiation time, using the binding context to source the lookup value and the response-extraction graph to locate the array path. Lower-level predicates (e.g. raw `status: 404`) are deliberately NOT in scope for Phase 1 — they belong on future template kinds applicable to non-edge subjects (resource lifecycle, etc.).",
+        },
+      },
+    },
+  },
+} as const;

--- a/path-analyser/src/ontology/scenarioTemplateSchema.ts
+++ b/path-analyser/src/ontology/scenarioTemplateSchema.ts
@@ -77,7 +77,7 @@ export const scenarioTemplateSchema = {
     ScenarioTemplate: {
       type: 'object',
       additionalProperties: false,
-      required: ['name', 'appliesTo', 'steps', 'description'],
+      required: ['name', 'appliesTo', 'steps'],
       properties: {
         '@type': {
           description: 'Optional JSON-LD type IRI. Ignored by the loader.',

--- a/scripts/build-ontology.ts
+++ b/scripts/build-ontology.ts
@@ -20,6 +20,7 @@ import { edgeSchema } from '../path-analyser/src/ontology/edgeSchema.ts';
 import { entityKindsSchema } from '../path-analyser/src/ontology/entityKindsSchema.ts';
 import { globalContextSeedsSchema } from '../path-analyser/src/ontology/globalContextSeedsSchema.ts';
 import { runtimeStatesSchema } from '../path-analyser/src/ontology/runtimeStatesSchema.ts';
+import { scenarioTemplateSchema } from '../path-analyser/src/ontology/scenarioTemplateSchema.ts';
 import { semanticsSchema } from '../path-analyser/src/ontology/semanticsSchema.ts';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -53,6 +54,10 @@ const ARTIFACTS: OntologyArtifact[] = [
   {
     jsonPath: join(REPO_ROOT, 'ontology', 'vocabulary', 'global-context-seeds.schema.json'),
     schema: globalContextSeedsSchema,
+  },
+  {
+    jsonPath: join(REPO_ROOT, 'ontology', 'vocabulary', 'scenario-template.schema.json'),
+    schema: scenarioTemplateSchema,
   },
 ];
 


### PR DESCRIPTION
Closes #269. Phase 1 of #268.

## What

Encoding only — no planner consumption yet (deferred to #270). Adds the TBox + ABox + L3 invariants needed for the planner work in #270 to land against a stable, validated ontology surface, following the #224 lift pattern.

The dependency graph encodes data-flow (which ops, in what order); scenario templates encode temporal/modal assertions (what to assert between or after those ops) — a property the graph fundamentally cannot express. See #268 for the architectural argument and the [`RoleUserMembership` walkthrough comment](https://github.com/camunda/api-test-generator/issues/268#issuecomment-4473850091) for the concrete shape of how high-level `expect: present | absent` predicates compile down to Playwright assertions using only the existing ontology + response-extraction graph.

## Changes

- **TBox** (`path-analyser/src/ontology/scenarioTemplateSchema.ts`): templates are ordered step lists with an `appliesTo` discriminator (Phase 1: `Edge` only). Step is a tagged union of `PrereqChain { for: <role> }`, `Invoke { op: <role> }`, and `Observe { op: <role>, expect: present | absent }`. `<role>` references resolve symbolically against the subject ABox at planner-instantiation time.
- **Generated TBox** (`ontology/vocabulary/scenario-template.schema.json`): regenerated via `npm run build:ontology`.
- **ABox** (`configs/camunda-oca/ontology/scenario-templates.json`): one `EdgeLifecycle` template applying uniformly to all 12 OCA edges from #224. Five steps: prereq-chain → invoke establishedBy → observe expect:present → invoke revokedBy → observe expect:absent.
- **Loader** (`path-analyser/src/ontology/loader.ts`): new `loadScenarioTemplatesAbox` mirroring the existing pattern; exports types via `FromSchema`. No consumers yet — wired up just enough so #270 can land without further loader work.
- **Cross-ref stub** (`path-analyser/src/ontology/crossRef/scenarioTemplateCrossRef.ts`): Lift 15 / #255's build-time guard requires every TBox slice to ship a registered cross-ref module. Phase 1 has no merged-domain cross-refs (the one needed feasibility check is graph-scoped and lives at L3); the stub declares an explicit `noChecksRationale`.
- **L3 invariants** (`configs/camunda-oca/regression-invariants.test.ts`):
  - Loader load path.
  - TBox-drift detector picks up the new artefact automatically (re-uses the existing ARTIFACTS-iterating drift test).
  - Every step's role reference resolves to a known field on its `appliesTo` subject ABox.
  - Every edge is covered by at least one `EdgeLifecycle` template — no silent under-scoping.
  - **(The gate for #270)** Every (edge × Observe step) pair is feasible at the response-shape level: the observation op's 200 response carries at least one `identifiedBy` semantic type inside an array. The planner will use that to compile `expect: present | absent` into concrete `toContain` / `not.toContain` assertions without needing an explicit array-locator escape hatch on the edge ABox.

## Design notes

- **Templates speak in roles, not raw operationIds** (`establishedBy`, `revokedBy`, `observableVia`). The planner resolves them against the subject ABox at instantiation time. Keeps templates portable across edges within a config and across configs.
- **Heuristic refinement caught by the invariants**: the initial `membership = identifiedBy − inputs` formulation (from the #268 walkthrough) failed for mapping-rule search ops, which accept the membership identifier as an *optional filter* input AND return it in the response. The right property is the simpler 'identifiedBy type appears array-nested in the response'; the scoping/membership split is a planner concern at instantiation time. Comment in the invariant records the reasoning.
- **`expect` vocabulary is high-level** (per the [#268 walkthrough recommendation](https://github.com/camunda/api-test-generator/issues/268#issuecomment-4473850091)): `present` / `absent`, not raw `status: 404`. The concrete value lives in the scenario binding context the planner already manages; the HTTP status is an implementation detail of the spec, not a semantic property of the edge.

## Out of scope

- Planner instantiation of `EdgeLifecycle` into `EndpointScenario`s — that's #270.
- Emitter rendering of `Observe` steps as Playwright assertions — #270.
- Templates for resource-CRUD or state-transition — later phases of #268.

## Verification

- Lint, all 6 `tsc --noEmit` typechecks ✅
- `npm run build:ontology` re-emits the new schema byte-identically ✅
- Regen pipeline byte-stable ✅ (no `generated/` drift — no planner consumer, as expected)
- `npm test` ✅ — **530 passed / 6 skipped** (was 525 baseline, +5 new invariants)