### PR TITLE
fix: filter establisher identifiedBy by ABox kind identifiers (#288 Phase 2, closes #138)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -660,32 +660,18 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
     expect(offenders).toEqual([]);
   });
 
-  // Skipped: new cluster-variables endpoint family in pinned spec
-  // (camunda/camunda PR #52322) leaves placeholders unbound; tracked at #138.
-  //
-  // Phase 1 of #288 (PR that lands this comment update) closed the
-  // feature-output binding-inheritance gap: `buildScenarioFromVariant`
-  // now inherits the planner's external mints + establisher self-mints
-  // from the donor chain scenario via the orchestrator. As a result the
-  // class-1 case below (external-entity identifiers like `clientIdVar`)
-  // is fully closed, and the class-2 case (self-establisher path-param
-  // root) is closed for endpoints whose self-establish path identifier
-  // is the variable's OWN identifier.
-  //
-  // One offender remains: `post--cluster-variables--tenants--{tenantId}`.
-  // Root cause is a deeper planner self-establish modelling issue —
-  // `createTenantClusterVariable` declares `establishes.identifiedBy[]`
-  // with `{in: path, name: tenantId, semanticType: TenantId}` AND
-  // `{in: body, name: name, semanticType: ClusterVariableName}`, which
-  // the planner treats as a single composite identifier (self-minting
-  // BOTH). But `tenantId` is semantically a foreign-key reference to
-  // an existing tenant, not part of the variable's own identity. The
-  // planner therefore neither chains in `createTenant` nor mints
-  // `tenantIdVar` externally for this endpoint. Fixing this requires
-  // distinguishing "owned identity" from "scoping foreign-key" in the
-  // establisher semantic graph — out of scope for #288 Phase 1
-  // (binding inheritance) and tracked separately under #288 Phase 2.
-  it.skip('every feature-output scenario binds or chains every {placeholder} whose path parameter has a recognised semanticType', () => {
+  // #138 — closed by #288 Phase 2 (graphLoader filters
+  // `establishes.identifiedBy[]` by the entity-kinds ABox `identifiers`
+  // field, so foreign-key path params like `tenantId` on
+  // `createTenantClusterVariable` remain in `requires.required` and the
+  // planner chains in `createTenant` to mint `tenantIdVar`). Phase 1
+  // (PR #291) closed the orchestrator-side binding-inheritance gap;
+  // Phase 2 (this PR) closes the planner-side composite-identifier
+  // modelling gap. Combined, every feature-output scenario now binds or
+  // chains every path-placeholder whose parameter has a recognised
+  // semanticType. Class-scoped guard remains active to catch regressions
+  // in either layer.
+  it('every feature-output scenario binds or chains every {placeholder} whose path parameter has a recognised semanticType', () => {
     // Class-scoped guard for the "un-extracted ${var} in URL" defect family:
     // when an endpoint's response analyser produces no shape (typically for
     // 204 No-Content operations like cancelProcessInstance, completeJob,
@@ -1154,23 +1140,18 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
     ).toEqual([]);
   });
 
-  // Skipped: new cluster-variables endpoint family in pinned spec
-  // (camunda/camunda PR #52322) lacks an authoritative producer; tracked at #138.
-  //
-  // Phase 1 of #288 (binding inheritance) does not address chain
-  // selection — `chainSource` in `path-analyser/src/index.ts` still
-  // falls back to the shortest multi-op planner scenario when no
-  // chain in `authoritativeMultiOp` covers every required type. For
-  // the tenant-cluster-variable family the planner DOES produce an
-  // authoritative chain (`createTenant -> createTenantClusterVariable
-  // -> updateTenantClusterVariable`) but the selector's
-  // `isAuthoritativeChain` predicate rejects it because the establisher
-  // self-mint pushes TenantId onto `op.produces` (graphLoader.ts:752-762)
-  // without setting `providerMap.TenantId = true`. The mismatch is
-  // tracked under #288 Phase 2 (chain selection + establisher-self-mint
-  // authority): broaden the chain-selector to count establisher
-  // self-mints as authoritative for `requires` resolution.
-  it.skip('every feature scenario chain contains an authoritative producer for each requiredSemanticType', () => {
+  // #138 — closed by #288 Phase 2. Root cause was that
+  // `createTenant` (which both establishes the Tenant kind AND
+  // authoritatively returns `tenantId` with provider:true in its 201
+  // response) was silently dropped from `producersByType.TenantId`
+  // because the establisher-skip in graphLoader filtered out every
+  // self-minted semantic type — including those an op also legitimately
+  // returns as a `provider:true` response leaf. The fix narrows the
+  // skip to entries that are ONLY synthesised (`!providerMap[st]`), so
+  // an op that double-qualifies as both establisher and authoritative
+  // producer stays in the producer index and `isAuthoritativeChain`
+  // selects a chain containing it.
+  it('every feature scenario chain contains an authoritative producer for each requiredSemanticType', () => {
     // Chain-selector correctness guard. The feature-output stage in
     // `path-analyser/src/index.ts` chooses one integration scenario from
     // the planner output to graft as the dependency chain in front of

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -559,7 +559,7 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
   // we forgot to update the ABox" (the locality-loss replacement
   // signal). See #210 §4b for the full rationale.
   if (aboxExternals !== null) {
-    const drift = detectEntityKindsDrift(opsRoot?.kindRegistry, operations, repoRoot);
+    const drift = detectEntityKindsDrift(opsRoot?.kindRegistry, operations, entityKindsAbox);
     if (drift.length > 0) {
       const detail = drift.map((d) => `  - ${d}`).join('\n');
       const message = `entity-kinds ABox drift detected:\n${detail}`;
@@ -1066,10 +1066,9 @@ function detectEdgeAnnotationDrift(
 function detectEntityKindsDrift(
   rawRegistry: RawGraphRoot['kindRegistry'] | undefined,
   operations: Record<string, OperationNode>,
-  repoRoot: string,
+  abox: ReturnType<typeof loadEntityKindsAbox>,
 ): string[] {
   const drift: string[] = [];
-  const abox = loadEntityKindsAbox(repoRoot);
   if (abox === null) return drift;
 
   const aboxByName = new Map(abox.kinds.map((k) => [k.name, k]));

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -143,6 +143,24 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
   // back to the legacy spec-annotation behaviour for backward compat.
   const edgeEstablishers = loadEdgeEstablishers(repoRoot);
 
+  // #288 Phase 2: load the entity-kinds ABox up front so `normalizeOp`
+  // can distinguish "owned identifier" from "scoping foreign-key" in
+  // `establishes.identifiedBy[]`. Example: `createTenantClusterVariable`
+  // declares `identifiedBy = [{TenantId, path}, {ClusterVariableName,
+  // body}]`. Only `ClusterVariableName` is genuinely client-minted by
+  // this op — `tenantId` is a foreign-key reference to an existing
+  // Tenant that must exist first. The ABox is the authoritative source
+  // for which semantic types are TRUE identifiers of a given kind
+  // (`TenantClusterVariable.identifiers = ['ClusterVariableName']`).
+  // When the ABox is absent (legacy configs, tmpDir tests),
+  // `kindIdentifiersByKind` is `null` and `normalizeOp` falls back to
+  // the legacy "all identifiedBy are self-minted" behaviour.
+  const entityKindsAbox = loadEntityKindsAbox(repoRoot);
+  const kindIdentifiersByKind: Map<string, Set<string>> | null =
+    entityKindsAbox !== null
+      ? new Map(entityKindsAbox.kinds.map((k) => [k.name, new Set(k.identifiers)]))
+      : null;
+
   const operations: Record<string, OperationNode> = {};
 
   // Support multiple possible root shapes
@@ -185,11 +203,11 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
         console.warn('[graphLoader] Skipping node without operationId/id/name:', Object.keys(op));
         continue;
       }
-      operations[opId] = normalizeOp(opId, op, edgeEstablishers);
+      operations[opId] = normalizeOp(opId, op, edgeEstablishers, kindIdentifiersByKind);
     }
   } else {
     for (const [opId, op] of Object.entries(candidateOps)) {
-      operations[opId] = normalizeOp(opId, op, edgeEstablishers);
+      operations[opId] = normalizeOp(opId, op, edgeEstablishers, kindIdentifiersByKind);
     }
   }
 
@@ -239,18 +257,47 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
     // clean while preserving per-op satisfaction tracking.
     const synthesisedFromEstablishes = new Set<string>();
     if (op.establishes && op.establishes.shape !== 'edge') {
+      const kindIdentifiers = kindIdentifiersByKind?.get(op.establishes.kind);
       for (const id of op.establishes.identifiedBy) {
+        // #288 Phase 2: only treat components that are TRUE identifiers
+        // of the kind as synthesised — mirroring the filter applied in
+        // `normalizeOp`. Without this, the foreign-key components have
+        // already been removed from `op.produces` upstream but the
+        // synthesised-set check below could still spuriously suppress
+        // them from `producersByType` had they snuck in.
+        if (kindIdentifiers && !kindIdentifiers.has(id.semanticType)) continue;
         synthesisedFromEstablishes.add(id.semanticType);
       }
     }
     for (const st of op.produces) {
-      if (synthesisedFromEstablishes.has(st)) continue;
+      // #288 Phase 2: an op that establishes type T AND authoritatively
+      // returns T in a 2xx response (provider:true) is legitimately a
+      // producer — its server-echoed value is the canonical source for
+      // downstream chains. `createTenant` is the motivating example:
+      // it establishes Tenant via body.tenantId (client-minted) AND
+      // its 201 response carries `tenantId` with provider:true. The
+      // earlier blanket skip of every synthesised entry kept
+      // createTenant out of `producersByType.TenantId`, which made
+      // `isAuthoritativeChain` exempt `TenantId` from gating and let
+      // the chain selector pick `createTenantClusterVariable` (a
+      // non-authoritative establisher) instead of `createTenant`.
+      if (synthesisedFromEstablishes.has(st) && !(op.providerMap?.[st] === true)) continue;
       const list = producersByType[st] ?? [];
       list.push(op.operationId);
       producersByType[st] = list;
     }
     if (op.establishes && op.establishes.shape !== 'edge') {
+      const kindIdentifiers = kindIdentifiersByKind?.get(op.establishes.kind);
       for (const id of op.establishes.identifiedBy) {
+        // #288 Phase 2: a foreign-key component (e.g. `tenantId` on
+        // createTenantClusterVariable) is NOT an entry this op
+        // establishes — it's a value the op consumes. Skip the
+        // foreign-key entries when building `establishersByType` so
+        // that index keeps its "registers a client-minted value"
+        // contract: querying `establishersByType.TenantId` returns only
+        // ops that genuinely mint a Tenant identifier (`createTenant`),
+        // not ops that scope under one.
+        if (kindIdentifiers && !kindIdentifiers.has(id.semanticType)) continue;
         const list = establishersByType[id.semanticType] ?? [];
         if (!list.includes(op.operationId)) list.push(op.operationId);
         establishersByType[id.semanticType] = list;
@@ -637,7 +684,12 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
   return graph;
 }
 
-function normalizeOp(opId: string, op: RawOp, edgeEstablishers: Set<string> | null): OperationNode {
+function normalizeOp(
+  opId: string,
+  op: RawOp,
+  edgeEstablishers: Set<string> | null,
+  kindIdentifiersByKind: Map<string, Set<string>> | null,
+): OperationNode {
   // Extract produced semantic types.
   // Priority:
   // 1. Explicit fields (producesSemanticTypes / producesSemanticType / produces / outputsSemanticTypes)
@@ -756,7 +808,20 @@ function normalizeOp(opId: string, op: RawOp, edgeEstablishers: Set<string> | nu
   const establishes = normalizeEstablishes(op.establishes, opId, edgeEstablishers);
   const establishedSemantics = new Set<string>();
   if (establishes && establishes.shape !== 'edge') {
+    // #288 Phase 2: distinguish "owned identifier" from "scoping
+    // foreign-key" inside `identifiedBy[]`. The entity-kinds ABox lists
+    // the kind's TRUE identifiers (e.g. TenantClusterVariable.identifiers
+    // = ['ClusterVariableName']). Components present in `identifiedBy`
+    // but NOT in the kind's identifiers set are foreign-key references
+    // to other entities (e.g. `tenantId` path param on
+    // createTenantClusterVariable) and must remain in `requires` so the
+    // planner chains in the establisher of the referenced entity
+    // (createTenant). When the ABox doesn't list this kind (or no ABox
+    // is available), fall back to the legacy "all identifiedBy are
+    // self-minted" behaviour for backward compatibility.
+    const kindIdentifiers = kindIdentifiersByKind?.get(establishes.kind);
     for (const id of establishes.identifiedBy) {
+      if (kindIdentifiers && !kindIdentifiers.has(id.semanticType)) continue;
       produces.push(id.semanticType);
       establishedSemantics.add(id.semanticType);
     }

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -53,6 +53,12 @@ async function main() {
   const suffix = 'path-analyser';
   const baseDir = cwd.endsWith(suffix) ? cwd : path.resolve(cwd, suffix);
   const repoRoot = path.resolve(baseDir, '..');
+  // #288 Phase 2 (review feedback): load the entity-kinds ABox ONCE
+  // per pipeline run and thread the parsed object to every consumer
+  // (post-hint identifier filter below + template instantiation
+  // further down). Re-loading + re-validating the same JSON file
+  // multiple times in one run was wasted I/O.
+  const entityKindsAbox = loadEntityKindsAbox(repoRoot);
   // Per-config layout (#128 PR 2): scenario JSON + feature output land
   // under generated/<config>/, not inside the path-analyser workspace.
   const outputDir = getScenariosDir(repoRoot);
@@ -143,10 +149,9 @@ async function main() {
   // from `requires.required` again here, undoing the Phase 2 fix and
   // letting BFS plan a single-op scenario with no chain to mint the
   // foreign key.
-  const entityKindsAboxForFilter = loadEntityKindsAbox(path.resolve(baseDir, '..'));
   const kindIdentifiersByKind: Map<string, Set<string>> | null =
-    entityKindsAboxForFilter !== null
-      ? new Map(entityKindsAboxForFilter.kinds.map((k) => [k.name, new Set(k.identifiers)]))
+    entityKindsAbox !== null
+      ? new Map(entityKindsAbox.kinds.map((k) => [k.name, new Set(k.identifiers)]))
       : null;
   for (const [opId, op] of Object.entries(graph.operations)) {
     const hint = hints[opId];
@@ -549,7 +554,7 @@ async function main() {
   // step cannot perturb byte-stability of the per-endpoint suites.
   const templatesAbox = loadScenarioTemplatesAbox(repoRoot);
   const edgesAbox = loadEdgesAbox(repoRoot);
-  const entityKindsAboxForTemplates = loadEntityKindsAbox(repoRoot);
+  const entityKindsAboxForTemplates = entityKindsAbox;
   if (templatesAbox && edgesAbox) {
     const results = instantiateAllTemplates(
       graph,

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -135,6 +135,19 @@ async function main() {
 
   // Enrich requirements from OpenAPI hints
   const hints = await loadOpenApiSemanticHints(baseDir);
+  // #288 Phase 2: rebuild the kind→identifiers map locally so the
+  // post-hint re-application of the establisher self-satisfaction drop
+  // uses the same "owned identifier only" filter that graphLoader
+  // applied during normalisation. Without this, foreign-key components
+  // (e.g. `tenantId` on createTenantClusterVariable) get suppressed
+  // from `requires.required` again here, undoing the Phase 2 fix and
+  // letting BFS plan a single-op scenario with no chain to mint the
+  // foreign key.
+  const entityKindsAboxForFilter = loadEntityKindsAbox(path.resolve(baseDir, '..'));
+  const kindIdentifiersByKind: Map<string, Set<string>> | null =
+    entityKindsAboxForFilter !== null
+      ? new Map(entityKindsAboxForFilter.kinds.map((k) => [k.name, new Set(k.identifiers)]))
+      : null;
   for (const [opId, op] of Object.entries(graph.operations)) {
     const hint = hints[opId];
     if (hint) {
@@ -163,7 +176,18 @@ async function main() {
     // are skipped — their `identifiedBy` components are pre-existing
     // inputs and the hint-derived `requires` for them is correct.
     if (op.establishes && op.establishes.shape !== 'edge') {
-      const established = new Set(op.establishes.identifiedBy.map((i) => i.semanticType));
+      // #288 Phase 2: mirror the kind-identifier filter applied in
+      // graphLoader.normalizeOp — only TRUE identifiers of the
+      // established kind get suppressed here. Foreign-key components
+      // (e.g. `tenantId` on `createTenantClusterVariable`) remain in
+      // `requires` so BFS chains in the establisher of the referenced
+      // entity (`createTenant`).
+      const kindIdentifiers = kindIdentifiersByKind?.get(op.establishes.kind);
+      const established = new Set(
+        op.establishes.identifiedBy
+          .filter((i) => !kindIdentifiers || kindIdentifiers.has(i.semanticType))
+          .map((i) => i.semanticType),
+      );
       op.requires.required = op.requires.required.filter((s) => !established.has(s));
       op.requires.optional = op.requires.optional.filter((s) => !established.has(s));
     }


### PR DESCRIPTION
Closes #138.

Second and final structural fix for #288 (collapsing the three parallel scenario-emitting paths). Phase 1 (#291) closed the orchestrator-side binding-inheritance gap; Phase 2 closes the planner-side composite-identifier modelling gap and the chain-authority gap they exposed.

### Problem

Two coupled defects in `path-analyser`:

1. **`establishes.identifiedBy[]` conflates owned identity and scoping foreign-keys.** `createTenantClusterVariable` declares `identifiedBy = [{TenantId, path}, {ClusterVariableName, body}]`, but only `ClusterVariableName` is genuinely client-minted by this op. `tenantId` is a foreign-key reference to an existing tenant. The planner therefore neither chained in `createTenant` nor minted `tenantIdVar` externally — the URL placeholder leaked at runtime.

2. **`createTenant` is silently excluded from `producersByType.TenantId`.** It both establishes Tenant via `body.tenantId` (client-minted) AND returns `tenantId` with `provider:true` in its 201 response. The blanket "establishers don't go into `producersByType`" skip dropped it, so `isAuthoritativeChain` exempted `TenantId` and the chain selector fell back to a non-authoritative 2-op chain.

### Fix

**`graphLoader.ts`** loads the entity-kinds ABox up front and builds `kindIdentifiersByKind: Map<kindName, Set<identifierSemantic>>`. The map is consulted in three places to filter `identifiedBy[]` by what the ABox declares as the kind's true identifiers:

- `normalizeOp`: only true identifiers populate `establishedSemantics` (and thus get suppressed from `requires.required`). Foreign-key components remain in `requires`, so BFS chains in the referenced entity's establisher.
- `producersByType` build: an op that appears in `synthesisedFromEstablishes` AND has `providerMap[t] === true` (legitimate authoritative producer) is no longer skipped.
- `establishersByType` build: foreign-key components don't claim establisher status.

When no ABox is available (tmpDir tests, unmigrated configs), all three sites fall back to the legacy "all identifiedBy are self-minted" behaviour.

**`index.ts`** mirrors the same kind-identifier filter at the post-hint re-application of the establisher self-satisfaction drop (lines 165-169). Without this, `loadOpenApiSemanticHints` re-adds the foreign key to `requires.required` and the orchestrator drops it again with the old filter.

### Verification

Red step proved both #138 L3 invariants failing on `main` against the regenerated pipeline:
- `every feature-output scenario binds or chains every {placeholder}…` — 1 offender (`post--cluster-variables--tenants--{tenantId}`)
- `every feature scenario chain contains an authoritative producer for each requiredSemanticType` — 3 offenders (`updateTenantClusterVariable`, `deleteTenantClusterVariable`, `getTenantClusterVariable`)

After Phase 2 both invariants are green; both unskipped. Concrete outcome:
- `producersByType.TenantId = ['createTenant']` (was `undefined`)
- `createTenantClusterVariable.requires.required = ['TenantId']` (was `[]`)
- `establishersByType.TenantId = ['createTenant']` (was `['createTenantClusterVariable', 'createTenant']`)
- Chain selector now grafts `createTenant → createTenantClusterVariable → updateTenantClusterVariable` for the PUT endpoint.

Local gates:
- `npm run lint` ✓
- `tsc --noEmit` × 5 workspace tsconfigs + `tests/tsconfig.json` ✓
- `npm run testsuite:generate` + `npm run generate:request-validation` ✓
- `npm test` ✓ — 547 passing / 2 skipped (was 545 / 4 skipped; the 2 newly green are the unskipped #138 invariants; the remaining 2 skips are `#37` startInstructions and `#139` variant-chain, unaffected).
