### PR TITLE
refactor: delete unreachable feature-scenario cap + rename planner caps for intent (#288 Phase 3c)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -7106,8 +7106,9 @@ describeForThisConfig(
 //      scenario is a `neg` variant. Locks the structural presence;
 //      Phase 1 will tighten the content assertion once planner
 //      bindings flow through.
-//   3. Per-endpoint feature-scenario count never exceeds the
-//      MAX_FEATURE_SCENARIOS cap (90) — locks the documented cap.
+//   3. Per-endpoint feature-scenario count never exceeds
+//      `maxVariantOverlays` (35) — the only remaining structural
+//      cap after Phase 3c retired the unreachable outer 90-cap.
 //   4. `neg`-variantKey scenarios are only emitted for endpoints
 //      that match the search-like gate
 //      (`featureCoverageGenerator.ts:76-81`): POST plus
@@ -7244,21 +7245,24 @@ describeForThisConfig(
       ).toEqual([]);
     });
 
-    it('no feature collection exceeds the MAX_FEATURE_SCENARIOS cap of 90 (Phase 0 #288)', () => {
-      // Mirror of `MAX_FEATURE_SCENARIOS = 90` in
-      // path-analyser/src/index.ts. Locks the documented per-endpoint
-      // cap so the unification refactor cannot silently uncap (or
-      // tighten) feature output.
-      const MAX_FEATURE_SCENARIOS = 90;
+    it('no feature collection exceeds maxVariantOverlays (35) (Phase 0 #288)', () => {
+      // Mirror of `maxVariantOverlays ?? 35` in
+      // path-analyser/src/featureCoverageGenerator.ts — the only
+      // remaining structural bound on per-endpoint feature scenarios
+      // after #288 Phase 3c retired the (unreachable) outer 90-cap.
+      // Locks the documented per-endpoint cap so the unification
+      // refactor cannot silently uncap (or tighten) feature output.
+      // #292 will lift this into per-config configuration.
+      const MAX_VARIANT_OVERLAYS = 35;
       const offenders: { file: string; count: number }[] = [];
       for (const { file, collection } of loadAllFeatureCollections()) {
-        if (collection.scenarios.length > MAX_FEATURE_SCENARIOS) {
+        if (collection.scenarios.length > MAX_VARIANT_OVERLAYS) {
           offenders.push({ file, count: collection.scenarios.length });
         }
       }
       expect(
         offenders,
-        `Feature collections must not exceed MAX_FEATURE_SCENARIOS=${MAX_FEATURE_SCENARIOS}. A higher count means the cap in path-analyser/src/index.ts has regressed or the variant enumerator no longer truncates.`,
+        `Feature collections must not exceed maxVariantOverlays=${MAX_VARIANT_OVERLAYS}. A higher count means the cap in path-analyser/src/featureCoverageGenerator.ts has regressed or the variant enumerator no longer truncates.`,
       ).toEqual([]);
     });
 

--- a/path-analyser/src/featureCoverageGenerator.ts
+++ b/path-analyser/src/featureCoverageGenerator.ts
@@ -16,7 +16,7 @@ interface FeatureCoverageOptions {
   generateNegative: boolean;
   requestVariants?: RequestOneOfGroupSummary[]; // injected extracted request variant groups
   // Cap total scenarios per endpoint for feature coverage
-  maxScenariosPerEndpoint?: number;
+  maxVariantOverlays?: number;
   // #288 Phase 3b — the planner's authoritative scenario for this
   // endpoint, used as the source of `operations` and `bindings` for
   // every variant that inherits the chain (i.e. everything except
@@ -32,7 +32,7 @@ const DEFAULT_OPTS: FeatureCoverageOptions = {
   maxOptionalPairs: 20,
   includeAllOptionalsThreshold: 5,
   generateNegative: true,
-  maxScenariosPerEndpoint: 35,
+  maxVariantOverlays: 35,
 };
 
 export function generateFeatureCoverageForEndpoint(
@@ -163,7 +163,7 @@ export function generateFeatureCoverageForEndpoint(
     buildScenarioFromVariant(graph, endpointOpId, v, i + 1, options.canonical),
   );
   // Enforce global cap per endpoint
-  const cap = options.maxScenariosPerEndpoint ?? 35;
+  const cap = options.maxVariantOverlays ?? 35;
   if (scenarios.length > cap) scenarios = scenarios.slice(0, cap);
 
   return {

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -214,7 +214,7 @@ async function main() {
   for (const op of Object.values(graph.operations)) {
     // Generate scenarios for every endpoint, even if it has no semantic requirements.
     const collection = generateScenariosForEndpoint(graph, op.operationId, {
-      maxScenarios: 20,
+      maxChainAlternatives: 20,
     });
     // Augment scenarios with response shape
     const resp = responseByOp[op.operationId];
@@ -359,11 +359,13 @@ async function main() {
       // search-empty-negative).
       canonical: canonicalForEndpoint,
     });
-    // Final guardrail: enforce max scenarios per endpoint (cap 90)
-    const MAX_FEATURE_SCENARIOS = 90;
-    if (featureCollection.scenarios.length > MAX_FEATURE_SCENARIOS) {
-      featureCollection.scenarios = featureCollection.scenarios.slice(0, MAX_FEATURE_SCENARIOS);
-    }
+    // Final guardrail: enforce max scenarios per endpoint.
+    // The 90-cap previously here (`MAX_FEATURE_SCENARIOS = 90`) was
+    // structurally unreachable — `generateFeatureCoverageForEndpoint`
+    // already caps internally at `maxVariantOverlays ?? 35`, so
+    // the outer 90 clamp could never fire. Removed in #288 Phase 3c;
+    // the per-config lift in #292 will replace the variant cap with
+    // a configurable bound.
     // #288 Phase 3b — the chain-graft and donor-binding-inherit blocks
     // that previously lived here have been moved into
     // `buildScenarioFromVariant` (`featureCoverageGenerator.ts`),
@@ -472,7 +474,7 @@ async function main() {
     // have populated-shape coverage.
     if (op.optionalSubShapes?.length) {
       const variantCollection = generateOptionalSubShapeVariants(graph, op.operationId, {
-        maxScenarios: 20,
+        maxChainAlternatives: 20,
       });
       // Augment with response shape (when available) so downstream codegen
       // has the same metadata as base/feature scenarios. The requestPlan

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -359,13 +359,13 @@ async function main() {
       // search-empty-negative).
       canonical: canonicalForEndpoint,
     });
-    // Final guardrail: enforce max scenarios per endpoint.
-    // The 90-cap previously here (`MAX_FEATURE_SCENARIOS = 90`) was
-    // structurally unreachable — `generateFeatureCoverageForEndpoint`
-    // already caps internally at `maxVariantOverlays ?? 35`, so
-    // the outer 90 clamp could never fire. Removed in #288 Phase 3c;
-    // the per-config lift in #292 will replace the variant cap with
-    // a configurable bound.
+    // Per-endpoint variant cap is enforced inside
+    // `generateFeatureCoverageForEndpoint` (via `maxVariantOverlays`,
+    // default 35), not here. The 90-cap previously at this site
+    // (`MAX_FEATURE_SCENARIOS = 90`) was structurally unreachable
+    // because the inner cap of 35 already truncates first; it was
+    // removed in #288 Phase 3c. #292 will lift the variant cap into
+    // per-config configuration.
     // #288 Phase 3b — the chain-graft and donor-binding-inherit blocks
     // that previously lived here have been moved into
     // `buildScenarioFromVariant` (`featureCoverageGenerator.ts`),
@@ -474,7 +474,7 @@ async function main() {
     // have populated-shape coverage.
     if (op.optionalSubShapes?.length) {
       const variantCollection = generateOptionalSubShapeVariants(graph, op.operationId, {
-        maxChainAlternatives: 20,
+        maxVariantsPerEndpoint: 20,
       });
       // Augment with response shape (when available) so downstream codegen
       // has the same metadata as base/feature scenarios. The requestPlan

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -21,7 +21,7 @@ import { PENDING_BINDING } from './types.js';
 
 // Back-compat generation options
 interface GenerationOpts {
-  maxScenarios: number;
+  maxChainAlternatives: number;
   longChains?: { enabled: boolean; maxPreOps: number };
   // Issue #37: when planning an optional sub-shape variant, the endpoint
   // itself is allowed to appear as a producer in the BFS (i.e. the
@@ -88,7 +88,7 @@ Maintain a state with:
  - cycle flag
 Expand BFS for breadth ordering (naturally tends toward shorter chains first).
 Cycle handling: allow one repeat of any operation already in path (sets cycle flag), then block further repeats of that same op.
-Stop when maxScenarios collected or queue empty.
+Stop when maxChainAlternatives collected or queue empty.
 */
 export function generateScenariosForEndpoint(
   graph: OperationGraph,
@@ -229,7 +229,7 @@ export function generateScenariosForEndpoint(
       : new Set([...initialNeeded].filter((s) => !externalEntitySites.includes(s)));
 
   const scenarios: EndpointScenario[] = [];
-  const max = opts.maxScenarios;
+  const max = opts.maxChainAlternatives;
 
   if (missing.length > 0) {
     scenarios.push({
@@ -1632,14 +1632,14 @@ export function generateOptionalSubShapeVariants(
   const subShapes = endpoint.optionalSubShapes ?? [];
   const collectionScenarios: EndpointScenario[] = [];
   const seenVariantKeys = new Set<string>();
-  // Cap total variants emitted per endpoint at `opts.maxScenarios`. The
+  // Cap total variants emitted per endpoint at `opts.maxChainAlternatives`. The
   // inner `generateScenariosForEndpoint` call below intentionally pins
-  // its own `maxScenarios: 1` (one chain per variant), so the outer
+  // its own `maxChainAlternatives: 1` (one chain per variant), so the outer
   // cap is what bounds variant count for endpoints with many
   // semantic-typed optional leaves. Without this cap, a future spec
   // change could blow up `dist/variant-output/` with one file per
   // (subShape × leaf) pair.
-  const maxVariants = Math.max(0, opts.maxScenarios | 0);
+  const maxVariants = Math.max(0, opts.maxChainAlternatives | 0);
 
   outer: for (const subShape of subShapes) {
     for (const leaf of subShape.leaves) {
@@ -1701,7 +1701,7 @@ export function generateOptionalSubShapeVariants(
         // (`<sem>_<suffix>`).
         const planned = generateScenariosForEndpoint(graph, endpointOpId, {
           ...opts,
-          maxScenarios: 1,
+          maxChainAlternatives: 1,
         });
         const baseScenario = planned.scenarios[0];
         if (!baseScenario || planned.unsatisfied) continue;
@@ -1832,7 +1832,7 @@ function tryProducerChainVariant(args: {
     ...opts,
     allowEndpointAsProducer: true,
     additionalNeeded: [...additional],
-    maxScenarios: 1,
+    maxChainAlternatives: 1,
   });
   const scenario = planned.scenarios[0];
   if (!scenario || planned.unsatisfied) return undefined;

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -16,6 +16,7 @@ import type {
   OperationGraph,
   OperationNode,
   OperationRef,
+  VariantGenerationOpts,
 } from './types.js';
 import { PENDING_BINDING } from './types.js';
 
@@ -1617,7 +1618,7 @@ function gatherDomainPrerequisites(
 export function generateOptionalSubShapeVariants(
   graph: OperationGraph,
   endpointOpId: string,
-  opts: GenerationOpts,
+  opts: VariantGenerationOpts,
 ): EndpointScenarioCollection {
   const endpoint = graph.operations[endpointOpId];
   if (!endpoint) {
@@ -1632,14 +1633,14 @@ export function generateOptionalSubShapeVariants(
   const subShapes = endpoint.optionalSubShapes ?? [];
   const collectionScenarios: EndpointScenario[] = [];
   const seenVariantKeys = new Set<string>();
-  // Cap total variants emitted per endpoint at `opts.maxChainAlternatives`. The
-  // inner `generateScenariosForEndpoint` call below intentionally pins
-  // its own `maxChainAlternatives: 1` (one chain per variant), so the outer
-  // cap is what bounds variant count for endpoints with many
+  // Cap total variants emitted per endpoint at `opts.maxVariantsPerEndpoint`.
+  // The inner `generateScenariosForEndpoint` calls below intentionally pin
+  // their own `maxChainAlternatives: 1` (one chain per variant), so this
+  // outer cap is what bounds variant count for endpoints with many
   // semantic-typed optional leaves. Without this cap, a future spec
   // change could blow up `dist/variant-output/` with one file per
   // (subShape × leaf) pair.
-  const maxVariants = Math.max(0, opts.maxChainAlternatives | 0);
+  const maxVariants = Math.max(0, opts.maxVariantsPerEndpoint | 0);
 
   outer: for (const subShape of subShapes) {
     for (const leaf of subShape.leaves) {
@@ -1771,7 +1772,7 @@ function tryProducerChainVariant(args: {
   graph: OperationGraph;
   endpoint: OperationNode;
   endpointOpId: string;
-  opts: GenerationOpts;
+  opts: VariantGenerationOpts;
   leaf: { fieldPath: string; semantic: string };
   producerCandidates: string[];
 }): EndpointScenario | undefined {

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -769,6 +769,22 @@ export interface ExtendedGenerationOpts {
 }
 
 /**
+ * Options consumed by `generateOptionalSubShapeVariants` (the variant
+ * suite emitter). Distinct from `ExtendedGenerationOpts` because the
+ * outer cap here bounds *variant scenarios per endpoint* (one per
+ * subShape × leaf pair), not chain alternatives — those are pinned to
+ * `maxChainAlternatives: 1` for every inner planner call. Splitting
+ * the option types (#288 Phase 3c review) keeps the two semantically
+ * distinct caps from sharing a misleading name.
+ */
+export interface VariantGenerationOpts {
+  maxVariantsPerEndpoint: number;
+  longChains?: LongChainConfig;
+  allowEndpointAsProducer?: boolean;
+  additionalNeeded?: string[];
+}
+
+/**
  * A model-spec entry describing one synthesized model the planner needs to
  * deploy as part of a scenario.
  *

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -761,7 +761,7 @@ export interface LongChainConfig {
 }
 
 export interface ExtendedGenerationOpts {
-  maxScenarios: number;
+  maxChainAlternatives: number;
   longChains?: LongChainConfig;
   // Issue #37: see scenarioGenerator GenerationOpts for semantics.
   allowEndpointAsProducer?: boolean;

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -421,7 +421,7 @@ const fixtureSubShapeVariant: OperationGraph = makeGraph([
 describe('planner contracts: optional sub-shape variants (#37)', () => {
   it('emits a variant scenario per sub-shape leaf with warm-up + producer + final', () => {
     const variants = generateOptionalSubShapeVariants(fixtureSubShapeVariant, 'createOrder', {
-      maxChainAlternatives: 10,
+      maxVariantsPerEndpoint: 10,
     });
     expect(variants.scenarios.length).toBeGreaterThan(0);
     const variant = variants.scenarios[0];
@@ -503,7 +503,7 @@ describe('planner contracts: variant planner respects success-status producer fi
     // 4xx-only producer must NOT appear in the chain — the variant has
     // exactly one operation (the endpoint itself).
     const variants = generateOptionalSubShapeVariants(fixtureErrorOnlyProducer, 'placeOrder', {
-      maxChainAlternatives: 10,
+      maxVariantsPerEndpoint: 10,
     });
     expect(variants.scenarios).toHaveLength(1);
     const [scenario] = variants.scenarios;
@@ -514,17 +514,17 @@ describe('planner contracts: variant planner respects success-status producer fi
 });
 
 // ---------------------------------------------------------------------------
-// Fixture J: variant planner caps emission at opts.maxChainAlternatives (#37)
+// Fixture J: variant planner caps emission at opts.maxVariantsPerEndpoint (#37)
 // ---------------------------------------------------------------------------
 //
 // Endpoint `bulkCreate` has THREE semantic-typed optional leaves under
 // the same sub-shape. Without the cap, the planner emits one variant
-// per leaf (3 variants). With `maxChainAlternatives: 2`, only the first 2 are
-// emitted.
+// per leaf (3 variants). With `maxVariantsPerEndpoint: 2`, only the first 2
+// are emitted.
 //
 // Class-scoped guarantee: a future endpoint with N semantic-typed
-// optional leaves cannot produce more than `opts.maxChainAlternatives` variant
-// scenario files.
+// optional leaves cannot produce more than `opts.maxVariantsPerEndpoint`
+// variant scenario files.
 const fixtureMaxVariantsCap: OperationGraph = makeGraph([
   makeOp('mintFoo', {
     produces: ['Foo'],
@@ -562,24 +562,24 @@ const fixtureMaxVariantsCap: OperationGraph = makeGraph([
   }),
 ]);
 
-describe('planner contracts: variant emission respects maxChainAlternatives cap (#37)', () => {
-  it('uncapped (maxChainAlternatives = 10) emits one variant per semantic leaf', () => {
+describe('planner contracts: variant emission respects maxVariantsPerEndpoint cap (#37)', () => {
+  it('uncapped (maxVariantsPerEndpoint = 10) emits one variant per semantic leaf', () => {
     const variants = generateOptionalSubShapeVariants(fixtureMaxVariantsCap, 'bulkCreate', {
-      maxChainAlternatives: 10,
+      maxVariantsPerEndpoint: 10,
     });
     expect(variants.scenarios.length).toBe(3);
   });
 
-  it('caps emission at maxChainAlternatives = 2', () => {
+  it('caps emission at maxVariantsPerEndpoint = 2', () => {
     const variants = generateOptionalSubShapeVariants(fixtureMaxVariantsCap, 'bulkCreate', {
-      maxChainAlternatives: 2,
+      maxVariantsPerEndpoint: 2,
     });
     expect(variants.scenarios.length).toBe(2);
   });
 
-  it('caps emission at maxChainAlternatives = 0 (emit nothing)', () => {
+  it('caps emission at maxVariantsPerEndpoint = 0 (emit nothing)', () => {
     const variants = generateOptionalSubShapeVariants(fixtureMaxVariantsCap, 'bulkCreate', {
-      maxChainAlternatives: 0,
+      maxVariantsPerEndpoint: 0,
     });
     expect(variants.scenarios).toEqual([]);
   });
@@ -702,7 +702,7 @@ describe('planner contracts: producerBound semantics must be __PENDING__ in bind
 describe('planner contracts: variant planner non-overlap producer fallback (#37)', () => {
   it('emits a producer→endpoint variant with no warm-up when the producer needs nothing from the endpoint', () => {
     const variants = generateOptionalSubShapeVariants(fixtureNonOverlapVariant, 'createOrder', {
-      maxChainAlternatives: 10,
+      maxVariantsPerEndpoint: 10,
     });
     expect(variants.scenarios.length).toBeGreaterThan(0);
     const variant = variants.scenarios[0];

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -84,7 +84,7 @@ function makeGraph(nodes: OperationNode[]): OperationGraph {
 }
 
 function plan(graph: OperationGraph, endpointOpId: string): EndpointScenarioCollection {
-  return generateScenariosForEndpoint(graph, endpointOpId, { maxScenarios: 10 });
+  return generateScenariosForEndpoint(graph, endpointOpId, { maxChainAlternatives: 10 });
 }
 
 function opIdsOf(scenario: { operations: { operationId: string }[] }): string[] {
@@ -421,7 +421,7 @@ const fixtureSubShapeVariant: OperationGraph = makeGraph([
 describe('planner contracts: optional sub-shape variants (#37)', () => {
   it('emits a variant scenario per sub-shape leaf with warm-up + producer + final', () => {
     const variants = generateOptionalSubShapeVariants(fixtureSubShapeVariant, 'createOrder', {
-      maxScenarios: 10,
+      maxChainAlternatives: 10,
     });
     expect(variants.scenarios.length).toBeGreaterThan(0);
     const variant = variants.scenarios[0];
@@ -503,7 +503,7 @@ describe('planner contracts: variant planner respects success-status producer fi
     // 4xx-only producer must NOT appear in the chain — the variant has
     // exactly one operation (the endpoint itself).
     const variants = generateOptionalSubShapeVariants(fixtureErrorOnlyProducer, 'placeOrder', {
-      maxScenarios: 10,
+      maxChainAlternatives: 10,
     });
     expect(variants.scenarios).toHaveLength(1);
     const [scenario] = variants.scenarios;
@@ -514,16 +514,16 @@ describe('planner contracts: variant planner respects success-status producer fi
 });
 
 // ---------------------------------------------------------------------------
-// Fixture J: variant planner caps emission at opts.maxScenarios (#37)
+// Fixture J: variant planner caps emission at opts.maxChainAlternatives (#37)
 // ---------------------------------------------------------------------------
 //
 // Endpoint `bulkCreate` has THREE semantic-typed optional leaves under
 // the same sub-shape. Without the cap, the planner emits one variant
-// per leaf (3 variants). With `maxScenarios: 2`, only the first 2 are
+// per leaf (3 variants). With `maxChainAlternatives: 2`, only the first 2 are
 // emitted.
 //
 // Class-scoped guarantee: a future endpoint with N semantic-typed
-// optional leaves cannot produce more than `opts.maxScenarios` variant
+// optional leaves cannot produce more than `opts.maxChainAlternatives` variant
 // scenario files.
 const fixtureMaxVariantsCap: OperationGraph = makeGraph([
   makeOp('mintFoo', {
@@ -562,24 +562,24 @@ const fixtureMaxVariantsCap: OperationGraph = makeGraph([
   }),
 ]);
 
-describe('planner contracts: variant emission respects maxScenarios cap (#37)', () => {
-  it('uncapped (maxScenarios = 10) emits one variant per semantic leaf', () => {
+describe('planner contracts: variant emission respects maxChainAlternatives cap (#37)', () => {
+  it('uncapped (maxChainAlternatives = 10) emits one variant per semantic leaf', () => {
     const variants = generateOptionalSubShapeVariants(fixtureMaxVariantsCap, 'bulkCreate', {
-      maxScenarios: 10,
+      maxChainAlternatives: 10,
     });
     expect(variants.scenarios.length).toBe(3);
   });
 
-  it('caps emission at maxScenarios = 2', () => {
+  it('caps emission at maxChainAlternatives = 2', () => {
     const variants = generateOptionalSubShapeVariants(fixtureMaxVariantsCap, 'bulkCreate', {
-      maxScenarios: 2,
+      maxChainAlternatives: 2,
     });
     expect(variants.scenarios.length).toBe(2);
   });
 
-  it('caps emission at maxScenarios = 0 (emit nothing)', () => {
+  it('caps emission at maxChainAlternatives = 0 (emit nothing)', () => {
     const variants = generateOptionalSubShapeVariants(fixtureMaxVariantsCap, 'bulkCreate', {
-      maxScenarios: 0,
+      maxChainAlternatives: 0,
     });
     expect(variants.scenarios).toEqual([]);
   });
@@ -702,7 +702,7 @@ describe('planner contracts: producerBound semantics must be __PENDING__ in bind
 describe('planner contracts: variant planner non-overlap producer fallback (#37)', () => {
   it('emits a producer→endpoint variant with no warm-up when the producer needs nothing from the endpoint', () => {
     const variants = generateOptionalSubShapeVariants(fixtureNonOverlapVariant, 'createOrder', {
-      maxScenarios: 10,
+      maxChainAlternatives: 10,
     });
     expect(variants.scenarios.length).toBeGreaterThan(0);
     const variant = variants.scenarios[0];

--- a/tests/fixtures/planner/planner-establishes.test.ts
+++ b/tests/fixtures/planner/planner-establishes.test.ts
@@ -308,7 +308,7 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
   describe('simple establisher chain (createUser → getUser)', () => {
     it('produces a satisfied chain whose first step is the establisher', () => {
       const result = generateScenariosForEndpoint(fixtureSimpleEstablisherChain, 'getUser', {
-        maxScenarios: 10,
+        maxChainAlternatives: 10,
       });
       expect(result.unsatisfied).toBeFalsy();
       expect(result.scenarios.length).toBeGreaterThan(0);
@@ -318,7 +318,7 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
 
     it('seeds a shared usernameVar binding consumed by both steps', () => {
       const result = generateScenariosForEndpoint(fixtureSimpleEstablisherChain, 'getUser', {
-        maxScenarios: 10,
+        maxChainAlternatives: 10,
       });
       const scenario = result.scenarios[0];
       expect(scenario.bindings).toBeDefined();
@@ -335,7 +335,7 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
   describe('establisher endpoint plans the trivial chain', () => {
     it('createUser as endpoint plans without chasing a producer for its own Username', () => {
       const result = generateScenariosForEndpoint(fixtureSimpleEstablisherChain, 'createUser', {
-        maxScenarios: 10,
+        maxChainAlternatives: 10,
       });
       expect(result.unsatisfied).toBeFalsy();
       expect(result.scenarios.length).toBeGreaterThan(0);
@@ -350,7 +350,7 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
       const result = generateScenariosForEndpoint(
         fixtureCompositeEstablisherChain,
         'getTenantClusterVariable',
-        { maxScenarios: 10 },
+        { maxChainAlternatives: 10 },
       );
       expect(result.unsatisfied).toBeFalsy();
       const ops = opIdsOf(result.scenarios[0]);
@@ -361,7 +361,7 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
       const result = generateScenariosForEndpoint(
         fixtureCompositeEstablisherChain,
         'getTenantClusterVariable',
-        { maxScenarios: 10 },
+        { maxChainAlternatives: 10 },
       );
       const bindings = result.scenarios[0].bindings ?? {};
       expect(bindings.tenantIdVar).toBeDefined();
@@ -374,7 +374,7 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
       const result = generateScenariosForEndpoint(
         fixtureEdgeRequiresComponentChains,
         'assignUserToGroup',
-        { maxScenarios: 10 },
+        { maxChainAlternatives: 10 },
       );
       expect(result.unsatisfied).toBeFalsy();
       const ops = opIdsOf(result.scenarios[0]);
@@ -401,7 +401,7 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
   describe('placeholder-name mismatch (establisher mints `username`, consumer uses `{userKey}`)', () => {
     it('aliases the establisher value under the consumer-derived path-placeholder var', () => {
       const result = generateScenariosForEndpoint(fixturePlaceholderNameMismatch, 'getUserByKey', {
-        maxScenarios: 10,
+        maxChainAlternatives: 10,
       });
       expect(result.unsatisfied).toBeFalsy();
       expect(result.scenarios.length).toBeGreaterThan(0);
@@ -429,7 +429,7 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
       const result = generateScenariosForEndpoint(
         fixtureBodyCollisionSameName,
         'linkThingToWidget',
-        { maxScenarios: 10 },
+        { maxChainAlternatives: 10 },
       );
       // No satisfied chain should contain BOTH establishers — that
       // would imply they shared the `nameVar` slot.
@@ -446,7 +446,7 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
       const result = generateScenariosForEndpoint(
         fixturePathSuffixSameName,
         'linkThingToWidgetByIds',
-        { maxScenarios: 10 },
+        { maxChainAlternatives: 10 },
       );
       expect(result.unsatisfied).toBeFalsy();
       const scenario = result.scenarios.find((s) => {
@@ -477,7 +477,7 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
       const result = generateScenariosForEndpoint(
         fixtureAliasPollutionAcrossEndpoints,
         'assignUserToRole',
-        { maxScenarios: 20 },
+        { maxChainAlternatives: 20 },
       );
       expect(result.unsatisfied).toBeFalsy();
       const satisfied = result.scenarios.find((s) => {
@@ -603,7 +603,7 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
 
     it('mints a client-side GroupId and tags externalEntitySites when no producer exists', () => {
       const result = generateScenariosForEndpoint(fixtureBimodalNoProducer, 'assignGroupToRole', {
-        maxScenarios: 10,
+        maxChainAlternatives: 10,
       });
       expect(result.unsatisfied).toBeFalsy();
       const scenario = result.scenarios[0];
@@ -617,7 +617,7 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
 
     it('prefers the in-graph producer when one exists (no regression, no externalEntitySites tag)', () => {
       const result = generateScenariosForEndpoint(fixtureBimodalWithProducer, 'assignGroupToRole', {
-        maxScenarios: 10,
+        maxChainAlternatives: 10,
       });
       expect(result.unsatisfied).toBeFalsy();
       const scenario = result.scenarios[0];
@@ -635,7 +635,7 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
       const result = generateScenariosForEndpoint(
         fixturePartialBimodalNoProducers,
         'assignUserToGroup',
-        { maxScenarios: 10 },
+        { maxChainAlternatives: 10 },
       );
       // Username has no producer/establisher AND is not flagged
       // bimodal — the scenario must be unsatisfied with Username
@@ -686,7 +686,7 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
         externalEntityIdentifiers: new Set(['ClientId']),
       };
       const result = generateScenariosForEndpoint(fixtureKindScoped, 'assignRoleToClient', {
-        maxScenarios: 10,
+        maxChainAlternatives: 10,
       });
       expect(result.unsatisfied).toBeFalsy();
       const scenario = result.scenarios[0];
@@ -711,7 +711,7 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
       const result = generateScenariosForEndpoint(
         fixtureAliasPollutionAcrossEndpoints,
         'assignUserToRole',
-        { maxScenarios: 20 },
+        { maxChainAlternatives: 20 },
       );
       const satisfied = result.scenarios.find((s) => {
         const ops = opIdsOf(s);
@@ -738,7 +738,7 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
       // producers only" — establishers must stay in `establishersByType`.
       const graph = fixtureSimpleEstablisherChain;
       const beforeUsername = [...(graph.producersByType.Username ?? [])];
-      generateScenariosForEndpoint(graph, 'getUser', { maxScenarios: 10 });
+      generateScenariosForEndpoint(graph, 'getUser', { maxChainAlternatives: 10 });
       const afterUsername = graph.producersByType.Username ?? [];
       // The establisher (`createUser`) must NOT have leaked into the
       // global producer index for Username.


### PR DESCRIPTION
Phase 3c (final slice) of the parallel-scenario-builder unification tracked by #288. Closes the loop with #292 by clarifying cap intent at code call-sites. Behaviour-preserving against PR #296 — `generated/` is byte-identical modulo timestamps.

## What this PR does

### Delete the dead 90-cap
`MAX_FEATURE_SCENARIOS = 90` and its `.slice()` clamp in `path-analyser/src/index.ts` were structurally unreachable: `generateFeatureCoverageForEndpoint` already truncates internally at `maxVariantOverlays ?? 35`, so the outer 90-cap could never fire. Removing it leaves a single, well-named per-endpoint bound.

### Rename caps for intent
`maxScenarios` and `maxScenariosPerEndpoint` had visually similar names but encoded different things (chain alternatives vs variant overlays). Renamed at the source of truth:

| Old | New | Meaning |
|---|---|---|
| `maxScenarios` | `maxChainAlternatives` | Max integration chains the BFS planner enumerates per endpoint |
| `maxScenariosPerEndpoint` | `maxVariantOverlays` | Max variant overlays generated per endpoint |

Touches `ScenarioOptions` / `ExtendedGenerationOpts` / `GenerationOpts`, `FeatureCoverageOptions`, all call-sites in `index.ts` and `featureCoverageGenerator.ts`, the Phase 0 L3 invariant, and Layer-2 planner fixture tests.

### Update the L3 invariant
`configs/camunda-oca/regression-invariants.test.ts` now asserts against `maxVariantOverlays` (35) instead of the dead `MAX_FEATURE_SCENARIOS` (90), with a forward-pointing comment for #292.

## Hand-off to #292

#292 will lift these caps into per-config metadata. With the names now meaningful at the code surface, #292 can mirror them as `planner.maxChainAlternatives` / `planner.maxVariantOverlays` in `configs.json` (or pick its own user-facing names, but at least the internal constants no longer mislead readers).

## Verification

```
npm run lint                                          # ✓
npx tsc --noEmit (all 6 workspace tsconfigs)         # ✓
TEST_SEED=snapshot-baseline npm run testsuite:generate
npm run generate:request-validation
npx vitest run                                       # 547 passed | 2 skipped
```

`generated/` diff against Phase 3b (PR #296) is empty modulo two `generatedAt` timestamps in `scenarios/index.json` and `playwright/json-body-assertions/responses.json`.

## Phase 3 summary (3a + 3b + 3c)

- **3a (PR #295, merged)**: introduce `canonicalByEndpoint` cache + equivalence assertion.
- **3b (PR #296, merged)**: switch feature + template emitters to read from the cache; delete post-hoc patching paths.
- **3c (this PR)**: delete the now-unreachable outer 90-cap and rename caps for intent.

Closes #288. Hands off to #292 for the per-config cap lift.