### PR TITLE
chore: document no-parallel-implementations rule in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,6 +477,18 @@ error.
   outputs at once.
 - Adding a new emitter target (`path-analyser/src/codegen/emitter.ts`) —
   the contract is currently experimental.
+- **Adding a parallel implementation of an existing pipeline stage**
+  (a new scenario builder alongside `scenarioGenerator.ts`, a new
+  Playwright emitter alongside `materializer/src/playwright/emitter.ts`,
+  a new feature-coverage generator alongside `featureCoverageGenerator.ts`,
+  etc.). In the PR description, justify why a unification with the
+  existing canonical implementation is not possible. Parallel
+  implementations drift: every diverged code path silently grows
+  bug-fix asymmetries and feature gaps that don't surface until much
+  later (see issues #286 and #288 for two concurrent examples of this
+  failure mode). If the new requirement genuinely doesn't fit the
+  canonical implementation, prefer extending the canonical one — even
+  if the extension is larger than the parallel implementation would be.
 
 **Never:**
 - Reintroduce an end-to-end snapshot/manifest guard (it was retired


### PR DESCRIPTION
Add a new `Ask first` bullet under **Boundaries** in AGENTS.md noting that introducing a parallel implementation of an existing pipeline stage (scenario builder, emitter, feature-coverage generator, …) requires explicit justification in the PR description.

## Why

Two concurrently-open issues both trace to the same anti-pattern:

- **#286** — two Playwright emitters (`materializer/src/playwright/templateEmitter.ts` and `materializer/src/playwright/emitter.ts`) render seedBindings in two different shapes (`?? seedBinding(...)` vs `if (=== undefined)`). Drift between sibling implementations.
- **#288** — three scenario builders (`scenarioGenerator.ts::generateScenariosForEndpoint`, `featureCoverageGenerator.ts::generateFeatureCoverageForEndpoint`, `scenarioGenerator.ts::generateOptionalSubShapeVariants`) handle binding seeds differently; only one is fully correct. Drift between sibling implementations.

The pattern: a new requirement landed as a sibling implementation rather than as an extension of the canonical one. Each sibling drifted independently. The cost showed up much later as silent bug-fix asymmetries and feature gaps.

## Change

One paragraph added to AGENTS.md under `Boundaries → Ask first`. No code changes.

References #286 and #288 as concrete examples so the rule has teeth.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>