### PR TITLE
refactor: switch feature + template emitters to canonical scenario cache (#288 Phase 3b)

### DIFF
--- a/path-analyser/src/featureCoverageGenerator.ts
+++ b/path-analyser/src/featureCoverageGenerator.ts
@@ -17,6 +17,15 @@ interface FeatureCoverageOptions {
   requestVariants?: RequestOneOfGroupSummary[]; // injected extracted request variant groups
   // Cap total scenarios per endpoint for feature coverage
   maxScenariosPerEndpoint?: number;
+  // #288 Phase 3b — the planner's authoritative scenario for this
+  // endpoint, used as the source of `operations` and `bindings` for
+  // every variant that inherits the chain (i.e. everything except
+  // search-empty-negative). When omitted (legacy callers, tests),
+  // variants fall back to the pre-3b blank-slate construction —
+  // single-op chain, no prereq bindings — which keeps the function
+  // usable in isolation but is not how the production pipeline calls
+  // it.
+  canonical?: EndpointScenario;
 }
 
 const DEFAULT_OPTS: FeatureCoverageOptions = {
@@ -86,6 +95,11 @@ export function generateFeatureCoverageForEndpoint(
       artifactSemantics: [],
       expectedResult: 'empty',
       negative: true,
+      // #288 Phase 3b — the search-empty-negative variant deliberately
+      // omits chain prerequisites so the search returns empty at
+      // runtime. This is the single case across the codebase where
+      // canonical-chain inheritance is wrong.
+      inheritChainPrereqs: false,
     });
   }
 
@@ -146,7 +160,7 @@ export function generateFeatureCoverageForEndpoint(
   }
 
   let scenarios: EndpointScenario[] = variants.map((v, i) =>
-    buildScenarioFromVariant(graph, endpointOpId, v, i + 1),
+    buildScenarioFromVariant(graph, endpointOpId, v, i + 1, options.canonical),
   );
   // Enforce global cap per endpoint
   const cap = options.maxScenariosPerEndpoint ?? 35;
