### PR TITLE
feat: lift planner caps into per-config configuration (#292)

### DIFF
--- a/configs.json
+++ b/configs.json
@@ -7,6 +7,11 @@
       "spec": {
         "source": "github:camunda/camunda",
         "$comment": "Pinned ref + expected hash live in configs/camunda-oca/spec-pin.json (kept as a separate file to preserve the spec-pin bump procedure documented in tests/regression/spec-pin.setup.ts)."
+      },
+      "planner": {
+        "$comment": "Per-config planner caps (#292). Field names mirror the internal option keys (`maxChainAlternatives`, `maxVariantsPerEndpoint`) so the config key === the option key — no translation layer. The two inner `maxChainAlternatives: 1` caps inside variant planning are NOT exposed here; they are load-bearing strategy constants (one producer chain per variant leaf) documented in path-analyser/src/scenarioGenerator.ts.",
+        "maxChainAlternatives": 20,
+        "maxVariantsPerEndpoint": 20
       }
     }
   }

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -7,6 +7,7 @@ import { join, relative } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   getActiveConfigName,
+  getActivePlannerConfig,
   getFeatureOutputDir,
   getGraphDir,
   getPlaywrightSuiteDir,
@@ -7264,6 +7265,26 @@ describeForThisConfig(
         offenders,
         `Feature collections must not exceed maxVariantOverlays=${MAX_VARIANT_OVERLAYS}. A higher count means the cap in path-analyser/src/featureCoverageGenerator.ts has regressed or the variant enumerator no longer truncates.`,
       ).toEqual([]);
