### PR TITLE
feat(#270): planner + emitter consumption of EdgeLifecycle template

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,14 @@ emits a self-contained, runnable Playwright project under
 `package.json`, `playwright.config.ts`, `tsconfig.json`, vendored
 runtime helpers (`support/`), fixtures, and a README.
 
+Template-derived suites (`#268` Phase 2 / `#270`) land under
+`generated/<config>/playwright/edges/<EdgeName>.lifecycle.spec.ts` —
+one per ABox-declared edge. Each suite runs the full lifecycle
+(establish → present-observe → revoke → absent-observe) and is sourced
+from `generated/<config>/scenarios/templates/EdgeLifecycle/<EdgeName>.json`,
+which the planner instantiates from the EdgeLifecycle TBox template
+(see `ontology/README.md`).
+
 ```bash
 npm run codegen:playwright -- <operationId>
 npm run codegen:playwright:all

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -6529,6 +6529,17 @@ describeForThisConfig(
       loadGraph();
       const opById = cachedOperationById;
       if (!opById) throw new Error('graph not loaded');
+      // Reconstruct the minimal OperationGraph shape the shared
+      // `findMembershipArrayPath` helper expects. The full
+      // OperationGraph carries dozens of fields the helper doesn't
+      // touch; we only need `operations[opId].responseSemanticTypes`
+      // and a stable narrow contract, so build a synthetic slice and
+      // pass it through. Keeps the single-source-of-truth helper
+      // honest: if a future change makes it consult more graph
+      // fields, this fixture surfaces the missing wiring.
+      const { findMembershipArrayPath } = await import(
+        '../../path-analyser/src/ontology/observeArrayPath.js'
+      );
       const offenders: string[] = [];
       const edgeTemplates = templates.templates.filter((t) => t.appliesTo.kind === 'Edge');
       for (const tpl of edgeTemplates) {
@@ -6580,12 +6591,14 @@ describeForThisConfig(
             // property is "appears in an array-nested response
             // field"; the scoping/membership split is a #270
             // planner concern at instantiation time.
-            const responses = op.responseSemanticTypes?.['200'] ?? [];
-            const arrayNestedSemanticTypes = new Set(
-              responses.filter((r) => r.fieldPath.includes('[]')).map((r) => r.semanticType),
-            );
-            const observable = edge.identifiedBy.filter((s) => arrayNestedSemanticTypes.has(s));
-            if (observable.length === 0) {
+            //
+            // Implementation note: this invariant uses the same
+            // `findMembershipArrayPath` helper the #270 planner
+            // calls, so a divergence between "feasible at L3" and
+            // "planner can locate" is impossible by construction.
+            const locator = findMembershipArrayPath(op, edge.identifiedBy);
+            if (locator === null) {
+              const responses = op.responseSemanticTypes?.['200'] ?? [];
               offenders.push(
                 `${tpl.name} × ${edge.name}: observation op '${opId}' 200 response has no array-nested field carrying any identifiedBy type (${edge.identifiedBy.join(', ')}); got: ${responses
                   .map((r) => `${r.semanticType}@${r.fieldPath}`)
@@ -6709,3 +6722,258 @@ describeForThisConfig('bundled-spec invariants: ontology publishing surface (#27
     );
   });
 });
