### PR TITLE
feat: publish ontology TBoxes to GitHub Pages (#272)

### DIFF
--- a/.github/workflows/ontology-url-check.yml
+++ b/.github/workflows/ontology-url-check.yml
@@ -1,0 +1,56 @@
+name: Ontology URL resolution check
+
+# Periodic and on-demand HEAD-check of every published TBox `$id` URL
+# and every per-config ABox `$schema` URL. This catches a regression
+# in the Pages publish path (deploy stuck, branch protections changed,
+# Pages disabled, paths-filter mis-tuned) before external consumers
+# notice the 404.
+#
+# Runs separately from PR CI because (a) it depends on network egress
+# from GitHub Actions to `camunda.github.io`, and (b) a brand-new
+# slice in a PR will not be deployed until the PR is merged — so
+# gating PR merge on URL resolution would be a deadlock.
+
+on:
+  schedule:
+    # Weekly on Monday 06:00 UTC. Cheap enough; frequent enough to
+    # catch a regression within a few days of merge.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ontology-url-check
+  cancel-in-progress: false
+
+jobs:
+  url-check:
+    name: HEAD every published ontology URL
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Run URL-resolution invariants
+        env:
+          # Opt-in flag consumed by the network-gated invariants in
+          # `configs/<config>/regression-invariants.test.ts`. The same
+          # tests `skipIf` it in PR CI, where running them would be
+          # both flaky (network) and useless (un-merged content is
+          # not yet deployed).
+          RUN_ONTOLOGY_URL_CHECK: '1'
+        run: npx vitest run configs/camunda-oca/regression-invariants.test.ts -t 'ontology URL resolution'

--- a/.github/workflows/publish-ontology.yml
+++ b/.github/workflows/publish-ontology.yml
@@ -1,0 +1,111 @@
+name: Publish ontology to GitHub Pages
+
+# Publishes the committed JSON Schema TBoxes under `ontology/vocabulary/`
+# so that the absolute `$id` URLs they declare actually resolve:
+#
+#   https://camunda.github.io/api-test-generator/ns/v1/<slice>.schema.json
+#
+# This makes good on the contract documented in every
+# `path-analyser/src/ontology/*Schema.ts` header: the JSON Schema
+# artefacts exist specifically so external SPARQL/SHACL/OWL/IDE
+# consumers can fetch them by URL.
+#
+# Setup requirement (one-time, repo admin):
+#   Settings → Pages → Source = "GitHub Actions". Until this is set,
+#   the `deploy` job will fail with "Get Pages site failed" — that is
+#   the expected, well-documented signal. Subsequent runs after the
+#   toggle is flipped will succeed without any change to this file.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ontology/**'
+      - 'path-analyser/src/ontology/**Schema.ts'
+      - 'scripts/build-ontology.ts'
+      - '.github/workflows/publish-ontology.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one in-flight deploy at a time; cancel superseded runs so
+# rapid pushes coalesce to the latest content.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build publishable site
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Regenerate ontology artefacts from TS source
+        # Defence-in-depth against a drifted commit: regenerate the
+        # JSON before publishing rather than trusting whatever is on
+        # disk. A regression invariant already gates this in PR CI,
+        # but publishing is the contract surface so we double-check.
+        run: npm run build:ontology
+
+      - name: Assemble publish directory
+        # The TBox `$id` URLs are of the form
+        # `https://camunda.github.io/api-test-generator/ns/v1/<slice>.schema.json`.
+        # GitHub Pages for a project repo serves at
+        # `https://camunda.github.io/<repo>/`, so the on-disk layout
+        # mirroring the URL is `public/ns/v1/<slice>.schema.json`.
+        run: |
+          set -euo pipefail
+          mkdir -p public/ns/v1
+          cp ontology/vocabulary/*.schema.json public/ns/v1/
+          cp ontology/README.md public/index.md 2>/dev/null || true
+          # Minimal landing page so visiting the root URL is not a 404.
+          # Listing is generated from the publish directory so it stays
+          # in sync with whatever was just copied.
+          {
+            echo '<!doctype html><meta charset="utf-8"><title>api-test-generator ontology</title>'
+            echo '<h1>api-test-generator ontology vocabulary</h1>'
+            echo '<p>Canonical JSON Schema TBoxes under <code>/ns/v1/</code>. The TS sources of truth live in '
+            echo '<a href="https://github.com/camunda/api-test-generator/tree/main/path-analyser/src/ontology">'
+            echo '<code>path-analyser/src/ontology/</code></a>.</p>'
+            echo '<h2>Vocabulary</h2><ul>'
+            for f in public/ns/v1/*.schema.json; do
+              name="$(basename "$f")"
+              echo "<li><a href=\"ns/v1/${name}\"><code>ns/v1/${name}</code></a></li>"
+            done
+            echo '</ul>'
+          } > public/index.html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/configs/camunda-oca/ontology/edges.json
+++ b/configs/camunda-oca/ontology/edges.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../ontology/vocabulary/edge.schema.json",
+  "$schema": "https://camunda.github.io/api-test-generator/ns/v1/edge.schema.json",
   "@context": {
     "@vocab": "https://camunda.github.io/api-test-generator/ns/v1/",
     "edges": {

--- a/configs/camunda-oca/ontology/scenario-templates.json
+++ b/configs/camunda-oca/ontology/scenario-templates.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../ontology/vocabulary/scenario-template.schema.json",
+  "$schema": "https://camunda.github.io/api-test-generator/ns/v1/scenario-template.schema.json",
   "@context": {
     "@vocab": "https://camunda.github.io/api-test-generator/ns/v1/",
     "templates": {

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -4040,8 +4040,7 @@ describeForThisConfig('bundled-spec invariants: edges ABox cross-references (#20
     // generic prefix-shape check lives in the '#272' invariant block
     // and applies to every ABox.
     const aboxPath = join(REPO_ROOT, 'configs', CONFIG_NAME, 'ontology', 'edges.json');
-    const expectedSchemaUrl =
-      'https://camunda.github.io/api-test-generator/ns/v1/edge.schema.json';
+    const expectedSchemaUrl = 'https://camunda.github.io/api-test-generator/ns/v1/edge.schema.json';
     interface AboxHeader {
       $schema?: unknown;
     }

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -4030,15 +4030,18 @@ describeForThisConfig('bundled-spec invariants: edges ABox cross-references (#20
     ).toEqual([]);
   });
 
-  it("the ABox file's $schema field resolves to the published TBox JSON (external tooling layout check)", () => {
+  it("the ABox file's $schema field is the canonical published TBox URL (external tooling layout check)", () => {
     // External JSON Schema tooling reads `$schema` from the ABox file
-    // to find the TBox. If the field drifts (typo, wrong relative
-    // path, missing) external validators silently skip validation
-    // even though the in-process loader is still happy. This invariant
-    // resolves the field as a path relative to the ABox and asserts
-    // the resulting absolute path is the published TBox file.
+    // to find the TBox. If the field drifts (typo, wrong slice URL,
+    // missing) external validators silently skip validation even
+    // though the in-process loader is still happy. Since #272 the
+    // `$schema` is the absolute published Pages URL; this invariant
+    // pins the specific edges-ABox → edge.schema.json binding. The
+    // generic prefix-shape check lives in the '#272' invariant block
+    // and applies to every ABox.
     const aboxPath = join(REPO_ROOT, 'configs', CONFIG_NAME, 'ontology', 'edges.json');
-    const expectedTboxPath = join(REPO_ROOT, 'ontology', 'vocabulary', 'edge.schema.json');
+    const expectedSchemaUrl =
+      'https://camunda.github.io/api-test-generator/ns/v1/edge.schema.json';
     interface AboxHeader {
       $schema?: unknown;
     }
@@ -4047,11 +4050,10 @@ describeForThisConfig('bundled-spec invariants: edges ABox cross-references (#20
     const schemaField = aboxJson.$schema;
     expect(typeof schemaField, 'ABox must declare a string `$schema` field').toBe('string');
     if (typeof schemaField !== 'string') return;
-    const resolved = join(aboxPath, '..', schemaField);
     expect(
-      resolved,
-      `ABox $schema='${schemaField}' resolves to '${resolved}', expected the published TBox at '${expectedTboxPath}'.`,
-    ).toBe(expectedTboxPath);
+      schemaField,
+      `ABox $schema must be the canonical published TBox URL '${expectedSchemaUrl}'; got '${schemaField}'.`,
+    ).toBe(expectedSchemaUrl);
   });
 
   it('the ABox @context maps every TBox term to the v1 ns IRI (JSON-LD contract for external RDF tooling)', () => {
@@ -6603,3 +6605,108 @@ describeForThisConfig(
     });
   },
 );
+
+describeForThisConfig('bundled-spec invariants: ontology publishing surface (#272)', () => {
+  // The committed TBox `$id` URLs and per-config ABox `$schema`
+  // URLs are the public contract surface for external SPARQL /
+  // SHACL / OWL / IDE consumers. These invariants pin the URL
+  // convention so the contract cannot silently drift.
+  const ONTOLOGY_URL_PREFIX = 'https://camunda.github.io/api-test-generator/ns/v1/';
+
+  it('every TBox `$id` follows the canonical ontology URL convention', () => {
+    // External consumers dereference ontology terms by `$id`. If a
+    // TBox slice declares a different prefix (e.g. raw.* or a
+    // branch URL), the IRI loses its stable identity even if the
+    // file happens to be reachable.
+    const vocabDir = join(REPO_ROOT, 'ontology', 'vocabulary');
+    const files = readdirSync(vocabDir).filter((f) => f.endsWith('.schema.json'));
+    expect(files.length, 'expected at least one TBox to exist').toBeGreaterThan(0);
+    const offenders: string[] = [];
+    for (const file of files) {
+      const parsed: unknown = JSON.parse(readFileSync(join(vocabDir, file), 'utf-8'));
+      if (
+        !parsed ||
+        typeof parsed !== 'object' ||
+        !('$id' in parsed) ||
+        typeof parsed.$id !== 'string'
+      ) {
+        offenders.push(`${file}: missing or non-string $id`);
+        continue;
+      }
+      const expected = `${ONTOLOGY_URL_PREFIX}${file}`;
+      if (parsed.$id !== expected) {
+        offenders.push(`${file}: $id is '${parsed.$id}', expected '${expected}'`);
+      }
+    }
+    expect(
+      offenders,
+      `Every TBox '$id' must be '${ONTOLOGY_URL_PREFIX}<filename>'; this URL is the published Pages identifier and the ontology IRI.`,
+    ).toEqual([]);
+  });
+
+  it('every per-config ABox `$schema` follows the canonical ontology URL convention', () => {
+    // The earlier mix of absolute (broken) and relative (IDE-only)
+    // `$schema` URLs across ABoxes was the symptom that surfaced
+    // #272. Pinning the convention here stops it creeping back in.
+    const aboxDir = join(REPO_ROOT, 'configs', 'camunda-oca', 'ontology');
+    const files = readdirSync(aboxDir).filter((f) => f.endsWith('.json'));
+    expect(files.length, 'expected at least one ABox to exist').toBeGreaterThan(0);
+    const offenders: string[] = [];
+    for (const file of files) {
+      const parsed: unknown = JSON.parse(readFileSync(join(aboxDir, file), 'utf-8'));
+      if (
+        !parsed ||
+        typeof parsed !== 'object' ||
+        !('$schema' in parsed) ||
+        typeof parsed.$schema !== 'string'
+      ) {
+        offenders.push(`${file}: missing or non-string $schema`);
+        continue;
+      }
+      const schemaUrl = parsed.$schema;
+      if (!schemaUrl.startsWith(ONTOLOGY_URL_PREFIX) || !schemaUrl.endsWith('.schema.json')) {
+        offenders.push(
+          `${file}: $schema is '${schemaUrl}', expected '${ONTOLOGY_URL_PREFIX}<slice>.schema.json'`,
+        );
+      }
+    }
+    expect(
+      offenders,
+      `Every ABox '$schema' must be an absolute '${ONTOLOGY_URL_PREFIX}<slice>.schema.json' URL so IDEs and external consumers resolve through the published Pages site.`,
+    ).toEqual([]);
+  });
+
+  describe('ontology URL resolution (network — gated by RUN_ONTOLOGY_URL_CHECK)', () => {
+    // Network-gated check. Runs only in the scheduled
+    // `ontology-url-check.yml` workflow, never in PR CI: a brand-new
+    // slice in a PR is not yet deployed (deploy happens on merge),
+    // and PR CI must not depend on network egress.
+    const shouldRun = process.env.RUN_ONTOLOGY_URL_CHECK === '1';
+
+    it.skipIf(!shouldRun)(
+      'every published TBox URL HEADs 200',
+      async () => {
+        const vocabDir = join(REPO_ROOT, 'ontology', 'vocabulary');
+        const files = readdirSync(vocabDir).filter((f) => f.endsWith('.schema.json'));
+        const offenders: string[] = [];
+        for (const file of files) {
+          const url = `${ONTOLOGY_URL_PREFIX}${file}`;
+          try {
+            const res = await fetch(url, { method: 'HEAD' });
+            if (res.status !== 200) {
+              offenders.push(`${url}: HTTP ${res.status}`);
+            }
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            offenders.push(`${url}: fetch failed — ${msg}`);
+          }
+        }
+        expect(
+          offenders,
+          'Every committed TBox $id URL must resolve to HTTP 200 on the published Pages site. Check publish-ontology.yml run history if this fails.',
+        ).toEqual([]);
+      },
+      60_000,
+    );
+  });
+});

--- a/ontology/README.md
+++ b/ontology/README.md
@@ -1,0 +1,67 @@
+# Ontology
+
+This directory contains the committed JSON Schema artefacts that
+define the **TBox** (vocabulary / class definitions) of the
+api-test-generator ontology.
+
+The TypeScript sources of truth live under
+[`path-analyser/src/ontology/`](../path-analyser/src/ontology/) — one
+`*Schema.ts` file per slice. The JSON files under
+[`vocabulary/`](./vocabulary/) are generated from them by
+[`scripts/build-ontology.ts`](../scripts/build-ontology.ts) (`npm run
+build:ontology`) so that **external SPARQL / SHACL / OWL / IDE
+consumers can fetch a plain JSON Schema by URL** without first
+building this repo.
+
+A Layer-3 regression invariant in
+[`configs/<config>/regression-invariants.test.ts`](../configs/camunda-oca/regression-invariants.test.ts)
+fails if any committed JSON drifts from its TS source of truth, so the
+generated artefacts cannot silently fall out of sync.
+
+## Publishing
+
+The JSON Schemas under `vocabulary/` are published to GitHub Pages by
+the [`publish-ontology.yml`](../.github/workflows/publish-ontology.yml)
+workflow on every push to `main` that touches the ontology surface.
+
+Each TBox declares an absolute `$id` of the form:
+
+```
+https://camunda.github.io/api-test-generator/ns/v1/<slice>.schema.json
+```
+
+…and every per-config ABox under `configs/<config>/ontology/*.json`
+uses the matching URL as its `$schema`. A structural Layer-3
+invariant pins that convention so ad-hoc relative `$schema` paths
+cannot creep back in.
+
+A separate scheduled workflow
+[`ontology-url-check.yml`](../.github/workflows/ontology-url-check.yml)
+HEAD-checks every published URL weekly to catch a stuck publish
+pipeline before external consumers notice the 404.
+
+### One-time setup (repo admin)
+
+GitHub Pages must be enabled with **Source = "GitHub Actions"**:
+
+> Settings → Pages → Build and deployment → Source = GitHub Actions
+
+Until this is set, the `publish-ontology.yml` `deploy` job fails with
+`Get Pages site failed` — that is the expected, self-documenting
+signal. No further configuration is required.
+
+## Adding a new TBox slice
+
+1. Add `path-analyser/src/ontology/<slice>Schema.ts` with the schema
+   constant and a paired `renderSchema` wrapper. See the existing
+   slices for the header conventions.
+2. Register the slice in `scripts/build-ontology.ts` `ARTIFACTS`.
+3. Run `npm run build:ontology` to emit
+   `ontology/vocabulary/<slice>.schema.json`.
+4. Add a corresponding ABox under `configs/<config>/ontology/<slice>.json`
+   with `$schema` set to the canonical absolute URL.
+5. Wire the loader + cross-ref module per Lift 15 / #255.
+6. Add the slice's Layer-3 invariants in
+   `configs/<config>/regression-invariants.test.ts`.
+
+The next push to `main` touching `ontology/**` re-publishes the site.


### PR DESCRIPTION
Closes #272.

## Why

Every `path-analyser/src/ontology/*Schema.ts` header documents that the
JSON Schema artefacts under `ontology/vocabulary/` exist specifically so
external SPARQL/SHACL/OWL/IDE consumers can fetch them by URL. Until now
that promise was broken: the absolute `$id` URLs in every TBox and most
ABox `$schema` fields 404'd because no Pages site was configured.

The IDE warning on `configs/camunda-oca/ontology/runtime-states.json`
("Unable to load schema from 'https://camunda.github.io/…'") is the
visible symptom; external RDF tooling cannot dereference the IRIs is the
underlying defect.

## What

1. **`publish-ontology.yml`**: on push-to-main touching `ontology/**` (or
   the TS source / build script), regenerates the JSON from TS source and
   deploys `public/ns/v1/<slice>.schema.json` to GitHub Pages. Layout
   mirrors the canonical URL so `/ns/v1/<slice>.schema.json` matches the
   declared `$id`. Concurrency-gated on the `pages` group so rapid pushes
   coalesce to the latest content.
2. **`ontology-url-check.yml`** (scheduled, weekly + workflow_dispatch):
   HEAD-checks every published URL. Runs **separately from PR CI** because
   brand-new slices in a PR aren't deployed until merge, and PR CI must
   not depend on network egress. Gated by `RUN_ONTOLOGY_URL_CHECK=1`.
3. **ABox `$schema` standardisation**: `edges.json` and
   `scenario-templates.json` flipped from relative
   `../../../ontology/vocabulary/...` to the canonical absolute
   `https://camunda.github.io/api-test-generator/ns/v1/<slice>.schema.json`,
   matching the other 5 ABoxes and the TBox `$id`. The earlier mix was
   the symptom that surfaced #272.
4. **`ontology/README.md`**: documents the publish model, the URL
   convention, the one-time admin setup, and a 'add a new TBox slice'
   checklist.
5. **L3 invariants** (in `configs/camunda-oca/regression-invariants.test.ts`):
   - Every TBox `$id` equals `https://camunda.github.io/api-test-generator/ns/v1/<filename>` — pins the IRI surface.
   - Every ABox `$schema` matches the same prefix + `.schema.json` suffix — stops the relative-form drift from creeping back in.
   - Network-gated 'every published TBox URL HEADs 200' check, only runs when `RUN_ONTOLOGY_URL_CHECK=1` is set.
   - Existing edges-ABox `$schema` test updated to assert the new canonical absolute URL instead of resolving a relative path.

## Required admin action (one-time)

```
Settings → Pages → Build and deployment → Source = 'GitHub Actions'
```

Until this is flipped, the publish workflow's `deploy` job will fail with
`Get Pages site failed` — that is the expected, self-documenting signal.
No further configuration is needed; subsequent runs after the toggle
succeed without any change to this PR's files. The publish workflow only
triggers on push-to-main, so this PR landing without the toggle flipped
does not block anything in PR CI.

## Verification after first successful deploy

```
$ curl -sI https://camunda.github.io/api-test-generator/ns/v1/runtime-states.schema.json
HTTP/2 200
```

…and the IDE 'Unable to load schema' warning that prompted #272
disappears for every ABox in every config.

## Gates

- Biome: clean.
- 7 typechecks (extractor, planner, emitter-sdk, materializer, request-validation, tests, generated-suites): pass.
- Regeneration: byte-stable.
- `npm test`: **532 pass, 7 skipped** (was 530 / 6; +2 structural URL invariants + 1 network-gated invariant that skips in PR CI).

## Out of scope

- Versioning beyond `/ns/v1/` (path already includes `v1`; a future `v2`
  publishes alongside).
- Vanity domain (`ontology.camunda.io/...`).
- Content negotiation / RDF serialization (the JSON-LD `@context` wiring
  in each ABox already handles RDF consumers).