@@ -166,17 +180,45 @@ function buildScenarioFromVariant(
   endpointId: string,
   variant: FeatureVariantSpec,
   index: number,
+  canonical: EndpointScenario | undefined,
 ): EndpointScenario {
   const endpoint = graph.operations[endpointId];
-  const opRefs: OperationRef[] = [toRef(endpoint)];
+  // #288 Phase 3b — inherit the planner's canonical chain (operations
+  // + bindings) unless the variant explicitly opts out
+  // (`inheritChainPrereqs: false`, currently only the
+  // search-empty-negative case). This replaces the post-hoc
+  // chain-graft + donor-binding-merge blocks that used to live in
+  // `path-analyser/src/index.ts` immediately after this call.
+  const inheritChain = variant.inheritChainPrereqs !== false;
+  const opRefs: OperationRef[] =
+    inheritChain && canonical && canonical.operations.length > 1
+      ? canonical.operations.map((o) => ({ ...o }))
+      : [toRef(endpoint)];
+  const inheritedBindings: Record<string, string> =
+    inheritChain && canonical?.bindings ? { ...canonical.bindings } : {};
+
   const produced = new Set<string>();
-  const bindings: Record<string, string> = {};
+  // Variant bindings overlay onto inherited bindings — variant wins
+  // on overlap, so negative-variant overrides like `${var}Nonexistent`
+  // are preserved. Without the merge, the variant would lose the
+  // planner's prereq mints (e.g. external-entity `clientIdVar`, the
+  // foreign-key `tenantIdVar` for createTenantClusterVariable's path
+  // param) and the emitter would render literal `${...Var}` at runtime.
+  const bindings: Record<string, string> = { ...inheritedBindings };
+  // Track synthetic bindings explicitly so the post-3b inherit doesn't
+  // accidentally classify inherited canonical bindings (e.g. `tenantIdVar`)
+  // as synthetic — `syntheticBindings` is specifically the negative-
+  // variant `${var}Nonexistent` overrides, used downstream to drive
+  // the emitter's "intentionally invalid lookup value" rendering.
+  const syntheticKeys: string[] = [];
   // Synthetic bindings for negative variant
   if (variant.negative) {
     for (const o of variant.optionals) {
       const varName = `${camelLower(o)}Var`;
-      bindings[`${varName}Nonexistent`] =
+      const key = `${varName}Nonexistent`;
+      bindings[key] =
         `${camelLower(o)}_nonexistent_${deterministicSuffix(`fc:neg:${endpoint.operationId}:${o}`)}`;
+      syntheticKeys.push(key);
     }
   } else {
     for (const o of variant.optionals) {
@@ -198,7 +240,7 @@ function buildScenarioFromVariant(
     expectedResult: { kind: variant.expectedResult },
     coverageTags: buildCoverageTags(variant),
     filtersUsed: variant.optionals,
-    syntheticBindings: variant.negative ? Object.keys(bindings) : undefined,
+    syntheticBindings: variant.negative ? syntheticKeys : undefined,
     bindings,
   };
   if (variant.duplicateTest) {

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -24,7 +24,7 @@ import {
   generateOptionalSubShapeVariants,
   generateScenariosForEndpoint,
 } from './scenarioGenerator.js';
-import { instantiateAllTemplates, type ScenarioStash } from './scenarioTemplateInstantiator.js';
+import { instantiateAllTemplates } from './scenarioTemplateInstantiator.js';
 import { computeSeedBindings } from './seedBindings.js';
 import type {
   ArtifactRegistryEntry,
@@ -202,24 +202,13 @@ async function main() {
   let processed = 0;
   // Aggregate deployment artifacts referenced by scenarios for manifest output
   const artifactsManifest = new Map<string, { kind: string; path: string; description?: string }>();
-  // #270: per-endpoint feature scenario stash. Populated as each
-  // endpoint is processed below with the first fully-planned feature
-  // scenario (`requestPlan` and `seedBindings` already stamped). The
-  // scenario template instantiator reads from this stash after the
-  // loop, so prereq-chain construction reuses the BFS planner's
-  // output verbatim instead of re-implementing it for templates.
-  const featureScenarioStash: ScenarioStash = new Map();
-
-  // #288 Phase 3a — additive canonical-scenario cache. Captures the
-  // planner's authoritative scenario (`chainSource` after the
-  // producer-authority filter, falling back to the first integration
-  // candidate, falling back to the first scenario) for every endpoint,
-  // independent of the feature-overlay path. Phase 3b will switch the
-  // template instantiator + `buildScenarioFromVariant` to read from
-  // here and delete `featureScenarioStash` plus the chain-graft /
-  // donor-binding inherit blocks below. For 3a the cache is purely
-  // additive: populated but consumed only by the equivalence
-  // assertion at the end of the feature loop.
+  // #288 Phase 3b — canonical-scenario cache. Captures the planner's
+  // authoritative scenario (`chainSource` after the producer-authority
+  // filter, falling back to the first integration candidate, falling
+  // back to the first scenario) for every endpoint. Consumed by
+  // `generateFeatureCoverageForEndpoint` (variants inherit operations
+  // + bindings) and by `instantiateAllTemplates` after the loop
+  // (template prereq chains).
   const canonicalByEndpoint: Map<string, EndpointScenario> = new Map();
 
   for (const op of Object.values(graph.operations)) {
@@ -254,15 +243,6 @@ async function main() {
     }
     const fileName = normalizeEndpointFileName(op.method, op.path);
     await writeFile(path.join(outputDir, fileName), JSON.stringify(collection, null, 2), 'utf8');
-    // Feature coverage scenarios (enhanced with integration chain + rudimentary body synthesis)
-    const featureCollection = generateFeatureCoverageForEndpoint(graph, op.operationId, {
-      requestVariants: requestIndex.byOperation[op.operationId],
-    });
-    // Final guardrail: enforce max scenarios per endpoint (cap 90)
-    const MAX_FEATURE_SCENARIOS = 90;
-    if (featureCollection.scenarios.length > MAX_FEATURE_SCENARIOS) {
-      featureCollection.scenarios = featureCollection.scenarios.slice(0, MAX_FEATURE_SCENARIOS);
-    }
     // Choose a representative integration scenario to supply the
     // dependency chain. Shortest non-`unsatisfied` chain with >1 ops,
     // *gated on producer authority for the endpoint's required types*.
@@ -283,6 +263,12 @@ async function main() {
     // length-only sort when no such chain exists, so endpoints whose
     // required types have no authoritative producer anywhere in the
     // graph (an upstream-spec gap) are not regressed.
+    //
+    // #288 Phase 3b: this block runs BEFORE `generateFeatureCoverageForEndpoint`
+    // so the canonical scenario can be passed in as the source of
+    // operations + bindings inheritance for every variant. The
+    // post-call graft/donor-binding-inherit blocks have been deleted
+    // in favour of inheritance at variant-construction time.
     const integrationCandidates = collection.scenarios.filter((sc) => sc.id !== 'unsatisfied');
     const requiredTypes = collection.requiredSemanticTypes ?? [];
     // Restrict the authoritative-producer check to required types that
@@ -317,72 +303,75 @@ async function main() {
       [...authoritativeMultiOp].sort(byLength)[0] ||
       [...multiOpCandidates].sort(byLength)[0] ||
       integrationCandidates[0];
-    // #288 Phase 3a — populate canonical cache for this endpoint.
-    // Prefers the same authoritative chain source the graft block
-    // below uses; falls back to the first integration candidate, then
-    // any scenario, so endpoints with no planned chain (single-op or
-    // unsatisfied-only) still have an entry. Phase 3b will consume.
+    // Canonical scenario for this endpoint — fed into
+    // `generateFeatureCoverageForEndpoint` below and into the template
+    // instantiator after the loop. Falls back to any scenario so
+    // single-op / unsatisfied-only endpoints still have an entry.
     const canonicalForEndpoint = chainSource || integrationCandidates[0] || collection.scenarios[0];
     if (canonicalForEndpoint) {
-      canonicalByEndpoint.set(op.operationId, canonicalForEndpoint);
+      // #288 Phase 3b — hydrate the canonical entry with `requestPlan`
+      // + `seedBindings` if the planner did not already do so.
+      // The planner's `if (resp)` augmentation block above only runs
+      // when the endpoint has a response shape, so 204 No-Content
+      // endpoints (cancelProcessInstance, completeJob, deleteUser, …)
+      // arrive here without a plan. Pre-3b this didn't matter because
+      // `featureScenarioStash` held the feature scenario (always
+      // hydrated post-`buildRequestPlan`); 3b's template instantiator
+      // reads from `canonicalByEndpoint` instead and refuses to
+      // compile templates whose referenced scenarios lack a plan.
+      //
+      // The hydration runs on a SHALLOW CLONE rather than the live
+      // `canonicalForEndpoint` reference, because `buildRequestPlan`
+      // has side-effects that mutate `scenario.bindings` (body-builder
+      // synthesises missing required-field placeholders, jobTypeVar
+      // for artifact deploys, globalContextSeeds entries, etc.). The
+      // original planner scenario is what feature-variant overlays
+      // inherit bindings from — mutating it would shift the per-
+      // variant binding-key insertion order in `feature-output/`,
+      // perturbing files we want to keep byte-identical across the
+      // refactor. The clone gets the plan; templates read it from
+      // the clone via `canonicalByEndpoint`.
+      let canonicalEntry = canonicalForEndpoint;
+      if (!canonicalForEndpoint.requestPlan) {
+        canonicalEntry = {
+          ...canonicalForEndpoint,
+          bindings: { ...(canonicalForEndpoint.bindings ?? {}) },
+        };
+        canonicalEntry.requestPlan = buildRequestPlan(
+          canonicalEntry,
+          resp,
+          graph,
+          canonical,
+          requestIndex.byOperation,
+          successStatusByOp,
+        );
+        canonicalEntry.seedBindings = computeSeedBindings(canonicalEntry);
+      }
+      canonicalByEndpoint.set(op.operationId, canonicalEntry);
     }
-    // The chain-graft + requestPlan synthesis must run for every endpoint,
-    // not just those with a response shape. Operations with a
-    // 204 No-Content response (cancelProcessInstance, completeJob,
-    // resolveIncident, deleteRole, deleteUser, …) used to fall into the
-    // `if (resp)` branch's else and be left as a single-step scenario, which
-    // the emitter then rendered with literal `${var}` placeholders in URLs.
-    // The response-shape assignments below are still gated on `resp` because
-    // they have no meaning when the response body is empty.
+
+    // Feature coverage scenarios (enhanced with integration chain + rudimentary body synthesis)
+    const featureCollection = generateFeatureCoverageForEndpoint(graph, op.operationId, {
+      requestVariants: requestIndex.byOperation[op.operationId],
+      // #288 Phase 3b — variants inherit operations + bindings from
+      // the canonical scenario at construction time, unless a variant
+      // explicitly sets `inheritChainPrereqs: false` (currently only
+      // search-empty-negative).
+      canonical: canonicalForEndpoint,
+    });
+    // Final guardrail: enforce max scenarios per endpoint (cap 90)
+    const MAX_FEATURE_SCENARIOS = 90;
+    if (featureCollection.scenarios.length > MAX_FEATURE_SCENARIOS) {
+      featureCollection.scenarios = featureCollection.scenarios.slice(0, MAX_FEATURE_SCENARIOS);
+    }
+    // #288 Phase 3b — the chain-graft and donor-binding-inherit blocks
+    // that previously lived here have been moved into
+    // `buildScenarioFromVariant` (`featureCoverageGenerator.ts`),
+    // which now clones the canonical scenario's operations + bindings
+    // before applying variant overlay. The post-pass below only adds
+    // per-scenario response-shape data and rebuilds requestPlan +
+    // seedBindings against the final (overlay-merged) bindings.
     for (const s of featureCollection.scenarios) {
-      // Graft chain if available and feature scenario currently only has endpoint op
-      // Special-case: for search-like empty-negative, skip grafting to produce an empty result without prerequisites
-      const isSearchLikeOp =
-        (op.method.toUpperCase() === 'POST' && /\/search$/.test(op.path)) ||
-        /search/i.test(op.operationId) ||
-        isJobActivatorOp(graph.domain, op.operationId);
-      const isEmptyNeg = s.expectedResult && s.expectedResult.kind === 'empty';
-      const skipGraft = isSearchLikeOp && isEmptyNeg;
-      if (
-        !skipGraft &&
-        chainSource &&
-        s.operations.length === 1 &&
-        chainSource.operations.length > 1
-      ) {
-        s.operations = chainSource.operations.map((o) => ({ ...o }));
-      }
-      // #288 Phase 1: inherit planner-computed bindings (external-mints
-      // for `acceptsExternal` edges + non-edge establisher self-mints
-      // for path/query/header identifiers) from the donor planner
-      // scenario. Without this, `buildScenarioFromVariant` starts with
-      // `bindings = {}` and only adds variant `optionals`, dropping
-      // required-prereq identifiers like `tenantIdVar` (self-establisher
-      // path param on updateTenantClusterVariable) and `clientIdVar`
-      // (external-entity placeholder), which then leak into emitted
-      // URLs as literal `${...Var}` at runtime. Variant bindings win on
-      // overlap so optional-variant overrides (e.g. `${var}Nonexistent`
-      // for the search-empty-negative variant) are preserved.
-      //
-      // Donor selection mirrors the chain-source pick above: prefer the
-      // authoritative multi-op chain, falling back to any other planner
-      // scenario for this endpoint. The donor's bindings always
-      // represent the canonical scenario for *this* endpoint, so the
-      // merge is meaningful even when no chain graft happened (donor
-      // scenario was single-op).
-      //
-      // Skip the inherit when `skipGraft` is true (search-empty-negative)
-      // for symmetry with the operations graft — the negative variant
-      // deliberately omits prerequisites so the search returns empty.
-      // In practice the donor's bindings are empty for search-like
-      // endpoints (which gate on `required.length === 0`), so the merge
-      // would be a no-op anyway; the explicit skip keeps the intent
-      // legible.
-      if (!skipGraft) {
-        const donor = chainSource || integrationCandidates[0];
-        if (donor?.bindings) {
-          s.bindings = { ...donor.bindings, ...(s.bindings ?? {}) };
-        }
-      }
       if (resp) {
         s.responseShapeSemantics = resp.producedSemantics || undefined;
         s.responseShapeFields = resp.fields.map((f) => ({
@@ -404,15 +393,6 @@ async function main() {
         successStatusByOp,
       );
       s.seedBindings = computeSeedBindings(s);
-      // #270: a feature-coverage variant may be a better fit than a
-      // base scenario for a given operationId, but only the first
-      // entry we see is kept — feature scenarios are emitted in the
-      // same "base scenario first" order that the BFS planner
-      // produces, so the stash mirrors the canonical chain the
-      // existing per-endpoint suites would render.
-      if (!featureScenarioStash.has(op.operationId)) {
-        featureScenarioStash.set(op.operationId, s);
-      }
       try {
         const final = s.requestPlan?.[s.requestPlan.length - 1];
         const groups = requestIndex.byOperation[op.operationId] || [];
@@ -545,32 +525,6 @@ async function main() {
     processed++;
   }
 
-  // #288 Phase 3a — equivalence assertion: the canonical cache must
-  // hold, for every endpoint with a feature-output stash entry, a
-  // scenario whose prereq operations (everything before the endpoint
-  // itself) match the stash's prereq operations exactly. This is the
-  // green/green contract for Phase 3b: when the stash is deleted and
-  // consumers switch to `canonicalByEndpoint`, the byte-identical
-  // regen against the 3a baseline (combined with this assertion
-  // having passed in 3a) proves the two were the same all along.
-  // Delete this assertion at the end of Phase 3b alongside the stash
-  // itself.
-  for (const [opId, stashed] of featureScenarioStash) {
-    const canonical = canonicalByEndpoint.get(opId);
-    if (!canonical) {
-      throw new Error(
-        `#288 Phase 3a invariant: canonicalByEndpoint missing entry for '${opId}' even though featureScenarioStash has one. The cache must be populated for every endpoint that produces a feature scenario.`,
-      );
-    }
-    const canonicalPrereqs = canonical.operations.slice(0, -1).map((o) => o.operationId);
-    const stashPrereqs = stashed.operations.slice(0, -1).map((o) => o.operationId);
-    if (canonicalPrereqs.join('|') !== stashPrereqs.join('|')) {
-      throw new Error(
-        `#288 Phase 3a invariant: canonical prereq chain for '${opId}' diverges from stash. canonical=[${canonicalPrereqs.join(',')}] stash=[${stashPrereqs.join(',')}]. Phase 3b cannot safely consume the cache while these disagree.`,
-      );
-    }
-  }
-
   const summary: GenerationSummary = {
     generatedAt: new Date().toISOString(),
     nodeVersion: process.version,
@@ -607,7 +561,7 @@ async function main() {
       graph,
       templatesAbox,
       edgesAbox,
-      featureScenarioStash,
+      canonicalByEndpoint,
       entityKindsAboxForTemplates,
     );
     // Wipe the ENTIRE templates partition first, then recreate the

--- a/path-analyser/src/scenarioTemplateInstantiator.ts
+++ b/path-analyser/src/scenarioTemplateInstantiator.ts
@@ -329,7 +329,7 @@ export interface TemplateInstantiationResult {
  *
  * Returns `null`-flavoured `{ error }` if any of the three referenced
  * operations (establishedBy, observableVia, revokedBy) is missing from
- * the canonical. The caller surfaces the error with the entity-kind name.
+ * the canonical map. The caller surfaces the error with the entity-kind name.
  */
 function compileEntityLifecycle(
   template: ScenarioTemplate,

--- a/path-analyser/src/scenarioTemplateInstantiator.ts
+++ b/path-analyser/src/scenarioTemplateInstantiator.ts
@@ -31,13 +31,13 @@ import type {
  *
  *   - **PrereqChain delegates to the existing BFS planner.** The
  *     instantiator does not reinvent dependency-chain construction; it
- *     pulls the already-planned feature scenario for the establisher
- *     out of the per-operation stash that the CLI built earlier in
- *     the same run. That scenario carries the BFS-derived
+ *     pulls the already-planned canonical scenario for the establisher
+ *     out of the per-operation canonical map that the CLI built
+ *     earlier in the same run. That scenario carries the BFS-derived
  *     `operations`, `requestPlan`, `bindings`, and `seedBindings` —
  *     everything the prereq chain needs.
  *
- *   - **Invoke and Observe steps reuse the per-operation feature
+ *   - **Invoke and Observe steps reuse the per-operation canonical
  *     scenario's final RequestStep.** The CLI invokes
  *     `buildRequestPlan` for every endpoint exactly once, regardless
  *     of how many templates reference it. The instantiator looks up
@@ -65,13 +65,18 @@ function bindingNameFor(semantic: string): string {
 }
 
 /**
- * Stash of already-planned scenarios keyed by operationId. The CLI
- * populates one entry per endpoint *after* it has called
- * `buildRequestPlan`/`computeSeedBindings` on the first feature
- * scenario, so by the time the instantiator runs every entry has a
- * fully-populated `requestPlan` and `seedBindings`.
+ * Per-operation canonical-scenario map keyed by operationId. The CLI
+ * populates one entry per endpoint with the planner's authoritative
+ * scenario (the same `chainSource` that supplies feature variant
+ * inheritance — see `index.ts` `canonicalByEndpoint`). By the time
+ * the instantiator runs every entry has a fully-populated
+ * `operations`, `bindings`, `requestPlan`, and `seedBindings`.
+ *
+ * Renamed from `ScenarioStash` in #288 Phase 3b when the per-operation
+ * cache was unified into a single canonical source (also consumed by
+ * `featureCoverageGenerator.buildScenarioFromVariant`).
  */
-export type ScenarioStash = Map<string, EndpointScenario>;
+export type CanonicalScenarioMap = Map<string, EndpointScenario>;
 
 /**
  * Produce the canonical 5-step {@link TemplateScenario} for one
@@ -79,7 +84,7 @@ export type ScenarioStash = Map<string, EndpointScenario>;
  *
  * Returns `null` if any of the three referenced operations
  * (establishedBy, revokedBy, observableVia) is missing from the
- * stash, or if the observation op has no array-nested membership
+ * canonical, or if the observation op has no array-nested membership
  * field. The caller surfaces the error with the edge name so the
  * diagnostic points at the row instead of the helper.
  */
@@ -87,22 +92,22 @@ function compileEdgeLifecycle(
   template: ScenarioTemplate,
   edge: Edge,
   graph: OperationGraph,
-  stash: ScenarioStash,
+  canonical: CanonicalScenarioMap,
 ): { scenario: TemplateScenario } | { error: string } {
-  const establishScenario = stash.get(edge.establishedBy);
-  const revokeScenario = stash.get(edge.revokedBy);
-  const observeScenario = stash.get(edge.observableVia);
+  const establishScenario = canonical.get(edge.establishedBy);
+  const revokeScenario = canonical.get(edge.revokedBy);
+  const observeScenario = canonical.get(edge.observableVia);
   if (!establishScenario)
     return {
-      error: `${template.name} × ${edge.name}: no stashed scenario for establishedBy='${edge.establishedBy}'`,
+      error: `${template.name} × ${edge.name}: no canonical scenario for establishedBy='${edge.establishedBy}'`,
     };
   if (!revokeScenario)
     return {
-      error: `${template.name} × ${edge.name}: no stashed scenario for revokedBy='${edge.revokedBy}'`,
+      error: `${template.name} × ${edge.name}: no canonical scenario for revokedBy='${edge.revokedBy}'`,
     };
   if (!observeScenario)
     return {
-      error: `${template.name} × ${edge.name}: no stashed scenario for observableVia='${edge.observableVia}'`,
+      error: `${template.name} × ${edge.name}: no canonical scenario for observableVia='${edge.observableVia}'`,
     };
 
   const establishPlan = establishScenario.requestPlan;
@@ -171,7 +176,7 @@ function compileEdgeLifecycle(
   // Helper: map an op's required semantics to {semanticType: bindingName}.
   // Used by Invoke and Observe alike. We consult the graph for the
   // op's `requires.required`; the bindingName follows the camelCase
-  // convention so callers don't need to inspect the stashed scenario
+  // convention so callers don't need to inspect the canonical scenario
   // bindings (the union table built above is the source of truth at
   // emit time; this map is the per-step view onto it).
   const inputsFor = (opId: string): Record<string, string> => {
@@ -324,13 +329,13 @@ export interface TemplateInstantiationResult {
  *
  * Returns `null`-flavoured `{ error }` if any of the three referenced
  * operations (establishedBy, observableVia, revokedBy) is missing from
- * the stash. The caller surfaces the error with the entity-kind name.
+ * the canonical. The caller surfaces the error with the entity-kind name.
  */
 function compileEntityLifecycle(
   template: ScenarioTemplate,
   kind: EntityKind,
   graph: OperationGraph,
-  stash: ScenarioStash,
+  canonical: CanonicalScenarioMap,
 ): { scenario: TemplateScenario } | { error: string } {
   // EntityLifecycle only applies to shape: "entity" rows; the schema
   // forbids the triple on shape: "external-entity" so this is also a
@@ -356,20 +361,20 @@ function compileEntityLifecycle(
     };
   }
 
-  const establishScenario = stash.get(establishOpId);
-  const revokeScenario = stash.get(revokeOpId);
-  const observeScenario = stash.get(observeOpId);
+  const establishScenario = canonical.get(establishOpId);
+  const revokeScenario = canonical.get(revokeOpId);
+  const observeScenario = canonical.get(observeOpId);
   if (!establishScenario)
     return {
-      error: `${template.name} × ${kind.name}: no stashed scenario for establishedBy='${establishOpId}'`,
+      error: `${template.name} × ${kind.name}: no canonical scenario for establishedBy='${establishOpId}'`,
     };
   if (!revokeScenario)
     return {
-      error: `${template.name} × ${kind.name}: no stashed scenario for revokedBy='${revokeOpId}'`,
+      error: `${template.name} × ${kind.name}: no canonical scenario for revokedBy='${revokeOpId}'`,
     };
   if (!observeScenario)
     return {
-      error: `${template.name} × ${kind.name}: no stashed scenario for observableVia='${observeOpId}'`,
+      error: `${template.name} × ${kind.name}: no canonical scenario for observableVia='${observeOpId}'`,
     };
 
   const establishPlan = establishScenario.requestPlan;
@@ -515,7 +520,7 @@ export function instantiateAllTemplates(
   graph: OperationGraph,
   templates: ScenarioTemplatesAbox,
   edges: EdgesAbox,
-  stash: ScenarioStash,
+  canonical: CanonicalScenarioMap,
   entityKinds: EntityKindsAbox | null,
 ): TemplateInstantiationResult[] {
   const out: TemplateInstantiationResult[] = [];
@@ -535,7 +540,7 @@ export function instantiateAllTemplates(
         );
       }
       for (const edge of edges.edges) {
-        const compiled = compileEdgeLifecycle(tpl, edge, graph, stash);
+        const compiled = compileEdgeLifecycle(tpl, edge, graph, canonical);
         if ('error' in compiled) {
           errors.push(compiled.error);
           continue;
@@ -565,7 +570,7 @@ export function instantiateAllTemplates(
         // here (not an error) because the template applies to the
         // whole ABox and the schema already classified them out.
         if (kind.shape !== 'entity') continue;
-        const compiled = compileEntityLifecycle(tpl, kind, graph, stash);
+        const compiled = compileEntityLifecycle(tpl, kind, graph, canonical);
         if ('error' in compiled) {
           errors.push(compiled.error);
           continue;

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -323,6 +323,13 @@ export interface FeatureVariantSpec {
     policy: string;
     secondStatus?: number;
   };
+  // #288 Phase 3b — opt out of the canonical chain inheritance.
+  // Defaults to true (omitted ⇒ inherit). The only current consumer
+  // is the search-empty-negative variant, which deliberately omits
+  // prerequisites so the search returns empty at runtime. Replaces
+  // the ad-hoc `isSearchLikeOp && isEmptyNeg` regex previously
+  // applied to every variant in `index.ts`.
+  inheritChainPrereqs?: boolean;
 }
 
 export interface GenerationSummary {


### PR DESCRIPTION
Phase 3b of the parallel-scenario-builder unification tracked by #288. Behaviour-preserving against PR #295 (Phase 3a) — `generated/` is byte-identical modulo timestamps.

## What this PR does

Switches the **feature** and **template** scenario consumers off the post-hoc patching path and onto the canonical-scenario cache (`canonicalByEndpoint`) introduced in Phase 3a. Feature variants now inherit operations + bindings at *construction* time inside `buildScenarioFromVariant` instead of being patched up afterwards in `path-analyser/src/index.ts`.

### Changes

- **`FeatureVariantSpec`** gains optional `inheritChainPrereqs?: boolean` (default `true`). The search-empty-negative variant in `featureCoverageGenerator.ts` sets it to `false` — those variants must not prepopulate state, so the search returns empty (answers open-question 1 from #288).
- **`buildScenarioFromVariant`** accepts the canonical planner scenario and, when inheriting, clones `operations` + `bindings` from it before applying the variant overlay. Synthetic negative-variant keys are tracked in an explicit `syntheticKeys` array so inherited canonical bindings don't get misclassified as synthetic.
- **`index.ts`** — chain-source selection moves *before* `generateFeatureCoverageForEndpoint` so the canonical scenario can be passed into feature generation. The post-hoc chain-graft block, donor-binding-inherit block, `featureScenarioStash`, and the Phase 3a equivalence assertion are all deleted.
- **Canonical hydration** — `canonicalByEndpoint` is hydrated (via a shallow clone) with `requestPlan` + `seedBindings` for endpoints whose planner output lacked them (204 No-Content responses: `cancelProcessInstance`, `completeJob`, `deleteUser`, …). The clone keeps the live planner scenario's `bindings` untouched so feature-variant key-insertion order in `feature-output/` matches pre-3b byte-for-byte.
- **Template instantiator** reads from `canonicalByEndpoint` instead of `featureScenarioStash`. `ScenarioStash` → `CanonicalScenarioMap`; `stash` param → `canonical` (answers open-question 2 from #288).

### What this PR does NOT do

- No cap renames or removals — `maxScenarios: 20`, `maxScenariosPerEndpoint: 35`, `MAX_FEATURE_SCENARIOS = 90` all stay as-is. Phase 3c will handle the rename + cleanup (answers open-question 3) and hands off to #292.

## Verification

```
npm run lint                                          # ✓
npx tsc --noEmit -p semantic-graph-extractor/...     # ✓
npx tsc --noEmit -p path-analyser/...                # ✓
npx tsc --noEmit -p emitter-sdk/...                  # ✓
npx tsc --noEmit -p materializer/...                 # ✓
npx tsc --noEmit -p request-validation/...           # ✓
npx tsc --noEmit -p tests/...                        # ✓
TEST_SEED=snapshot-baseline npm run testsuite:generate
npm run generate:request-validation
npx vitest run                                       # 547 passed | 2 skipped
```

`generated/` diff against `main` is empty modulo two `generatedAt` timestamps:
- `scenarios/index.json`
- `playwright/json-body-assertions/responses.json`

Refs #288.