+
+// ===========================================================================
+// #270 Phase 2: template-derived scenarios + edges Playwright suite.
+//
+// The instantiator (path-analyser/src/scenarioTemplateInstantiator.ts) compiles
+// every (template × edge) pair declared in the ABoxes into a TemplateScenario
+// JSON file under generated/<config>/scenarios/templates/<TemplateName>/<EdgeName>.json,
+// and the Playwright emitter materialises one
+// generated/<config>/playwright/edges/<EdgeName>.lifecycle.spec.ts per edge.
+//
+// These invariants pin the structural contract of that output — coverage
+// (every edge has a JSON + a .spec.ts), shape (5 steps in the established →
+// observe(present) → revoke → observe(absent) order), assertion
+// well-formedness (membershipSemanticType ∈ edge.identifiedBy, non-empty
+// arrayPath / elementField), and binding-table closure (the membership
+// value is sourced from a known binding rather than invented at emit
+// time). The L3 layer plus the green/green refactor discipline keeps the
+// template surface honest as the planner grows.
+// ===========================================================================
+describeForThisConfig(
+  'bundled-spec invariants: template-derived scenarios (#268 Phase 2 / #270)',
+  () => {
+    const TEMPLATES_ROOT = join(SCENARIOS_DIR, 'templates');
+    const EDGE_LIFECYCLE_DIR = join(TEMPLATES_ROOT, 'EdgeLifecycle');
+    const EDGES_SUITE_DIR = join(GENERATED_TESTS_DIR, 'edges');
+
+    interface TemplateScenarioFile {
+      templateName: string;
+      subjectName: string;
+      subjectKind: string;
+      scenario: {
+        templateName: string;
+        subjectName: string;
+        subjectKind: string;
+        steps: TemplateStep[];
+        bindings: Record<string, string>;
+      };
+    }
+    interface PrereqChainStep {
+      kind: 'prereqChain';
+      targetOperationId: string;
+      operations: { operationId: string }[];
+      bindings: Record<string, string>;
+      seedBindings: string[];
+      requestPlan: unknown[];
+    }
+    interface InvokeStep {
+      kind: 'invoke';
+      operationId: string;
+      inputs: Record<string, string>;
+      produces: Record<string, string>;
+      requestPlan: unknown;
+    }
+    interface ObserveStep {
+      kind: 'observe';
+      operationId: string;
+      inputs: Record<string, string>;
+      requestPlan: unknown;
+      assertion: {
+        kind: 'membership';
+        expect: 'present' | 'absent';
+        arrayPath: string[];
+        elementField: string;
+        membershipSemanticType: string;
+      };
+    }
+    type TemplateStep = PrereqChainStep | InvokeStep | ObserveStep;
+
+    function loadTemplateFile(edgeName: string): TemplateScenarioFile {
+      const p = join(EDGE_LIFECYCLE_DIR, `${edgeName}.json`);
+      if (!existsSync(p)) {
+        throw new Error(
+          `Template scenario JSON not found at ${p}. Run 'npm run testsuite:generate' first.`,
+        );
+      }
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON; downstream invariants validate structure.
+      return JSON.parse(readFileSync(p, 'utf8')) as TemplateScenarioFile;
+    }
+
+    it('every edge in the edges ABox has a generated EdgeLifecycle template scenario JSON', async () => {
+      const { loadEdgesAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const edges = loadEdgesAbox(REPO_ROOT);
+      if (!edges) throw new Error('edges ABox missing');
+      if (!existsSync(EDGE_LIFECYCLE_DIR)) {
+        throw new Error(
+          `EdgeLifecycle template scenarios directory not found at ${EDGE_LIFECYCLE_DIR}. Run 'npm run testsuite:generate' first.`,
+        );
+      }
+      const present = new Set(
+        readdirSync(EDGE_LIFECYCLE_DIR)
+          .filter((f) => f.endsWith('.json'))
+          .map((f) => f.slice(0, -'.json'.length)),
+      );
+      const missing = edges.edges.filter((e) => !present.has(e.name)).map((e) => e.name);
+      expect(
+        missing,
+        `Every edge in edges.json must have a corresponding ${EDGE_LIFECYCLE_DIR}/<edge>.json. ` +
+          `Missing edges indicate the instantiator skipped a (template × edge) pair.`,
+      ).toEqual([]);
+    });
+
+    it('every emitted EdgeLifecycle scenario has the canonical 5-step shape (prereqChain → invoke → observe(present) → invoke → observe(absent))', async () => {
+      const { loadEdgesAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const edges = loadEdgesAbox(REPO_ROOT);
+      if (!edges) throw new Error('edges ABox missing');
+      const offenders: string[] = [];
+      for (const edge of edges.edges) {
+        const file = loadTemplateFile(edge.name);
+        const steps = file.scenario.steps;
+        if (steps.length !== 5) {
+          offenders.push(`${edge.name}: expected 5 steps, got ${steps.length}`);
+          continue;
+        }
+        const kinds = steps.map((s) => s.kind).join(',');
+        if (kinds !== 'prereqChain,invoke,observe,invoke,observe') {
+          offenders.push(
+            `${edge.name}: expected step kinds prereqChain,invoke,observe,invoke,observe; got ${kinds}`,
+          );
+          continue;
+        }
+        const inv1 = steps[1];
+        const obs1 = steps[2];
+        const inv2 = steps[3];
+        const obs2 = steps[4];
+        if (inv1.kind !== 'invoke' || inv1.operationId !== edge.establishedBy) {
+          offenders.push(
+            `${edge.name}: step[1] must invoke establishedBy (${edge.establishedBy}); got ${inv1.kind === 'invoke' ? inv1.operationId : inv1.kind}`,
+          );
+        }
+        if (obs1.kind !== 'observe' || obs1.operationId !== edge.observableVia) {
+          offenders.push(
+            `${edge.name}: step[2] must observe observableVia (${edge.observableVia}); got ${obs1.kind === 'observe' ? obs1.operationId : obs1.kind}`,
+          );
+        } else if (obs1.assertion.expect !== 'present') {
+          offenders.push(
+            `${edge.name}: step[2] observe.expect must be 'present'; got '${obs1.assertion.expect}'`,
+          );
+        }
+        if (inv2.kind !== 'invoke' || inv2.operationId !== edge.revokedBy) {
+          offenders.push(
+            `${edge.name}: step[3] must invoke revokedBy (${edge.revokedBy}); got ${inv2.kind === 'invoke' ? inv2.operationId : inv2.kind}`,
+          );
+        }
+        if (obs2.kind !== 'observe' || obs2.operationId !== edge.observableVia) {
+          offenders.push(
+            `${edge.name}: step[4] must observe observableVia (${edge.observableVia}); got ${obs2.kind === 'observe' ? obs2.operationId : obs2.kind}`,
+          );
+        } else if (obs2.assertion.expect !== 'absent') {
+          offenders.push(
+            `${edge.name}: step[4] observe.expect must be 'absent'; got '${obs2.assertion.expect}'`,
+          );
+        }
+      }
+      expect(
+        offenders,
+        'Every EdgeLifecycle scenario must follow the 5-step canonical shape — the template TBox + #270 planner enforce this jointly.',
+      ).toEqual([]);
+    });
+
+    it('every observe step has a well-formed membership assertion (membershipSemanticType ∈ identifiedBy, non-empty arrayPath, non-empty elementField)', async () => {
+      const { loadEdgesAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const edges = loadEdgesAbox(REPO_ROOT);
+      if (!edges) throw new Error('edges ABox missing');
+      const offenders: string[] = [];
+      for (const edge of edges.edges) {
+        const file = loadTemplateFile(edge.name);
+        const identifiedBy = new Set(edge.identifiedBy);
+        for (const [i, step] of file.scenario.steps.entries()) {
+          if (step.kind !== 'observe') continue;
+          const a = step.assertion;
+          if (!identifiedBy.has(a.membershipSemanticType)) {
+            offenders.push(
+              `${edge.name}: step[${i}] membershipSemanticType '${a.membershipSemanticType}' is not in edge.identifiedBy (${edge.identifiedBy.join(', ')})`,
+            );
+          }
+          if (!Array.isArray(a.arrayPath) || a.arrayPath.length === 0) {
+            offenders.push(`${edge.name}: step[${i}] assertion.arrayPath must be non-empty`);
+          }
+          if (typeof a.elementField !== 'string' || a.elementField.length === 0) {
+            offenders.push(
+              `${edge.name}: step[${i}] assertion.elementField must be a non-empty string`,
+            );
+          }
+        }
+      }
+      expect(
+        offenders,
+        'Every observe step assertion must be well-formed: membership semantic in identifiedBy, non-empty arrayPath, non-empty elementField.',
+      ).toEqual([]);
+    });
+
+    it('every observe.membershipSemanticType has a matching entry in the scenario binding table (the asserted value is sourced from a known binding, not invented at emit time)', async () => {
+      const { loadEdgesAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const edges = loadEdgesAbox(REPO_ROOT);
+      if (!edges) throw new Error('edges ABox missing');
+      const offenders: string[] = [];
+      for (const edge of edges.edges) {
+        const file = loadTemplateFile(edge.name);
+        const bindings = file.scenario.bindings ?? {};
+        for (const [i, step] of file.scenario.steps.entries()) {
+          if (step.kind !== 'observe') continue;
+          const sem = step.assertion.membershipSemanticType;
+          if (!(sem in bindings)) {
+            offenders.push(
+              `${edge.name}: step[${i}] membershipSemanticType '${sem}' has no entry in scenario.bindings ({${Object.keys(bindings).join(', ')}}). ` +
+                'Without a binding, the emitter has no value to assert.',
+            );
+          }
+        }
+      }
+      expect(
+        offenders,
+        'Every observe membership identifier must round-trip through the scenario binding table so the emitter can resolve the asserted value via ctx[<bindingName>].',
+      ).toEqual([]);
+    });
+
+    it('RoleUserMembership observe pins arrayPath=[items] and elementField=username (ambiguity-stability guard for findMembershipArrayPath)', () => {
+      // Stability guard for the array-locator heuristic: when more than
+      // one identifiedBy semantic appears array-nested in the same
+      // response, the helper returns the FIRST match. If a future
+      // change re-shuffles iteration order or extractor output, the
+      // chosen path for RoleUserMembership flips silently — this
+      // invariant catches that.
+      const file = loadTemplateFile('RoleUserMembership');
+      const observeSteps = file.scenario.steps.filter(
+        (s): s is ObserveStep => s.kind === 'observe',
+      );
+      expect(observeSteps.length).toBe(2);
+      for (const obs of observeSteps) {
+        expect(obs.assertion.arrayPath).toEqual(['items']);
+        expect(obs.assertion.elementField).toBe('username');
+        expect(obs.assertion.membershipSemanticType).toBe('Username');
+      }
+    });
+
+    it('every edge has a generated Playwright lifecycle suite under generated/<config>/playwright/edges/', async () => {
+      const { loadEdgesAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const edges = loadEdgesAbox(REPO_ROOT);
+      if (!edges) throw new Error('edges ABox missing');
+      if (!existsSync(EDGES_SUITE_DIR)) {
+        throw new Error(
+          `Edges lifecycle suite directory not found at ${EDGES_SUITE_DIR}. Run 'npm run testsuite:generate' first.`,
+        );
+      }
+      const present = new Set(readdirSync(EDGES_SUITE_DIR));
+      const missing = edges.edges
+        .filter((e) => !present.has(`${e.name}.lifecycle.spec.ts`))
+        .map((e) => e.name);
+      expect(
+        missing,
+        `Every edge in edges.json must have a corresponding ${EDGES_SUITE_DIR}/<edge>.lifecycle.spec.ts.`,
+      ).toEqual([]);
+    });
+  },
+);

--- a/materializer/src/index.ts
+++ b/materializer/src/index.ts
@@ -17,6 +17,7 @@ import {
   getActiveConfigName,
   getFeatureOutputDir,
   getPlaywrightSuiteDir,
+  getTemplateScenariosDir,
   getVariantOutputDir,
 } from 'path-analyser/configResolver';
 import {
@@ -36,6 +37,7 @@ import {
   materializeSupport,
 } from './playwright/materialize-support.js';
 import { loadRoleBundlesForActiveConfig } from './playwright/roleRenderer.js';
+import { emitTemplateSuites } from './playwright/templateEmitter.js';
 
 // Built-in emitter registrations. RoleHookProviders are no longer
 // registered statically here: every provider lives next to its role
@@ -506,8 +508,32 @@ async function run() {
         console.warn('Skipping variant file (parse/emission failed):', f, msg);
       }
     }
+    // Template-derived suites (Lift 22 / #270). One Playwright suite per
+    // edge under `<playwrightSuiteDir>/edges/`. Only the Playwright emitter
+    // wires this — other emitters opt in by implementing their own
+    // template-aware renderer. The scenarios are produced by the planner
+    // (`scenarioTemplateInstantiator.ts`); if the directory is missing
+    // (older planner runs, configs that don't ship an EdgeLifecycle
+    // template), `emitTemplateSuites` no-ops.
+    let lifecycleCount = 0;
+    if (emitter.id === PlaywrightEmitter.id) {
+      const edgesOutDir = path.join(outDir, 'edges');
+      // Wipe the per-template subdir for the same reason the parent
+      // `outDir` is wiped above: stale specs from a previous spec version
+      // must not survive into the current run.
+      await fs.rm(edgesOutDir, { recursive: true, force: true });
+      const written = await emitTemplateSuites({
+        scenariosDir: getTemplateScenariosDir(repoRoot, 'EdgeLifecycle'),
+        outDir: edgesOutDir,
+        globalContextSeeds: globalContextSeeds.map((s) => ({
+          binding: s.binding,
+          seedRule: s.seedRule,
+        })),
+      });
+      lifecycleCount = written.length;
+    }
     console.log(
-      `Generated test suites for ${count} endpoints (+${variantCount} variant suites) in ${outDir} (target: ${emitter.id})`,
+      `Generated test suites for ${count} endpoints (+${variantCount} variant suites, +${lifecycleCount} lifecycle suites) in ${outDir} (target: ${emitter.id})`,
     );
     return;
   }

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -22,6 +22,14 @@ import {
   materializeSupport,
 } from './materialize-support.js';
 import { renderRoleCallSite, renderRoleImports, stepMatchesRole } from './roleRenderer.js';
+import {
+  buildUrlExpression,
+  escapeQuotes,
+  renderEventualWait,
+  renderInlineStepLines,
+  stepNeedsAwaitForOp,
+  toOptionalAccessor,
+} from './stepRenderer.js';
 
 interface EmitOptions {
   outDir: string;
@@ -261,11 +269,16 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   //      rendered as a standalone `awaitEventually(...)` block after the
   //      producer's request/expect block; this trigger ensures the
   //      import is present even when no step is itself an EC read.
-  const needsAwaitEventually = collection.scenarios.some(
-    (s) =>
-      stepNeedsAwait(s).length > 0 ||
-      (s.requestPlan ?? []).some((step) => (step.eventualWaitsAfter?.length ?? 0) > 0),
-  );
+  const needsAwaitEventually = collection.scenarios.some((s) => {
+    const ecOps = new Set<string>();
+    for (const op of s.operations) {
+      if (op.eventuallyConsistent) ecOps.add(op.operationId);
+    }
+    return (
+      (s.requestPlan ?? []).some((step) => stepNeedsAwaitForOp(step, ecOps)) ||
+      (s.requestPlan ?? []).some((step) => (step.eventualWaitsAfter?.length ?? 0) > 0)
+    );
+  });
 
   // Default `recordResponses` to true so callers that omit the option keep
   // the pre-config behaviour. Threaded down into renderScenarioTest so the
@@ -524,7 +537,14 @@ function renderScenarioTest(
     return body.join('\n');
   }
   const requestPlan = s.requestPlan;
-  const awaitStepIndices = new Set(stepNeedsAwait(s));
+  // Source of truth for EC: each `s.operations[].eventuallyConsistent` (a flag
+  // the extractor stamps from the `x-eventually-consistent` vendor extension).
+  // The scenario-level summary fields are not populated for every scenario
+  // kind, so the per-op flag is consulted directly.
+  const ecOps = new Set<string>();
+  for (const op of s.operations) {
+    if (op.eventuallyConsistent) ecOps.add(op.operationId);
+  }
   requestPlan.forEach((step: RequestStep, idx: number) => {
     const varName = `resp${idx + 1}`;
     const urlExpr = buildUrlExpression(step.pathTemplate);
@@ -556,7 +576,7 @@ function renderScenarioTest(
       urlExpr,
       method,
       sentinelLocals,
-      awaitStepIndices,
+      shouldAwaitEventually: stepNeedsAwaitForOp(step, ecOps),
     });
     const roleMatch = findRoleForStep(step);
     if (roleMatch) {
@@ -691,258 +711,6 @@ function renderScenarioTest(
   });
   body.push('});');
   return body.join('\n');
-}
-
-function buildUrlExpression(pathTemplate: string): string {
-  // Replace {param} with string interpolation referencing ctx binding paramVar if exists
-  return (
-    '`' +
-    pathTemplate.replace(/\{([^}]+)\}/g, (_, p) => `\${ctx.${camelCase(p)}Var || '\${${p}}'}`) +
-    '`'
-  );
-}
-
-/**
- * Render the generic per-step inline code lines. Used both as the body
- * source for non-role steps (pushed directly onto the scenario body array)
- * and as `defaultRender` in the role scope so role templates can implement
- * a wrap pattern via `{{{defaultRender}}}` (see ROLES.md).
- */
-interface InlineStepRenderInput {
-  step: RequestStep;
-  idx: number;
-  varName: string;
-  urlExpr: string;
-  method: string;
-  sentinelLocals: Map<string, string>;
-  awaitStepIndices: Set<number>;
-}
-function renderInlineStepLines({
-  step,
-  idx,
-  varName,
-  urlExpr,
-  method,
-  sentinelLocals,
-  awaitStepIndices,
-}: InlineStepRenderInput): string[] {
-  const lines: string[] = [];
-  const bodyVar = `body${idx + 1}`;
-  lines.push(`    const url = baseUrl + ${urlExpr};`);
-  if (step.bodyKind === 'json' && step.bodyTemplate) {
-    const json = JSON.stringify(step.bodyTemplate, null, 4).replace(
-      /"\\?\$\{([^}]+)\}"/g,
-      (_, v) => `ctx["${v}"]`,
-    );
-    lines.push(`    const ${bodyVar} = ${json};`);
-  } else if (step.bodyKind === 'multipart' && step.multipartTemplate) {
-    // Non-createDeployment multipart template
-    const tpl = JSON.stringify(step.multipartTemplate, null, 4).replace(
-      /"\\?\$\{([^}]+)\}"/g,
-      (_, v) => `ctx["${v}"]`,
-    );
-    lines.push(`    const ${bodyVar} = ${tpl};`);
-  }
-  const opts: string[] = [];
-  opts.push('headers: await authHeaders()');
-  if (step.bodyKind === 'json' && step.bodyTemplate) opts.push(`data: ${bodyVar}`);
-  if (step.bodyKind === 'multipart' && step.multipartTemplate) {
-    // Convert template to Playwright's expected multipart shape: a keyed object map.
-    // Field values are stringified (`String(v)`); file values are passed as
-    // `{ name, mimeType, buffer }`. The element type below mirrors the
-    // permissive subset of Playwright's `multipart` option that we actually
-    // emit, so the generated suite typechecks under `strict: true` when
-    // `request.post({ multipart })` is called.
-    lines.push(
-      `    const multipart: Record<string, string | { name: string; mimeType: string; buffer: Buffer }> = {};`,
-    );
-    lines.push(`    for (const [k,v] of Object.entries(${bodyVar}.fields||{})) {`);
-    // Emit a strip branch for every globalContextSeeds entry whose
-    // sentinel local was declared in the prologue. The emitter never
-    // hard-codes a field name here — the field name is the metadata key
-    // and the local was named after it.
-    for (const [fieldName, local] of sentinelLocals) {
-      lines.push(`      if (k === '${fieldName}' && ${local}) continue;`);
-    }
-    lines.push(`      if (v !== undefined && v !== null) multipart[k] = String(v);`);
-    lines.push(`    }`);
-    lines.push(`    for (const [k,v] of Object.entries(${bodyVar}.files||{})) {
-        if (typeof v === 'string' && v.startsWith('@@FILE:')) {
-          const p = v.slice('@@FILE:'.length);
-          const buf = await resolveFixture(p);
-          const name = p.split('/').pop() || 'file';
-          multipart[k] = { name, mimeType: 'application/octet-stream', buffer: buf };
-        } else {
-          multipart[k] = String(v);
-        }
-      }`);
-    opts.push('multipart: multipart');
-  }
-  // (#106) Eventually-consistent reads are wrapped with awaitEventually(),
-  // which retries the same request within a budget until the response is
-  // observably consistent (default predicate for POST .../search:
-  // `body.items.length > 0`; for GET: any 200) and returns the final
-  // APIResponse. Non-EC steps go straight through `request.${method}`.
-  if (awaitStepIndices.has(idx)) {
-    lines.push(`    const ${varName} = await awaitEventually(`);
-    lines.push(`      async () => request.${method}(url, { ${opts.join(', ')} }),`);
-    lines.push(
-      `      { method: '${step.method.toUpperCase()}', operationId: '${step.operationId}' },`,
-    );
-    lines.push(`    );`);
-  } else {
-    lines.push(`    const ${varName} = await request.${method}(url, { ${opts.join(', ')} });`);
-  }
-  lines.push(`    if (${varName}.status() !== ${step.expect.status}) {`);
-  lines.push(`      try { console.error('Response body:', await ${varName}.text()); } catch {}`);
-  lines.push(`    }`);
-  lines.push(`    expect(${varName}.status()).toBe(${step.expect.status});`);
-  return lines;
-}
-
-function escapeQuotes(s: string): string {
-  return s.replace(/'/g, "'");
-}
-function camelCase(s: string) {
-  return s.charAt(0).toLowerCase() + s.slice(1);
-}
-
-/**
- * Render a planner-annotated eventual-state wait as a sibling block to a
- * producer step (#159 PR B). The emitted code:
- *
- *   - resolves the witness URL with the same ctx-binding rewrite the
- *     request steps use (`buildUrlExpression`), so a witness referencing
- *     `{processInstanceKey}` picks up `ctx.processInstanceKeyVar` already
- *     extracted from the producer's response;
- *   - wraps the witness fetch in `awaitEventually(...)` with a structured
- *     predicate generated from the spec — no user-supplied predicate
- *     string is interpolated, so the on-disk config cannot smuggle
- *     arbitrary code into the emitted suite.
- *
- * Returns the source lines (no trailing newlines) for direct push onto
- * the scenario body buffer.
- *
- * Safety: the witness predicate's `path` is validated against
- * `/^[A-Za-z_$][A-Za-z0-9_$]*$/` by the domain-semantics validator
- * (`WitnessPredicateSchema`), so the bracket-access key emitted below
- * is identifier-safe. `equals` is constrained to string|number|boolean,
- * round-tripped through JSON.stringify, which produces a valid TS
- * literal for each of those scalar shapes.
- */
-function renderEventualWait(wait: EventualWaitSpec, idx: number): string[] {
-  const out: string[] = [];
-  const w = wait.witness;
-  const respVar = `witnessResp${idx + 1}`;
-  out.push(`  // Wait for ${wait.state} (eventual; witness: ${w.operationId})`);
-  out.push(`  {`);
-  out.push(`    const witnessUrl = baseUrl + ${buildUrlExpression(w.pathTemplate)};`);
-  const optionFields: string[] = [
-    `method: '${w.method.toUpperCase()}'`,
-    `operationId: '${w.operationId}'`,
-  ];
-  if (typeof w.waitUpToMs === 'number') optionFields.push(`waitUpToMs: ${w.waitUpToMs}`);
-  if (typeof w.pollIntervalMs === 'number')
-    optionFields.push(`pollIntervalMs: ${w.pollIntervalMs}`);
-  // Predicate body: narrow `unknown` to a record, read the configured
-  // top-level field, compare with the configured scalar. Indentation
-  // matches the surrounding `await awaitEventually(...)` call so the
-  // emitted file passes biome's formatter without a separate pass.
-  optionFields.push(`predicate: (body) => {
-        if (body === null || typeof body !== 'object') return false;
-        const v = (body as Record<string, unknown>)['${w.predicate.path}'];
-        return v === ${JSON.stringify(w.predicate.equals)};
-      }`);
-  const method = w.method.toLowerCase();
-  // Capture awaitEventually's return value and assert on the status the
-  // same way request-step blocks do. awaitEventually returns early
-  // (without throwing) on hard-fail statuses (400/401/403/409/422/5xx)
-  // so the caller can produce a useful diff via expect(...).toBe(200);
-  // ignoring the response (the pre-review shape) would let the scenario
-  // proceed to the consumer step and attribute the eventual failure to
-  // the wrong place. The 200 assertion below tags the failure to the
-  // witness wait. (#159 PR B review.)
-  out.push(`    const ${respVar} = await awaitEventually(`);
-  out.push(`      async () => request.${method}(witnessUrl, { headers: await authHeaders() }),`);
-  out.push(`      {`);
-  for (let i = 0; i < optionFields.length; i++) {
-    const sep = i === optionFields.length - 1 ? '' : ',';
-    out.push(`        ${optionFields[i]}${sep}`);
-  }
-  out.push(`      },`);
-  out.push(`    );`);
-  out.push(`    if (${respVar}.status() !== 200) {`);
-  out.push(
-    `      try { console.error('Witness response body:', await ${respVar}.text()); } catch {}`,
-  );
-  out.push(`    }`);
-  out.push(`    expect(${respVar}.status()).toBe(200);`);
-  out.push(`  }`);
-  return out;
-}
-
-/**
- * Decide which request steps in a scenario should be wrapped with
- * `awaitEventually(...)`. A step is wrapped iff:
- *
- *   1. its `operationId` is listed in `scenario.eventualConsistencyOps`
- *      (the planner marks ops whose authoritative outputs land in
- *      Operate/Tasklist secondary storage with indexing lag); AND
- *   2. it is a *read* step — `GET` or `POST .../search` — because the
- *      poller's retry semantics (404-on-GET, items.length predicate)
- *      apply to reads, not to writes. A write that is itself flagged
- *      EC returns 200 quickly; the lag manifests on the *next* read; AND
- *   3. it expects a `200` (we never poll an error scenario).
- *
- * Returns the set of step indices the emitter should wrap. Exposed
- * (un-exported, file-local) so the import-needed check at the top of
- * `buildSuiteSource` and the per-step wrap decision share one
- * predicate — they cannot drift.
- */
-function stepNeedsAwait(s: EndpointScenario): number[] {
-  if (!s.requestPlan) return [];
-  // Source of truth: each `s.operations[].eventuallyConsistent` (a flag the
-  // extractor stamps from the `x-eventually-consistent` vendor extension).
-  // The `s.eventualConsistencyOps`/`s.hasEventuallyConsistent` fields are
-  // *summaries* the planner computes for some scenario kinds (multi-step
-  // chains, trivial scenarios) but not all (featureCoverage scenarios
-  // leave them undefined). Reading the per-op flag directly avoids that
-  // gap.
-  const ecOps = new Set<string>();
-  for (const op of s.operations) {
-    if (op.eventuallyConsistent) ecOps.add(op.operationId);
-  }
-  if (ecOps.size === 0) return [];
-  const out: number[] = [];
-  for (let i = 0; i < s.requestPlan.length; i++) {
-    const step = s.requestPlan[i];
-    if (!ecOps.has(step.operationId)) continue;
-    if (step.expect.status !== 200) continue;
-    const method = step.method.toUpperCase();
-    const isReadShape =
-      method === 'GET' || (method === 'POST' && /\/search\/?$/.test(step.pathTemplate));
-    if (!isReadShape) continue;
-    out.push(i);
-  }
-  return out;
-}
-
-// Build an accessor using optional chaining for nested/array paths, e.g. a.b[0].c -> ?.a?.b?.[0]?.c
-function toOptionalAccessor(fieldPath: string): string {
-  // Similar to toPathAccessor but with optional chaining and safe array index segments
-  const parts = fieldPath.split('.');
-  return parts
-    .map((p, i) => {
-      const m = p.match(/^([a-zA-Z_][a-zA-Z0-9_]*)(\[[0-9]+\])?$/);
-      if (m) {
-        const base = `${i === 0 ? '?.' : '?.'}${m[1]}`; // always prefix with ?.
-        const idx = m[2] ? `?.${m[2]}` : '';
-        return base + idx;
-      }
-      // fallback for unusual keys
-      return `?.['${p.replace(/'/g, "\\'")}']`;
-    })
-    .join('');
 }
 
 // Produce a seeded value expression for a binding variable name (string generation focus).

--- a/materializer/src/playwright/stepRenderer.ts
+++ b/materializer/src/playwright/stepRenderer.ts
@@ -1,0 +1,251 @@
+import type { EventualWaitSpec, RequestStep } from 'path-analyser/types';
+
+/**
+ * Shared per-step rendering primitives consumed by both the per-endpoint
+ * Playwright emitter (`emitter.ts`) and the template-scenario emitter
+ * (`templateEmitter.ts`).
+ *
+ * Both emitters previously maintained their own copies of these
+ * primitives. PR #274 reviews surfaced a recurring class of bugs caused
+ * by divergence (placeholder-substitution regex, eventual-consistency
+ * wrapping, single-parse-of-response-JSON, etc.). Centralising the
+ * primitives here eliminates the entire class — the only way a future
+ * change can drift one path from the other is if a caller reimplements
+ * a primitive locally.
+ */
+
+/**
+ * Regex matching body-template placeholders. Accepts both forms the
+ * planner is known to emit:
+ *
+ *   - `"${var}"`   — bare (template scenarios)
+ *   - `"\${var}"`  — backslash-escaped (per-endpoint scenarios; the
+ *                     planner backslash-escapes inside multipart values)
+ *
+ * Centralising the regex prevents one emitter from accepting only one
+ * form and silently passing the other through as a literal string.
+ */
+export const BODY_PLACEHOLDER_RE = /"\\?\$\{([^}]+)\}"/g;
+
+/**
+ * Build the `baseUrl + ${...}` URL expression for a path template.
+ * Substitutes `{paramName}` with `${ctx.paramNameVar || '${paramName}'}`
+ * — the literal-placeholder fallback gives the broker a recognisable
+ * URL (and a 4xx) when a path-param binding is missing, rather than
+ * the ambiguous string `"undefined"`.
+ */
+export function buildUrlExpression(pathTemplate: string): string {
+  return (
+    '`' +
+    pathTemplate.replace(/\{([^}]+)\}/g, (_, p) => `\${ctx.${camelCase(p)}Var || '\${${p}}'}`) +
+    '`'
+  );
+}
+
+export function camelCase(s: string): string {
+  return s.charAt(0).toLowerCase() + s.slice(1);
+}
+
+export function escapeQuotes(s: string): string {
+  return s.replace(/'/g, "'");
+}
+
+/**
+ * Build an accessor using optional chaining for nested/array paths,
+ * e.g. `a.b[0].c` → `?.a?.b?.[0]?.c`. Used by both emitters when
+ * rendering `extractInto(ctx, '<bind>', json<...accessor>)`.
+ */
+export function toOptionalAccessor(fieldPath: string): string {
+  const parts = fieldPath.split('.');
+  return parts
+    .map((p) => {
+      const m = p.match(/^([a-zA-Z_][a-zA-Z0-9_]*)(\[[0-9]+\])?$/);
+      if (m) {
+        const base = `?.${m[1]}`;
+        const idx = m[2] ? `?.${m[2]}` : '';
+        return base + idx;
+      }
+      return `?.['${p.replace(/'/g, "\\'")}']`;
+    })
+    .join('');
+}
+
+/**
+ * Predicate-only EC wrap decision. A step is wrappable iff:
+ *   1. its `operationId` is in `ecOps` (the planner-derived set of
+ *      operations marked `x-eventually-consistent`);
+ *   2. it is a read shape — `GET` or `POST .../search` (writes return
+ *      quickly even when EC; the lag manifests on the next read);
+ *   3. it expects a `200` (we never poll an error scenario).
+ *
+ * Returning `boolean` (instead of a Set of step indices) makes the
+ * predicate uniformly usable from both emitters, regardless of how they
+ * carry the EC set on the scenario object.
+ */
+export function stepNeedsAwaitForOp(step: RequestStep, ecOps: ReadonlySet<string>): boolean {
+  if (!ecOps.has(step.operationId)) return false;
+  if (step.expect.status !== 200) return false;
+  const method = step.method.toUpperCase();
+  const isReadShape =
+    method === 'GET' || (method === 'POST' && /\/search\/?$/.test(step.pathTemplate));
+  return isReadShape;
+}
+
+/**
+ * Inputs to {@link renderInlineStepLines}. Optional fields default to
+ * the per-endpoint emitter's pre-refactor behaviour so existing
+ * callers stay byte-identical without passing extra arguments.
+ */
+export interface InlineStepRenderInput {
+  step: RequestStep;
+  idx: number;
+  varName: string;
+  urlExpr: string;
+  method: string;
+  /**
+   * Per-multipart-field sentinel locals declared in the test prologue.
+   * Used to strip default-valued fields from emitted multipart bodies.
+   * Empty for template-scenario callers (no multipart steps today).
+   */
+  sentinelLocals?: Map<string, string>;
+  /** Whether this step should be wrapped with `awaitEventually(...)`. */
+  shouldAwaitEventually?: boolean;
+}
+
+/**
+ * Render the generic per-step inline body lines (URL + body + auth +
+ * EC wrap + request call + status assertion + error logging). The
+ * returned lines start at 4-space indent — the per-endpoint emitter
+ * appends them directly inside a `test.step(...)` callback at 2-space
+ * outer depth; the template emitter re-indents them by 2 extra spaces
+ * to fit its `test.describe` → `test(...)` → `test.step(...)` nesting.
+ *
+ * Body-template placeholder substitution uses {@link BODY_PLACEHOLDER_RE}
+ * which accepts both `"${var}"` and `"\${var}"` forms.
+ */
+export function renderInlineStepLines({
+  step,
+  idx,
+  varName,
+  urlExpr,
+  method,
+  sentinelLocals,
+  shouldAwaitEventually,
+}: InlineStepRenderInput): string[] {
+  const lines: string[] = [];
+  const bodyVar = `body${idx + 1}`;
+  const sentinels = sentinelLocals ?? new Map<string, string>();
+  lines.push(`    const url = baseUrl + ${urlExpr};`);
+  if (step.bodyKind === 'json' && step.bodyTemplate) {
+    const json = JSON.stringify(step.bodyTemplate, null, 4).replace(
+      BODY_PLACEHOLDER_RE,
+      (_, v) => `ctx["${v}"]`,
+    );
+    lines.push(`    const ${bodyVar} = ${json};`);
+  } else if (step.bodyKind === 'multipart' && step.multipartTemplate) {
+    const tpl = JSON.stringify(step.multipartTemplate, null, 4).replace(
+      BODY_PLACEHOLDER_RE,
+      (_, v) => `ctx["${v}"]`,
+    );
+    lines.push(`    const ${bodyVar} = ${tpl};`);
+  }
+  const opts: string[] = [];
+  opts.push('headers: await authHeaders()');
+  if (step.bodyKind === 'json' && step.bodyTemplate) opts.push(`data: ${bodyVar}`);
+  if (step.bodyKind === 'multipart' && step.multipartTemplate) {
+    lines.push(
+      `    const multipart: Record<string, string | { name: string; mimeType: string; buffer: Buffer }> = {};`,
+    );
+    lines.push(`    for (const [k,v] of Object.entries(${bodyVar}.fields||{})) {`);
+    for (const [fieldName, local] of sentinels) {
+      lines.push(`      if (k === '${fieldName}' && ${local}) continue;`);
+    }
+    lines.push(`      if (v !== undefined && v !== null) multipart[k] = String(v);`);
+    lines.push(`    }`);
+    lines.push(`    for (const [k,v] of Object.entries(${bodyVar}.files||{})) {
+        if (typeof v === 'string' && v.startsWith('@@FILE:')) {
+          const p = v.slice('@@FILE:'.length);
+          const buf = await resolveFixture(p);
+          const name = p.split('/').pop() || 'file';
+          multipart[k] = { name, mimeType: 'application/octet-stream', buffer: buf };
+        } else {
+          multipart[k] = String(v);
+        }
+      }`);
+    opts.push('multipart: multipart');
+  }
+  if (shouldAwaitEventually) {
+    lines.push(`    const ${varName} = await awaitEventually(`);
+    lines.push(`      async () => request.${method}(url, { ${opts.join(', ')} }),`);
+    lines.push(
+      `      { method: '${step.method.toUpperCase()}', operationId: '${step.operationId}' },`,
+    );
+    lines.push(`    );`);
+  } else {
+    lines.push(`    const ${varName} = await request.${method}(url, { ${opts.join(', ')} });`);
+  }
+  lines.push(`    if (${varName}.status() !== ${step.expect.status}) {`);
+  lines.push(`      try { console.error('Response body:', await ${varName}.text()); } catch {}`);
+  lines.push(`    }`);
+  lines.push(`    expect(${varName}.status()).toBe(${step.expect.status});`);
+  return lines;
+}
+
+/**
+ * Render a planner-annotated eventual-state wait as a sibling block to
+ * a producer step (#159 PR B). Returned lines start at 2-space outer
+ * indent (sibling to the producer's `await test.step(...)` call); the
+ * template emitter re-indents by +2 spaces to fit its deeper nesting.
+ *
+ * The witness predicate's `path` is validated to a JS identifier by
+ * the domain-semantics validator (`WitnessPredicateSchema`), so the
+ * bracket-access key emitted below is identifier-safe.
+ */
+export function renderEventualWait(wait: EventualWaitSpec, idx: number): string[] {
+  const out: string[] = [];
+  const w = wait.witness;
+  const respVar = `witnessResp${idx + 1}`;
+  out.push(`  // Wait for ${wait.state} (eventual; witness: ${w.operationId})`);
+  out.push(`  {`);
+  out.push(`    const witnessUrl = baseUrl + ${buildUrlExpression(w.pathTemplate)};`);
+  const optionFields: string[] = [
+    `method: '${w.method.toUpperCase()}'`,
+    `operationId: '${w.operationId}'`,
+  ];
+  if (typeof w.waitUpToMs === 'number') optionFields.push(`waitUpToMs: ${w.waitUpToMs}`);
+  if (typeof w.pollIntervalMs === 'number')
+    optionFields.push(`pollIntervalMs: ${w.pollIntervalMs}`);
+  optionFields.push(`predicate: (body) => {
+        if (body === null || typeof body !== 'object') return false;
+        const v = (body as Record<string, unknown>)['${w.predicate.path}'];
+        return v === ${JSON.stringify(w.predicate.equals)};
+      }`);
+  const method = w.method.toLowerCase();
+  out.push(`    const ${respVar} = await awaitEventually(`);
+  out.push(`      async () => request.${method}(witnessUrl, { headers: await authHeaders() }),`);
+  out.push(`      {`);
+  for (let i = 0; i < optionFields.length; i++) {
+    const sep = i === optionFields.length - 1 ? '' : ',';
+    out.push(`        ${optionFields[i]}${sep}`);
+  }
+  out.push(`      },`);
+  out.push(`    );`);
+  out.push(`    if (${respVar}.status() !== 200) {`);
+  out.push(
+    `      try { console.error('Witness response body:', await ${respVar}.text()); } catch {}`,
+  );
+  out.push(`    }`);
+  out.push(`    expect(${respVar}.status()).toBe(200);`);
+  out.push(`  }`);
+  return out;
+}
+
+/**
+ * Re-indent a block of pre-rendered lines by prepending `extra` to
+ * every non-empty line. Used by callers (the template emitter) that
+ * embed shared-rendered blocks inside a deeper outer scope than the
+ * per-endpoint emitter assumes.
+ */
+export function reindent(lines: readonly string[], extra: string): string[] {
+  return lines.map((l) => (l.length === 0 ? l : extra + l));
+}

--- a/materializer/src/playwright/stepRenderer.ts
+++ b/materializer/src/playwright/stepRenderer.ts
@@ -47,7 +47,12 @@ export function camelCase(s: string): string {
 }
 
 export function escapeQuotes(s: string): string {
-  return s.replace(/'/g, "'");
+  // Escape for embedding in a single-quoted TS string literal: backslashes
+  // first (otherwise they'd swallow the apostrophe-escaping backslash we
+  // add next), then apostrophes. The previous shape (`'` → `'`) was a
+  // no-op typo that would have emitted invalid TypeScript for any label
+  // containing an apostrophe (e.g. "user's profile"). (#274 review.)
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 }
 
 /**

--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -1,0 +1,355 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { ObserveStep, RequestStep, TemplateScenarioFile } from 'path-analyser/types';
+
+/**
+ * Per-suite globals used by the universal-seed prologue (Lift 22 / #270).
+ * Mirrors the subset of {@link GlobalContextSeed} the existing per-endpoint
+ * emitter consumes — kept narrow so the template emitter does not depend on
+ * any planner-side type that may grow new fields.
+ */
+export interface TemplateGlobalContextSeed {
+  binding: string;
+  seedRule: string;
+}
+
+export interface EmitTemplateSuitesOptions {
+  /**
+   * Absolute path to the EdgeLifecycle scenarios directory, i.e.
+   * `generated/<config>/scenarios/templates/EdgeLifecycle/`.
+   * Each `.json` underneath is read and rendered to one
+   * `<EdgeName>.lifecycle.spec.ts`.
+   */
+  scenariosDir: string;
+  /**
+   * Absolute path to the destination directory, i.e.
+   * `generated/<config>/playwright/edges/`. Wiped and recreated by the
+   * caller (the materializer's `run()`).
+   */
+  outDir: string;
+  /**
+   * Forwarded verbatim from the materializer's per-endpoint emit path —
+   * keeps the universal-seed prologue identical across both code paths so
+   * a future schema change cannot leave the template suites silently
+   * referencing an obsolete binding name.
+   */
+  globalContextSeeds: readonly TemplateGlobalContextSeed[];
+}
+
+/**
+ * Read every EdgeLifecycle template scenario JSON from `scenariosDir` and
+ * write one Playwright suite per edge to `outDir`. The emitted suite shape
+ * is:
+ *
+ *   1. universal-seed prologue (one `ctx.<binding> ??= seedBinding(...)` per
+ *      configured GlobalContextSeed),
+ *   2. one `seedBinding('<name>')` per `PrereqChainStep.seedBindings` entry
+ *      not already covered by (1),
+ *   3. inline render of each `PrereqChainStep.requestPlan` step,
+ *   4. inline render of the `InvokeStep.requestPlan` (the establisher),
+ *   5. inline render of the present-`ObserveStep` plus its membership
+ *      assertion (`.toContain`),
+ *   6. inline render of the revoke `InvokeStep.requestPlan`,
+ *   7. inline render of the absent-`ObserveStep` plus its membership
+ *      assertion (`.not.toContain`).
+ *
+ * Returns the absolute paths of files written, in emit order.
+ */
+export async function emitTemplateSuites(opts: EmitTemplateSuitesOptions): Promise<string[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(opts.scenariosDir);
+  } catch (e) {
+    if (typeof e === 'object' && e !== null && 'code' in e && Reflect.get(e, 'code') === 'ENOENT') {
+      return [];
+    }
+    throw e;
+  }
+  const jsonFiles = entries.filter((f) => f.endsWith('.json')).sort();
+  await fs.mkdir(opts.outDir, { recursive: true });
+  const written: string[] = [];
+  for (const f of jsonFiles) {
+    const raw = await fs.readFile(path.join(opts.scenariosDir, f), 'utf8');
+    const parsed = parseTemplateScenarioFile(raw, f);
+    const source = renderLifecycleSuite(parsed, opts.globalContextSeeds);
+    const outPath = path.join(opts.outDir, `${parsed.subjectName}.lifecycle.spec.ts`);
+    await fs.writeFile(outPath, source, 'utf8');
+    written.push(outPath);
+  }
+  return written;
+}
+
+// ---------------------------------------------------------------------------
+// Parsing (runtime contract boundary)
+// ---------------------------------------------------------------------------
+
+function parseTemplateScenarioFile(raw: string, fileName: string): TemplateScenarioFile {
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(
+      `Template scenario file ${fileName} is not valid JSON: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+  // The on-disk shape is owned by the planner-side TemplateScenarioFile type.
+  // The scenario instantiator wrote it, the L3 invariants assert its shape,
+  // and the runtime call paths below access only fields the invariants
+  // already guard. Suppression is the documented escape hatch for parsed
+  // JSON at a contract boundary.
+  // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+  return json as TemplateScenarioFile;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+function renderLifecycleSuite(
+  file: TemplateScenarioFile,
+  globalContextSeeds: readonly TemplateGlobalContextSeed[],
+): string {
+  const scenario = file.scenario;
+  const steps = scenario.steps;
+  // Validate template shape before emit. The L3 invariants already
+  // guarantee this on `npm test`, but the emitter is its own entry point
+  // (materializer CLI, future per-suite invocations) and must not produce
+  // a syntactically valid spec that secretly elides a step.
+  if (steps.length !== 5) {
+    throw new Error(
+      `EdgeLifecycle template ${file.subjectName} must have exactly 5 steps; got ${steps.length}.`,
+    );
+  }
+  const [prereq, establish, observePresent, revoke, observeAbsent] = steps;
+  if (prereq.kind !== 'prereqChain') {
+    throw new Error(`Step 0 of ${file.subjectName} must be a prereqChain step.`);
+  }
+  if (establish.kind !== 'invoke') {
+    throw new Error(`Step 1 of ${file.subjectName} must be an invoke step.`);
+  }
+  if (observePresent.kind !== 'observe' || observePresent.assertion.expect !== 'present') {
+    throw new Error(`Step 2 of ${file.subjectName} must be a present-observe step.`);
+  }
+  if (revoke.kind !== 'invoke') {
+    throw new Error(`Step 3 of ${file.subjectName} must be an invoke step.`);
+  }
+  if (observeAbsent.kind !== 'observe' || observeAbsent.assertion.expect !== 'absent') {
+    throw new Error(`Step 4 of ${file.subjectName} must be an absent-observe step.`);
+  }
+
+  const lines: string[] = [];
+  lines.push("import { expect, test } from '@playwright/test';");
+  lines.push("import { authHeaders, buildBaseUrl } from '../support/env';");
+  lines.push("import { initSpecSalt, seedBinding } from '../support/seeding';");
+  lines.push('');
+  lines.push(`initSpecSalt('${file.subjectName}.lifecycle');`);
+  lines.push('');
+  lines.push(`test.describe('${file.subjectName} lifecycle', () => {`);
+  lines.push(
+    `  test('establish ${file.subjectName}, observe present, revoke, observe absent', async ({ request }) => {`,
+  );
+  lines.push('    const baseUrl = buildBaseUrl();');
+  lines.push('    const ctx: Record<string, unknown> = {};');
+
+  // (1) universal-seed prologue
+  const globalSeedNames = new Set(globalContextSeeds.map((s) => s.binding));
+  for (const seed of globalContextSeeds) {
+    lines.push(
+      `    ctx['${seed.binding}'] = ctx['${seed.binding}'] ?? seedBinding('${seed.seedRule}');`,
+    );
+  }
+
+  // (2) per-scenario seedBindings (filtered to avoid double-seeding globals)
+  const seedNames = (prereq.seedBindings ?? []).filter((n) => !globalSeedNames.has(n));
+  for (const name of seedNames) {
+    lines.push(`    if (ctx['${name}'] === undefined) {`);
+    lines.push(`      ctx['${name}'] = seedBinding('${name}');`);
+    lines.push('    }');
+  }
+  // Literal bindings from the BFS scenario (non-PENDING) flow into ctx so a
+  // later step can read the planner-minted value before any extract overwrites
+  // it. PENDING entries are covered by the seedBindings loop above. Iterates
+  // `prereq.bindings` (binding-name-keyed, same shape as
+  // `EndpointScenario.bindings`) — NOT `scenario.bindings`, which is
+  // semantic-type-keyed and would resolve to meaningless ctx keys.
+  for (const [k, v] of Object.entries(prereq.bindings)) {
+    if (v === '__PENDING__') continue;
+    if (globalSeedNames.has(k)) continue; // already covered by prologue
+    lines.push(`    ctx['${k}'] = ${JSON.stringify(v)};`);
+  }
+
+  // (3) prereqChain inline
+  let stepIdx = 0;
+  for (const rp of prereq.requestPlan) {
+    lines.push('');
+    appendInlineRequestStep(lines, rp, stepIdx, `prereq: ${rp.operationId}`);
+    stepIdx++;
+  }
+
+  // (4) establish invoke
+  lines.push('');
+  appendInlineRequestStep(
+    lines,
+    establish.requestPlan,
+    stepIdx,
+    `invoke (establish): ${establish.operationId}`,
+  );
+  stepIdx++;
+
+  // (5) observe present
+  lines.push('');
+  appendObserveStep(lines, observePresent, scenario.bindings, stepIdx, 'observe (present)');
+  stepIdx++;
+
+  // (6) revoke invoke
+  lines.push('');
+  appendInlineRequestStep(
+    lines,
+    revoke.requestPlan,
+    stepIdx,
+    `invoke (revoke): ${revoke.operationId}`,
+  );
+  stepIdx++;
+
+  // (7) observe absent
+  lines.push('');
+  appendObserveStep(lines, observeAbsent, scenario.bindings, stepIdx, 'observe (absent)');
+
+  lines.push('  });');
+  lines.push('});');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function appendInlineRequestStep(
+  lines: string[],
+  step: RequestStep,
+  idx: number,
+  label: string,
+): void {
+  const respVar = `resp${idx + 1}`;
+  const bodyVar = `body${idx + 1}`;
+  const urlExpr = buildUrlExpression(step.pathTemplate);
+  const method = step.method.toLowerCase();
+  lines.push(`    await test.step('${escapeQuotes(label)}', async () => {`);
+  lines.push(`      const url = baseUrl + ${urlExpr};`);
+  const opts: string[] = ['headers: await authHeaders()'];
+  if (step.bodyKind === 'json' && step.bodyTemplate !== undefined) {
+    const json = JSON.stringify(step.bodyTemplate, null, 2).replace(
+      /"\$\{([^}]+)\}"/g,
+      (_, v) => `ctx['${v}']`,
+    );
+    // Indent the JSON literal so it lines up with the surrounding two-level
+    // (8-space) body — pretty-printing without this leaves the inner lines
+    // at column 0 and trips the suite's strict tsconfig include via Biome.
+    const indented = json.replace(/\n/g, '\n      ');
+    lines.push(`      const ${bodyVar} = ${indented};`);
+    opts.push(`data: ${bodyVar}`);
+  }
+  lines.push(`      const ${respVar} = await request.${method}(url, { ${opts.join(', ')} });`);
+  lines.push(`      if (${respVar}.status() !== ${step.expect.status}) {`);
+  lines.push(`        try { console.error('Response body:', await ${respVar}.text()); } catch {}`);
+  lines.push('      }');
+  lines.push(`      expect(${respVar}.status()).toBe(${step.expect.status});`);
+  lines.push('    });');
+}
+
+function appendObserveStep(
+  lines: string[],
+  step: ObserveStep,
+  scenarioBindings: Record<string, string>,
+  idx: number,
+  label: string,
+): void {
+  const respVar = `resp${idx + 1}`;
+  const urlExpr = buildUrlExpression(step.requestPlan.pathTemplate);
+  const method = step.requestPlan.method.toLowerCase();
+  lines.push(`    await test.step('${escapeQuotes(label)}', async () => {`);
+  lines.push(`      const url = baseUrl + ${urlExpr};`);
+  const opts: string[] = ['headers: await authHeaders()'];
+  if (step.requestPlan.bodyKind === 'json' && step.requestPlan.bodyTemplate !== undefined) {
+    const json = JSON.stringify(step.requestPlan.bodyTemplate, null, 2).replace(
+      /"\$\{([^}]+)\}"/g,
+      (_, v) => `ctx['${v}']`,
+    );
+    const indented = json.replace(/\n/g, '\n      ');
+    lines.push(`      const body${idx + 1} = ${indented};`);
+    opts.push(`data: body${idx + 1}`);
+  }
+  lines.push(`      const ${respVar} = await request.${method}(url, { ${opts.join(', ')} });`);
+  lines.push(`      expect(${respVar}.status()).toBe(${step.requestPlan.expect.status});`);
+  // Body extraction + membership assertion. The array lives at `arrayPath`
+  // under the parsed JSON. `unknown` is preserved through the access chain;
+  // the per-step `.map(...)` callback type-asserts via a runtime guard so
+  // the emitted suite typechecks under `strict: true`.
+  lines.push(`      const __body = await ${respVar}.json();`);
+  const accessChain = buildOptionalAccessChain('__body', step.assertion.arrayPath);
+  lines.push(`      const __raw = ${accessChain};`);
+  lines.push('      const __arr = Array.isArray(__raw) ? __raw : [];');
+  lines.push(
+    `      const __values = __arr.map((r) => (r as Record<string, unknown>)['${step.assertion.elementField}']);`,
+  );
+  const bindingName = resolveBindingNameForSemantic(
+    step.assertion.membershipSemanticType,
+    scenarioBindings,
+  );
+  const verb = step.assertion.expect === 'present' ? 'toContain' : 'not.toContain';
+  lines.push(`      expect(__values).${verb}(ctx['${bindingName}']);`);
+  lines.push('    });');
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildUrlExpression(pathTemplate: string): string {
+  // `{paramName}` → `${ctx[paramNameVar] ?? '{paramName}'}`. The fallback to
+  // the literal placeholder is defensive: when a path-param binding is
+  // missing the broker will 4xx with a recognisable URL rather than the
+  // ambiguous string "undefined".
+  return (
+    '`' +
+    pathTemplate.replace(/\{([^}]+)\}/g, (_, p) => `\${ctx['${camelCase(p)}Var'] ?? '{${p}}'}`) +
+    '`'
+  );
+}
+
+function buildOptionalAccessChain(rootExpr: string, segments: readonly string[]): string {
+  // Optional chain over a `unknown` root: cast each level to an indexable
+  // record. Keeps the emitted suite strict-mode clean because the array
+  // path may be deeply nested (`['data', 'rows']` etc.) and an intermediate
+  // `null` / `undefined` would otherwise throw at runtime.
+  let acc = rootExpr;
+  for (const seg of segments) {
+    acc = `(${acc} as Record<string, unknown> | null | undefined)?.['${seg}']`;
+  }
+  return acc;
+}
+
+function resolveBindingNameForSemantic(
+  semanticType: string,
+  bindings: Record<string, string>,
+): string {
+  // `TemplateScenario.bindings` is semantic-type-keyed (e.g. `'Username' →
+  // '__PENDING__'`) while the runtime ctx is binding-name-keyed
+  // (`ctx['usernameVar']`). Convention (#270): the BFS planner names
+  // bindings `<camelSemantic>Var`. Verify the *semantic type* exists in
+  // the scenario binding table to catch instantiator drift early —
+  // without this, a missing entry would silently emit `ctx[undefined]`.
+  if (!(semanticType in bindings)) {
+    throw new Error(
+      `Membership assertion for semantic type '${semanticType}' is not present ` +
+        `in the scenario binding table. Known semantic types: ` +
+        `${Object.keys(bindings).join(', ')}.`,
+    );
+  }
+  return `${semanticType.charAt(0).toLowerCase()}${semanticType.slice(1)}Var`;
+}
+
+function escapeQuotes(s: string): string {
+  return s.replace(/'/g, "\\'");
+}
+
+function camelCase(s: string): string {
+  return s.charAt(0).toLowerCase() + s.slice(1);
+}

--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -70,6 +70,16 @@ export interface EmitTemplateSuitesOptions {
  * Returns the absolute paths of files written, in emit order.
  */
 export async function emitTemplateSuites(opts: EmitTemplateSuitesOptions): Promise<string[]> {
+  // Validate the two seed fields this emitter interpolates directly into
+  // single-quoted TS string literals (binding + seedRule) so a malformed
+  // or hostile seed value cannot produce invalid (or unsafe) generated
+  // code. The per-endpoint emitter's `assertSafeGlobalContextSeeds`
+  // helper expects the full GlobalContextSeed schema (fieldName,
+  // defaultSentinel, …) which this entry point does not see — callers
+  // project to the narrow {binding, seedRule} shape on the way in. The
+  // local check below covers the same risk surface (string-literal
+  // injection) for that narrower payload. (#274 review.)
+  assertSafeTemplateSeeds(opts.globalContextSeeds);
   let entries: string[];
   try {
     entries = await fs.readdir(opts.scenariosDir);
@@ -274,7 +284,12 @@ function renderLifecycleSuite(
 // ---------------------------------------------------------------------------
 
 const EXTRA_INDENT = '  '; // +2 spaces vs the shared renderer's 4-space baseline
-const WAIT_INDENT = '    '; // +4 spaces: waits indent at the inner test-step depth
+// Shared `renderEventualWait` emits at 2-space outer indent. Template
+// suite's `await test.step(...)` calls live at 4-space depth (inside
+// `describe → test`), so waits become true siblings of the step at
+// +2 spaces re-indent — NOT +4 (which would over-indent them past the
+// step body). (#274 review.)
+const WAIT_INDENT = '  ';
 
 function appendInlineRequestStep(
   lines: string[],
@@ -457,4 +472,43 @@ function resolveBindingNameForSemantic(
     );
   }
   return bindingName;
+}
+
+// ---------------------------------------------------------------------------
+// Seed validation (string-literal-injection defence)
+// ---------------------------------------------------------------------------
+
+// Identifier-like: lowercase/uppercase letters, digits, underscore, dash,
+// dollar; must start with a letter, underscore, or dollar. Covers every
+// binding name and seedRule the planner emits today (Lift-22 universal
+// seeds, per-edge generated seeds) without permitting characters that
+// could break out of a single-quoted TS string literal (quote, backslash,
+// newline, template-literal markers).
+const SAFE_SEED_TOKEN = /^[A-Za-z_$][A-Za-z0-9_$-]*$/;
+
+function assertSafeTemplateSeeds(seeds: readonly TemplateGlobalContextSeed[] | undefined): void {
+  if (seeds === undefined) return;
+  if (!Array.isArray(seeds)) {
+    throw new Error(
+      `globalContextSeeds must be an array when provided (received ${
+        seeds === null ? 'null' : typeof seeds
+      }).`,
+    );
+  }
+  for (let i = 0; i < seeds.length; i++) {
+    const s = seeds[i];
+    if (s === null || typeof s !== 'object') {
+      throw new Error(`globalContextSeeds[${i}] must be an object.`);
+    }
+    if (typeof s.binding !== 'string' || !SAFE_SEED_TOKEN.test(s.binding)) {
+      throw new Error(
+        `globalContextSeeds[${i}].binding must match ${SAFE_SEED_TOKEN.source} (got ${JSON.stringify(s.binding)}).`,
+      );
+    }
+    if (typeof s.seedRule !== 'string' || !SAFE_SEED_TOKEN.test(s.seedRule)) {
+      throw new Error(
+        `globalContextSeeds[${i}].seedRule must match ${SAFE_SEED_TOKEN.source} (got ${JSON.stringify(s.seedRule)}).`,
+      );
+    }
+  }
 }

--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -1,6 +1,11 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import type { ObserveStep, RequestStep, TemplateScenarioFile } from 'path-analyser/types';
+import type {
+  EventualWaitSpec,
+  ObserveStep,
+  RequestStep,
+  TemplateScenarioFile,
+} from 'path-analyser/types';
 
 /**
  * Per-suite globals used by the universal-seed prologue (Lift 22 / #270).
@@ -137,10 +142,33 @@ function renderLifecycleSuite(
     throw new Error(`Step 4 of ${file.subjectName} must be an absent-observe step.`);
   }
 
+  // Collect every RequestStep the suite will render so the per-suite
+  // import list reflects the actual code paths emitted below. The
+  // emitter has three optional helpers (extractInto, awaitEventually)
+  // whose imports must be omitted when unused — otherwise the
+  // strict-mode generated-suites typecheck flags
+  // `noUnusedImports` and CI fails.
+  const allRequestSteps: RequestStep[] = [
+    ...prereq.requestPlan,
+    establish.requestPlan,
+    observePresent.requestPlan,
+    revoke.requestPlan,
+    observeAbsent.requestPlan,
+  ];
+  const needsExtractInto = allRequestSteps.some((rp) => (rp.extract?.length ?? 0) > 0);
+  const needsAwaitEventually = allRequestSteps.some(
+    (rp) => (rp.eventualWaitsAfter?.length ?? 0) > 0,
+  );
+
   const lines: string[] = [];
   lines.push("import { expect, test } from '@playwright/test';");
   lines.push("import { authHeaders, buildBaseUrl } from '../support/env';");
-  lines.push("import { initSpecSalt, seedBinding } from '../support/seeding';");
+  const seedingImports = ['initSpecSalt', 'seedBinding'];
+  if (needsExtractInto) seedingImports.push('extractInto');
+  lines.push(`import { ${seedingImports.join(', ')} } from '../support/seeding';`);
+  if (needsAwaitEventually) {
+    lines.push("import { awaitEventually } from '../support/await-eventually';");
+  }
   lines.push('');
   lines.push(`initSpecSalt('${file.subjectName}.lifecycle');`);
   lines.push('');
@@ -251,7 +279,36 @@ function appendInlineRequestStep(
   lines.push(`        try { console.error('Response body:', await ${respVar}.text()); } catch {}`);
   lines.push('      }');
   lines.push(`      expect(${respVar}.status()).toBe(${step.expect.status});`);
+  // Response extraction. Mirrors the per-endpoint emitter's per-step
+  // extract loop so a planner-annotated extract (e.g. server-assigned
+  // RoleId echoed in the createRole response) flows back into ctx and
+  // is visible to later prereq / invoke / observe steps. Without this,
+  // a future template whose establisher consumes a server-generated
+  // identifier (rather than the client-seeded one OCA edges happen to
+  // use) would silently send `undefined` and the suite would 4xx at
+  // runtime with no diagnostic at emit time.
+  for (const ex of step.extract ?? []) {
+    if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(ex.bind)) {
+      throw new Error(
+        `Refusing to emit extract for non-identifier bind name '${ex.bind}' (operationId=${step.operationId}).`,
+      );
+    }
+    lines.push(`      const json${idx + 1} = await ${respVar}.json();`);
+    lines.push(
+      `      extractInto(ctx, '${ex.bind}', ${buildOptionalAccessChain(`json${idx + 1}`, ex.fieldPath.split('.'))});`,
+    );
+  }
   lines.push('    });');
+  // Planner-annotated eventual-state waits (#159 PR B) — emitted as a
+  // sibling block at the same indentation as the test step so the
+  // wait's locals stay isolated. None of the current OCA edges
+  // populate `eventualWaitsAfter`, but future Edge-scoped templates
+  // whose establishers transition through an eventual state will,
+  // and silently dropping the planner's annotation here would race
+  // the subsequent observe step.
+  for (const wait of step.eventualWaitsAfter ?? []) {
+    appendEventualWait(lines, wait, idx);
+  }
 }
 
 function appendObserveStep(
@@ -295,7 +352,76 @@ function appendObserveStep(
   );
   const verb = step.assertion.expect === 'present' ? 'toContain' : 'not.toContain';
   lines.push(`      expect(__values).${verb}(ctx['${bindingName}']);`);
+  // Planner-annotated extracts on the observe step's request plan
+  // (mirrors the per-endpoint emitter's per-step extract loop). None
+  // of the current OCA edge observers populate `extract`, but the
+  // loader contract permits it and silently dropping the annotation
+  // would surface as a stale ctx for any consumer-of-observer
+  // template authored after Phase 2.
+  for (const ex of step.requestPlan.extract ?? []) {
+    if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(ex.bind)) {
+      throw new Error(
+        `Refusing to emit extract for non-identifier bind name '${ex.bind}' (observe operationId=${step.operationId}).`,
+      );
+    }
+    lines.push(
+      `      extractInto(ctx, '${ex.bind}', ${buildOptionalAccessChain('__body', ex.fieldPath.split('.'))});`,
+    );
+  }
   lines.push('    });');
+  // Symmetrical eventual-wait emission for the observe step's request
+  // plan; see `appendInlineRequestStep` for rationale.
+  for (const wait of step.requestPlan.eventualWaitsAfter ?? []) {
+    appendEventualWait(lines, wait, idx);
+  }
+}
+
+function appendEventualWait(lines: string[], wait: EventualWaitSpec, stepIdx: number): void {
+  // #159 PR B-equivalent wait block, emitted at the same indentation as
+  // the sibling `test.step(...)` call so the wait's locals (`witnessUrl`,
+  // `witnessRespN`) stay out of the step's closure. The predicate body
+  // narrows `unknown` to a record before the top-level field read so the
+  // emitted suite typechecks under strict mode.
+  const respVar = `witnessResp${stepIdx + 1}`;
+  const w = wait.witness;
+  if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(w.predicate.path)) {
+    throw new Error(
+      `Refusing to emit witness predicate with non-identifier path '${w.predicate.path}'.`,
+    );
+  }
+  lines.push(`    // Wait for ${wait.state} (eventual; witness: ${w.operationId})`);
+  lines.push('    {');
+  lines.push(`      const witnessUrl = baseUrl + ${buildUrlExpression(w.pathTemplate)};`);
+  const optionLines: string[] = [];
+  optionLines.push(`        method: '${w.method.toUpperCase()}',`);
+  optionLines.push(`        operationId: '${w.operationId}',`);
+  if (typeof w.waitUpToMs === 'number') {
+    optionLines.push(`        waitUpToMs: ${w.waitUpToMs},`);
+  }
+  if (typeof w.pollIntervalMs === 'number') {
+    optionLines.push(`        pollIntervalMs: ${w.pollIntervalMs},`);
+  }
+  optionLines.push('        predicate: (body) => {');
+  optionLines.push('          if (body === null || typeof body !== "object") return false;');
+  optionLines.push(`          const v = (body as Record<string, unknown>)['${w.predicate.path}'];`);
+  optionLines.push(`          return v === ${JSON.stringify(w.predicate.equals)};`);
+  optionLines.push('        },');
+  const method = w.method.toLowerCase();
+  lines.push(`      const ${respVar} = await awaitEventually(`);
+  lines.push(
+    `        async () => request.${method}(witnessUrl, { headers: await authHeaders() }),`,
+  );
+  lines.push('        {');
+  for (const ol of optionLines) lines.push(ol);
+  lines.push('        },');
+  lines.push('      );');
+  lines.push(`      if (${respVar}.status() !== 200) {`);
+  lines.push(
+    `        try { console.error('Witness response body:', await ${respVar}.text()); } catch {}`,
+  );
+  lines.push('      }');
+  lines.push(`      expect(${respVar}.status()).toBe(200);`);
+  lines.push('    }');
 }
 
 // ---------------------------------------------------------------------------

--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -334,7 +334,17 @@ function appendObserveStep(
   lines.push(`      const __body = await ${respVar}.json();`);
   const accessChain = buildOptionalAccessChain('__body', step.assertion.arrayPath);
   lines.push(`      const __raw = ${accessChain};`);
-  lines.push('      const __arr = Array.isArray(__raw) ? __raw : [];');
+  // Fail loudly when the planner-declared arrayPath does not resolve to
+  // an array — the previous silent `Array.isArray(__raw) ? __raw : []`
+  // fallback would let an absent-observe assertion pass against a
+  // malformed response (e.g. server returned 200 with an unexpected
+  // shape), masking real defects. (#274 review.)
+  lines.push('      if (!Array.isArray(__raw)) {');
+  lines.push(
+    `        throw new Error('Observe assertion at arrayPath ${JSON.stringify(step.assertion.arrayPath).replace(/'/g, "\\'")} expected an array but got: ' + JSON.stringify(__raw));`,
+  );
+  lines.push('      }');
+  lines.push('      const __arr: unknown[] = __raw;');
   const elementSegments = step.assertion.elementField.split('.').filter((s) => s.length > 0);
   if (elementSegments.length === 0) {
     throw new Error(`Empty elementField on observe assertion for operationId=${step.operationId}.`);
@@ -430,18 +440,21 @@ function resolveBindingNameForSemantic(
   semanticType: string,
   bindings: Record<string, string>,
 ): string {
-  // `TemplateScenario.bindings` is semantic-type-keyed (e.g. `'Username' →
-  // '__PENDING__'`) while the runtime ctx is binding-name-keyed
-  // (`ctx['usernameVar']`). Convention (#270): the BFS planner names
-  // bindings `<camelSemantic>Var`. Verify the *semantic type* exists in
-  // the scenario binding table to catch instantiator drift early —
-  // without this, a missing entry would silently emit `ctx[undefined]`.
-  if (!(semanticType in bindings)) {
+  // `TemplateScenario.bindings` is semantic-type-keyed: each value is the
+  // binding name the planner minted for that semantic (e.g.
+  // `{ 'Username': 'usernameVar' }`). Read the map directly rather than
+  // re-deriving the binding name from the semantic-type identifier — the
+  // map is the authoritative source, and recomputing here would emit the
+  // wrong ctx key if the planner's naming convention ever diverged from
+  // the `<camelSemantic>Var` rule (e.g. for a semantic whose canonical
+  // binding name had a suffix the convention doesn't cover).
+  const bindingName = bindings[semanticType];
+  if (bindingName === undefined) {
     throw new Error(
       `Membership assertion for semantic type '${semanticType}' is not present ` +
         `in the scenario binding table. Known semantic types: ` +
         `${Object.keys(bindings).join(', ')}.`,
     );
   }
-  return `${semanticType.charAt(0).toLowerCase()}${semanticType.slice(1)}Var`;
+  return bindingName;
 }

--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -6,6 +6,15 @@ import type {
   RequestStep,
   TemplateScenarioFile,
 } from 'path-analyser/types';
+import {
+  buildUrlExpression,
+  escapeQuotes,
+  reindent,
+  renderEventualWait,
+  renderInlineStepLines,
+  stepNeedsAwaitForOp,
+  toOptionalAccessor,
+} from './stepRenderer.js';
 
 /**
  * Per-suite globals used by the universal-seed prologue (Lift 22 / #270).
@@ -155,10 +164,16 @@ function renderLifecycleSuite(
     revoke.requestPlan,
     observeAbsent.requestPlan,
   ];
+  const ecOps = new Set<string>(scenario.eventuallyConsistentOps ?? []);
+  // `needsAwaitEventually` covers BOTH eventual-state waits (PR B style
+  // annotated waits) AND read-shape steps whose operationId is in the
+  // ABox EC set. The latter mirrors the per-endpoint emitter's wrap
+  // decision (`stepNeedsAwaitForOp`) so the two emitters cannot drift
+  // on which steps get awaitEventually() wrapping.
   const needsExtractInto = allRequestSteps.some((rp) => (rp.extract?.length ?? 0) > 0);
-  const needsAwaitEventually = allRequestSteps.some(
-    (rp) => (rp.eventualWaitsAfter?.length ?? 0) > 0,
-  );
+  const needsAwaitEventually =
+    allRequestSteps.some((rp) => (rp.eventualWaitsAfter?.length ?? 0) > 0) ||
+    allRequestSteps.some((rp) => stepNeedsAwaitForOp(rp, ecOps));
 
   const lines: string[] = [];
   lines.push("import { expect, test } from '@playwright/test';");
@@ -210,7 +225,7 @@ function renderLifecycleSuite(
   let stepIdx = 0;
   for (const rp of prereq.requestPlan) {
     lines.push('');
-    appendInlineRequestStep(lines, rp, stepIdx, `prereq: ${rp.operationId}`);
+    appendInlineRequestStep(lines, rp, stepIdx, `prereq: ${rp.operationId}`, ecOps);
     stepIdx++;
   }
 
@@ -221,12 +236,13 @@ function renderLifecycleSuite(
     establish.requestPlan,
     stepIdx,
     `invoke (establish): ${establish.operationId}`,
+    ecOps,
   );
   stepIdx++;
 
   // (5) observe present
   lines.push('');
-  appendObserveStep(lines, observePresent, scenario.bindings, stepIdx, 'observe (present)');
+  appendObserveStep(lines, observePresent, scenario.bindings, stepIdx, 'observe (present)', ecOps);
   stepIdx++;
 
   // (6) revoke invoke
@@ -236,12 +252,13 @@ function renderLifecycleSuite(
     revoke.requestPlan,
     stepIdx,
     `invoke (revoke): ${revoke.operationId}`,
+    ecOps,
   );
   stepIdx++;
 
   // (7) observe absent
   lines.push('');
-  appendObserveStep(lines, observeAbsent, scenario.bindings, stepIdx, 'observe (absent)');
+  appendObserveStep(lines, observeAbsent, scenario.bindings, stepIdx, 'observe (absent)', ecOps);
 
   lines.push('  });');
   lines.push('});');
@@ -249,72 +266,41 @@ function renderLifecycleSuite(
   return lines.join('\n');
 }
 
+// ---------------------------------------------------------------------------
+// Per-step rendering — delegates to the shared `stepRenderer` module so
+// the template and per-endpoint emitters cannot drift on placeholder
+// substitution, eventual-consistency wrapping, body emission, status
+// assertion, or extract shape (#270 review: avoid the divergence class).
+// ---------------------------------------------------------------------------
+
+const EXTRA_INDENT = '  '; // +2 spaces vs the shared renderer's 4-space baseline
+const WAIT_INDENT = '    '; // +4 spaces: waits indent at the inner test-step depth
+
 function appendInlineRequestStep(
   lines: string[],
   step: RequestStep,
   idx: number,
   label: string,
+  ecOps: ReadonlySet<string>,
 ): void {
   const respVar = `resp${idx + 1}`;
-  const bodyVar = `body${idx + 1}`;
   const urlExpr = buildUrlExpression(step.pathTemplate);
   const method = step.method.toLowerCase();
   lines.push(`    await test.step('${escapeQuotes(label)}', async () => {`);
-  lines.push(`      const url = baseUrl + ${urlExpr};`);
-  const opts: string[] = ['headers: await authHeaders()'];
-  if (step.bodyKind === 'json' && step.bodyTemplate !== undefined) {
-    const json = JSON.stringify(step.bodyTemplate, null, 2).replace(
-      /"\$\{([^}]+)\}"/g,
-      (_, v) => `ctx['${v}']`,
-    );
-    // Indent the JSON literal so it lines up with the surrounding two-level
-    // (8-space) body — pretty-printing without this leaves the inner lines
-    // at column 0 and trips the suite's strict tsconfig include via Biome.
-    const indented = json.replace(/\n/g, '\n      ');
-    lines.push(`      const ${bodyVar} = ${indented};`);
-    opts.push(`data: ${bodyVar}`);
-  }
-  lines.push(`      const ${respVar} = await request.${method}(url, { ${opts.join(', ')} });`);
-  lines.push(`      if (${respVar}.status() !== ${step.expect.status}) {`);
-  lines.push(`        try { console.error('Response body:', await ${respVar}.text()); } catch {}`);
-  lines.push('      }');
-  lines.push(`      expect(${respVar}.status()).toBe(${step.expect.status});`);
-  // Response extraction. Mirrors the per-endpoint emitter's per-step
-  // extract loop so a planner-annotated extract (e.g. server-assigned
-  // RoleId echoed in the createRole response) flows back into ctx and
-  // is visible to later prereq / invoke / observe steps. Without this,
-  // a future template whose establisher consumes a server-generated
-  // identifier (rather than the client-seeded one OCA edges happen to
-  // use) would silently send `undefined` and the suite would 4xx at
-  // runtime with no diagnostic at emit time.
-  const extracts = step.extract ?? [];
-  if (extracts.length > 0) {
-    // Parse the response body ONCE per step. A previous shape declared
-    // `const jsonN = await ${respVar}.json()` inside the per-extract
-    // loop, which redeclared the same identifier when a step had more
-    // than one extract and broke the strict-mode generated-suites
-    // typecheck. The per-endpoint emitter does the same single-parse
-    // pattern (materializer/src/playwright/emitter.ts).
-    lines.push(`      const json${idx + 1} = await ${respVar}.json();`);
-    for (const ex of extracts) {
-      if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(ex.bind)) {
-        throw new Error(
-          `Refusing to emit extract for non-identifier bind name '${ex.bind}' (operationId=${step.operationId}).`,
-        );
-      }
-      lines.push(
-        `      extractInto(ctx, '${ex.bind}', ${buildOptionalAccessChain(`json${idx + 1}`, ex.fieldPath.split('.'))});`,
-      );
-    }
-  }
+  // The shared `renderInlineStepLines` returns lines at 4-space indent
+  // (the per-endpoint emitter's baseline). Re-indent by +2 to fit the
+  // template suite's deeper nesting (`describe → test → test.step`).
+  const inline = renderInlineStepLines({
+    step,
+    idx,
+    varName: respVar,
+    urlExpr,
+    method,
+    shouldAwaitEventually: stepNeedsAwaitForOp(step, ecOps),
+  });
+  for (const line of reindent(inline, EXTRA_INDENT)) lines.push(line);
+  appendExtracts(lines, step, respVar, idx, '      ');
   lines.push('    });');
-  // Planner-annotated eventual-state waits (#159 PR B) — emitted as a
-  // sibling block at the same indentation as the test step so the
-  // wait's locals stay isolated. None of the current OCA edges
-  // populate `eventualWaitsAfter`, but future Edge-scoped templates
-  // whose establishers transition through an eventual state will,
-  // and silently dropping the planner's annotation here would race
-  // the subsequent observe step.
   for (const wait of step.eventualWaitsAfter ?? []) {
     appendEventualWait(lines, wait, idx);
   }
@@ -326,37 +312,29 @@ function appendObserveStep(
   scenarioBindings: Record<string, string>,
   idx: number,
   label: string,
+  ecOps: ReadonlySet<string>,
 ): void {
   const respVar = `resp${idx + 1}`;
   const urlExpr = buildUrlExpression(step.requestPlan.pathTemplate);
   const method = step.requestPlan.method.toLowerCase();
   lines.push(`    await test.step('${escapeQuotes(label)}', async () => {`);
-  lines.push(`      const url = baseUrl + ${urlExpr};`);
-  const opts: string[] = ['headers: await authHeaders()'];
-  if (step.requestPlan.bodyKind === 'json' && step.requestPlan.bodyTemplate !== undefined) {
-    const json = JSON.stringify(step.requestPlan.bodyTemplate, null, 2).replace(
-      /"\$\{([^}]+)\}"/g,
-      (_, v) => `ctx['${v}']`,
-    );
-    const indented = json.replace(/\n/g, '\n      ');
-    lines.push(`      const body${idx + 1} = ${indented};`);
-    opts.push(`data: body${idx + 1}`);
-  }
-  lines.push(`      const ${respVar} = await request.${method}(url, { ${opts.join(', ')} });`);
-  lines.push(`      expect(${respVar}.status()).toBe(${step.requestPlan.expect.status});`);
-  // Body extraction + membership assertion. The array lives at `arrayPath`
-  // under the parsed JSON. `unknown` is preserved through the access chain;
-  // the per-step `.map(...)` callback type-asserts via a runtime guard so
-  // the emitted suite typechecks under `strict: true`.
+  const inline = renderInlineStepLines({
+    step: step.requestPlan,
+    idx,
+    varName: respVar,
+    urlExpr,
+    method,
+    shouldAwaitEventually: stepNeedsAwaitForOp(step.requestPlan, ecOps),
+  });
+  for (const line of reindent(inline, EXTRA_INDENT)) lines.push(line);
+  // Membership assertion (template-unique). Walks the planner-declared
+  // arrayPath into the parsed body, projects each element via the
+  // `elementField` chain (dotted paths supported), and asserts
+  // presence/absence of the scenario-bound value.
   lines.push(`      const __body = await ${respVar}.json();`);
   const accessChain = buildOptionalAccessChain('__body', step.assertion.arrayPath);
   lines.push(`      const __raw = ${accessChain};`);
   lines.push('      const __arr = Array.isArray(__raw) ? __raw : [];');
-  // `elementField` can be a dotted path (e.g. `member.username` for
-  // `data.items[].member.username`) — see findMembershipArrayPath's
-  // field-path parsing doc. A literal `['member.username']` lookup
-  // would always miss; resolve via an optional-access chain per
-  // element instead.
   const elementSegments = step.assertion.elementField.split('.').filter((s) => s.length > 0);
   if (elementSegments.length === 0) {
     throw new Error(`Empty elementField on observe assertion for operationId=${step.operationId}.`);
@@ -369,99 +347,78 @@ function appendObserveStep(
   );
   const verb = step.assertion.expect === 'present' ? 'toContain' : 'not.toContain';
   lines.push(`      expect(__values).${verb}(ctx['${bindingName}']);`);
-  // Planner-annotated extracts on the observe step's request plan
-  // (mirrors the per-endpoint emitter's per-step extract loop). None
-  // of the current OCA edge observers populate `extract`, but the
-  // loader contract permits it and silently dropping the annotation
-  // would surface as a stale ctx for any consumer-of-observer
-  // template authored after Phase 2.
+  // Note: the shared `renderInlineStepLines` does not emit extracts —
+  // those live here at the appender layer so the membership assertion
+  // sits between the inline call and any planner-declared extracts.
+  // The observe step parses the body once for the membership read above;
+  // any extracts re-use `__body` rather than re-parsing.
   for (const ex of step.requestPlan.extract ?? []) {
     if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(ex.bind)) {
       throw new Error(
         `Refusing to emit extract for non-identifier bind name '${ex.bind}' (observe operationId=${step.operationId}).`,
       );
     }
-    lines.push(
-      `      extractInto(ctx, '${ex.bind}', ${buildOptionalAccessChain('__body', ex.fieldPath.split('.'))});`,
-    );
+    lines.push(`      extractInto(ctx, '${ex.bind}', __body${toOptionalAccessor(ex.fieldPath)});`);
   }
   lines.push('    });');
-  // Symmetrical eventual-wait emission for the observe step's request
-  // plan; see `appendInlineRequestStep` for rationale.
   for (const wait of step.requestPlan.eventualWaitsAfter ?? []) {
     appendEventualWait(lines, wait, idx);
   }
 }
 
-function appendEventualWait(lines: string[], wait: EventualWaitSpec, stepIdx: number): void {
-  // #159 PR B-equivalent wait block, emitted at the same indentation as
-  // the sibling `test.step(...)` call so the wait's locals (`witnessUrl`,
-  // `witnessRespN`) stay out of the step's closure. The predicate body
-  // narrows `unknown` to a record before the top-level field read so the
-  // emitted suite typechecks under strict mode.
-  const respVar = `witnessResp${stepIdx + 1}`;
-  const w = wait.witness;
-  if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(w.predicate.path)) {
-    throw new Error(
-      `Refusing to emit witness predicate with non-identifier path '${w.predicate.path}'.`,
+function appendExtracts(
+  lines: string[],
+  step: RequestStep,
+  respVar: string,
+  idx: number,
+  indent: string,
+): void {
+  const extracts = step.extract ?? [];
+  if (extracts.length === 0) return;
+  // Single-parse pattern: `await respVar.json()` once, then reuse.
+  // Matches the per-endpoint emitter (emitter.ts) so a multi-extract
+  // step cannot redeclare `jsonN` and break the strict-mode generated-
+  // suites typecheck.
+  const jsonVar = `json${idx + 1}`;
+  lines.push(`${indent}const ${jsonVar} = await ${respVar}.json();`);
+  for (const ex of extracts) {
+    if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(ex.bind)) {
+      throw new Error(
+        `Refusing to emit extract for non-identifier bind name '${ex.bind}' (operationId=${step.operationId}).`,
+      );
+    }
+    lines.push(
+      `${indent}extractInto(ctx, '${ex.bind}', ${jsonVar}${toOptionalAccessor(ex.fieldPath)});`,
     );
   }
-  lines.push(`    // Wait for ${wait.state} (eventual; witness: ${w.operationId})`);
-  lines.push('    {');
-  lines.push(`      const witnessUrl = baseUrl + ${buildUrlExpression(w.pathTemplate)};`);
-  const optionLines: string[] = [];
-  optionLines.push(`        method: '${w.method.toUpperCase()}',`);
-  optionLines.push(`        operationId: '${w.operationId}',`);
-  if (typeof w.waitUpToMs === 'number') {
-    optionLines.push(`        waitUpToMs: ${w.waitUpToMs},`);
+}
+
+function appendEventualWait(lines: string[], wait: EventualWaitSpec, stepIdx: number): void {
+  if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(wait.witness.predicate.path)) {
+    throw new Error(
+      `Refusing to emit witness predicate with non-identifier path '${wait.witness.predicate.path}'.`,
+    );
   }
-  if (typeof w.pollIntervalMs === 'number') {
-    optionLines.push(`        pollIntervalMs: ${w.pollIntervalMs},`);
+  // Shared `renderEventualWait` emits at 2-space indent (sibling to the
+  // per-endpoint emitter's `test.step` at top-level). Template needs
+  // +4 spaces to sit as a sibling to its inner `await test.step(...)`.
+  for (const line of reindent(renderEventualWait(wait, stepIdx), WAIT_INDENT)) {
+    lines.push(line);
   }
-  optionLines.push('        predicate: (body) => {');
-  optionLines.push('          if (body === null || typeof body !== "object") return false;');
-  optionLines.push(`          const v = (body as Record<string, unknown>)['${w.predicate.path}'];`);
-  optionLines.push(`          return v === ${JSON.stringify(w.predicate.equals)};`);
-  optionLines.push('        },');
-  const method = w.method.toLowerCase();
-  lines.push(`      const ${respVar} = await awaitEventually(`);
-  lines.push(
-    `        async () => request.${method}(witnessUrl, { headers: await authHeaders() }),`,
-  );
-  lines.push('        {');
-  for (const ol of optionLines) lines.push(ol);
-  lines.push('        },');
-  lines.push('      );');
-  lines.push(`      if (${respVar}.status() !== 200) {`);
-  lines.push(
-    `        try { console.error('Witness response body:', await ${respVar}.text()); } catch {}`,
-  );
-  lines.push('      }');
-  lines.push(`      expect(${respVar}.status()).toBe(200);`);
-  lines.push('    }');
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Template-local helpers (not part of the shared step-renderer contract)
 // ---------------------------------------------------------------------------
-
-function buildUrlExpression(pathTemplate: string): string {
-  // `{paramName}` → `${ctx[paramNameVar] ?? '{paramName}'}`. The fallback to
-  // the literal placeholder is defensive: when a path-param binding is
-  // missing the broker will 4xx with a recognisable URL rather than the
-  // ambiguous string "undefined".
-  return (
-    '`' +
-    pathTemplate.replace(/\{([^}]+)\}/g, (_, p) => `\${ctx['${camelCase(p)}Var'] ?? '{${p}}'}`) +
-    '`'
-  );
-}
 
 function buildOptionalAccessChain(rootExpr: string, segments: readonly string[]): string {
   // Optional chain over a `unknown` root: cast each level to an indexable
-  // record. Keeps the emitted suite strict-mode clean because the array
-  // path may be deeply nested (`['data', 'rows']` etc.) and an intermediate
-  // `null` / `undefined` would otherwise throw at runtime.
+  // record. Used by the observe-step membership assertion's array-path
+  // walk and per-element field projection. Kept local because the
+  // per-endpoint emitter's extract path uses `toOptionalAccessor`
+  // (string-based dotted paths) instead; the membership assertion
+  // operates on an already-segmented path so a different shape is
+  // appropriate.
   let acc = rootExpr;
   for (const seg of segments) {
     acc = `(${acc} as Record<string, unknown> | null | undefined)?.['${seg}']`;
@@ -487,12 +444,4 @@ function resolveBindingNameForSemantic(
     );
   }
   return `${semanticType.charAt(0).toLowerCase()}${semanticType.slice(1)}Var`;
-}
-
-function escapeQuotes(s: string): string {
-  return s.replace(/'/g, "\\'");
-}
-
-function camelCase(s: string): string {
-  return s.charAt(0).toLowerCase() + s.slice(1);
 }

--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -287,16 +287,25 @@ function appendInlineRequestStep(
   // identifier (rather than the client-seeded one OCA edges happen to
   // use) would silently send `undefined` and the suite would 4xx at
   // runtime with no diagnostic at emit time.
-  for (const ex of step.extract ?? []) {
-    if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(ex.bind)) {
-      throw new Error(
-        `Refusing to emit extract for non-identifier bind name '${ex.bind}' (operationId=${step.operationId}).`,
+  const extracts = step.extract ?? [];
+  if (extracts.length > 0) {
+    // Parse the response body ONCE per step. A previous shape declared
+    // `const jsonN = await ${respVar}.json()` inside the per-extract
+    // loop, which redeclared the same identifier when a step had more
+    // than one extract and broke the strict-mode generated-suites
+    // typecheck. The per-endpoint emitter does the same single-parse
+    // pattern (materializer/src/playwright/emitter.ts).
+    lines.push(`      const json${idx + 1} = await ${respVar}.json();`);
+    for (const ex of extracts) {
+      if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(ex.bind)) {
+        throw new Error(
+          `Refusing to emit extract for non-identifier bind name '${ex.bind}' (operationId=${step.operationId}).`,
+        );
+      }
+      lines.push(
+        `      extractInto(ctx, '${ex.bind}', ${buildOptionalAccessChain(`json${idx + 1}`, ex.fieldPath.split('.'))});`,
       );
     }
-    lines.push(`      const json${idx + 1} = await ${respVar}.json();`);
-    lines.push(
-      `      extractInto(ctx, '${ex.bind}', ${buildOptionalAccessChain(`json${idx + 1}`, ex.fieldPath.split('.'))});`,
-    );
   }
   lines.push('    });');
   // Planner-annotated eventual-state waits (#159 PR B) — emitted as a
@@ -343,9 +352,17 @@ function appendObserveStep(
   const accessChain = buildOptionalAccessChain('__body', step.assertion.arrayPath);
   lines.push(`      const __raw = ${accessChain};`);
   lines.push('      const __arr = Array.isArray(__raw) ? __raw : [];');
-  lines.push(
-    `      const __values = __arr.map((r) => (r as Record<string, unknown>)['${step.assertion.elementField}']);`,
-  );
+  // `elementField` can be a dotted path (e.g. `member.username` for
+  // `data.items[].member.username`) — see findMembershipArrayPath's
+  // field-path parsing doc. A literal `['member.username']` lookup
+  // would always miss; resolve via an optional-access chain per
+  // element instead.
+  const elementSegments = step.assertion.elementField.split('.').filter((s) => s.length > 0);
+  if (elementSegments.length === 0) {
+    throw new Error(`Empty elementField on observe assertion for operationId=${step.operationId}.`);
+  }
+  const elementAccess = buildOptionalAccessChain('r', elementSegments);
+  lines.push(`      const __values = __arr.map((r) => ${elementAccess});`);
   const bindingName = resolveBindingNameForSemantic(
     step.assertion.membershipSemanticType,
     scenarioBindings,

--- a/path-analyser/src/configResolver.ts
+++ b/path-analyser/src/configResolver.ts
@@ -124,6 +124,15 @@ export function getScenariosDir(repoRoot: string): string {
   return path.join(getGeneratedDir(repoRoot), 'scenarios');
 }
 
+/**
+ * Per-template subdirectory under the scenarios partition (#270).
+ * Layout: `generated/<config>/scenarios/templates/<TemplateName>/`.
+ * One JSON file per (template × subject) pair lands underneath.
+ */
+export function getTemplateScenariosDir(repoRoot: string, templateName: string): string {
+  return path.join(getScenariosDir(repoRoot), 'templates', templateName);
+}
+
 export function getFeatureOutputDir(repoRoot: string): string {
   return path.join(getGeneratedDir(repoRoot), 'feature-output');
 }

--- a/path-analyser/src/configResolver.ts
+++ b/path-analyser/src/configResolver.ts
@@ -125,12 +125,24 @@ export function getScenariosDir(repoRoot: string): string {
 }
 
 /**
+ * Root of the per-config template-scenarios partition (#270). The
+ * orchestrator wipes this entire tree before writing per-template
+ * subdirectories so an ABox template that's been removed (or whose
+ * `appliesTo` no longer matches any subject) can't leave a stale
+ * directory behind. Deriving the wipe set from current `results`
+ * would miss exactly those cases.
+ */
+export function getTemplateScenariosRootDir(repoRoot: string): string {
+  return path.join(getScenariosDir(repoRoot), 'templates');
+}
+
+/**
  * Per-template subdirectory under the scenarios partition (#270).
  * Layout: `generated/<config>/scenarios/templates/<TemplateName>/`.
  * One JSON file per (template × subject) pair lands underneath.
  */
 export function getTemplateScenariosDir(repoRoot: string, templateName: string): string {
-  return path.join(getScenariosDir(repoRoot), 'templates', templateName);
+  return path.join(getTemplateScenariosRootDir(repoRoot), templateName);
 }
 
 export function getFeatureOutputDir(repoRoot: string): string {

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -8,6 +8,7 @@ import {
   getFeatureOutputDir,
   getScenariosDir,
   getTemplateScenariosDir,
+  getTemplateScenariosRootDir,
   getVariantOutputDir,
 } from './configResolver.js';
 import { writeExtractionOutputs } from './extractSchemas.js';
@@ -490,12 +491,17 @@ async function main() {
   const edgesAbox = loadEdgesAbox(repoRoot);
   if (templatesAbox && edgesAbox) {
     const results = instantiateAllTemplates(graph, templatesAbox, edgesAbox, featureScenarioStash);
-    // Wipe + recreate per-template subdirectories so a removed
-    // edge / template can't leave a stale file behind.
+    // Wipe the ENTIRE templates partition first, then recreate the
+    // per-template subdirectories we actually produced. Deriving the
+    // wipe set from `results.map(r => r.templateName)` would miss
+    // templates removed from the ABox (or whose `appliesTo` changed
+    // to match no subject), leaving their previous per-template
+    // directory — and stale per-subject JSON inside it — on disk
+    // across runs. (#270 review.)
+    await rm(getTemplateScenariosRootDir(repoRoot), { recursive: true, force: true });
     const templatesByName = new Set(results.map((r) => r.templateName));
     for (const tplName of templatesByName) {
       const dir = getTemplateScenariosDir(repoRoot, tplName);
-      await rm(dir, { recursive: true, force: true });
       await mkdir(dir, { recursive: true });
     }
     for (const r of results) {

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -7,16 +7,19 @@ import {
   getActiveConfigDir,
   getFeatureOutputDir,
   getScenariosDir,
+  getTemplateScenariosDir,
   getVariantOutputDir,
 } from './configResolver.js';
 import { writeExtractionOutputs } from './extractSchemas.js';
 import { generateFeatureCoverageForEndpoint } from './featureCoverageGenerator.js';
 import { loadGraph, loadOpenApiSemanticHints } from './graphLoader.js';
+import { loadEdgesAbox, loadScenarioTemplatesAbox } from './ontology/loader.js';
 import { isDeploymentGatewayOp, isJobActivatorOp } from './ontology/operationRoles.js';
 import {
   generateOptionalSubShapeVariants,
   generateScenariosForEndpoint,
 } from './scenarioGenerator.js';
+import { instantiateAllTemplates, type ScenarioStash } from './scenarioTemplateInstantiator.js';
 import { computeSeedBindings } from './seedBindings.js';
 import type {
   ArtifactRegistryEntry,
@@ -165,6 +168,13 @@ async function main() {
   let processed = 0;
   // Aggregate deployment artifacts referenced by scenarios for manifest output
   const artifactsManifest = new Map<string, { kind: string; path: string; description?: string }>();
+  // #270: per-endpoint feature scenario stash. Populated as each
+  // endpoint is processed below with the first fully-planned feature
+  // scenario (`requestPlan` and `seedBindings` already stamped). The
+  // scenario template instantiator reads from this stash after the
+  // loop, so prereq-chain construction reuses the BFS planner's
+  // output verbatim instead of re-implementing it for templates.
+  const featureScenarioStash: ScenarioStash = new Map();
 
   for (const op of Object.values(graph.operations)) {
     // Generate scenarios for every endpoint, even if it has no semantic requirements.
@@ -307,7 +317,15 @@ async function main() {
         successStatusByOp,
       );
       s.seedBindings = computeSeedBindings(s);
-      // Validation: for JSON requests with oneOf groups, non-negative scenarios must set exactly one variant's required keys
+      // #270: a feature-coverage variant may be a better fit than a
+      // base scenario for a given operationId, but only the first
+      // entry we see is kept — feature scenarios are emitted in the
+      // same "base scenario first" order that the BFS planner
+      // produces, so the stash mirrors the canonical chain the
+      // existing per-endpoint suites would render.
+      if (!featureScenarioStash.has(op.operationId)) {
+        featureScenarioStash.set(op.operationId, s);
+      }
       try {
         const final = s.requestPlan?.[s.requestPlan.length - 1];
         const groups = requestIndex.byOperation[op.operationId] || [];
@@ -459,6 +477,45 @@ async function main() {
   }
 
   console.log(`Generated scenario files for ${processed} endpoints.`);
+
+  // #270 — Phase 2 of #268. After every endpoint has been planned and
+  // its feature scenario stashed, instantiate any ABox-declared
+  // scenario templates against their applicable subjects and write
+  // one JSON file per (template × subject) pair to
+  //   generated/<config>/scenarios/templates/<TemplateName>/<SubjectName>.json
+  // The output is purely additive — existing BFS-derived scenarios
+  // under generated/<config>/scenarios/*.json are untouched, so this
+  // step cannot perturb byte-stability of the per-endpoint suites.
+  const templatesAbox = loadScenarioTemplatesAbox(repoRoot);
+  const edgesAbox = loadEdgesAbox(repoRoot);
+  if (templatesAbox && edgesAbox) {
+    const results = instantiateAllTemplates(graph, templatesAbox, edgesAbox, featureScenarioStash);
+    // Wipe + recreate per-template subdirectories so a removed
+    // edge / template can't leave a stale file behind.
+    const templatesByName = new Set(results.map((r) => r.templateName));
+    for (const tplName of templatesByName) {
+      const dir = getTemplateScenariosDir(repoRoot, tplName);
+      await rm(dir, { recursive: true, force: true });
+      await mkdir(dir, { recursive: true });
+    }
+    for (const r of results) {
+      const file: import('./types.js').TemplateScenarioFile = {
+        templateName: r.templateName,
+        subjectName: r.subjectName,
+        subjectKind: r.subjectKind,
+        scenario: r.scenario,
+      };
+      const dir = getTemplateScenariosDir(repoRoot, r.templateName);
+      await writeFile(
+        path.join(dir, `${r.subjectName}.json`),
+        JSON.stringify(file, null, 2),
+        'utf8',
+      );
+    }
+    console.log(
+      `Generated ${results.length} template scenario file(s) across ${templatesByName.size} template(s).`,
+    );
+  }
 }
 
 // Only auto-invoke main() when this module is executed directly as a

--- a/path-analyser/src/ontology/observeArrayPath.ts
+++ b/path-analyser/src/ontology/observeArrayPath.ts
@@ -1,0 +1,82 @@
+import type { OperationNode } from '../types.js';
+
+/**
+ * Shared helper for #270 — locating the array-nested response field on
+ * an observation operation that carries a membership identifier.
+ *
+ * The #269 feasibility invariant ("every edge × Observe step is
+ * feasible…") and the #270 planner instantiator must compute the same
+ * thing: scan the operation's `responseSemanticTypes['200']` entries
+ * for one whose `fieldPath` contains a `[]` marker AND whose
+ * `semanticType` is one of the edge's `identifiedBy` types. Both
+ * consumers live behind this single helper so a future tweak (e.g.
+ * allowing 201-only observers) happens in one place instead of two.
+ *
+ * Returns the membership locator (path into the response body to the
+ * carrier array plus the property name on each element) or `null` if
+ * no `identifiedBy` type appears array-nested in the response. The
+ * planner treats `null` as a hard error at instantiation time; the
+ * invariant collects the offenders into a single diagnostic.
+ *
+ * Field-path parsing: the semantic-graph extractor emits paths like
+ *   - `items[].username`              → arrayPath=['items'],        elementField='username'
+ *   - `data.items[].member.username`  → arrayPath=['data','items'], elementField='member.username'
+ *   - `items[]`                       → arrayPath=['items'],        elementField='' (rejected)
+ *
+ * Only the first `[]` is used to split: the helper assumes the
+ * membership identifier sits on a top-level array of records, which
+ * holds for every OCA edge observation op in Phase 1. A second `[]`
+ * deeper into the element shape would indicate a nested array of
+ * records, which the present/absent assertion cannot meaningfully
+ * express without a richer DSL.
+ *
+ * Ambiguity: when more than one identifiedBy semantic appears
+ * array-nested in the same response, the helper returns the FIRST
+ * match in iteration order of `responseSemanticTypes['200']`. The
+ * regression invariants pin the chosen path for at least one known
+ * edge (RoleUserMembership → items / username) so a silent re-shuffle
+ * of the heuristic would surface.
+ *
+ * Accepting a single operation node (rather than the whole
+ * OperationGraph + an opId) keeps the helper independent of the
+ * planner's graph shape, which means the L3 invariant can call it
+ * with the lightweight node shape it already has from
+ * `cachedOperationById` without round-tripping through a synthetic
+ * graph object.
+ */
+export interface MembershipArrayPath {
+  arrayPath: string[];
+  elementField: string;
+  membershipSemanticType: string;
+}
+
+export function findMembershipArrayPath(
+  op:
+    | Pick<OperationNode, 'responseSemanticTypes'>
+    | { responseSemanticTypes?: Record<string, { semanticType: string; fieldPath: string }[]> }
+    | undefined,
+  identifiedBy: readonly string[],
+): MembershipArrayPath | null {
+  if (!op) return null;
+  const responses = op.responseSemanticTypes?.['200'] ?? [];
+  const identifiedSet = new Set(identifiedBy);
+  for (const entry of responses) {
+    if (!identifiedSet.has(entry.semanticType)) continue;
+    if (!entry.fieldPath.includes('[]')) continue;
+    const idx = entry.fieldPath.indexOf('[]');
+    const before = entry.fieldPath.slice(0, idx);
+    const after = entry.fieldPath.slice(idx + 2);
+    // Strip a leading '.' from the post-`[]` remainder so a path like
+    // `items[].username` yields elementField='username' not '.username'.
+    const elementField = after.startsWith('.') ? after.slice(1) : after;
+    if (!elementField) continue;
+    const arrayPath = before.split('.').filter((s) => s.length > 0);
+    if (arrayPath.length === 0) continue;
+    return {
+      arrayPath,
+      elementField,
+      membershipSemanticType: entry.semanticType,
+    };
+  }
+  return null;
+}

--- a/path-analyser/src/scenarioTemplateInstantiator.ts
+++ b/path-analyser/src/scenarioTemplateInstantiator.ts
@@ -224,6 +224,26 @@ function compileEdgeLifecycle(
 
   const lastOf = (plan: RequestStep[]): RequestStep => plan[plan.length - 1];
 
+  // Aggregate the set of operationIds across all five steps whose source
+  // OperationSpec carries `eventuallyConsistent: true`. Threaded onto the
+  // compiled TemplateScenario so the emitter can wrap read-shape steps in
+  // `awaitEventually(...)` (the same predicate the per-endpoint emitter
+  // uses). Without this, lifecycle suites whose observe step targets an
+  // eventually-consistent search op would race the establish/revoke
+  // mutation. (#270 review.)
+  const allOpIds = new Set<string>([
+    ...prereqOps.map((o) => o.operationId),
+    edge.establishedBy,
+    edge.observableVia,
+    edge.revokedBy,
+  ]);
+  const eventuallyConsistentOps: string[] = [];
+  for (const opId of allOpIds) {
+    const op = graph.operations[opId];
+    if (op?.eventuallyConsistent) eventuallyConsistentOps.push(opId);
+  }
+  eventuallyConsistentOps.sort();
+
   const steps: TemplateStep[] = [
     {
       kind: 'prereqChain',
@@ -282,6 +302,7 @@ function compileEdgeLifecycle(
       subjectKind: 'Edge',
       steps,
       bindings,
+      eventuallyConsistentOps,
     },
   };
 }

--- a/path-analyser/src/scenarioTemplateInstantiator.ts
+++ b/path-analyser/src/scenarioTemplateInstantiator.ts
@@ -309,6 +309,18 @@ export function instantiateAllTemplates(
   const errors: string[] = [];
   for (const tpl of templates.templates) {
     if (tpl.appliesTo.kind !== 'Edge') continue;
+    // Phase-2 hard-codes the EdgeLifecycle compilation pipeline rather
+    // than walking `tpl.steps`. New Edge-scoped templates therefore need
+    // their own compiler (Phases 3-5 of #268). Refuse-by-default so an
+    // unrecognised template name fails loudly instead of silently
+    // re-emitting EdgeLifecycle's shape against the wrong vocabulary.
+    if (tpl.name !== 'EdgeLifecycle') {
+      throw new Error(
+        `No compiler registered for scenario template '${tpl.name}'. ` +
+          `Phase 2 (#270) only ships the EdgeLifecycle compiler; additional ` +
+          `Edge-scoped templates need their own dispatch in instantiateAllTemplates.`,
+      );
+    }
     for (const edge of edges.edges) {
       const compiled = compileEdgeLifecycle(tpl, edge, graph, stash);
       if ('error' in compiled) {

--- a/path-analyser/src/scenarioTemplateInstantiator.ts
+++ b/path-analyser/src/scenarioTemplateInstantiator.ts
@@ -1,0 +1,332 @@
+import type {
+  Edge,
+  EdgesAbox,
+  ScenarioTemplate,
+  ScenarioTemplatesAbox,
+} from './ontology/loader.js';
+import { findMembershipArrayPath } from './ontology/observeArrayPath.js';
+import type {
+  EndpointScenario,
+  OperationGraph,
+  OperationRef,
+  RequestStep,
+  TemplateScenario,
+  TemplateStep,
+} from './types.js';
+
+/**
+ * #270 — Scenario template instantiator (Phase 2 of #268).
+ *
+ * For every (template × applicable subject) pair in the ABoxes,
+ * compile the template into a {@link TemplateScenario}. The compiled
+ * scenarios are written to
+ * `generated/<config>/scenarios/templates/<TemplateName>/<SubjectName>.json`
+ * by the path-analyser CLI entrypoint; the Playwright emitter
+ * (materializer/src/playwright/templateEmitter.ts) consumes them to
+ * produce the lifecycle .spec.ts files.
+ *
+ * Design choices the instantiator pins:
+ *
+ *   - **PrereqChain delegates to the existing BFS planner.** The
+ *     instantiator does not reinvent dependency-chain construction; it
+ *     pulls the already-planned feature scenario for the establisher
+ *     out of the per-operation stash that the CLI built earlier in
+ *     the same run. That scenario carries the BFS-derived
+ *     `operations`, `requestPlan`, `bindings`, and `seedBindings` —
+ *     everything the prereq chain needs.
+ *
+ *   - **Invoke and Observe steps reuse the per-operation feature
+ *     scenario's final RequestStep.** The CLI invokes
+ *     `buildRequestPlan` for every endpoint exactly once, regardless
+ *     of how many templates reference it. The instantiator looks up
+ *     the same scenario the CLI cached and copies the final step.
+ *
+ *   - **Observe membership locator is shared with the #269 feasibility
+ *     invariant** via `findMembershipArrayPath`. A change in either
+ *     consumer requires updating the helper, not duplicating
+ *     parser logic in two places.
+ *
+ * Inputs/produces shape: the instantiator emits `inputs` and
+ * `produces` maps keyed by **semantic type** (e.g. `RoleId`), with
+ * **binding name** values (e.g. `roleIdVar`). The binding-name
+ * convention matches `buildRequestPlan`'s `${camelCase(semantic)}Var`
+ * rule so emitters can reach a value with `ctx[<bindingName>]`
+ * without consulting the scenario binding table at every site.
+ */
+
+function camelCase(name: string): string {
+  return name.length > 0 ? name.charAt(0).toLowerCase() + name.slice(1) : name;
+}
+
+function bindingNameFor(semantic: string): string {
+  return `${camelCase(semantic)}Var`;
+}
+
+/**
+ * Stash of already-planned scenarios keyed by operationId. The CLI
+ * populates one entry per endpoint *after* it has called
+ * `buildRequestPlan`/`computeSeedBindings` on the first feature
+ * scenario, so by the time the instantiator runs every entry has a
+ * fully-populated `requestPlan` and `seedBindings`.
+ */
+export type ScenarioStash = Map<string, EndpointScenario>;
+
+/**
+ * Produce the canonical 5-step {@link TemplateScenario} for one
+ * (`EdgeLifecycle` template × edge) pair.
+ *
+ * Returns `null` if any of the three referenced operations
+ * (establishedBy, revokedBy, observableVia) is missing from the
+ * stash, or if the observation op has no array-nested membership
+ * field. The caller surfaces the error with the edge name so the
+ * diagnostic points at the row instead of the helper.
+ */
+function compileEdgeLifecycle(
+  template: ScenarioTemplate,
+  edge: Edge,
+  graph: OperationGraph,
+  stash: ScenarioStash,
+): { scenario: TemplateScenario } | { error: string } {
+  const establishScenario = stash.get(edge.establishedBy);
+  const revokeScenario = stash.get(edge.revokedBy);
+  const observeScenario = stash.get(edge.observableVia);
+  if (!establishScenario)
+    return {
+      error: `${template.name} × ${edge.name}: no stashed scenario for establishedBy='${edge.establishedBy}'`,
+    };
+  if (!revokeScenario)
+    return {
+      error: `${template.name} × ${edge.name}: no stashed scenario for revokedBy='${edge.revokedBy}'`,
+    };
+  if (!observeScenario)
+    return {
+      error: `${template.name} × ${edge.name}: no stashed scenario for observableVia='${edge.observableVia}'`,
+    };
+
+  const establishPlan = establishScenario.requestPlan;
+  const revokePlan = revokeScenario.requestPlan;
+  const observePlan = observeScenario.requestPlan;
+  if (!establishPlan?.length || !revokePlan?.length || !observePlan?.length)
+    return {
+      error: `${template.name} × ${edge.name}: one of the referenced scenarios is missing a requestPlan`,
+    };
+
+  // The PrereqChain is everything in the establishedBy scenario
+  // EXCEPT the establisher itself (which is invoked by the following
+  // InvokeStep). The matching slice of `operations` and `requestPlan`
+  // share an index because `buildRequestPlan` walks `operations` in
+  // order, one RequestStep per operation. Both arrays may be longer
+  // than each other when a final-step duplicate invocation is
+  // appended (`duplicateTest`), but that only happens for endpoints
+  // with `duplicateTest` set — none of the OCA edge establishers
+  // have one. We assert one-to-one alignment to fail loud if a
+  // future spec change introduces a mismatch.
+  const establishOps = establishScenario.operations;
+  if (establishOps.length !== establishPlan.length) {
+    return {
+      error: `${template.name} × ${edge.name}: establishedBy scenario operations.length (${establishOps.length}) ≠ requestPlan.length (${establishPlan.length}); duplicate invocation on an establisher is unsupported`,
+    };
+  }
+  const prereqOps: OperationRef[] = establishOps.slice(0, -1).map((o) => ({ ...o }));
+  const prereqPlan: RequestStep[] = establishPlan.slice(0, -1);
+
+  // The aggregated binding table — union of every step's bindings,
+  // keyed by semantic type (per the public TemplateScenario contract,
+  // not by binding name as on EndpointScenario.bindings).
+  //
+  // The instantiator builds it from the union of the establishedBy
+  // scenario's `bindings` (binding-name keyed, e.g. `roleIdVar`)
+  // AND its `seedBindings` (binding names with no in-graph producer,
+  // e.g. `clientIdVar` for external-entity kinds like Client). The
+  // emitter resolves a semantic type back to a binding name via this
+  // table, so both populated bindings and to-be-seeded ones need
+  // to round-trip.
+  //
+  // Why include all of them (not just identifiedBy): the seeded
+  // bindings (e.g. `nameVar`, `passwordVar` for createUser) need to
+  // round-trip too so the emitter can prime them via seedBinding().
+  // The membership-closure invariant (#270 L3) only asserts the
+  // identifiedBy entries are present, not that the table is
+  // minimal — keeping it inclusive matches the EndpointScenario
+  // contract.
+  const bindings: Record<string, string> = {};
+  const aggregateBindingNames = new Set<string>([
+    ...Object.keys(establishScenario.bindings ?? {}),
+    ...(establishScenario.seedBindings ?? []),
+  ]);
+  for (const bindName of aggregateBindingNames) {
+    // Recover the semantic type by stripping the trailing 'Var' and
+    // upper-casing the first letter. This matches the inverse of
+    // `bindingNameFor`. A binding name that doesn't end in 'Var'
+    // (none exist today) would be passed through as-is so the
+    // emitter still sees a stable round-trip key.
+    const sem = bindName.endsWith('Var')
+      ? bindName.slice(0, -3).charAt(0).toUpperCase() + bindName.slice(0, -3).slice(1)
+      : bindName;
+    bindings[sem] = bindName;
+  }
+
+  // Helper: map an op's required semantics to {semanticType: bindingName}.
+  // Used by Invoke and Observe alike. We consult the graph for the
+  // op's `requires.required`; the bindingName follows the camelCase
+  // convention so callers don't need to inspect the stashed scenario
+  // bindings (the union table built above is the source of truth at
+  // emit time; this map is the per-step view onto it).
+  const inputsFor = (opId: string): Record<string, string> => {
+    const op = graph.operations[opId];
+    const result: Record<string, string> = {};
+    for (const sem of op?.requires.required ?? []) {
+      result[sem] = bindingNameFor(sem);
+    }
+    return result;
+  };
+  // Producer view: every authoritative response semantic. Edge
+  // establishers tend to be 204s with no producers, but the field is
+  // present in the type for non-edge templates that may follow.
+  const producesFor = (opId: string): Record<string, string> => {
+    const op = graph.operations[opId];
+    const result: Record<string, string> = {};
+    for (const leaf of op?.responseSemanticLeaves ?? []) {
+      if (!leaf.provider) continue;
+      result[leaf.semantic] = bindingNameFor(leaf.semantic);
+    }
+    return result;
+  };
+
+  // Observe step: locate the membership array. The helper returns
+  // null when no identifiedBy semantic appears array-nested in the
+  // observation op's 200 response — the L3 feasibility invariant
+  // from #269 has already pinned that this cannot happen for any
+  // OCA edge, but we surface a structured error rather than throw
+  // to keep the instantiator drop-in for future configs whose
+  // edges might not yet satisfy the precondition.
+  const observeOp = graph.operations[edge.observableVia];
+  const locator = findMembershipArrayPath(observeOp, edge.identifiedBy);
+  if (!locator) {
+    return {
+      error: `${template.name} × ${edge.name}: findMembershipArrayPath returned null for observableVia='${edge.observableVia}'; an edge with no array-nested identifiedBy semantic on its observation op cannot be observed via present/absent membership`,
+    };
+  }
+
+  // Observe `inputs` are the SCOPING identifiers — identifiedBy
+  // members the op consumes (path or filter params), minus the
+  // membership identifier (which is asserted on the response, not
+  // submitted). The scoping inputs come from the union
+  // `identifiedBy ∩ op.requires.required`; the membership
+  // identifier is whatever locator.membershipSemanticType says.
+  const observeRequired = new Set(observeOp?.requires.required ?? []);
+  const observeInputs: Record<string, string> = {};
+  for (const sem of edge.identifiedBy) {
+    if (sem === locator.membershipSemanticType) continue;
+    if (!observeRequired.has(sem)) continue;
+    observeInputs[sem] = bindingNameFor(sem);
+  }
+
+  const lastOf = (plan: RequestStep[]): RequestStep => plan[plan.length - 1];
+
+  const steps: TemplateStep[] = [
+    {
+      kind: 'prereqChain',
+      targetOperationId: edge.establishedBy,
+      operations: prereqOps,
+      bindings: { ...(establishScenario.bindings ?? {}) },
+      seedBindings: [...(establishScenario.seedBindings ?? [])],
+      requestPlan: prereqPlan,
+    },
+    {
+      kind: 'invoke',
+      operationId: edge.establishedBy,
+      inputs: inputsFor(edge.establishedBy),
+      produces: producesFor(edge.establishedBy),
+      requestPlan: lastOf(establishPlan),
+    },
+    {
+      kind: 'observe',
+      operationId: edge.observableVia,
+      inputs: observeInputs,
+      requestPlan: lastOf(observePlan),
+      assertion: {
+        kind: 'membership',
+        expect: 'present',
+        arrayPath: locator.arrayPath,
+        elementField: locator.elementField,
+        membershipSemanticType: locator.membershipSemanticType,
+      },
+    },
+    {
+      kind: 'invoke',
+      operationId: edge.revokedBy,
+      inputs: inputsFor(edge.revokedBy),
+      produces: producesFor(edge.revokedBy),
+      requestPlan: lastOf(revokePlan),
+    },
+    {
+      kind: 'observe',
+      operationId: edge.observableVia,
+      inputs: observeInputs,
+      requestPlan: lastOf(observePlan),
+      assertion: {
+        kind: 'membership',
+        expect: 'absent',
+        arrayPath: locator.arrayPath,
+        elementField: locator.elementField,
+        membershipSemanticType: locator.membershipSemanticType,
+      },
+    },
+  ];
+
+  return {
+    scenario: {
+      templateName: template.name,
+      subjectName: edge.name,
+      subjectKind: 'Edge',
+      steps,
+      bindings,
+    },
+  };
+}
+
+export interface TemplateInstantiationResult {
+  templateName: string;
+  subjectName: string;
+  subjectKind: 'Edge';
+  scenario: TemplateScenario;
+}
+
+/**
+ * Compile every (template × applicable subject) pair declared by the
+ * given ABoxes. Throws if any pair fails to compile — failures here
+ * indicate a misconfiguration that the L3 invariants should have
+ * caught upstream (#269), so the loud failure mode is intentional.
+ */
+export function instantiateAllTemplates(
+  graph: OperationGraph,
+  templates: ScenarioTemplatesAbox,
+  edges: EdgesAbox,
+  stash: ScenarioStash,
+): TemplateInstantiationResult[] {
+  const out: TemplateInstantiationResult[] = [];
+  const errors: string[] = [];
+  for (const tpl of templates.templates) {
+    if (tpl.appliesTo.kind !== 'Edge') continue;
+    for (const edge of edges.edges) {
+      const compiled = compileEdgeLifecycle(tpl, edge, graph, stash);
+      if ('error' in compiled) {
+        errors.push(compiled.error);
+        continue;
+      }
+      out.push({
+        templateName: tpl.name,
+        subjectName: edge.name,
+        subjectKind: 'Edge',
+        scenario: compiled.scenario,
+      });
+    }
+  }
+  if (errors.length > 0) {
+    throw new Error(
+      `Scenario template instantiation failed for ${errors.length} (template × subject) pair(s):\n${errors.map((e) => `  - ${e}`).join('\n')}`,
+    );
+  }
+  return out;
+}

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -908,7 +908,19 @@ export interface TemplateScenario {
   subjectName: string;
   subjectKind: 'Edge';
   steps: TemplateStep[];
-  /** Aggregated bindings across all steps; same shape as EndpointScenario.bindings. */
+  /**
+   * Aggregated semantic-type → placeholder map across all steps. The
+   * keys are semantic-type identifiers (e.g. `'Username'`, `'RoleId'`)
+   * — NOT binding names. This intentionally diverges from
+   * `EndpointScenario.bindings` (which is binding-name-keyed) because
+   * the membership assertion on an `ObserveStep` is expressed in
+   * semantic-type terms (`assertion.membershipSemanticType`) and the
+   * emitter resolves the ctx binding name from the semantic type via
+   * the planner's `<camelSemantic>Var` naming convention. The per-step
+   * `PrereqChainStep.bindings` map remains binding-name-keyed (mirrors
+   * `EndpointScenario.bindings`) so the existing per-endpoint emitter
+   * code paths apply unchanged.
+   */
   bindings: Record<string, string>;
 }
 

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -909,17 +909,21 @@ export interface TemplateScenario {
   subjectKind: 'Edge';
   steps: TemplateStep[];
   /**
-   * Aggregated semantic-type → placeholder map across all steps. The
+   * Aggregated semantic-type → binding-name map across all steps. The
    * keys are semantic-type identifiers (e.g. `'Username'`, `'RoleId'`)
-   * — NOT binding names. This intentionally diverges from
-   * `EndpointScenario.bindings` (which is binding-name-keyed) because
-   * the membership assertion on an `ObserveStep` is expressed in
-   * semantic-type terms (`assertion.membershipSemanticType`) and the
-   * emitter resolves the ctx binding name from the semantic type via
-   * the planner's `<camelSemantic>Var` naming convention. The per-step
-   * `PrereqChainStep.bindings` map remains binding-name-keyed (mirrors
-   * `EndpointScenario.bindings`) so the existing per-endpoint emitter
-   * code paths apply unchanged.
+   * and the values are the planner-minted binding names the runtime
+   * `ctx` is keyed by (e.g. `'usernameVar'`, `'roleIdVar'`). This
+   * intentionally diverges from `EndpointScenario.bindings` (whose
+   * keys ARE binding names and whose values are concrete placeholders
+   * like `'__PENDING__'` or literal values): the membership assertion
+   * on an `ObserveStep` is expressed in semantic-type terms
+   * (`assertion.membershipSemanticType`), and the emitter looks the
+   * binding name up directly in this map rather than re-deriving it
+   * from the semantic-type identifier — so a future change to the
+   * planner's naming convention requires no emitter change. The
+   * per-step `PrereqChainStep.bindings` map remains binding-name-keyed
+   * (mirrors `EndpointScenario.bindings`) so the existing per-endpoint
+   * emitter code paths apply unchanged.
    */
   bindings: Record<string, string>;
   /**

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -797,3 +797,129 @@ export interface GeneratedModelSpec {
    */
   metadata?: Record<string, unknown>;
 }
+
+// ---------------------------------------------------------------------------
+// #270 — Scenario template instantiation (Phase 2 of #268).
+//
+// Template-derived scenarios are emitted alongside (not in place of) the
+// BFS-derived `EndpointScenario`s. They are written to
+// `generated/<config>/scenarios/templates/<TemplateName>/<EdgeName>.json`
+// and consumed by the Playwright emitter to produce
+// `generated/<config>/playwright/edges/<EdgeName>.lifecycle.spec.ts`.
+// The two output trees are independent — no field on `EndpointScenario`
+// is touched here.
+// ---------------------------------------------------------------------------
+
+/**
+ * A `PrereqChain` template step: a planned dependency chain that
+ * establishes everything a subsequent `InvokeStep` requires before it
+ * runs. Derived by delegating to `generateScenariosForEndpoint` against
+ * the target operationId and dropping the target itself (which is
+ * invoked by the following `InvokeStep`, not by the prereq chain).
+ *
+ * The `bindings`, `seedBindings` and `requestPlan` fields mirror the
+ * same-named fields on `EndpointScenario` so the emitter can reuse the
+ * existing per-step renderer.
+ */
+export interface PrereqChainStep {
+  kind: 'prereqChain';
+  /** OperationId the chain is intended to enable. Diagnostic only. */
+  targetOperationId: string;
+  /** Ordered list of prerequisite operations (target op excluded). */
+  operations: OperationRef[];
+  /** Same shape as `EndpointScenario.bindings`. */
+  bindings: Record<string, string>;
+  /** Same shape as `EndpointScenario.seedBindings`. */
+  seedBindings: string[];
+  /** Per-operation request plan, parallel to `operations`. */
+  requestPlan: RequestStep[];
+}
+
+/**
+ * A single-operation invocation. Carries the request plan for that one
+ * operation and a description of which scenario bindings flow into it
+ * (`inputs`) and which the response contributes back (`produces`).
+ */
+export interface InvokeStep {
+  kind: 'invoke';
+  operationId: string;
+  /** semanticType → binding name consumed by this invocation. */
+  inputs: Record<string, string>;
+  /** semanticType → binding name produced by this invocation. */
+  produces: Record<string, string>;
+  /** Request plan for THIS invocation only (one step). */
+  requestPlan: RequestStep;
+}
+
+/**
+ * A membership assertion against an observation operation's 2xx
+ * response. The assertion compiles to
+ * `expect(items.map(r => r.<elementField>)).[not.]toContain(<value>)`
+ * at emit time. `value` is sourced from the scenario binding table
+ * keyed by `membershipSemanticType`.
+ */
+export interface ObserveStep {
+  kind: 'observe';
+  operationId: string;
+  /**
+   * semanticType → binding name consumed by the observation call's
+   * inputs (path params / body). The scoping/membership split:
+   * `identifiedBy ∩ inputs` go here; the remaining identifiedBy
+   * member is the membership identifier asserted on the response.
+   */
+  inputs: Record<string, string>;
+  requestPlan: RequestStep;
+  assertion: {
+    kind: 'membership';
+    expect: 'present' | 'absent';
+    /**
+     * Path into the 2xx response body to the array carrying the
+     * membership rows. Each segment is a property name; the last
+     * segment names the array property itself (e.g. `['items']`).
+     */
+    arrayPath: string[];
+    /**
+     * Property name on each array element that carries the membership
+     * identifier value (e.g. `'username'` for RoleUserMembership).
+     */
+    elementField: string;
+    /**
+     * Semantic type of the membership identifier. The emitter
+     * resolves this against the scenario binding table to find the
+     * value being asserted.
+     */
+    membershipSemanticType: string;
+  };
+}
+
+export type TemplateStep = PrereqChainStep | InvokeStep | ObserveStep;
+
+/**
+ * A scenario produced by instantiating a `ScenarioTemplate` against a
+ * concrete subject (currently only `Edge`). The step list is a
+ * discriminated union; the binding table is the union of all bindings
+ * declared anywhere in the steps so consumers don't need to walk the
+ * step list to learn which symbolic names exist.
+ */
+export interface TemplateScenario {
+  /** Identifier of the template (e.g. `'EdgeLifecycle'`). */
+  templateName: string;
+  /** Identifier of the subject the template was instantiated against. */
+  subjectName: string;
+  subjectKind: 'Edge';
+  steps: TemplateStep[];
+  /** Aggregated bindings across all steps; same shape as EndpointScenario.bindings. */
+  bindings: Record<string, string>;
+}
+
+/**
+ * Per-template, per-subject scenario file shape. One file per
+ * (template × subject) pair under
+ * `generated/<config>/scenarios/templates/<TemplateName>/<SubjectName>.json`.
+ */
+export interface TemplateScenarioFile {
+  templateName: string;
+  subjectName: string;
+  subjectKind: 'Edge';
+  scenario: TemplateScenario;
+}

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -922,6 +922,17 @@ export interface TemplateScenario {
    * code paths apply unchanged.
    */
   bindings: Record<string, string>;
+  /**
+   * Aggregated set of `operationId`s in this template scenario whose
+   * source `OperationSpec.eventuallyConsistent` flag is `true` (i.e.
+   * the spec carries the `x-eventually-consistent` vendor extension).
+   * Threaded through so the template emitter can wrap read-shape steps
+   * in `awaitEventually(...)` exactly like the per-endpoint emitter
+   * does — without re-consulting the dependency graph at emission
+   * time. Empty list is permitted (and is the common case for OCA
+   * edges); the field is required to make the contract explicit.
+   */
+  eventuallyConsistentOps: string[];
 }
 
 /**


### PR DESCRIPTION
Closes #270 (Phase 2 of #268).

Builds on the EdgeLifecycle TBox + ABox shipped in #269/#271 by adding
the planner instantiator and the Playwright emitter that consume it.
For each of the 12 OCA edges the pipeline now emits a
`generated/<config>/playwright/edges/<EdgeName>.lifecycle.spec.ts`
suite that establishes the edge, observes it present, revokes it, and
observes it absent.

### Four-commit TDD layering

1. `feat(#270): TemplateScenario types + L3 invariants (red)` —
   adds `TemplateScenario`, `TemplateStep` union, `ObserveStep`,
   etc. to `path-analyser/src/types.ts`; extracts the shared
   `findMembershipArrayPath()` helper and refactors the #269
   feasibility invariant to call it (one source of truth for the
   array-locator heuristic); adds the new bundled-spec invariants
   block (coverage, 5-step shape, well-formedness, binding-table
   closure, suite emission). Invariants fail at this point — the
   deliberate red signal.

2. `feat(#270): scenario template instantiator (Phase 2)` — new
   `path-analyser/src/scenarioTemplateInstantiator.ts` that delegates
   PrereqChain compilation to the existing BFS planner via a
   per-operation feature-scenario stash (no chain logic reimplemented),
   emits one JSON per (template × edge) under
   `generated/<config>/scenarios/templates/EdgeLifecycle/`. Unions
   `bindings ∪ seedBindings` so external-entity identifiers (e.g.
   `ClientId` for the three Client-edges) round-trip through the
   aggregate binding table. All Phase 1 L3 invariants now pass except
   the suite-emission one — the deliberate Phase 3 red.

3. `feat(#270): Playwright emitter for EdgeLifecycle template
   scenarios (Phase 3)` — new
   `materializer/src/playwright/templateEmitter.ts` that reads each
   template scenario and renders a self-contained spec: universal-seed
   prologue, per-scenario seedBindings, inline prereq chain, establish
   invoke, present observe (`expect(...).toContain(...)`), revoke
   invoke, absent observe (`expect(...).not.toContain(...)`). Wired
   into `materializer/src/index.ts` after variant emission; only
   the Playwright emitter triggers it.

4. `docs(#270): note template-derived edge lifecycle suites in
   README`.

### Verification

- `npm run lint` clean.
- All 7 typechecks green (extractor, planner, emitter-sdk,
  materializer, request-validation, tests, generated suites under
  strict mode).
- `npm test`: **538 passed, 7 skipped** (+6 new L3 invariants over
  the pre-#270 baseline of 532).
- Byte-stability on existing BFS-derived output: the only additions
  under `generated/camunda-oca/` are
  `scenarios/templates/EdgeLifecycle/*.json` (Phase 2) and
  `playwright/edges/*.lifecycle.spec.ts` (Phase 3) — no other
  generated file changed.

### Out of scope (Phases 3-5 of #268)

- Resource-CRUD templates, state-transition templates,
  request-validation folding.
- New `expect` predicates beyond membership.
- Live broker execution of the emitted lifecycle suites (the suite
  typechecks under strict mode, but real-broker validation is a
  separate ticket).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>