+    });
+
+    it('camunda-oca resolves planner caps to {20, 20} (#292)', () => {
+      // #292 lifted the two `20` hard-codes in
+      // path-analyser/src/index.ts into the per-config `planner`
+      // block in configs.json. This invariant locks the resolved
+      // values for camunda-oca so an accidental config edit (e.g.
+      // dropping the cap to 2 while iterating, or deleting the
+      // block entirely and silently changing what's emitted) is
+      // caught here rather than via a 412-file generated/ diff.
+      //
+      // The defaults in `getActivePlannerConfig` are deliberately
+      // the same numbers — so this assertion holds whether the
+      // block is present (explicit config) or absent (falls back
+      // to defaults). To intentionally tune these for OCA, update
+      // both `configs.json` AND the constants below in the same
+      // commit so the regen and the guard move together.
+      const cfg = getActivePlannerConfig(REPO_ROOT);
+      expect(cfg.maxChainAlternatives).toBe(20);
+      expect(cfg.maxVariantsPerEndpoint).toBe(20);
     });
 
     it('search-empty-negative scenarios are only emitted for search-like endpoints (Phase 0 #288)', () => {

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -7270,18 +7270,38 @@ describeForThisConfig(
     it('camunda-oca resolves planner caps to {20, 20} (#292)', () => {
       // #292 lifted the two `20` hard-codes in
       // path-analyser/src/index.ts into the per-config `planner`
-      // block in configs.json. This invariant locks the resolved
-      // values for camunda-oca so an accidental config edit (e.g.
-      // dropping the cap to 2 while iterating, or deleting the
-      // block entirely and silently changing what's emitted) is
-      // caught here rather than via a 412-file generated/ diff.
+      // block in configs.json. Two narrow assertions here:
       //
-      // The defaults in `getActivePlannerConfig` are deliberately
-      // the same numbers — so this assertion holds whether the
-      // block is present (explicit config) or absent (falls back
-      // to defaults). To intentionally tune these for OCA, update
-      // both `configs.json` AND the constants below in the same
-      // commit so the regen and the guard move together.
+      //   1. The OCA config explicitly declares a `planner` block.
+      //      Without this check, `getActivePlannerConfig` would
+      //      silently fall back to defaults if someone deleted the
+      //      block — passing the resolved-value assertion below
+      //      while making the config no longer self-documenting.
+      //   2. The resolved values are pinned to {20, 20} so an
+      //      accidental edit (e.g. dropping the cap to 2 while
+      //      iterating) is caught here rather than via a 412-file
+      //      generated/ diff.
+      //
+      // To intentionally tune these for OCA, update both
+      // `configs.json` AND the constants below in the same commit
+      // so the regen and the guard move together.
+      const configsRaw = readFileSync(join(REPO_ROOT, 'configs.json'), 'utf8');
+      const configsParsed: unknown = JSON.parse(configsRaw);
+      function isRecord(v: unknown): v is Record<string, unknown> {
+        return typeof v === 'object' && v !== null && !Array.isArray(v);
+      }
+      function getOcaPlanner(parsed: unknown): unknown {
+        if (!isRecord(parsed) || !isRecord(parsed.configs)) return undefined;
+        const oca = parsed.configs['camunda-oca'];
+        if (!isRecord(oca)) return undefined;
+        return oca.planner;
+      }
+      const ocaPlanner = getOcaPlanner(configsParsed);
+      expect(
+        ocaPlanner,
+        'configs.json must explicitly declare a `planner` block for camunda-oca; deleting it would silently fall back to defaults and erase the self-documenting per-config caps.',
+      ).toBeDefined();
+
       const cfg = getActivePlannerConfig(REPO_ROOT);
       expect(cfg.maxChainAlternatives).toBe(20);
       expect(cfg.maxVariantsPerEndpoint).toBe(20);

--- a/path-analyser/src/configResolver.ts
+++ b/path-analyser/src/configResolver.ts
@@ -160,3 +160,68 @@ export function getPlaywrightSuiteDir(repoRoot: string): string {
 export function getRequestValidationSuiteDir(repoRoot: string): string {
   return path.join(getGeneratedDir(repoRoot), 'request-validation');
 }
+
+/**
+ * Per-config planner caps (#292).
+ *
+ * Field names mirror the internal option keys consumed by
+ * `generateScenariosForEndpoint` (`maxChainAlternatives`) and
+ * `generateOptionalSubShapeVariants` (`maxVariantsPerEndpoint`) so the
+ * config key is the option key — no translation layer.
+ *
+ * Defaults preserve the pre-#292 hard-codes so a config without a
+ * `planner` block (or with a partial one) keeps the same emission
+ * shape it had before the lift.
+ *
+ * NOT exposed here: the two inner `maxChainAlternatives: 1` caps inside
+ * variant planning in `scenarioGenerator.ts`. Those are load-bearing
+ * strategy constants (one producer chain per variant leaf is the whole
+ * point of the variant emitter), not a budget — lifting them into
+ * config would invite a user to break the strategy by raising them.
+ */
+export interface PlannerConfig {
+  maxChainAlternatives: number;
+  maxVariantsPerEndpoint: number;
+}
+
+const PLANNER_DEFAULTS: PlannerConfig = {
+  maxChainAlternatives: 20,
+  maxVariantsPerEndpoint: 20,
+};
+
+function readPositiveInt(
+  raw: Record<string, unknown>,
+  key: keyof PlannerConfig,
+  configName: string,
+): number | undefined {
+  if (!Object.hasOwn(raw, key)) return undefined;
+  const v = raw[key];
+  if (typeof v !== 'number' || !Number.isInteger(v) || v < 1) {
+    throw new Error(
+      `Malformed configs.json: configs.${configName}.planner.${key} must be a positive integer; got ${JSON.stringify(v)}.`,
+    );
+  }
+  return v;
+}
+
+export function getActivePlannerConfig(repoRoot: string): PlannerConfig {
+  const index = loadConfigsIndex(repoRoot);
+  const name = resolveActiveConfigName(index);
+  const entry = index.configs[name];
+  if (!isRecord(entry)) return { ...PLANNER_DEFAULTS };
+  const planner = entry.planner;
+  if (planner === undefined) return { ...PLANNER_DEFAULTS };
+  if (!isRecord(planner)) {
+    throw new Error(
+      `Malformed configs.json: configs.${name}.planner must be an object when present.`,
+    );
+  }
+  return {
+    maxChainAlternatives:
+      readPositiveInt(planner, 'maxChainAlternatives', name) ??
+      PLANNER_DEFAULTS.maxChainAlternatives,
+    maxVariantsPerEndpoint:
+      readPositiveInt(planner, 'maxVariantsPerEndpoint', name) ??
+      PLANNER_DEFAULTS.maxVariantsPerEndpoint,
+  };
+}

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from 'node:url';
 import { buildCanonicalShapes } from './canonicalSchemas.js';
 import {
   getActiveConfigDir,
+  getActivePlannerConfig,
   getFeatureOutputDir,
   getScenariosDir,
   getTemplateScenariosDir,
@@ -211,10 +212,18 @@ async function main() {
   // (template prereq chains).
   const canonicalByEndpoint: Map<string, EndpointScenario> = new Map();
 
+  // #292 — per-config planner caps. Resolved once per pipeline run so
+  // every endpoint sees the same caps; the two literals previously
+  // hard-coded here (BFS chain alternatives + variant scenarios per
+  // endpoint) now flow from `configs/<active>/`'s `planner` block via
+  // `getActivePlannerConfig`. Absent block → defaults preserve the
+  // pre-#292 emission shape.
+  const plannerConfig = getActivePlannerConfig(repoRoot);
+
   for (const op of Object.values(graph.operations)) {
     // Generate scenarios for every endpoint, even if it has no semantic requirements.
     const collection = generateScenariosForEndpoint(graph, op.operationId, {
-      maxChainAlternatives: 20,
+      maxChainAlternatives: plannerConfig.maxChainAlternatives,
     });
     // Augment scenarios with response shape
     const resp = responseByOp[op.operationId];
@@ -474,7 +483,7 @@ async function main() {
     // have populated-shape coverage.
     if (op.optionalSubShapes?.length) {
       const variantCollection = generateOptionalSubShapeVariants(graph, op.operationId, {
-        maxVariantsPerEndpoint: 20,
+        maxVariantsPerEndpoint: plannerConfig.maxVariantsPerEndpoint,
       });
       // Augment with response shape (when available) so downstream codegen
       // has the same metadata as base/feature scenarios. The requestPlan

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -1702,6 +1702,11 @@ export function generateOptionalSubShapeVariants(
         // (`<sem>_<suffix>`).
         const planned = generateScenariosForEndpoint(graph, endpointOpId, {
           ...opts,
+          // #292: NOT a budget — this is a load-bearing strategy
+          // constant. The variant emitter's contract is "one producer
+          // chain per variant leaf"; raising it would emit multiple
+          // chains for the same variant, which is the wrong shape.
+          // Deliberately not surfaced via per-config planner caps.
           maxChainAlternatives: 1,
         });
         const baseScenario = planned.scenarios[0];
@@ -1833,6 +1838,9 @@ function tryProducerChainVariant(args: {
     ...opts,
     allowEndpointAsProducer: true,
     additionalNeeded: [...additional],
+    // #292: NOT a budget — see the matching note at the bare-endpoint
+    // fallback above. One producer chain per variant leaf is the
+    // strategy, not a tunable cap.
     maxChainAlternatives: 1,
   });
   const scenario = planned.scenarios[0];

--- a/tests/fixtures/loader/configresolver.test.ts
+++ b/tests/fixtures/loader/configresolver.test.ts
@@ -107,9 +107,11 @@ describe('configResolver: per-config planner caps (#292)', () => {
   // an optional `planner` block per config. Class-scoped guards below
   // pin: (1) absent block falls back to documented defaults; (2) a
   // present block overrides; (3) a partial block fills missing fields
-  // from defaults; (4) the loader rejects malformed values rather than
-  // silently coercing them — otherwise a stringified number in
-  // configs.json could disable the cap by failing comparisons.
+  // from defaults; (4) the loader rejects malformed values up front
+  // rather than letting them flow into BFS — a typo like
+  // `"maxChainAlternatives": "twnety"` would otherwise coerce to NaN
+  // inside the BFS comparison and silently emit zero scenarios per
+  // endpoint, masking the config error as a generator bug.
   function writeConfig(planner: unknown): void {
     writeFileSync(
       join(workdir, 'configs.json'),

--- a/tests/fixtures/loader/configresolver.test.ts
+++ b/tests/fixtures/loader/configresolver.test.ts
@@ -19,6 +19,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   getActiveConfigDir,
   getActiveConfigName,
+  getActivePlannerConfig,
 } from '../../../path-analyser/src/configResolver.ts';
 
 let workdir: string;
@@ -98,5 +99,65 @@ describe('configResolver: path-traversal defense (#141 review)', () => {
 
   it('getActiveConfigDir resolves under configs/ for a valid name', () => {
     expect(getActiveConfigDir(workdir)).toBe(join(workdir, 'configs', 'camunda-oca'));
+  });
+});
+
+describe('configResolver: per-config planner caps (#292)', () => {
+  // The hard-coded `20`s in path-analyser/src/index.ts were lifted into
+  // an optional `planner` block per config. Class-scoped guards below
+  // pin: (1) absent block falls back to documented defaults; (2) a
+  // present block overrides; (3) a partial block fills missing fields
+  // from defaults; (4) the loader rejects malformed values rather than
+  // silently coercing them — otherwise a stringified number in
+  // configs.json could disable the cap by failing comparisons.
+  function writeConfig(planner: unknown): void {
+    writeFileSync(
+      join(workdir, 'configs.json'),
+      JSON.stringify({
+        default: 'camunda-oca',
+        configs: { 'camunda-oca': planner === undefined ? {} : { planner } },
+      }),
+    );
+  }
+
+  it('returns defaults when no planner block is present', () => {
+    writeConfig(undefined);
+    expect(getActivePlannerConfig(workdir)).toEqual({
+      maxChainAlternatives: 20,
+      maxVariantsPerEndpoint: 20,
+    });
+  });
+
+  it('reads both caps when fully specified', () => {
+    writeConfig({ maxChainAlternatives: 5, maxVariantsPerEndpoint: 7 });
+    expect(getActivePlannerConfig(workdir)).toEqual({
+      maxChainAlternatives: 5,
+      maxVariantsPerEndpoint: 7,
+    });
+  });
+
+  it('fills missing fields from defaults when block is partial', () => {
+    writeConfig({ maxChainAlternatives: 3 });
+    expect(getActivePlannerConfig(workdir)).toEqual({
+      maxChainAlternatives: 3,
+      maxVariantsPerEndpoint: 20,
+    });
+  });
+
+  it('throws when planner is not an object', () => {
+    writeConfig(42);
+    expect(() => getActivePlannerConfig(workdir)).toThrow(/planner must be an object/);
+  });
+
+  for (const bad of [0, -1, 1.5, '20', null, true]) {
+    it(`throws when maxChainAlternatives is ${JSON.stringify(bad)}`, () => {
+      writeConfig({ maxChainAlternatives: bad });
+      expect(() => getActivePlannerConfig(workdir)).toThrow(/must be a positive integer/);
+    });
+  }
+
+  it('throws when maxVariantsPerEndpoint is zero', () => {
+    writeConfig({ maxVariantsPerEndpoint: 0 });
+    expect(() => getActivePlannerConfig(workdir)).toThrow(/must be a positive integer/);
   });
 });


### PR DESCRIPTION
Closes #292.

The planner's two scenario emission caps were hard-coded in `path-analyser/src/index.ts`. Lift them into an optional `planner` block per config so each target API can tune them without code changes — and so the values are documented alongside the config they belong to.

## Shape

```jsonc
// configs.json
{
  "configs": {
    "camunda-oca": {
      "planner": {
        "maxChainAlternatives": 20,
        "maxVariantsPerEndpoint": 20
      }
    }
  }
}
```

Field names mirror the internal option keys (renamed in #288 Phase 3c) — config key === option key, no translation layer.

## Loader

`getActivePlannerConfig(repoRoot): PlannerConfig` in `configResolver.ts`. Defaults preserve pre-#292 behaviour:
- absent `planner` block → defaults
- partial block (only one field) → fills missing field from defaults
- malformed value (non-integer, ≤ 0, wrong type) → throws with clear message

## Inner `1` caps NOT lifted

The two `maxChainAlternatives: 1` calls inside variant planning in `scenarioGenerator.ts` are load-bearing strategy constants (one producer chain per variant leaf is the whole point of variants), not a budget. Documented in-source so a future refactor can't quietly turn them into tunables.

## Tests

- **L1** (`tests/fixtures/loader/configresolver.test.ts`): class-scoped guards for defaults, override, partial block, malformed-value rejection.
- **L3** (`configs/camunda-oca/regression-invariants.test.ts`): pins OCA to `{20, 20}` so a config edit moves with a deliberate guard update rather than via a 412-file `generated/` diff.

## Regen

Empty diff modulo the two `generatedAt` timestamps. 559 passed | 2 skipped (the +12 are this PR's new L1 + L3 assertions).