### PR TITLE
refactor: unify Playwright ctx-seeding through emitCtxSeeding helper (#286)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1352,6 +1352,63 @@ describeForThisConfig('bundled-spec invariants: planner variant output (#37)', (
 });
 
 describeForThisConfig('bundled-spec invariants: emitted Playwright suite', () => {
+  it('no emitted Playwright suite uses the legacy `=== undefined` guard around `seedBinding(` (#286)', () => {
+    // Class-scoped guard for the #286 normalisation. Pre-#286 the
+    // per-scenario seedBindings loop in BOTH emitters emitted
+    //
+    //   if (ctx['<k>'] === undefined) { ctx['<k>'] = seedBinding('<k>'); }
+    //
+    // while the universal-seed prologue used the terse `??` form.
+    // #286 collapses both paths through `materializer/src/playwright/
+    // ctxSeeding.ts` and emits the `??` form uniformly. This
+    // invariant rejects any reappearance of the verbose form across
+    // every emitted suite — feature, variant, AND lifecycle (entities/
+    // and edges/ subdirectories) — so a future emitter contributor
+    // who copies the old shape (or biome:fix-generated rewriting a
+    // `??` into `if`) is caught by the regen, not by review.
+    if (!existsSync(GENERATED_TESTS_DIR)) {
+      throw new Error(
+        `Generated tests directory not found at ${GENERATED_TESTS_DIR}. Run 'npm run testsuite:generate' first.`,
+      );
+    }
+    function* walkSpecs(dir: string): Generator<string> {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          yield* walkSpecs(full);
+        } else if (entry.isFile() && entry.name.endsWith('.spec.ts')) {
+          yield full;
+        }
+      }
+    }
+    // Matches both the single-line form (`if (ctx['x'] === undefined)
+    // { ctx['x'] = seedBinding('x'); }`) and the multi-line form the
+    // template emitter used pre-#286 (`if (ctx['x'] === undefined) {\n
+    // ctx['x'] = seedBinding('x');\n }`). The `[\s\S]*?` allows the
+    // newline-separated body without depending on the `s` flag.
+    const legacyPattern = /===\s*undefined[\s\S]*?seedBinding\s*\(/;
+    const offenders: string[] = [];
+    for (const full of walkSpecs(GENERATED_TESTS_DIR)) {
+      const src = readFileSync(full, 'utf8');
+      // Restrict the search to spans that wouldn't accidentally
+      // match unrelated `=== undefined` checks followed by a seed
+      // many lines later: take the body line by line and only flag
+      // matches within a 3-line sliding window.
+      const lines = src.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        const window = lines.slice(i, i + 3).join('\n');
+        if (legacyPattern.test(window) && window.includes('ctx[')) {
+          offenders.push(`${relative(REPO_ROOT, full)}:${i + 1}`);
+          break;
+        }
+      }
+    }
+    expect(
+      offenders,
+      'Every emitted Playwright suite must seed bindings via the terse `??` form (#286). The legacy `=== undefined` guard means an emitter regressed to the pre-#286 shape; both `materializer/src/playwright/emitter.ts` and `templateEmitter.ts` must call `emitCtxSeeding` from `materializer/src/playwright/ctxSeeding.ts`.',
+    ).toEqual([]);
+  });
+
   it('no generated test contains a stray __invalidEnum sentinel object (#39)', () => {
     // Layer-3 mirror of the targeted enum-violation test in
     // tests/request-validation/. Catches any future analyser that

--- a/materializer/src/playwright/ctxSeeding.ts
+++ b/materializer/src/playwright/ctxSeeding.ts
@@ -1,0 +1,96 @@
+/**
+ * Single source of truth for `ctx`-seeding lines in emitted Playwright
+ * suites (#286).
+ *
+ * Two emitters write the seed prologue at the top of every test body:
+ *  - `emitter.ts`             — per-endpoint feature / variant suites
+ *  - `templateEmitter.ts`     — entity / edge lifecycle suites
+ *
+ * Pre-#286 the two sites grew the same logic independently and drifted
+ * on (a) the per-scenario `seedBindings` form (`=== undefined` vs `??`)
+ * and (b) the ordering of literals, seedBindings, and the universal-
+ * seed prologue. The ordering drift was a latent bug: in
+ * `templateEmitter.ts` a literal emitted AFTER the prologue would have
+ * clobbered a `??`-seeded global if any scenario ever had a literal
+ * whose name collided with a `globalContextSeeds` entry — the only
+ * reason that never surfaced is that no scenario today has such a
+ * collision.
+ *
+ * Canonical emission order (applied uniformly by both emitters):
+ *
+ *   1. Literal bindings from `scenario.bindings` (skip `PENDING_BINDING`).
+ *   2. Per-scenario `seedBindings` (filtered against globalSeedNames so
+ *      a binding handled by the prologue is not also seeded here).
+ *   3. Universal-seed prologue from `globalContextSeeds`.
+ *
+ * Every seeded line uses the terse `??` form:
+ *
+ *   ctx['<k>'] = ctx['<k>'] ?? seedBinding('<rule>');
+ *
+ * `??` is safe at every step because (1) literals are emitted first
+ * and a defined value short-circuits `??`, (2) `seedBindings` and the
+ * prologue are mutually exclusive (the `globalSeedNames` filter
+ * removes the overlap), (3) literals that happen to share a name with
+ * a prologue entry survive the prologue unchanged (again — `??` short-
+ * circuits on any defined value, including the empty string and `0`).
+ *
+ * `null` is NOT preserved: a literal `ctx['x'] = null` will be re-
+ * seeded by a later prologue or seedBindings entry. The planner does
+ * not emit `null` literals for any seeded binding today; if a future
+ * planner change ever needs `null` to be distinct from "missing",
+ * tighten back to `=== undefined` HERE (so both emitters move
+ * together) rather than at the call sites.
+ */
+
+import { PENDING_BINDING } from 'path-analyser/types';
+
+/**
+ * Subset of {@link GlobalContextSeed} consumed by this helper. The
+ * `templateEmitter` only knows about `binding` + `seedRule`; the
+ * per-endpoint emitter consumes a richer shape (multipart sentinel
+ * locals etc.) but emits those locals separately, after the helper.
+ */
+export interface CtxSeedingGlobal {
+  readonly binding: string;
+  readonly seedRule: string;
+}
+
+export interface EmitCtxSeedingOptions {
+  /** Per-line indent. Two spaces for `emitter.ts`, four for `templateEmitter.ts`. */
+  indent: string;
+  /** Scenario's literal bindings; `PENDING_BINDING` values are skipped. */
+  bindings: Readonly<Record<string, unknown>> | undefined;
+  /** Planner-driven seed names. Already-known globals are filtered out internally. */
+  seedBindings: readonly string[] | undefined;
+  /** Universal-seed prologue entries (the ABox-driven list). */
+  globalContextSeeds: readonly CtxSeedingGlobal[];
+}
+
+export function emitCtxSeeding(opts: EmitCtxSeedingOptions): string[] {
+  const { indent, bindings, seedBindings, globalContextSeeds } = opts;
+  const lines: string[] = [];
+  const globalSeedNames = new Set(globalContextSeeds.map((s) => s.binding));
+
+  const literalEntries = bindings
+    ? Object.entries(bindings).filter(([, v]) => v !== PENDING_BINDING)
+    : [];
+  const seedNames = (seedBindings ?? []).filter((n) => !globalSeedNames.has(n));
+
+  if (literalEntries.length > 0 || seedNames.length > 0) {
+    lines.push(`${indent}// Seed scenario bindings`);
+    for (const [k, v] of literalEntries) {
+      lines.push(`${indent}ctx['${k}'] = ${JSON.stringify(v)};`);
+    }
+    for (const name of seedNames) {
+      lines.push(`${indent}ctx['${name}'] = ctx['${name}'] ?? seedBinding('${name}');`);
+    }
+  }
+
+  for (const seed of globalContextSeeds) {
+    lines.push(
+      `${indent}ctx['${seed.binding}'] = ctx['${seed.binding}'] ?? seedBinding('${seed.seedRule}');`,
+    );
+  }
+
+  return lines;
+}

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -13,8 +13,8 @@ import type {
   GlobalContextSeed,
   RequestStep,
 } from 'path-analyser/types';
-import { PENDING_BINDING } from 'path-analyser/types';
 import type { ImportsTemplateScope, PlaywrightRoleScope } from '../roles.js';
+import { emitCtxSeeding } from './ctxSeeding.js';
 import {
   loadProjectScaffoldingFiles,
   materializeFixtures,
@@ -443,68 +443,26 @@ function renderScenarioTest(
   //      the global-context-seeds ABox): every emitted scenario must seed
   //      certain universal bindings (e.g. the default-tenant identifier
   //      under single-tenant mode). Handled by the "universal-seed
-  //      prologue" further down.
+  //      prologue" appended after planner-driven seeds.
   //
-  // When the same binding name appears in BOTH lists, the universal-seed
-  // prologue is authoritative (#157): its `??` form is strictly more
-  // defensive (covers `null` and `undefined`), uses the explicit
-  // `seedRule` from the config (which can differ from the binding name),
-  // and runs unconditionally before step 0. We therefore filter such
-  // names out of `seedBindingsList` so the redundant `=== undefined`
-  // guard isn't emitted. The `bindings` loop still emits literal
-  // (non-PENDING) values; the seedBindings list never contains literals
-  // (computeSeedBindings filters them out), so the loops are
-  // non-overlapping.
-  const globalSeedNames = new Set(globalContextSeeds.map((seed) => seed.binding));
-  const seedBindingsList = (s.seedBindings ?? []).filter((k) => !globalSeedNames.has(k));
-  if (s.bindings && Object.keys(s.bindings).length) {
-    body.push('  // Seed scenario bindings');
-    for (const [k, v] of Object.entries(s.bindings)) {
-      if (v === PENDING_BINDING) continue; // handled by seedBindings below
-      // Literal bindings flow into ctx unconditionally so any later
-      // step (or the same step's body) can read the planner-minted
-      // value before any extract overwrites it. The seedBindings list
-      // never contains literals (computeSeedBindings filters them
-      // out), so emitting both is safe.
-      body.push(`  ctx['${k}'] = ${JSON.stringify(v)};`);
-    }
-  }
-  if (seedBindingsList.length) {
-    if (!s.bindings || !Object.keys(s.bindings).length) {
-      body.push('  // Seed scenario bindings');
-    }
-    for (const k of seedBindingsList) {
-      // `=== undefined` (not `??`) so a literal-bound binding above
-      // that happens to share a name with a seedBindings entry — not
-      // possible today (computeSeedBindings filters literals) but
-      // belt-and-braces — does not get re-seeded.
-      body.push(`  if (ctx['${k}'] === undefined) { ctx['${k}'] = seedBinding('${k}'); }`);
-    }
-  }
-  // Universal-seed prologue derived from the global-context-seeds ABox.
-  // Each entry emits a single nullish-coalesced assignment that is idempotent
-  // over both bindings-loop outcomes above:
-  //   - literal binding (`ctx['<k>'] = "value";`) — `??` short-circuits, value preserved
-  //   - no assignment at all (fresh `ctx`) — `??` falls through to seedBinding(...)
-  // The seedBindings loop above no longer overlaps with this prologue
-  // (#157 — globalContextSeeds names are filtered out of seedBindingsList),
-  // so this is the authoritative pre-step-0 seeder for every entry here.
-  // `??` (not `=== undefined`) is intentional: any nullish binding value
-  // (`null` or `undefined`) is treated as missing and triggers seeding.
-  // The planner does not currently emit `null` literals in `s.bindings`
-  // for any global seed; revisit before tightening to `=== undefined`
-  // if a future seed ever needs `null` to remain distinct from "missing".
-  //
-  // Entries that declare a defaultSentinel + stripFromMultipartWhenDefault
-  // also emit a `__<fieldName>IsDefault` local that drives the multipart
-  // skip branch below — this is the only place the emitter knows about the
-  // sentinel.
-  //
-  // The local is only emitted when the scenario has at least one inline
-  // multipart step (i.e. a multipart step that is NOT dispatched to a
-  // role). Role-bound steps pass strips as a JSON literal argument and
-  // never read the prologue local; omitting it for role-only scenarios
-  // prevents an unused-variable error in the generated suite.
+  // Both sources flow through the shared `emitCtxSeeding` helper (#286)
+  // so a future schema change cannot drift the two emitters apart
+  // again. The helper emits in canonical order — literals → planner
+  // seedBindings → prologue — and every seeded line uses the terse
+  // `??` form; see materializer/src/playwright/ctxSeeding.ts for why
+  // `??` is safe at each step.
+  body.push(
+    ...emitCtxSeeding({
+      indent: '  ',
+      bindings: s.bindings,
+      seedBindings: s.seedBindings,
+      globalContextSeeds,
+    }),
+  );
+  // Multipart-sentinel locals (`__<fieldName>IsDefault`) are emitted
+  // alongside the prologue entries that drive them — only this
+  // emitter knows the sentinel exists, so the helper deliberately
+  // doesn't see this concern.
   //
   // Safety: `binding`, `fieldName`, `seedRule` are all required by the
   // domain-semantics validator (#87) to match `/^[A-Za-z_$][A-Za-z0-9_$]*$/`,
@@ -512,14 +470,17 @@ function renderScenarioTest(
   // backslashes, or line terminators. That lets us interpolate them
   // directly into emitted single-quoted TS string literals without an
   // escape pass.
+  //
+  // The local is only emitted when the scenario has at least one inline
+  // multipart step (i.e. a multipart step that is NOT dispatched to a
+  // role). Role-bound steps pass strips as a JSON literal argument and
+  // never read the prologue local; omitting it for role-only scenarios
+  // prevents an unused-variable error in the generated suite.
   const hasInlineMultipartStep = (s.requestPlan ?? []).some(
     (step) => step.bodyKind === 'multipart' && !!step.multipartTemplate && !findRoleForStep(step),
   );
   const sentinelLocals = new Map<string, string>(); // fieldName -> local var name
   for (const seed of globalContextSeeds) {
-    body.push(
-      `  ctx['${seed.binding}'] = ctx['${seed.binding}'] ?? seedBinding('${seed.seedRule}');`,
-    );
     if (
       hasInlineMultipartStep &&
       seed.stripFromMultipartWhenDefault &&

--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -6,6 +6,7 @@ import type {
   RequestStep,
   TemplateScenarioFile,
 } from 'path-analyser/types';
+import { emitCtxSeeding } from './ctxSeeding.js';
 import {
   buildUrlExpression,
   escapeQuotes,
@@ -247,26 +248,17 @@ function renderLifecycleSuite(
   lines.push('    const baseUrl = buildBaseUrl();');
   lines.push('    const ctx: Record<string, unknown> = {};');
 
-  // (1) universal-seed prologue
-  const globalSeedNames = new Set(globalContextSeeds.map((s) => s.binding));
-  for (const seed of globalContextSeeds) {
-    lines.push(
-      `    ctx['${seed.binding}'] = ctx['${seed.binding}'] ?? seedBinding('${seed.seedRule}');`,
-    );
-  }
-
-  // (2) per-scenario seedBindings (filtered to avoid double-seeding globals)
-  const seedNames = (prereq.seedBindings ?? []).filter((n) => !globalSeedNames.has(n));
-  for (const name of seedNames) {
-    lines.push(`    if (ctx['${name}'] === undefined) {`);
-    lines.push(`      ctx['${name}'] = seedBinding('${name}');`);
-    lines.push('    }');
-  }
-  for (const [k, v] of Object.entries(prereq.bindings)) {
-    if (v === '__PENDING__') continue;
-    if (globalSeedNames.has(k)) continue; // already covered by prologue
-    lines.push(`    ctx['${k}'] = ${JSON.stringify(v)};`);
-  }
+  // Canonical seeding: literals → planner seedBindings → universal
+  // prologue. Shared with `emitter.ts` via `emitCtxSeeding` (#286) so
+  // the two emitters can no longer drift on form or ordering.
+  lines.push(
+    ...emitCtxSeeding({
+      indent: '    ',
+      bindings: prereq.bindings,
+      seedBindings: prereq.seedBindings,
+      globalContextSeeds,
+    }),
+  );
 
   // (3) prereqChain inline
   let stepIdx = 0;

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -243,24 +243,30 @@ describe('emitter: universal-seed prologue (no __seededTenant flag, #79/#80; ?? 
     expect(content).not.toMatch(/__seededTenant/);
   });
 
-  test('seedBindings entry NOT in globalContextSeeds still emits the `=== undefined` guard (#157 — pin both directions of the filter)', async () => {
-    // Class-scoped guard for the new filter. The fix in #157 must only
-    // drop bindings covered by globalContextSeeds; bindings that the
-    // planner needs seeded pre-step-0 but which have no domain-semantics
-    // entry must still produce the `=== undefined` guard form, because
-    // the universal-seed prologue won't cover them.
+  test('seedBindings entry NOT in globalContextSeeds emits the terse `??` form (#286 — unified seed emission)', async () => {
+    // Class-scoped guard for the unified seed-emission shape from
+    // #286. Pre-#286 the seedBindings loop emitted the verbose
+    //   `if (ctx['x'] === undefined) { ctx['x'] = seedBinding('x'); }`
+    // form for bindings NOT covered by globalContextSeeds, while the
+    // universal-seed prologue used the terse `??` form. #286
+    // collapsed both paths through `emitCtxSeeding` so every seeded
+    // line — planner-driven OR config-driven — uses the same shape.
     //
-    // A binding NOT in globalContextSeeds and listed in seedBindings:
-    const widgetKeyGuard = `if (ctx['widgetKeyVar'] === undefined) { ctx['widgetKeyVar'] = seedBinding('widgetKeyVar'); }`;
+    // The filter direction this test pins is unchanged: a binding
+    // listed in `seedBindings` but NOT in `globalContextSeeds` is
+    // still seeded by the planner-driven loop (it must not be
+    // dropped), but the emitted line now matches the prologue form.
+    const widgetKeyTerse = `ctx['widgetKeyVar'] = ctx['widgetKeyVar'] ?? seedBinding('widgetKeyVar');`;
+    const legacyGuard = `if (ctx['widgetKeyVar'] === undefined)`;
     const content = await renderFirst(
       buildCollectionWithBindings(
         { widgetKeyVar: '__PENDING__' },
         { seedBindings: ['widgetKeyVar'] },
       ),
     );
-    expect(countOccurrences(content, widgetKeyGuard)).toBe(1);
-    // And it does NOT receive a `??` line (because it's not in globalContextSeeds).
-    expect(content).not.toContain(`ctx['widgetKeyVar'] = ctx['widgetKeyVar'] ?? seedBinding(`);
+    expect(countOccurrences(content, widgetKeyTerse)).toBe(1);
+    // And the pre-#286 verbose guard form is gone.
+    expect(content).not.toContain(legacyGuard);
   });
 
   test('literal tenantIdVar still seeds even when an extract targets the same binding (#136)', async () => {


### PR DESCRIPTION
Closes #286.

## What changed

Two Playwright emitters wrote the test-body seed prologue independently and drifted on:

| Concern | `emitter.ts` | `templateEmitter.ts` |
|---|---|---|
| seedBindings form | `if (=== undefined)` | `if (=== undefined)` |
| Prologue form | `??` | `??` |
| Order | literals → seedBindings → prologue | **prologue → seedBindings → literals** ⚠️ |

The ordering drift in `templateEmitter` was a latent bug — a literal emitted *after* a `??`-seeded global would clobber it if any scenario ever had a colliding literal. None do today, but the inconsistency was real.

## Approach

Lift seed emission into a single helper:

```ts
// materializer/src/playwright/ctxSeeding.ts
emitCtxSeeding({ indent, bindings, seedBindings, globalContextSeeds }): string[]
```

Canonical order, applied uniformly:
1. Literal bindings from `scenario.bindings` (skip `PENDING_BINDING`).
2. Planner `seedBindings` (filtered against `globalSeedNames`).
3. Universal-seed prologue from `globalContextSeeds`.

All seeded lines use the terse `??` form. Safe at each step because (a) literals come first and short-circuit `??`, (b) seedBindings and the prologue are made non-overlapping by the existing `globalSeedNames` filter, (c) the prologue `??` already preserved literal values.

The multipart-sentinel `__<fieldName>IsDefault` locals stay in `emitter.ts` (only it knows the sentinel exists) and are appended after the prologue.

## Stale comments removed

- `emitter.ts:477-480` "belt-and-braces" — was guarding a literal-vs-seedBindings collision that `computeSeedBindings` rules out, and `??` would have survived that case anyway.
- `emitter.ts:444-446` "globals are strictly more defensive" — no longer applies; both paths emit identical shapes.

## Tests

- **L3** (`configs/camunda-oca/regression-invariants.test.ts`): new class-scoped invariant rejects any `=== undefined` ... `seedBinding(` span across every emitted suite (feature, variant, lifecycle — recursive walk).
- **L1** (`tests/codegen/playwright-emitter.test.ts`): the test previously pinning the verbose form for non-global seedBindings is rewritten to pin the unified terse form. Renamed from `(#157 — pin both directions of the filter)` to `(#286 — unified seed emission)`. This is the intentional behaviour change AGENTS.md asks contributors to document; the filter direction the test guards is unchanged.

## Regen

`generated/` is gitignored, so the 194-file change does not need a separate commit. Every diff line replaces the verbose 3-line guard with the terse 1-line `??` assignment. 560 pass / 2 skip; lint + all 6 typechecks green.