### PR TITLE
fix: inherit planner bindings into feature-output scenarios (#288 Phase 1)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -662,21 +662,29 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
 
   // Skipped: new cluster-variables endpoint family in pinned spec
   // (camunda/camunda PR #52322) leaves placeholders unbound; tracked at #138.
-  // Skipped: pinned-spec bump (camunda/camunda PR #52322) surfaces two
-  // real planner-side feature-output binding gaps that this invariant
-  // correctly flags:
-  //   1. external-entity identifiers (e.g. `clientId` for the Client
-  //      kind, `shape: 'external-entity'`) are never seeded into
-  //      `bindings`, so unassign/assign edge chains rendering URLs
-  //      with `{clientId}` leak `${clientIdVar}` at runtime;
-  //   2. self-establisher chain roots (e.g. `createTenantClusterVariable`
-  //      as the first chain step for cluster-variable endpoints) need
-  //      both identifier inputs seeded — currently the planner seeds
-  //      only the body-field identifier (`name`) and not the path-param
-  //      identifier (`tenantId`).
-  // Both are production planner gaps in feature-output binding
-  // propagation, not test-definition gaps. Tracked at #138; fix scope
-  // is the planner's seedBindings/feature-output stage.
+  //
+  // Phase 1 of #288 (PR that lands this comment update) closed the
+  // feature-output binding-inheritance gap: `buildScenarioFromVariant`
+  // now inherits the planner's external mints + establisher self-mints
+  // from the donor chain scenario via the orchestrator. As a result the
+  // class-1 case below (external-entity identifiers like `clientIdVar`)
+  // is fully closed, and the class-2 case (self-establisher path-param
+  // root) is closed for endpoints whose self-establish path identifier
+  // is the variable's OWN identifier.
+  //
+  // One offender remains: `post--cluster-variables--tenants--{tenantId}`.
+  // Root cause is a deeper planner self-establish modelling issue —
+  // `createTenantClusterVariable` declares `establishes.identifiedBy[]`
+  // with `{in: path, name: tenantId, semanticType: TenantId}` AND
+  // `{in: body, name: name, semanticType: ClusterVariableName}`, which
+  // the planner treats as a single composite identifier (self-minting
+  // BOTH). But `tenantId` is semantically a foreign-key reference to
+  // an existing tenant, not part of the variable's own identity. The
+  // planner therefore neither chains in `createTenant` nor mints
+  // `tenantIdVar` externally for this endpoint. Fixing this requires
+  // distinguishing "owned identity" from "scoping foreign-key" in the
+  // establisher semantic graph — out of scope for #288 Phase 1
+  // (binding inheritance) and tracked separately under #288 Phase 2.
   it.skip('every feature-output scenario binds or chains every {placeholder} whose path parameter has a recognised semanticType', () => {
     // Class-scoped guard for the "un-extracted ${var} in URL" defect family:
     // when an endpoint's response analyser produces no shape (typically for
@@ -1148,19 +1156,20 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
 
   // Skipped: new cluster-variables endpoint family in pinned spec
   // (camunda/camunda PR #52322) lacks an authoritative producer; tracked at #138.
-  // Skipped: pinned-spec bump (camunda/camunda PR #52322) surfaces a
-  // related but distinct planner gap from #138 — the authoritative-
-  // producer index here only counts `provider:true` response semantics,
-  // so for cluster-variable chains the establisher
-  // `createTenantClusterVariable` is not recognised as an authoritative
-  // producer of `TenantId` (it self-satisfies via a path-param input,
-  // which the planner seeds at request time). Fix scope is broadening
-  // this index to include `op.establishes.identifiedBy[].semanticType`
-  // for non-edge establishers (mirroring graphLoader.ts `produces`
-  // synthesis), but only after the planner-side seedBindings gap on
-  // path-param establisher identifiers (#138 follow-up) is closed —
-  // otherwise this invariant would pass while the emitted URLs still
-  // leak `${tenantIdVar}` at runtime.
+  //
+  // Phase 1 of #288 (binding inheritance) does not address chain
+  // selection — `chainSource` in `path-analyser/src/index.ts` still
+  // falls back to the shortest multi-op planner scenario when no
+  // chain in `authoritativeMultiOp` covers every required type. For
+  // the tenant-cluster-variable family the planner DOES produce an
+  // authoritative chain (`createTenant -> createTenantClusterVariable
+  // -> updateTenantClusterVariable`) but the selector's
+  // `isAuthoritativeChain` predicate rejects it because the establisher
+  // self-mint pushes TenantId onto `op.produces` (graphLoader.ts:752-762)
+  // without setting `providerMap.TenantId = true`. The mismatch is
+  // tracked under #288 Phase 2 (chain selection + establisher-self-mint
+  // authority): broaden the chain-selector to count establisher
+  // self-mints as authoritative for `requires` resolution.
   it.skip('every feature scenario chain contains an authoritative producer for each requiredSemanticType', () => {
     // Chain-selector correctness guard. The feature-output stage in
     // `path-analyser/src/index.ts` chooses one integration scenario from

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -301,6 +301,38 @@ async function main() {
       ) {
         s.operations = chainSource.operations.map((o) => ({ ...o }));
       }
+      // #288 Phase 1: inherit planner-computed bindings (external-mints
+      // for `acceptsExternal` edges + non-edge establisher self-mints
+      // for path/query/header identifiers) from the donor planner
+      // scenario. Without this, `buildScenarioFromVariant` starts with
+      // `bindings = {}` and only adds variant `optionals`, dropping
+      // required-prereq identifiers like `tenantIdVar` (self-establisher
+      // path param on updateTenantClusterVariable) and `clientIdVar`
+      // (external-entity placeholder), which then leak into emitted
+      // URLs as literal `${...Var}` at runtime. Variant bindings win on
+      // overlap so optional-variant overrides (e.g. `${var}Nonexistent`
+      // for the search-empty-negative variant) are preserved.
+      //
+      // Donor selection mirrors the chain-source pick above: prefer the
+      // authoritative multi-op chain, falling back to any other planner
+      // scenario for this endpoint. The donor's bindings always
+      // represent the canonical scenario for *this* endpoint, so the
+      // merge is meaningful even when no chain graft happened (donor
+      // scenario was single-op).
+      //
+      // Skip the inherit when `skipGraft` is true (search-empty-negative)
+      // for symmetry with the operations graft — the negative variant
+      // deliberately omits prerequisites so the search returns empty.
+      // In practice the donor's bindings are empty for search-like
+      // endpoints (which gate on `required.length === 0`), so the merge
+      // would be a no-op anyway; the explicit skip keeps the intent
+      // legible.
+      if (!skipGraft) {
+        const donor = chainSource || integrationCandidates[0];
+        if (donor?.bindings) {
+          s.bindings = { ...donor.bindings, ...(s.bindings ?? {}) };
+        }
+      }
       if (resp) {
         s.responseShapeSemantics = resp.producedSemantics || undefined;
         s.responseShapeFields = resp.fields.map((f) => ({


### PR DESCRIPTION
## Summary

Phase 1 of #288 — inherits planner bindings into feature-output scenarios, closing the immediate `${...Var}`-leak class introduced by the pinned-spec bump (#138).

`featureCoverageGenerator.ts::buildScenarioFromVariant` previously started every scenario with `bindings = {}` and only added variant `optionals`, dropping the required-prereq identifiers the canonical planner had already computed (external-entity mints for `acceptsExternal` edges; non-edge establisher self-mints for path/query/header identifiers). Downstream emitters reading `feature-output/` (Playwright feature suite + edge/entity lifecycle suites via `featureScenarioStash`) therefore rendered URLs with literal `${...Var}` at runtime.

## Approach

In the orchestrator (`path-analyser/src/index.ts`), after the existing chain graft, merge the donor planner scenario's bindings into each feature scenario:

```ts
if (!skipGraft) {
  const donor = chainSource || integrationCandidates[0];
  if (donor?.bindings) {
    s.bindings = { ...donor.bindings, ...(s.bindings ?? {}) };
  }
}
```

- **Donor selection** mirrors the existing `chainSource` pick (authoritative multi-op → shortest multi-op → first candidate). The donor's bindings are always canonical for this endpoint.
- **Variant bindings win on overlap** so optional-variant overrides (e.g. `${var}Nonexistent` for search-empty-negative) are preserved.
- **Skip for search-empty-negative** (symmetric with the existing `skipGraft` operations branch). In practice donors for search-like endpoints have empty bindings anyway because the gating rule requires `required.length === 0`; the explicit skip keeps the intent legible.

Minimal-touch fix in the orchestrator rather than restructuring `buildScenarioFromVariant`'s signature. A future Phase 2 PR can collapse the orchestrator-side merge into the builder once chain-source ownership is also unified.

## Concrete drift

For `PUT /cluster-variables/tenants/{tenantId}/{name}` (one of the #138 regressions):

```diff
- bindings: { nameVar: '__PENDING__' }
+ bindings: {
+   tenantIdVar: 'tenantClusterVariable_okid',
+   nameVar: 'tenantClusterVariable_bhto'
+ }
```

The emitted URL `/cluster-variables/tenants/${tenantIdVar}/${nameVar}` now substitutes both vars at runtime instead of leaking the literal `${tenantIdVar}` placeholder.

## Verification

```
$ npm run testsuite:generate && npm run generate:request-validation && npm test
…
configs/camunda-oca/regression-invariants.test.ts (146 tests | 4 skipped) 1654ms
Test Files  54 passed (54)
     Tests  545 passed | 4 skipped (549)
```

- **545 passing | 4 skipped** — identical headline to `main`.
- **Phase 0 invariants from #290 are unaffected**: `variantKey`, `expectedResult.kind`, `syntheticBindings` presence, scenario count, and `neg` gating are structurally unchanged. Confirmed green.
- **#136 / #152 establisher body-identifier invariants stay green**: body bindings already had a separate seeding path; this PR only adds path/query/header identifiers.
- **Two #138 L3 skips stay skipped, with updated comments:**
  - **`every feature-output scenario binds or chains every {placeholder}…`** — class 1 (external-entity identifiers like `clientIdVar`) is now fully closed. Most class-2 (self-establisher path-param) is closed. **One offender remains**: `post--cluster-variables--tenants--{tenantId}` (`createTenantClusterVariable`). Root cause is a deeper establisher-modelling issue — the planner treats a foreign-key scoping path param as part of the variable's composite identity and self-mints it, instead of either chaining `createTenant` or minting it externally. Out of scope for Phase 1; re-scoped to #288 Phase 2.
  - **`every feature scenario chain contains an authoritative producer…`** — pure chain-selection issue, independent of bindings. `isAuthoritativeChain` rejects the longer `createTenant → createTenantClusterVariable → updateTenantClusterVariable` chain because the establisher self-mint pushes TenantId onto `op.produces` without setting `providerMap.TenantId = true`. Re-scoped to #288 Phase 2 (chain selection + establisher-self-mint authority).
- **Lint clean** (`npm run lint`); **all five workspace typechecks clean**.

## What this unblocks

The downstream `featureScenarioStash` is now populated with correctly-bound scenarios, so the edge-lifecycle and entity-lifecycle suites also inherit the fix transparently — every Playwright suite that consumed feature-output via the stash now emits substituted URLs for the external-entity and most self-establisher cases.

Refs #288 (Phase 1), #138.
