### PR TITLE
fix: update createDeployment provider-set invariant for pinned spec (#137)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -181,14 +181,16 @@ describeForThisConfig('bundled-spec invariants: extractor classification', () =>
     expect(node?.required).toBe(false);
   });
 
-  // Skipped: pinned spec now adds DecisionDefinitionId to the createDeployment
-  // provider set (camunda/camunda PR #52322 / merge SHA b9d355d). Tracked at #137.
-  it.skip('createDeployment provides the full {ProcessDefinitionKey, ProcessDefinitionId, DecisionDefinitionKey, DecisionRequirementsKey, FormKey} provider set (#34)', () => {
+  it('createDeployment provides the full {DecisionDefinitionId, DecisionDefinitionKey, DecisionRequirementsKey, FormKey, ProcessDefinitionId, ProcessDefinitionKey} provider set (#34 / #137)', () => {
     // Locks in `x-semantic-provider` array-form recognition: the response
     // payload uses array-form `x-semantic-provider` on `deployments[].*`,
     // and #34 made the inheritedProvider flag thread through the nested
-    // object subtrees so every listed key is flagged provider:true.
+    // object subtrees so every listed key is flagged provider:true. The
+    // pinned spec bump (#134, camunda/camunda PR #52322, merge SHA
+    // b9d355d) added DecisionDefinitionId to the authoritative set —
+    // see #137 for the rationale and the migration trail.
     expect(providersOf('createDeployment')).toEqual([
+      'DecisionDefinitionId',
       'DecisionDefinitionKey',
       'DecisionRequirementsKey',
       'FormKey',


### PR DESCRIPTION
Closes #137.

Unskips the L3 invariant that pins the `createDeployment` response provider set. The spec-pin bump in #134 (camunda/camunda PR #52322, merge SHA `b9d355d`) added `DecisionDefinitionId` to the upstream `x-semantic-provider` annotations on `deployments[].*`. The extractor already flags it correctly; only the test's expected list was stale.

### New authoritative set
```
- [DecisionDefinitionKey, DecisionRequirementsKey, FormKey, ProcessDefinitionId, ProcessDefinitionKey]
+ [DecisionDefinitionId, DecisionDefinitionKey, DecisionRequirementsKey, FormKey, ProcessDefinitionId, ProcessDefinitionKey]
```

### Downstream verification
Per the issue's call-out ("verify nothing downstream (e.g. `evaluateDecision` chain) regressed"), I ran the full test suite: **539 passed | 6 skipped** across 54 files. No chain regressed.

### L3 skip count
`7 → 6` — the remaining 6 are:
- 5 tracked at **#138 / #139** (cluster-variables + variant regressions from the same spec-pin bump)
- 1 deliberate network-gated opt-in (`RUN_ONTOLOGY_URL_CHECK`)