### PR TITLE
feat: spec-coverage-analyzer spike (#277)

### DIFF
--- a/spec-coverage-analyzer/README.md
+++ b/spec-coverage-analyzer/README.md
@@ -102,10 +102,17 @@ Derived per Josh's #277 framing — flagging the spec-uncomputable surface so th
 - **No 405 (method-not-allowed) generation.** Could enumerate undeclared methods per path; not in spike.
 - **Cross-field range heuristic is naïve.** Only catches paired `*Before` / `*After` properties; cross-field rules between differently-named fields (e.g. `password ≠ username`) need explicit ABox.
 
-## Next steps (per #277)
+## Next steps
 
-1. Land this spike for review against #277.
-2. Pick the heaviest needs-ABox bucket and design the ABox slice (likely `duplicatePolicy` since Josh already sketched it in 8.8).
-3. Wire the analyzer to read the ABox once a slice lands, so `409-conflict` items move from "needs ABox" to "covered by ABox fact, computable".
-4. Cross-validate by running on the Camunda Hub spec — confirm the rule table generalises.
-5. Repurpose `coverage-analysis/` (which analyses generator *output*) as a verification check: "does the generator emit what the analyzer says it should?".
+In priority order, with dependencies:
+
+1. **Land `duplicatePolicy` as the first ABox slice.** Cheapest unblock — Josh has already designed it (8.8); needs to be expressed as a new file under `configs/camunda-oca/ontology/duplicatePolicy.json` with `{ operationId → policy }` entries for the ~59 create-style endpoints flagged. **Independent of this analyzer spike's review outcome — could start in parallel.** Owner: TBD.
+2. **Wire the analyzer to read the ABox.** After (1), update `build_plan.py` to consume `duplicatePolicy` and reclassify those 59 plan items from `needs-abox` to `computable`. Validates the analyzer ↔ ABox contract on the smallest slice before scaling.
+3. **Ship the 404 fake-ID emitter ([#279](https://github.com/camunda/api-test-generator/issues/279)).** First proof of the full loop: analyzer flags a plan item as computable → emitter generates the actual test → tests run. No dependency on any ABox slice; `ontology/semantics.json` already encodes the path-param identifier types. ~1 day's work, closes ~127 upstream-equivalent tests.
+4. **Run the analyzer against the Camunda Hub spec.** Validates the rule table generalises beyond OCA.
+5. **Repurpose `coverage-analysis/` ([PR #278](https://github.com/camunda/api-test-generator/pull/278))** as a verification check: "does the generator emit what the analyzer says it should?". Becomes a CI gate rather than a static snapshot.
+
+**Deferred** (do not start until step 2 has validated the analyzer ↔ ABox contract):
+- RBAC ABox slice (190 items — biggest unlock but biggest scoping effort).
+- Filter-semantics ABox slice (106 items).
+- Camunda Hub generalisation (wait for stable OCA-side loop).

--- a/spec-coverage-analyzer/README.md
+++ b/spec-coverage-analyzer/README.md
@@ -1,0 +1,111 @@
+# Spec-coverage-analyzer (spike for #277)
+
+> **Status:** spike. Reads an OpenAPI spec and emits a test plan, tagging
+> each plan item as either computable from the spec alone or requiring
+> domain knowledge (an ABox fact, named in the output).
+>
+> Independent of `coverage-analysis/`, which runs in the opposite
+> direction — analysing what the generator already emits. This tool
+> answers "what *should* be emitted, given the spec?".
+
+Built per [#277](https://github.com/camunda/api-test-generator/issues/277).
+Run against `spec/camunda-oca/bundled/rest-api.bundle.json` by default;
+any OpenAPI 3.x spec works. Designed to be re-run on the Camunda Hub spec
+when that lands.
+
+## Files
+
+| file | what it is |
+|---|---|
+| `build_plan.py` | The analyzer. Walks the spec, applies a rule table per operation, emits the artifacts below. No deps beyond the Python stdlib. |
+| `plan.csv` | One row per `(operation, plan-item)` tuple. Columns: `operationId, method, path, kind, detail, computable, abox_fact`. |
+| `plan.md` | Per-endpoint readable summary of the plan. |
+| `needs-abox.md` | Aggregated view of plan items that need ABox facts, grouped by the missing fact. The shortest answer to "which ABox slices are most load-bearing?". |
+
+## Run
+
+```sh
+python3 spec-coverage-analyzer/build_plan.py
+# or against an arbitrary spec:
+python3 spec-coverage-analyzer/build_plan.py path/to/openapi.json
+```
+
+Requires `spec/camunda-oca/bundled/rest-api.bundle.json` to exist locally
+(see the main `README.md` for the `npm run fetch-spec` setup).
+
+## Snapshot against the OCA spec
+
+- **190 operations** × ~9.6 plan items each → **1817 plan items**
+- **1027** computable from spec alone (56%)
+- **790** need ABox / domain knowledge (44%)
+
+The needs-ABox load is concentrated in a handful of facts:
+
+| missing ABox fact | plan items it would unblock |
+|---|---:|
+| RBAC: permissions required per endpoint | 190 |
+| spec-gap: which endpoints actually require auth | 189 |
+| creation chain per identifier semantic-type | 120 |
+| filter-field-semantics + sort-field-allowlist per entity | 106 |
+| duplicatePolicy per endpoint (idempotent / conflict / replace) | 59 |
+| consistency window per entity | 43 |
+| scale thresholds + expected response time per entity | 43 |
+| lifecycle state machine for this entity | 40 |
+
+The 401 spec-gap result is itself a finding: the OCA spec declares
+`securitySchemes` (BearerAuth, basicAuth) but only applies them on
+`getAuthentication`. Every other operation in the spec doesn't actually
+say it requires auth — even though the deployment behaviour is "auth
+required". That's a spec/reality drift the analyzer surfaces as a
+needs-ABox item ("encode deployment-mode auth applicability"), not a
+spec-derivable 401.
+
+## Rule table (current scope)
+
+### Computable rules (1027 items / 14 kinds)
+
+Derived purely from the spec:
+
+- **happy-path** — every operation gets one.
+- **bad-request:missing-required** — per required field on the request body.
+- **bad-request:type-mismatch** — per typed property.
+- **bad-request:format-invalid** — per `format`-tagged property.
+- **bad-request:enum-violation** — per `enum`-tagged property.
+- **bad-request:range-violation** — per property with `minimum`/`maximum`/`exclusive*`.
+- **bad-request:additional-property** — per object schema with `additionalProperties: false`.
+- **bad-request:oneof-violation** — per `oneOf`/`anyOf` schema.
+- **404-not-found** — per path parameter (replace with fake-but-valid ID).
+- **401-unauthorized** — per operation with declared `security` (currently only `getAuthentication` in OCA).
+- **pagination-sort:request-shape** — per operation that declares `page`/`sort`/`limit` query params or top-level body fields.
+- **filter:request-shape** — per request body with a `filter` property.
+- **documented-XXX** — per non-2xx response code documented in the spec (500, 503, 504, 415, 406, …) but not already covered by a more specific rule.
+
+### Needs-ABox rules (790 items / 9 kinds)
+
+Derived per Josh's #277 framing — flagging the spec-uncomputable surface so the ABox gaps are visible:
+
+- **401-unauthorized (spec-gap)** — spec declares `securitySchemes` but doesn't apply them. Needs: deployment-mode auth applicability per endpoint.
+- **403-forbidden** — Needs: RBAC permissions per endpoint.
+- **409-conflict** — for create-style and replace-style endpoints. Needs: `duplicatePolicy` (idempotent / conflict / replace).
+- **business-entity-lifecycle** — flagged by three hypotheses: state-transition verbs in the path (`/cancel`, `/complete`, `/resolve`, `/migrate`), operationId prefixes (`activate*`, `complete*`, `resolve*`, `migrate*`, `cancel*`), or 409 on a non-collection POST. Needs: lifecycle state machine per entity.
+- **prerequisite-resource** — flagged for every operation with at least one path param. Needs: creation chain per identifier semantic-type.
+- **eventual-consistency** — flagged on every `/search` endpoint. Needs: consistency window per entity (or eventually-consistent flag).
+- **scale-large-n** — flagged on every `/search` endpoint. Needs: scale thresholds + expected response time per entity.
+- **cross-field-range** — flagged when the request body has paired `*Before` / `*After` fields. Needs: cross-field validation rules.
+- **pagination-sort / filter behaviour-assertion** — flagged separately from the request-shape rule: emitting the field is computable, asserting result correctness (sort order, filter result) is not. Needs: filter-field semantics + sort-field allowlist per entity.
+
+## Limitations (known scope cuts in the spike)
+
+- **Shallow schema walk.** The walker resolves one level of `$ref` and looks at one level of `properties`. Nested objects, recursive schemas, and deeply nested `oneOf` branches are under-explored.
+- **No idempotency-key detection.** Endpoints accepting `Idempotency-Key` headers aren't yet a separate plan-item kind.
+- **No content-type / 415 detection.** Wrong-content-type plan items are not generated even when alternative content types are declared.
+- **No 405 (method-not-allowed) generation.** Could enumerate undeclared methods per path; not in spike.
+- **Cross-field range heuristic is naïve.** Only catches paired `*Before` / `*After` properties; cross-field rules between differently-named fields (e.g. `password ≠ username`) need explicit ABox.
+
+## Next steps (per #277)
+
+1. Land this spike for review against #277.
+2. Pick the heaviest needs-ABox bucket and design the ABox slice (likely `duplicatePolicy` since Josh already sketched it in 8.8).
+3. Wire the analyzer to read the ABox once a slice lands, so `409-conflict` items move from "needs ABox" to "covered by ABox fact, computable".
+4. Cross-validate by running on the Camunda Hub spec — confirm the rule table generalises.
+5. Repurpose `coverage-analysis/` (which analyses generator *output*) as a verification check: "does the generator emit what the analyzer says it should?".

--- a/spec-coverage-analyzer/build_plan.py
+++ b/spec-coverage-analyzer/build_plan.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""
+Spec-coverage-analyzer (spike for #277).
+
+Given an OpenAPI 3.x bundle, emit a test plan derived purely from the spec,
+tagging each plan item as either:
+  - `computable`   — the analyzer can fully decide this from the spec alone
+  - `needs-abox:X` — the analyzer cannot decide this without domain knowledge;
+                    name the missing fact in X
+
+No ABox integration in this spike. The needs-abox tags are surfaced
+verbatim so we can quantify what's missing from the ontology before
+building the integration.
+
+Outputs (written next to this script):
+  - plan.csv        — one row per (operation, plan-item) tuple
+  - plan.md         — per-endpoint readable summary
+  - needs-abox.md   — aggregated list of missing ABox facts, grouped by kind
+
+Run:
+    python3 build_plan.py [path/to/openapi.json]
+
+Defaults to ../spec/camunda-oca/bundled/rest-api.bundle.json.
+"""
+import csv
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_SPEC = os.path.normpath(os.path.join(SCRIPT_DIR, '..', 'spec', 'camunda-oca', 'bundled', 'rest-api.bundle.json'))
+OUT = SCRIPT_DIR
+
+# ---------- Spec loader with shallow $ref resolution ----------
+def load_spec(path):
+    with open(path) as fp:
+        return json.load(fp)
+
+def resolve_ref(spec, ref):
+    """Resolve a single $ref like '#/components/schemas/X' to the target object.
+    Returns the target dict, or {} if not found. No recursive deref — caller
+    handles deeper walking.
+    """
+    if not isinstance(ref, str) or not ref.startswith('#/'):
+        return {}
+    cur = spec
+    for part in ref[2:].split('/'):
+        if not isinstance(cur, dict) or part not in cur:
+            return {}
+        cur = cur[part]
+    return cur if isinstance(cur, dict) else {}
+
+def deref(spec, obj):
+    """If obj is a $ref, resolve it once. Returns the resolved (or original) object."""
+    if isinstance(obj, dict) and '$ref' in obj and len(obj) == 1:
+        return resolve_ref(spec, obj['$ref'])
+    return obj
+
+# ---------- Plan item helpers ----------
+def plan_item(op_id, method, path, kind, detail, computable, abox_fact=None):
+    return {
+        'operationId': op_id,
+        'method': method,
+        'path': path,
+        'kind': kind,
+        'detail': detail,
+        'computable': 'yes' if computable else 'no',
+        'abox_fact': abox_fact or '',
+    }
+
+# ---------- Body-schema walker (shallow) ----------
+def walk_body(spec, body_schema):
+    """Yield (kind, detail) plan-suggestions from a request body schema.
+    Only walks one level deep — sufficient for spike coverage.
+    """
+    s = deref(spec, body_schema)
+    if not isinstance(s, dict):
+        return
+
+    # Required field list (missing-required-X)
+    for req in s.get('required', []) or []:
+        yield ('bad-request:missing-required', f'field={req}')
+
+    # Object-shape: additionalProperties=false → extra-prop tests
+    if s.get('additionalProperties') is False:
+        yield ('bad-request:additional-property', 'closed schema')
+
+    # Walk each declared property — emit enum/format/type-mismatch items
+    props = s.get('properties', {}) or {}
+    for pname, pdef in props.items():
+        p = deref(spec, pdef)
+        if not isinstance(p, dict):
+            continue
+        if p.get('enum'):
+            yield ('bad-request:enum-violation', f'field={pname}, enum={p["enum"][:3]}{"…" if len(p["enum"])>3 else ""}')
+        if p.get('format'):
+            yield ('bad-request:format-invalid', f'field={pname}, format={p["format"]}')
+        if 'type' in p and p['type'] in ('string', 'integer', 'number', 'boolean', 'array', 'object'):
+            yield ('bad-request:type-mismatch', f'field={pname}, type={p["type"]}')
+        # Numeric range
+        if any(k in p for k in ('minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum')):
+            yield ('bad-request:range-violation', f'field={pname}')
+
+    # oneOf / anyOf → schema-branch tests
+    if 'oneOf' in s:
+        yield ('bad-request:oneof-violation', f'oneOf branches={len(s["oneOf"])}')
+    if 'anyOf' in s:
+        yield ('bad-request:oneof-violation', f'anyOf branches={len(s["anyOf"])}')
+
+    # Recognised top-level fields that imply pagination/filter
+    if 'page' in props:
+        yield ('pagination-sort:request-shape', 'page object in body')
+    if 'sort' in props:
+        yield ('pagination-sort:request-shape', 'sort array in body')
+    if 'filter' in props:
+        yield ('filter:request-shape', 'filter object in body')
+
+# ---------- Heuristics for business-entity detection ----------
+STATE_TRANSITION_VERBS = (
+    '/cancel', '/cancellation', '/complete', '/completion', '/resolve',
+    '/resolution', '/migrate', '/modification', '/activate', '/activation',
+    '/assignment', '/correlation', '/broadcast', '/publication',
+)
+BUSINESS_OP_PREFIXES = (
+    'activate', 'complete', 'resolve', 'migrate', 'cancel', 'fail',
+    'unassign', 'broadcast', 'correlate', 'pin', 'reset',
+)
+def looks_business_entity(op_id, path, method, responses):
+    """Apply the 3 hypotheses from the #277 kickoff. Returns reason or None."""
+    if any(v in path for v in STATE_TRANSITION_VERBS):
+        return f'path has state-transition verb'
+    for prefix in BUSINESS_OP_PREFIXES:
+        if op_id.lower().startswith(prefix):
+            return f'operationId prefix `{prefix}` implies state transition'
+    # 409 on non-collection POST → business rule
+    if method == 'POST' and '409' in (responses or {}) and not path.endswith('/search'):
+        return '409 documented on non-collection POST'
+    return None
+
+# ---------- Path-param fake-ID detection ----------
+def path_params(parameters):
+    return [p for p in (parameters or []) if p.get('in') == 'path']
+
+def query_params(parameters):
+    return [p for p in (parameters or []) if p.get('in') == 'query']
+
+PAGINATION_QUERY_NAMES = {'page', 'limit', 'from', 'pageSize', 'pageNumber', 'cursor', 'sort', 'sortBy', 'orderBy'}
+
+# ---------- Main analyzer ----------
+def analyze(spec_path):
+    spec = load_spec(spec_path)
+    global_security = bool(spec.get('security'))
+    # Detect spec gap: securitySchemes declared but security is not applied
+    # globally. Per-operation security may still be declared on a handful of
+    # endpoints (e.g. /authentication/me) — those get a computable 401.
+    # Operations that *don't* declare their own security in such a spec are
+    # the ambiguous ones: the spec doesn't say auth is required, but the
+    # deployment behaviour says it is. Emit those as needs-ABox.
+    declared_schemes = bool((spec.get('components') or {}).get('securitySchemes'))
+    spec_undeclared_security = declared_schemes and not global_security
+    rows = []
+
+    for path, methods in spec.get('paths', {}).items():
+        if not isinstance(methods, dict):
+            continue
+        path_level_params = methods.get('parameters') or []
+        for method, op in methods.items():
+            if method.lower() not in ('get', 'post', 'put', 'patch', 'delete'):
+                continue
+            if not isinstance(op, dict):
+                continue
+            op_id = op.get('operationId') or f'{method}-{path}'
+            method_u = method.upper()
+            params = (op.get('parameters') or []) + path_level_params
+            responses = op.get('responses') or {}
+
+            # 1. Happy-path — always
+            rows.append(plan_item(op_id, method_u, path, 'happy-path', 'documented success response', True))
+
+            # 2. 401 unauthorized — if security required (per-op or global)
+            op_security = op.get('security')
+            if op_security is None and global_security:
+                rows.append(plan_item(op_id, method_u, path,
+                    '401-unauthorized', 'global security; strip auth header', True))
+            elif op_security and op_security != []:
+                rows.append(plan_item(op_id, method_u, path,
+                    '401-unauthorized', 'per-op security; strip auth header', True))
+            elif op_security == []:
+                pass  # explicitly unauthenticated
+            elif spec_undeclared_security:
+                # Spec defines securitySchemes but never applies them. Real OCA
+                # behaviour is "auth required"; flag as needs-ABox so the test
+                # plan still captures the 401 surface.
+                rows.append(plan_item(op_id, method_u, path,
+                    '401-unauthorized', 'spec declares securitySchemes but does not apply them',
+                    False, 'spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)'))
+
+            # 3. 404 not-found (fake-ID) — per path parameter
+            for p in path_params(params):
+                name = p.get('name', '?')
+                schema = deref(spec, p.get('schema') or {})
+                rows.append(plan_item(op_id, method_u, path,
+                    '404-not-found',
+                    f'path param={name}, type={schema.get("type", "?")}, format={schema.get("format", "")}',
+                    True))
+
+            # 4. Bad-request — walk request body
+            rb = op.get('requestBody')
+            if isinstance(rb, dict):
+                rb = deref(spec, rb)
+                content = (rb.get('content') or {})
+                for media_type, m in content.items():
+                    if media_type != 'application/json':
+                        continue
+                    schema = m.get('schema')
+                    if not schema:
+                        continue
+                    for kind, detail in walk_body(spec, schema):
+                        is_filter_or_pagi = kind.startswith('pagination-sort') or kind.startswith('filter')
+                        # Pagination/filter request-shape is computable; behaviour is not
+                        if is_filter_or_pagi:
+                            rows.append(plan_item(op_id, method_u, path, kind, detail, True))
+                            # Also flag behaviour assertion as needs-ABox
+                            abox_kind = kind.split(':')[0] + ':behaviour-assertion'
+                            rows.append(plan_item(op_id, method_u, path, abox_kind,
+                                'asserting result correctness, not just status',
+                                False,
+                                'filter-field-semantics + sort-field-allowlist per entity'))
+                        else:
+                            rows.append(plan_item(op_id, method_u, path, kind, detail, True))
+
+            # 5. Pagination/sort from query params
+            qp_names = {p.get('name') for p in query_params(params)}
+            for n in PAGINATION_QUERY_NAMES & qp_names:
+                rows.append(plan_item(op_id, method_u, path,
+                    'pagination-sort:request-shape', f'query param={n}', True))
+
+            # 6. needs-ABox: 409 conflict (only flag for create-style endpoints)
+            method_is_create = method_u == 'POST' and not path.endswith('/search') and '{' not in path
+            method_is_idempotent_put = method_u == 'PUT' and '{' in path
+            if method_is_create or method_is_idempotent_put:
+                rows.append(plan_item(op_id, method_u, path,
+                    '409-conflict', 'create-or-replace with same identifier',
+                    False, 'duplicatePolicy per endpoint (idempotent | conflict | replace)'))
+
+            # 7. needs-ABox: 403 forbidden
+            # If documented in responses, we know it's possible; emitter still needs RBAC ABox
+            if '403' in responses:
+                rows.append(plan_item(op_id, method_u, path,
+                    '403-forbidden', '403 documented in spec', False,
+                    'RBAC: permissions required per endpoint'))
+            else:
+                rows.append(plan_item(op_id, method_u, path,
+                    '403-forbidden', '403 not documented; emitter needs to know if RBAC applies', False,
+                    'RBAC: permissions required per endpoint'))
+
+            # 8. needs-ABox: business-entity lifecycle
+            reason = looks_business_entity(op_id, path, method_u, responses)
+            if reason:
+                rows.append(plan_item(op_id, method_u, path,
+                    'business-entity-lifecycle', reason, False,
+                    'lifecycle state machine for this entity'))
+
+            # 9. needs-ABox: prerequisite resources (heuristic: path params hint at this)
+            if path_params(params):
+                rows.append(plan_item(op_id, method_u, path,
+                    'prerequisite-resource',
+                    f'{len(path_params(params))} path param(s) imply a referenced resource',
+                    False, 'creation chain per identifier semantic-type'))
+
+            # 10. needs-ABox: eventual consistency (search endpoints)
+            if path.endswith('/search'):
+                rows.append(plan_item(op_id, method_u, path,
+                    'eventual-consistency',
+                    'search may lag behind writes',
+                    False, 'consistency window per entity (or eventually-consistent flag)'))
+                # 10b. needs-ABox: scale (search at 10K+ entities)
+                rows.append(plan_item(op_id, method_u, path,
+                    'scale-large-n',
+                    'behaviour at 10K+ entities; pagination limits, timeout, ordering stability',
+                    False, 'scale thresholds + expected response time per entity'))
+
+            # 11. needs-ABox: cross-field range (heuristic — detect pairs of *Before / *After in body)
+            rb_for_xfield = op.get('requestBody')
+            if isinstance(rb_for_xfield, dict):
+                rb_for_xfield = deref(spec, rb_for_xfield)
+                content = rb_for_xfield.get('content', {})
+                json_schema = deref(spec, (content.get('application/json') or {}).get('schema') or {})
+                props = json_schema.get('properties', {}) or {}
+                # naïve pairing: any prop ending in 'Before' that has a matching '*After'
+                befores = {n[:-6] for n in props if n.endswith('Before')}
+                afters = {n[:-5] for n in props if n.endswith('After')}
+                pairs = befores & afters
+                if pairs:
+                    rows.append(plan_item(op_id, method_u, path,
+                        'cross-field-range',
+                        f'paired fields: {", ".join(sorted(pairs))}',
+                        False, 'cross-field validation rules (e.g. before > after rejected)'))
+                # Also look for any "filter" object with nested *Before/*After — common search pattern
+                filter_schema = deref(spec, props.get('filter') or {})
+                fprops = filter_schema.get('properties', {}) or {}
+                f_pairs = {n[:-6] for n in fprops if n.endswith('Before')} & {n[:-5] for n in fprops if n.endswith('After')}
+                if f_pairs:
+                    rows.append(plan_item(op_id, method_u, path,
+                        'cross-field-range',
+                        f'paired filter fields: {", ".join(sorted(f_pairs))}',
+                        False, 'cross-field validation rules (e.g. before > after rejected)'))
+
+            # 11. Documented response codes → coverage opportunity
+            for code in (responses or {}):
+                if code in ('200', '201', '204', '4XX', '5XX', 'default'):
+                    continue
+                if code.startswith('2'):
+                    continue
+                if code in ('400', '401', '403', '404', '409'):
+                    continue  # already covered above
+                rows.append(plan_item(op_id, method_u, path,
+                    f'documented-{code}', f'response code {code} documented in spec', True))
+
+    return rows
+
+# ---------- Output ----------
+def write_csv(rows, path):
+    with open(path, 'w', newline='', encoding='utf-8') as fp:
+        w = csv.DictWriter(fp, fieldnames=['operationId','method','path','kind','detail','computable','abox_fact'])
+        w.writeheader()
+        w.writerows(rows)
+
+def write_per_endpoint_md(rows, path):
+    by_op = defaultdict(list)
+    for r in rows:
+        by_op[(r['operationId'], r['method'], r['path'])].append(r)
+
+    with open(path, 'w', encoding='utf-8') as fp:
+        fp.write('# Spec-derived test plan\n\n')
+        fp.write(f'Total operations: **{len(by_op)}**. Total plan items: **{len(rows)}**.\n\n')
+
+        comp = sum(1 for r in rows if r['computable'] == 'yes')
+        nonc = len(rows) - comp
+        fp.write(f'- Computable from spec alone: **{comp}**\n')
+        fp.write(f'- Needs ABox / domain knowledge: **{nonc}**\n\n')
+
+        fp.write('## Per-operation plan\n\n')
+        for (op_id, method, p), items in sorted(by_op.items()):
+            fp.write(f'### `{method} {p}` — `{op_id}` ({len(items)} items)\n\n')
+            fp.write('| kind | detail | computable | needed ABox fact |\n')
+            fp.write('|---|---|:-:|---|\n')
+            for r in sorted(items, key=lambda x: (x['computable'] != 'yes', x['kind'])):
+                comp_mark = '✓' if r['computable'] == 'yes' else ''
+                # Escape pipes so they don't break the markdown table layout.
+                detail = r['detail'].replace('|', r'\|')
+                fact = (r['abox_fact'] or '—').replace('|', r'\|')
+                fp.write(f'| {r["kind"]} | {detail} | {comp_mark} | {fact} |\n')
+            fp.write('\n')
+
+def write_needs_abox_md(rows, path):
+    """Aggregate needs-ABox plan items grouped by the missing fact."""
+    by_fact = defaultdict(list)
+    for r in rows:
+        if r['computable'] == 'no':
+            by_fact[r['abox_fact']].append(r)
+
+    by_kind = defaultdict(int)
+    for r in rows:
+        if r['computable'] == 'no':
+            by_kind[r['kind']] += 1
+
+    with open(path, 'w', encoding='utf-8') as fp:
+        fp.write('# Needs-ABox gap report\n\n')
+        fp.write('Plan items the analyzer cannot decide without domain knowledge. '
+                 'Grouped by the missing ABox fact.\n\n')
+
+        fp.write('## Summary — plan-item kinds that need ABox\n\n')
+        fp.write('| kind | items |\n|---|---:|\n')
+        for kind, n in sorted(by_kind.items(), key=lambda x: -x[1]):
+            fp.write(f'| {kind} | {n} |\n')
+        fp.write('\n')
+
+        fp.write('## Grouped by missing ABox fact\n\n')
+        for fact, items in sorted(by_fact.items(), key=lambda x: -len(x[1])):
+            fp.write(f'### `{fact}` — {len(items)} plan items\n\n')
+            by_kind_here = defaultdict(int)
+            for r in items:
+                by_kind_here[r['kind']] += 1
+            kinds_line = ', '.join(f'{k}={v}' for k, v in by_kind_here.items())
+            fp.write(f'**Plan-item kinds**: {kinds_line}\n\n')
+
+            # Show a few sample operations
+            sample_ops = sorted({(r['method'], r['path'], r['operationId']) for r in items})[:8]
+            fp.write('**Sample operations** (up to 8):\n\n')
+            for m, p, op in sample_ops:
+                fp.write(f'- `{m} {p}` (`{op}`)\n')
+            if len({(r['operationId']) for r in items}) > 8:
+                fp.write(f'- … and {len({r["operationId"] for r in items}) - 8} more\n')
+            fp.write('\n')
+
+# ---------- Entry point ----------
+if __name__ == '__main__':
+    spec_path = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_SPEC
+    if not os.path.exists(spec_path):
+        print(f'ERROR: spec not found at {spec_path}', file=sys.stderr)
+        print(f'Hint: run `npm run fetch-spec` (or `npm run pipeline`) first.', file=sys.stderr)
+        sys.exit(1)
+
+    rows = analyze(spec_path)
+    write_csv(rows, os.path.join(OUT, 'plan.csv'))
+    write_per_endpoint_md(rows, os.path.join(OUT, 'plan.md'))
+    write_needs_abox_md(rows, os.path.join(OUT, 'needs-abox.md'))
+
+    comp = sum(1 for r in rows if r['computable'] == 'yes')
+    nonc = len(rows) - comp
+    print(f'wrote plan.csv, plan.md, needs-abox.md')
+    print(f'  total plan items: {len(rows)}')
+    print(f'  computable from spec: {comp}')
+    print(f'  needs ABox:           {nonc}')

--- a/spec-coverage-analyzer/needs-abox.md
+++ b/spec-coverage-analyzer/needs-abox.md
@@ -1,0 +1,148 @@
+# Needs-ABox gap report
+
+Plan items the analyzer cannot decide without domain knowledge. Grouped by the missing ABox fact.
+
+## Summary — plan-item kinds that need ABox
+
+| kind | items |
+|---|---:|
+| 403-forbidden | 190 |
+| 401-unauthorized | 189 |
+| prerequisite-resource | 120 |
+| 409-conflict | 59 |
+| pagination-sort:behaviour-assertion | 57 |
+| filter:behaviour-assertion | 49 |
+| eventual-consistency | 43 |
+| scale-large-n | 43 |
+| business-entity-lifecycle | 40 |
+
+## Grouped by missing ABox fact
+
+### `RBAC: permissions required per endpoint` — 190 plan items
+
+**Plan-item kinds**: 403-forbidden=190
+
+**Sample operations** (up to 8):
+
+- `DELETE /authorizations/{authorizationKey}` (`deleteAuthorization`)
+- `DELETE /cluster-variables/global/{name}` (`deleteGlobalClusterVariable`)
+- `DELETE /cluster-variables/tenants/{tenantId}/{name}` (`deleteTenantClusterVariable`)
+- `DELETE /documents/{documentId}` (`deleteDocument`)
+- `DELETE /global-task-listeners/{id}` (`deleteGlobalTaskListener`)
+- `DELETE /groups/{groupId}` (`deleteGroup`)
+- `DELETE /groups/{groupId}/clients/{clientId}` (`unassignClientFromGroup`)
+- `DELETE /groups/{groupId}/mapping-rules/{mappingRuleId}` (`unassignMappingRuleFromGroup`)
+- … and 182 more
+
+### `spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)` — 189 plan items
+
+**Plan-item kinds**: 401-unauthorized=189
+
+**Sample operations** (up to 8):
+
+- `DELETE /authorizations/{authorizationKey}` (`deleteAuthorization`)
+- `DELETE /cluster-variables/global/{name}` (`deleteGlobalClusterVariable`)
+- `DELETE /cluster-variables/tenants/{tenantId}/{name}` (`deleteTenantClusterVariable`)
+- `DELETE /documents/{documentId}` (`deleteDocument`)
+- `DELETE /global-task-listeners/{id}` (`deleteGlobalTaskListener`)
+- `DELETE /groups/{groupId}` (`deleteGroup`)
+- `DELETE /groups/{groupId}/clients/{clientId}` (`unassignClientFromGroup`)
+- `DELETE /groups/{groupId}/mapping-rules/{mappingRuleId}` (`unassignMappingRuleFromGroup`)
+- … and 181 more
+
+### `creation chain per identifier semantic-type` — 120 plan items
+
+**Plan-item kinds**: prerequisite-resource=120
+
+**Sample operations** (up to 8):
+
+- `DELETE /authorizations/{authorizationKey}` (`deleteAuthorization`)
+- `DELETE /cluster-variables/global/{name}` (`deleteGlobalClusterVariable`)
+- `DELETE /cluster-variables/tenants/{tenantId}/{name}` (`deleteTenantClusterVariable`)
+- `DELETE /documents/{documentId}` (`deleteDocument`)
+- `DELETE /global-task-listeners/{id}` (`deleteGlobalTaskListener`)
+- `DELETE /groups/{groupId}` (`deleteGroup`)
+- `DELETE /groups/{groupId}/clients/{clientId}` (`unassignClientFromGroup`)
+- `DELETE /groups/{groupId}/mapping-rules/{mappingRuleId}` (`unassignMappingRuleFromGroup`)
+- … and 112 more
+
+### `filter-field-semantics + sort-field-allowlist per entity` — 106 plan items
+
+**Plan-item kinds**: pagination-sort:behaviour-assertion=57, filter:behaviour-assertion=49
+
+**Sample operations** (up to 8):
+
+- `POST /agent-instances/search` (`searchAgentInstances`)
+- `POST /audit-logs/search` (`searchAuditLogs`)
+- `POST /authorizations/search` (`searchAuthorizations`)
+- `POST /batch-operation-items/search` (`searchBatchOperationItems`)
+- `POST /batch-operations/search` (`searchBatchOperations`)
+- `POST /cluster-variables/search` (`searchClusterVariables`)
+- `POST /correlated-message-subscriptions/search` (`searchCorrelatedMessageSubscriptions`)
+- `POST /decision-definitions/search` (`searchDecisionDefinitions`)
+- … and 51 more
+
+### `duplicatePolicy per endpoint (idempotent | conflict | replace)` — 59 plan items
+
+**Plan-item kinds**: 409-conflict=59
+
+**Sample operations** (up to 8):
+
+- `POST /agent-instances` (`createAgentInstance`)
+- `POST /authorizations` (`createAuthorization`)
+- `POST /clock/reset` (`resetClock`)
+- `POST /cluster-variables/global` (`createGlobalClusterVariable`)
+- `POST /conditionals/evaluation` (`evaluateConditionals`)
+- `POST /decision-definitions/evaluation` (`evaluateDecision`)
+- `POST /decision-instances/deletion` (`deleteDecisionInstancesBatchOperation`)
+- `POST /deployments` (`createDeployment`)
+- … and 51 more
+
+### `consistency window per entity (or eventually-consistent flag)` — 43 plan items
+
+**Plan-item kinds**: eventual-consistency=43
+
+**Sample operations** (up to 8):
+
+- `POST /agent-instances/search` (`searchAgentInstances`)
+- `POST /audit-logs/search` (`searchAuditLogs`)
+- `POST /authorizations/search` (`searchAuthorizations`)
+- `POST /batch-operation-items/search` (`searchBatchOperationItems`)
+- `POST /batch-operations/search` (`searchBatchOperations`)
+- `POST /cluster-variables/search` (`searchClusterVariables`)
+- `POST /correlated-message-subscriptions/search` (`searchCorrelatedMessageSubscriptions`)
+- `POST /decision-definitions/search` (`searchDecisionDefinitions`)
+- … and 35 more
+
+### `scale thresholds + expected response time per entity` — 43 plan items
+
+**Plan-item kinds**: scale-large-n=43
+
+**Sample operations** (up to 8):
+
+- `POST /agent-instances/search` (`searchAgentInstances`)
+- `POST /audit-logs/search` (`searchAuditLogs`)
+- `POST /authorizations/search` (`searchAuthorizations`)
+- `POST /batch-operation-items/search` (`searchBatchOperationItems`)
+- `POST /batch-operations/search` (`searchBatchOperations`)
+- `POST /cluster-variables/search` (`searchClusterVariables`)
+- `POST /correlated-message-subscriptions/search` (`searchCorrelatedMessageSubscriptions`)
+- `POST /decision-definitions/search` (`searchDecisionDefinitions`)
+- … and 35 more
+
+### `lifecycle state machine for this entity` — 40 plan items
+
+**Plan-item kinds**: business-entity-lifecycle=40
+
+**Sample operations** (up to 8):
+
+- `DELETE /groups/{groupId}/clients/{clientId}` (`unassignClientFromGroup`)
+- `DELETE /groups/{groupId}/mapping-rules/{mappingRuleId}` (`unassignMappingRuleFromGroup`)
+- `DELETE /groups/{groupId}/users/{username}` (`unassignUserFromGroup`)
+- `DELETE /roles/{roleId}/clients/{clientId}` (`unassignRoleFromClient`)
+- `DELETE /roles/{roleId}/groups/{groupId}` (`unassignRoleFromGroup`)
+- `DELETE /roles/{roleId}/mapping-rules/{mappingRuleId}` (`unassignRoleFromMappingRule`)
+- `DELETE /roles/{roleId}/users/{username}` (`unassignRoleFromUser`)
+- `DELETE /tenants/{tenantId}/clients/{clientId}` (`unassignClientFromTenant`)
+- … and 32 more
+

--- a/spec-coverage-analyzer/plan.csv
+++ b/spec-coverage-analyzer/plan.csv
@@ -1,0 +1,1818 @@
+operationId,method,path,kind,detail,computable,abox_fact
+createAgentInstance,POST,/agent-instances,happy-path,documented success response,yes,
+createAgentInstance,POST,/agent-instances,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createAgentInstance,POST,/agent-instances,bad-request:missing-required,field=elementInstanceKey,yes,
+createAgentInstance,POST,/agent-instances,bad-request:missing-required,field=definition,yes,
+createAgentInstance,POST,/agent-instances,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+createAgentInstance,POST,/agent-instances,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+createAgentInstance,POST,/agent-instances,documented-500,response code 500 documented in spec,yes,
+createAgentInstance,POST,/agent-instances,documented-503,response code 503 documented in spec,yes,
+getAgentInstance,GET,/agent-instances/{agentInstanceKey},happy-path,documented success response,yes,
+getAgentInstance,GET,/agent-instances/{agentInstanceKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getAgentInstance,GET,/agent-instances/{agentInstanceKey},404-not-found,"path param=agentInstanceKey, type=string, format=AgentInstanceKey",yes,
+getAgentInstance,GET,/agent-instances/{agentInstanceKey},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getAgentInstance,GET,/agent-instances/{agentInstanceKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getAgentInstance,GET,/agent-instances/{agentInstanceKey},documented-500,response code 500 documented in spec,yes,
+getAgentInstance,GET,/agent-instances/{agentInstanceKey},documented-503,response code 503 documented in spec,yes,
+updateAgentInstance,PATCH,/agent-instances/{agentInstanceKey},happy-path,documented success response,yes,
+updateAgentInstance,PATCH,/agent-instances/{agentInstanceKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+updateAgentInstance,PATCH,/agent-instances/{agentInstanceKey},404-not-found,"path param=agentInstanceKey, type=string, format=AgentInstanceKey",yes,
+updateAgentInstance,PATCH,/agent-instances/{agentInstanceKey},bad-request:type-mismatch,"field=tools, type=array",yes,
+updateAgentInstance,PATCH,/agent-instances/{agentInstanceKey},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+updateAgentInstance,PATCH,/agent-instances/{agentInstanceKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+updateAgentInstance,PATCH,/agent-instances/{agentInstanceKey},documented-500,response code 500 documented in spec,yes,
+searchAgentInstances,POST,/agent-instances/search,happy-path,documented success response,yes,
+searchAgentInstances,POST,/agent-instances/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchAgentInstances,POST,/agent-instances/search,bad-request:additional-property,closed schema,yes,
+searchAgentInstances,POST,/agent-instances/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchAgentInstances,POST,/agent-instances/search,pagination-sort:request-shape,sort array in body,yes,
+searchAgentInstances,POST,/agent-instances/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchAgentInstances,POST,/agent-instances/search,filter:request-shape,filter object in body,yes,
+searchAgentInstances,POST,/agent-instances/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchAgentInstances,POST,/agent-instances/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchAgentInstances,POST,/agent-instances/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchAgentInstances,POST,/agent-instances/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchAgentInstances,POST,/agent-instances/search,documented-500,response code 500 documented in spec,yes,
+searchAuditLogs,POST,/audit-logs/search,happy-path,documented success response,yes,
+searchAuditLogs,POST,/audit-logs/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchAuditLogs,POST,/audit-logs/search,bad-request:additional-property,closed schema,yes,
+searchAuditLogs,POST,/audit-logs/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchAuditLogs,POST,/audit-logs/search,pagination-sort:request-shape,sort array in body,yes,
+searchAuditLogs,POST,/audit-logs/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchAuditLogs,POST,/audit-logs/search,filter:request-shape,filter object in body,yes,
+searchAuditLogs,POST,/audit-logs/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchAuditLogs,POST,/audit-logs/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchAuditLogs,POST,/audit-logs/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchAuditLogs,POST,/audit-logs/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchAuditLogs,POST,/audit-logs/search,documented-500,response code 500 documented in spec,yes,
+getAuditLog,GET,/audit-logs/{auditLogKey},happy-path,documented success response,yes,
+getAuditLog,GET,/audit-logs/{auditLogKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getAuditLog,GET,/audit-logs/{auditLogKey},404-not-found,"path param=auditLogKey, type=string, format=AuditLogKey",yes,
+getAuditLog,GET,/audit-logs/{auditLogKey},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getAuditLog,GET,/audit-logs/{auditLogKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getAuditLog,GET,/audit-logs/{auditLogKey},documented-500,response code 500 documented in spec,yes,
+getAuthentication,GET,/authentication/me,happy-path,documented success response,yes,
+getAuthentication,GET,/authentication/me,401-unauthorized,per-op security; strip auth header,yes,
+getAuthentication,GET,/authentication/me,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getAuthentication,GET,/authentication/me,documented-500,response code 500 documented in spec,yes,
+createAuthorization,POST,/authorizations,happy-path,documented success response,yes,
+createAuthorization,POST,/authorizations,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createAuthorization,POST,/authorizations,bad-request:oneof-violation,oneOf branches=2,yes,
+createAuthorization,POST,/authorizations,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+createAuthorization,POST,/authorizations,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+createAuthorization,POST,/authorizations,documented-500,response code 500 documented in spec,yes,
+createAuthorization,POST,/authorizations,documented-503,response code 503 documented in spec,yes,
+searchAuthorizations,POST,/authorizations/search,happy-path,documented success response,yes,
+searchAuthorizations,POST,/authorizations/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchAuthorizations,POST,/authorizations/search,bad-request:additional-property,closed schema,yes,
+searchAuthorizations,POST,/authorizations/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchAuthorizations,POST,/authorizations/search,pagination-sort:request-shape,sort array in body,yes,
+searchAuthorizations,POST,/authorizations/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchAuthorizations,POST,/authorizations/search,filter:request-shape,filter object in body,yes,
+searchAuthorizations,POST,/authorizations/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchAuthorizations,POST,/authorizations/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchAuthorizations,POST,/authorizations/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchAuthorizations,POST,/authorizations/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchAuthorizations,POST,/authorizations/search,documented-500,response code 500 documented in spec,yes,
+updateAuthorization,PUT,/authorizations/{authorizationKey},happy-path,documented success response,yes,
+updateAuthorization,PUT,/authorizations/{authorizationKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+updateAuthorization,PUT,/authorizations/{authorizationKey},404-not-found,"path param=authorizationKey, type=string, format=AuthorizationKey",yes,
+updateAuthorization,PUT,/authorizations/{authorizationKey},bad-request:oneof-violation,oneOf branches=2,yes,
+updateAuthorization,PUT,/authorizations/{authorizationKey},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+updateAuthorization,PUT,/authorizations/{authorizationKey},403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+updateAuthorization,PUT,/authorizations/{authorizationKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+updateAuthorization,PUT,/authorizations/{authorizationKey},documented-500,response code 500 documented in spec,yes,
+updateAuthorization,PUT,/authorizations/{authorizationKey},documented-503,response code 503 documented in spec,yes,
+getAuthorization,GET,/authorizations/{authorizationKey},happy-path,documented success response,yes,
+getAuthorization,GET,/authorizations/{authorizationKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getAuthorization,GET,/authorizations/{authorizationKey},404-not-found,"path param=authorizationKey, type=string, format=AuthorizationKey",yes,
+getAuthorization,GET,/authorizations/{authorizationKey},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getAuthorization,GET,/authorizations/{authorizationKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getAuthorization,GET,/authorizations/{authorizationKey},documented-500,response code 500 documented in spec,yes,
+deleteAuthorization,DELETE,/authorizations/{authorizationKey},happy-path,documented success response,yes,
+deleteAuthorization,DELETE,/authorizations/{authorizationKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+deleteAuthorization,DELETE,/authorizations/{authorizationKey},404-not-found,"path param=authorizationKey, type=string, format=AuthorizationKey",yes,
+deleteAuthorization,DELETE,/authorizations/{authorizationKey},403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+deleteAuthorization,DELETE,/authorizations/{authorizationKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+deleteAuthorization,DELETE,/authorizations/{authorizationKey},documented-500,response code 500 documented in spec,yes,
+deleteAuthorization,DELETE,/authorizations/{authorizationKey},documented-503,response code 503 documented in spec,yes,
+searchBatchOperationItems,POST,/batch-operation-items/search,happy-path,documented success response,yes,
+searchBatchOperationItems,POST,/batch-operation-items/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchBatchOperationItems,POST,/batch-operation-items/search,bad-request:additional-property,closed schema,yes,
+searchBatchOperationItems,POST,/batch-operation-items/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchBatchOperationItems,POST,/batch-operation-items/search,pagination-sort:request-shape,sort array in body,yes,
+searchBatchOperationItems,POST,/batch-operation-items/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchBatchOperationItems,POST,/batch-operation-items/search,filter:request-shape,filter object in body,yes,
+searchBatchOperationItems,POST,/batch-operation-items/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchBatchOperationItems,POST,/batch-operation-items/search,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+searchBatchOperationItems,POST,/batch-operation-items/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchBatchOperationItems,POST,/batch-operation-items/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchBatchOperationItems,POST,/batch-operation-items/search,documented-500,response code 500 documented in spec,yes,
+searchBatchOperations,POST,/batch-operations/search,happy-path,documented success response,yes,
+searchBatchOperations,POST,/batch-operations/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchBatchOperations,POST,/batch-operations/search,bad-request:additional-property,closed schema,yes,
+searchBatchOperations,POST,/batch-operations/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchBatchOperations,POST,/batch-operations/search,pagination-sort:request-shape,sort array in body,yes,
+searchBatchOperations,POST,/batch-operations/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchBatchOperations,POST,/batch-operations/search,filter:request-shape,filter object in body,yes,
+searchBatchOperations,POST,/batch-operations/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchBatchOperations,POST,/batch-operations/search,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+searchBatchOperations,POST,/batch-operations/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchBatchOperations,POST,/batch-operations/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchBatchOperations,POST,/batch-operations/search,documented-500,response code 500 documented in spec,yes,
+getBatchOperation,GET,/batch-operations/{batchOperationKey},happy-path,documented success response,yes,
+getBatchOperation,GET,/batch-operations/{batchOperationKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getBatchOperation,GET,/batch-operations/{batchOperationKey},404-not-found,"path param=batchOperationKey, type=string, format=BatchOperationKey | uuid",yes,
+getBatchOperation,GET,/batch-operations/{batchOperationKey},403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+getBatchOperation,GET,/batch-operations/{batchOperationKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getBatchOperation,GET,/batch-operations/{batchOperationKey},documented-500,response code 500 documented in spec,yes,
+cancelBatchOperation,POST,/batch-operations/{batchOperationKey}/cancellation,happy-path,documented success response,yes,
+cancelBatchOperation,POST,/batch-operations/{batchOperationKey}/cancellation,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+cancelBatchOperation,POST,/batch-operations/{batchOperationKey}/cancellation,404-not-found,"path param=batchOperationKey, type=string, format=BatchOperationKey | uuid",yes,
+cancelBatchOperation,POST,/batch-operations/{batchOperationKey}/cancellation,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+cancelBatchOperation,POST,/batch-operations/{batchOperationKey}/cancellation,business-entity-lifecycle,path has state-transition verb,no,lifecycle state machine for this entity
+cancelBatchOperation,POST,/batch-operations/{batchOperationKey}/cancellation,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+cancelBatchOperation,POST,/batch-operations/{batchOperationKey}/cancellation,documented-500,response code 500 documented in spec,yes,
+resumeBatchOperation,POST,/batch-operations/{batchOperationKey}/resumption,happy-path,documented success response,yes,
+resumeBatchOperation,POST,/batch-operations/{batchOperationKey}/resumption,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+resumeBatchOperation,POST,/batch-operations/{batchOperationKey}/resumption,404-not-found,"path param=batchOperationKey, type=string, format=BatchOperationKey | uuid",yes,
+resumeBatchOperation,POST,/batch-operations/{batchOperationKey}/resumption,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+resumeBatchOperation,POST,/batch-operations/{batchOperationKey}/resumption,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+resumeBatchOperation,POST,/batch-operations/{batchOperationKey}/resumption,documented-500,response code 500 documented in spec,yes,
+resumeBatchOperation,POST,/batch-operations/{batchOperationKey}/resumption,documented-503,response code 503 documented in spec,yes,
+suspendBatchOperation,POST,/batch-operations/{batchOperationKey}/suspension,happy-path,documented success response,yes,
+suspendBatchOperation,POST,/batch-operations/{batchOperationKey}/suspension,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+suspendBatchOperation,POST,/batch-operations/{batchOperationKey}/suspension,404-not-found,"path param=batchOperationKey, type=string, format=BatchOperationKey | uuid",yes,
+suspendBatchOperation,POST,/batch-operations/{batchOperationKey}/suspension,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+suspendBatchOperation,POST,/batch-operations/{batchOperationKey}/suspension,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+suspendBatchOperation,POST,/batch-operations/{batchOperationKey}/suspension,documented-500,response code 500 documented in spec,yes,
+suspendBatchOperation,POST,/batch-operations/{batchOperationKey}/suspension,documented-503,response code 503 documented in spec,yes,
+pinClock,PUT,/clock,happy-path,documented success response,yes,
+pinClock,PUT,/clock,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+pinClock,PUT,/clock,bad-request:missing-required,field=timestamp,yes,
+pinClock,PUT,/clock,bad-request:additional-property,closed schema,yes,
+pinClock,PUT,/clock,bad-request:format-invalid,"field=timestamp, format=int64",yes,
+pinClock,PUT,/clock,bad-request:type-mismatch,"field=timestamp, type=integer",yes,
+pinClock,PUT,/clock,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+pinClock,PUT,/clock,business-entity-lifecycle,operationId prefix `pin` implies state transition,no,lifecycle state machine for this entity
+pinClock,PUT,/clock,documented-500,response code 500 documented in spec,yes,
+pinClock,PUT,/clock,documented-503,response code 503 documented in spec,yes,
+resetClock,POST,/clock/reset,happy-path,documented success response,yes,
+resetClock,POST,/clock/reset,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+resetClock,POST,/clock/reset,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+resetClock,POST,/clock/reset,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+resetClock,POST,/clock/reset,business-entity-lifecycle,operationId prefix `reset` implies state transition,no,lifecycle state machine for this entity
+resetClock,POST,/clock/reset,documented-500,response code 500 documented in spec,yes,
+resetClock,POST,/clock/reset,documented-503,response code 503 documented in spec,yes,
+createGlobalClusterVariable,POST,/cluster-variables/global,happy-path,documented success response,yes,
+createGlobalClusterVariable,POST,/cluster-variables/global,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createGlobalClusterVariable,POST,/cluster-variables/global,bad-request:missing-required,field=name,yes,
+createGlobalClusterVariable,POST,/cluster-variables/global,bad-request:missing-required,field=value,yes,
+createGlobalClusterVariable,POST,/cluster-variables/global,bad-request:type-mismatch,"field=value, type=object",yes,
+createGlobalClusterVariable,POST,/cluster-variables/global,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+createGlobalClusterVariable,POST,/cluster-variables/global,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+createGlobalClusterVariable,POST,/cluster-variables/global,documented-500,response code 500 documented in spec,yes,
+getGlobalClusterVariable,GET,/cluster-variables/global/{name},happy-path,documented success response,yes,
+getGlobalClusterVariable,GET,/cluster-variables/global/{name},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getGlobalClusterVariable,GET,/cluster-variables/global/{name},404-not-found,"path param=name, type=string, format=ClusterVariableName",yes,
+getGlobalClusterVariable,GET,/cluster-variables/global/{name},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getGlobalClusterVariable,GET,/cluster-variables/global/{name},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getGlobalClusterVariable,GET,/cluster-variables/global/{name},documented-500,response code 500 documented in spec,yes,
+updateGlobalClusterVariable,PUT,/cluster-variables/global/{name},happy-path,documented success response,yes,
+updateGlobalClusterVariable,PUT,/cluster-variables/global/{name},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+updateGlobalClusterVariable,PUT,/cluster-variables/global/{name},404-not-found,"path param=name, type=string, format=ClusterVariableName",yes,
+updateGlobalClusterVariable,PUT,/cluster-variables/global/{name},bad-request:missing-required,field=value,yes,
+updateGlobalClusterVariable,PUT,/cluster-variables/global/{name},bad-request:type-mismatch,"field=value, type=object",yes,
+updateGlobalClusterVariable,PUT,/cluster-variables/global/{name},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+updateGlobalClusterVariable,PUT,/cluster-variables/global/{name},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+updateGlobalClusterVariable,PUT,/cluster-variables/global/{name},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+updateGlobalClusterVariable,PUT,/cluster-variables/global/{name},documented-500,response code 500 documented in spec,yes,
+deleteGlobalClusterVariable,DELETE,/cluster-variables/global/{name},happy-path,documented success response,yes,
+deleteGlobalClusterVariable,DELETE,/cluster-variables/global/{name},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+deleteGlobalClusterVariable,DELETE,/cluster-variables/global/{name},404-not-found,"path param=name, type=string, format=ClusterVariableName",yes,
+deleteGlobalClusterVariable,DELETE,/cluster-variables/global/{name},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+deleteGlobalClusterVariable,DELETE,/cluster-variables/global/{name},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+deleteGlobalClusterVariable,DELETE,/cluster-variables/global/{name},documented-500,response code 500 documented in spec,yes,
+searchClusterVariables,POST,/cluster-variables/search,happy-path,documented success response,yes,
+searchClusterVariables,POST,/cluster-variables/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchClusterVariables,POST,/cluster-variables/search,bad-request:additional-property,closed schema,yes,
+searchClusterVariables,POST,/cluster-variables/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchClusterVariables,POST,/cluster-variables/search,pagination-sort:request-shape,sort array in body,yes,
+searchClusterVariables,POST,/cluster-variables/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchClusterVariables,POST,/cluster-variables/search,filter:request-shape,filter object in body,yes,
+searchClusterVariables,POST,/cluster-variables/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchClusterVariables,POST,/cluster-variables/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchClusterVariables,POST,/cluster-variables/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchClusterVariables,POST,/cluster-variables/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchClusterVariables,POST,/cluster-variables/search,documented-500,response code 500 documented in spec,yes,
+createTenantClusterVariable,POST,/cluster-variables/tenants/{tenantId},happy-path,documented success response,yes,
+createTenantClusterVariable,POST,/cluster-variables/tenants/{tenantId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createTenantClusterVariable,POST,/cluster-variables/tenants/{tenantId},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+createTenantClusterVariable,POST,/cluster-variables/tenants/{tenantId},bad-request:missing-required,field=name,yes,
+createTenantClusterVariable,POST,/cluster-variables/tenants/{tenantId},bad-request:missing-required,field=value,yes,
+createTenantClusterVariable,POST,/cluster-variables/tenants/{tenantId},bad-request:type-mismatch,"field=value, type=object",yes,
+createTenantClusterVariable,POST,/cluster-variables/tenants/{tenantId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+createTenantClusterVariable,POST,/cluster-variables/tenants/{tenantId},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+createTenantClusterVariable,POST,/cluster-variables/tenants/{tenantId},documented-500,response code 500 documented in spec,yes,
+getTenantClusterVariable,GET,/cluster-variables/tenants/{tenantId}/{name},happy-path,documented success response,yes,
+getTenantClusterVariable,GET,/cluster-variables/tenants/{tenantId}/{name},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getTenantClusterVariable,GET,/cluster-variables/tenants/{tenantId}/{name},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+getTenantClusterVariable,GET,/cluster-variables/tenants/{tenantId}/{name},404-not-found,"path param=name, type=string, format=ClusterVariableName",yes,
+getTenantClusterVariable,GET,/cluster-variables/tenants/{tenantId}/{name},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getTenantClusterVariable,GET,/cluster-variables/tenants/{tenantId}/{name},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getTenantClusterVariable,GET,/cluster-variables/tenants/{tenantId}/{name},documented-500,response code 500 documented in spec,yes,
+updateTenantClusterVariable,PUT,/cluster-variables/tenants/{tenantId}/{name},happy-path,documented success response,yes,
+updateTenantClusterVariable,PUT,/cluster-variables/tenants/{tenantId}/{name},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+updateTenantClusterVariable,PUT,/cluster-variables/tenants/{tenantId}/{name},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+updateTenantClusterVariable,PUT,/cluster-variables/tenants/{tenantId}/{name},404-not-found,"path param=name, type=string, format=ClusterVariableName",yes,
+updateTenantClusterVariable,PUT,/cluster-variables/tenants/{tenantId}/{name},bad-request:missing-required,field=value,yes,
+updateTenantClusterVariable,PUT,/cluster-variables/tenants/{tenantId}/{name},bad-request:type-mismatch,"field=value, type=object",yes,
+updateTenantClusterVariable,PUT,/cluster-variables/tenants/{tenantId}/{name},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+updateTenantClusterVariable,PUT,/cluster-variables/tenants/{tenantId}/{name},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+updateTenantClusterVariable,PUT,/cluster-variables/tenants/{tenantId}/{name},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+updateTenantClusterVariable,PUT,/cluster-variables/tenants/{tenantId}/{name},documented-500,response code 500 documented in spec,yes,
+deleteTenantClusterVariable,DELETE,/cluster-variables/tenants/{tenantId}/{name},happy-path,documented success response,yes,
+deleteTenantClusterVariable,DELETE,/cluster-variables/tenants/{tenantId}/{name},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+deleteTenantClusterVariable,DELETE,/cluster-variables/tenants/{tenantId}/{name},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+deleteTenantClusterVariable,DELETE,/cluster-variables/tenants/{tenantId}/{name},404-not-found,"path param=name, type=string, format=ClusterVariableName",yes,
+deleteTenantClusterVariable,DELETE,/cluster-variables/tenants/{tenantId}/{name},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+deleteTenantClusterVariable,DELETE,/cluster-variables/tenants/{tenantId}/{name},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+deleteTenantClusterVariable,DELETE,/cluster-variables/tenants/{tenantId}/{name},documented-500,response code 500 documented in spec,yes,
+evaluateConditionals,POST,/conditionals/evaluation,happy-path,documented success response,yes,
+evaluateConditionals,POST,/conditionals/evaluation,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+evaluateConditionals,POST,/conditionals/evaluation,bad-request:missing-required,field=variables,yes,
+evaluateConditionals,POST,/conditionals/evaluation,bad-request:type-mismatch,"field=variables, type=object",yes,
+evaluateConditionals,POST,/conditionals/evaluation,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+evaluateConditionals,POST,/conditionals/evaluation,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+evaluateConditionals,POST,/conditionals/evaluation,documented-500,response code 500 documented in spec,yes,
+evaluateConditionals,POST,/conditionals/evaluation,documented-503,response code 503 documented in spec,yes,
+searchCorrelatedMessageSubscriptions,POST,/correlated-message-subscriptions/search,happy-path,documented success response,yes,
+searchCorrelatedMessageSubscriptions,POST,/correlated-message-subscriptions/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchCorrelatedMessageSubscriptions,POST,/correlated-message-subscriptions/search,bad-request:additional-property,closed schema,yes,
+searchCorrelatedMessageSubscriptions,POST,/correlated-message-subscriptions/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchCorrelatedMessageSubscriptions,POST,/correlated-message-subscriptions/search,pagination-sort:request-shape,sort array in body,yes,
+searchCorrelatedMessageSubscriptions,POST,/correlated-message-subscriptions/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchCorrelatedMessageSubscriptions,POST,/correlated-message-subscriptions/search,filter:request-shape,filter object in body,yes,
+searchCorrelatedMessageSubscriptions,POST,/correlated-message-subscriptions/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchCorrelatedMessageSubscriptions,POST,/correlated-message-subscriptions/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchCorrelatedMessageSubscriptions,POST,/correlated-message-subscriptions/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchCorrelatedMessageSubscriptions,POST,/correlated-message-subscriptions/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchCorrelatedMessageSubscriptions,POST,/correlated-message-subscriptions/search,documented-500,response code 500 documented in spec,yes,
+evaluateDecision,POST,/decision-definitions/evaluation,happy-path,documented success response,yes,
+evaluateDecision,POST,/decision-definitions/evaluation,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+evaluateDecision,POST,/decision-definitions/evaluation,bad-request:oneof-violation,oneOf branches=2,yes,
+evaluateDecision,POST,/decision-definitions/evaluation,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+evaluateDecision,POST,/decision-definitions/evaluation,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+evaluateDecision,POST,/decision-definitions/evaluation,documented-500,response code 500 documented in spec,yes,
+evaluateDecision,POST,/decision-definitions/evaluation,documented-503,response code 503 documented in spec,yes,
+searchDecisionDefinitions,POST,/decision-definitions/search,happy-path,documented success response,yes,
+searchDecisionDefinitions,POST,/decision-definitions/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchDecisionDefinitions,POST,/decision-definitions/search,bad-request:additional-property,closed schema,yes,
+searchDecisionDefinitions,POST,/decision-definitions/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchDecisionDefinitions,POST,/decision-definitions/search,pagination-sort:request-shape,sort array in body,yes,
+searchDecisionDefinitions,POST,/decision-definitions/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchDecisionDefinitions,POST,/decision-definitions/search,filter:request-shape,filter object in body,yes,
+searchDecisionDefinitions,POST,/decision-definitions/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchDecisionDefinitions,POST,/decision-definitions/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchDecisionDefinitions,POST,/decision-definitions/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchDecisionDefinitions,POST,/decision-definitions/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchDecisionDefinitions,POST,/decision-definitions/search,documented-500,response code 500 documented in spec,yes,
+getDecisionDefinition,GET,/decision-definitions/{decisionDefinitionKey},happy-path,documented success response,yes,
+getDecisionDefinition,GET,/decision-definitions/{decisionDefinitionKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getDecisionDefinition,GET,/decision-definitions/{decisionDefinitionKey},404-not-found,"path param=decisionDefinitionKey, type=string, format=DecisionDefinitionKey",yes,
+getDecisionDefinition,GET,/decision-definitions/{decisionDefinitionKey},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getDecisionDefinition,GET,/decision-definitions/{decisionDefinitionKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getDecisionDefinition,GET,/decision-definitions/{decisionDefinitionKey},documented-500,response code 500 documented in spec,yes,
+getDecisionDefinitionXML,GET,/decision-definitions/{decisionDefinitionKey}/xml,happy-path,documented success response,yes,
+getDecisionDefinitionXML,GET,/decision-definitions/{decisionDefinitionKey}/xml,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getDecisionDefinitionXML,GET,/decision-definitions/{decisionDefinitionKey}/xml,404-not-found,"path param=decisionDefinitionKey, type=string, format=DecisionDefinitionKey",yes,
+getDecisionDefinitionXML,GET,/decision-definitions/{decisionDefinitionKey}/xml,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getDecisionDefinitionXML,GET,/decision-definitions/{decisionDefinitionKey}/xml,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getDecisionDefinitionXML,GET,/decision-definitions/{decisionDefinitionKey}/xml,documented-500,response code 500 documented in spec,yes,
+searchDecisionInstances,POST,/decision-instances/search,happy-path,documented success response,yes,
+searchDecisionInstances,POST,/decision-instances/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchDecisionInstances,POST,/decision-instances/search,bad-request:additional-property,closed schema,yes,
+searchDecisionInstances,POST,/decision-instances/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchDecisionInstances,POST,/decision-instances/search,pagination-sort:request-shape,sort array in body,yes,
+searchDecisionInstances,POST,/decision-instances/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchDecisionInstances,POST,/decision-instances/search,filter:request-shape,filter object in body,yes,
+searchDecisionInstances,POST,/decision-instances/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchDecisionInstances,POST,/decision-instances/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchDecisionInstances,POST,/decision-instances/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchDecisionInstances,POST,/decision-instances/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchDecisionInstances,POST,/decision-instances/search,documented-500,response code 500 documented in spec,yes,
+getDecisionInstance,GET,/decision-instances/{decisionEvaluationInstanceKey},happy-path,documented success response,yes,
+getDecisionInstance,GET,/decision-instances/{decisionEvaluationInstanceKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getDecisionInstance,GET,/decision-instances/{decisionEvaluationInstanceKey},404-not-found,"path param=decisionEvaluationInstanceKey, type=string, format=DecisionEvaluationInstanceKey",yes,
+getDecisionInstance,GET,/decision-instances/{decisionEvaluationInstanceKey},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getDecisionInstance,GET,/decision-instances/{decisionEvaluationInstanceKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getDecisionInstance,GET,/decision-instances/{decisionEvaluationInstanceKey},documented-500,response code 500 documented in spec,yes,
+deleteDecisionInstance,POST,/decision-instances/{decisionEvaluationKey}/deletion,happy-path,documented success response,yes,
+deleteDecisionInstance,POST,/decision-instances/{decisionEvaluationKey}/deletion,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+deleteDecisionInstance,POST,/decision-instances/{decisionEvaluationKey}/deletion,404-not-found,"path param=decisionEvaluationKey, type=string, format=DecisionEvaluationKey",yes,
+deleteDecisionInstance,POST,/decision-instances/{decisionEvaluationKey}/deletion,bad-request:additional-property,closed schema,yes,
+deleteDecisionInstance,POST,/decision-instances/{decisionEvaluationKey}/deletion,bad-request:format-invalid,"field=operationReference, format=int64",yes,
+deleteDecisionInstance,POST,/decision-instances/{decisionEvaluationKey}/deletion,bad-request:type-mismatch,"field=operationReference, type=integer",yes,
+deleteDecisionInstance,POST,/decision-instances/{decisionEvaluationKey}/deletion,bad-request:range-violation,field=operationReference,yes,
+deleteDecisionInstance,POST,/decision-instances/{decisionEvaluationKey}/deletion,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+deleteDecisionInstance,POST,/decision-instances/{decisionEvaluationKey}/deletion,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+deleteDecisionInstance,POST,/decision-instances/{decisionEvaluationKey}/deletion,documented-500,response code 500 documented in spec,yes,
+deleteDecisionInstance,POST,/decision-instances/{decisionEvaluationKey}/deletion,documented-503,response code 503 documented in spec,yes,
+deleteDecisionInstancesBatchOperation,POST,/decision-instances/deletion,happy-path,documented success response,yes,
+deleteDecisionInstancesBatchOperation,POST,/decision-instances/deletion,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+deleteDecisionInstancesBatchOperation,POST,/decision-instances/deletion,bad-request:missing-required,field=filter,yes,
+deleteDecisionInstancesBatchOperation,POST,/decision-instances/deletion,bad-request:additional-property,closed schema,yes,
+deleteDecisionInstancesBatchOperation,POST,/decision-instances/deletion,bad-request:format-invalid,"field=operationReference, format=int64",yes,
+deleteDecisionInstancesBatchOperation,POST,/decision-instances/deletion,bad-request:type-mismatch,"field=operationReference, type=integer",yes,
+deleteDecisionInstancesBatchOperation,POST,/decision-instances/deletion,bad-request:range-violation,field=operationReference,yes,
+deleteDecisionInstancesBatchOperation,POST,/decision-instances/deletion,filter:request-shape,filter object in body,yes,
+deleteDecisionInstancesBatchOperation,POST,/decision-instances/deletion,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+deleteDecisionInstancesBatchOperation,POST,/decision-instances/deletion,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+deleteDecisionInstancesBatchOperation,POST,/decision-instances/deletion,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+deleteDecisionInstancesBatchOperation,POST,/decision-instances/deletion,documented-500,response code 500 documented in spec,yes,
+searchDecisionRequirements,POST,/decision-requirements/search,happy-path,documented success response,yes,
+searchDecisionRequirements,POST,/decision-requirements/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchDecisionRequirements,POST,/decision-requirements/search,bad-request:additional-property,closed schema,yes,
+searchDecisionRequirements,POST,/decision-requirements/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchDecisionRequirements,POST,/decision-requirements/search,pagination-sort:request-shape,sort array in body,yes,
+searchDecisionRequirements,POST,/decision-requirements/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchDecisionRequirements,POST,/decision-requirements/search,filter:request-shape,filter object in body,yes,
+searchDecisionRequirements,POST,/decision-requirements/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchDecisionRequirements,POST,/decision-requirements/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchDecisionRequirements,POST,/decision-requirements/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchDecisionRequirements,POST,/decision-requirements/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchDecisionRequirements,POST,/decision-requirements/search,documented-500,response code 500 documented in spec,yes,
+getDecisionRequirements,GET,/decision-requirements/{decisionRequirementsKey},happy-path,documented success response,yes,
+getDecisionRequirements,GET,/decision-requirements/{decisionRequirementsKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getDecisionRequirements,GET,/decision-requirements/{decisionRequirementsKey},404-not-found,"path param=decisionRequirementsKey, type=string, format=DecisionRequirementsKey",yes,
+getDecisionRequirements,GET,/decision-requirements/{decisionRequirementsKey},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getDecisionRequirements,GET,/decision-requirements/{decisionRequirementsKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getDecisionRequirements,GET,/decision-requirements/{decisionRequirementsKey},documented-500,response code 500 documented in spec,yes,
+getDecisionRequirementsXML,GET,/decision-requirements/{decisionRequirementsKey}/xml,happy-path,documented success response,yes,
+getDecisionRequirementsXML,GET,/decision-requirements/{decisionRequirementsKey}/xml,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getDecisionRequirementsXML,GET,/decision-requirements/{decisionRequirementsKey}/xml,404-not-found,"path param=decisionRequirementsKey, type=string, format=DecisionRequirementsKey",yes,
+getDecisionRequirementsXML,GET,/decision-requirements/{decisionRequirementsKey}/xml,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getDecisionRequirementsXML,GET,/decision-requirements/{decisionRequirementsKey}/xml,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getDecisionRequirementsXML,GET,/decision-requirements/{decisionRequirementsKey}/xml,documented-500,response code 500 documented in spec,yes,
+createDeployment,POST,/deployments,happy-path,documented success response,yes,
+createDeployment,POST,/deployments,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createDeployment,POST,/deployments,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+createDeployment,POST,/deployments,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+createDeployment,POST,/deployments,documented-503,response code 503 documented in spec,yes,
+createDocument,POST,/documents,happy-path,documented success response,yes,
+createDocument,POST,/documents,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createDocument,POST,/documents,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+createDocument,POST,/documents,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+createDocument,POST,/documents,documented-415,response code 415 documented in spec,yes,
+createDocuments,POST,/documents/batch,happy-path,documented success response,yes,
+createDocuments,POST,/documents/batch,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createDocuments,POST,/documents/batch,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+createDocuments,POST,/documents/batch,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+createDocuments,POST,/documents/batch,documented-415,response code 415 documented in spec,yes,
+getDocument,GET,/documents/{documentId},happy-path,documented success response,yes,
+getDocument,GET,/documents/{documentId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getDocument,GET,/documents/{documentId},404-not-found,"path param=documentId, type=string, format=DocumentId",yes,
+getDocument,GET,/documents/{documentId},403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+getDocument,GET,/documents/{documentId},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getDocument,GET,/documents/{documentId},documented-500,response code 500 documented in spec,yes,
+deleteDocument,DELETE,/documents/{documentId},happy-path,documented success response,yes,
+deleteDocument,DELETE,/documents/{documentId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+deleteDocument,DELETE,/documents/{documentId},404-not-found,"path param=documentId, type=string, format=DocumentId",yes,
+deleteDocument,DELETE,/documents/{documentId},403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+deleteDocument,DELETE,/documents/{documentId},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+deleteDocument,DELETE,/documents/{documentId},documented-500,response code 500 documented in spec,yes,
+createDocumentLink,POST,/documents/{documentId}/links,happy-path,documented success response,yes,
+createDocumentLink,POST,/documents/{documentId}/links,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createDocumentLink,POST,/documents/{documentId}/links,404-not-found,"path param=documentId, type=string, format=DocumentId",yes,
+createDocumentLink,POST,/documents/{documentId}/links,bad-request:format-invalid,"field=timeToLive, format=int64",yes,
+createDocumentLink,POST,/documents/{documentId}/links,bad-request:type-mismatch,"field=timeToLive, type=integer",yes,
+createDocumentLink,POST,/documents/{documentId}/links,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+createDocumentLink,POST,/documents/{documentId}/links,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+activateAdHocSubProcessActivities,POST,/element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation,happy-path,documented success response,yes,
+activateAdHocSubProcessActivities,POST,/element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+activateAdHocSubProcessActivities,POST,/element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation,404-not-found,"path param=adHocSubProcessInstanceKey, type=string, format=ElementInstanceKey",yes,
+activateAdHocSubProcessActivities,POST,/element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation,bad-request:missing-required,field=elements,yes,
+activateAdHocSubProcessActivities,POST,/element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation,bad-request:type-mismatch,"field=elements, type=array",yes,
+activateAdHocSubProcessActivities,POST,/element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation,bad-request:type-mismatch,"field=cancelRemainingInstances, type=boolean",yes,
+activateAdHocSubProcessActivities,POST,/element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+activateAdHocSubProcessActivities,POST,/element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation,business-entity-lifecycle,path has state-transition verb,no,lifecycle state machine for this entity
+activateAdHocSubProcessActivities,POST,/element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+activateAdHocSubProcessActivities,POST,/element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation,documented-500,response code 500 documented in spec,yes,
+activateAdHocSubProcessActivities,POST,/element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation,documented-503,response code 503 documented in spec,yes,
+searchElementInstances,POST,/element-instances/search,happy-path,documented success response,yes,
+searchElementInstances,POST,/element-instances/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchElementInstances,POST,/element-instances/search,bad-request:additional-property,closed schema,yes,
+searchElementInstances,POST,/element-instances/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchElementInstances,POST,/element-instances/search,pagination-sort:request-shape,sort array in body,yes,
+searchElementInstances,POST,/element-instances/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchElementInstances,POST,/element-instances/search,filter:request-shape,filter object in body,yes,
+searchElementInstances,POST,/element-instances/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchElementInstances,POST,/element-instances/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchElementInstances,POST,/element-instances/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchElementInstances,POST,/element-instances/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchElementInstances,POST,/element-instances/search,documented-500,response code 500 documented in spec,yes,
+getElementInstance,GET,/element-instances/{elementInstanceKey},happy-path,documented success response,yes,
+getElementInstance,GET,/element-instances/{elementInstanceKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getElementInstance,GET,/element-instances/{elementInstanceKey},404-not-found,"path param=elementInstanceKey, type=string, format=ElementInstanceKey",yes,
+getElementInstance,GET,/element-instances/{elementInstanceKey},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getElementInstance,GET,/element-instances/{elementInstanceKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getElementInstance,GET,/element-instances/{elementInstanceKey},documented-500,response code 500 documented in spec,yes,
+searchElementInstanceIncidents,POST,/element-instances/{elementInstanceKey}/incidents/search,happy-path,documented success response,yes,
+searchElementInstanceIncidents,POST,/element-instances/{elementInstanceKey}/incidents/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchElementInstanceIncidents,POST,/element-instances/{elementInstanceKey}/incidents/search,404-not-found,"path param=elementInstanceKey, type=string, format=ElementInstanceKey",yes,
+searchElementInstanceIncidents,POST,/element-instances/{elementInstanceKey}/incidents/search,bad-request:additional-property,closed schema,yes,
+searchElementInstanceIncidents,POST,/element-instances/{elementInstanceKey}/incidents/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchElementInstanceIncidents,POST,/element-instances/{elementInstanceKey}/incidents/search,pagination-sort:request-shape,sort array in body,yes,
+searchElementInstanceIncidents,POST,/element-instances/{elementInstanceKey}/incidents/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchElementInstanceIncidents,POST,/element-instances/{elementInstanceKey}/incidents/search,filter:request-shape,filter object in body,yes,
+searchElementInstanceIncidents,POST,/element-instances/{elementInstanceKey}/incidents/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchElementInstanceIncidents,POST,/element-instances/{elementInstanceKey}/incidents/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchElementInstanceIncidents,POST,/element-instances/{elementInstanceKey}/incidents/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchElementInstanceIncidents,POST,/element-instances/{elementInstanceKey}/incidents/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchElementInstanceIncidents,POST,/element-instances/{elementInstanceKey}/incidents/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchElementInstanceIncidents,POST,/element-instances/{elementInstanceKey}/incidents/search,documented-500,response code 500 documented in spec,yes,
+createElementInstanceVariables,PUT,/element-instances/{elementInstanceKey}/variables,happy-path,documented success response,yes,
+createElementInstanceVariables,PUT,/element-instances/{elementInstanceKey}/variables,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createElementInstanceVariables,PUT,/element-instances/{elementInstanceKey}/variables,404-not-found,"path param=elementInstanceKey, type=string, format=ElementInstanceKey",yes,
+createElementInstanceVariables,PUT,/element-instances/{elementInstanceKey}/variables,bad-request:missing-required,field=variables,yes,
+createElementInstanceVariables,PUT,/element-instances/{elementInstanceKey}/variables,bad-request:additional-property,closed schema,yes,
+createElementInstanceVariables,PUT,/element-instances/{elementInstanceKey}/variables,bad-request:type-mismatch,"field=variables, type=object",yes,
+createElementInstanceVariables,PUT,/element-instances/{elementInstanceKey}/variables,bad-request:type-mismatch,"field=local, type=boolean",yes,
+createElementInstanceVariables,PUT,/element-instances/{elementInstanceKey}/variables,bad-request:format-invalid,"field=operationReference, format=int64",yes,
+createElementInstanceVariables,PUT,/element-instances/{elementInstanceKey}/variables,bad-request:type-mismatch,"field=operationReference, type=integer",yes,
+createElementInstanceVariables,PUT,/element-instances/{elementInstanceKey}/variables,bad-request:range-violation,field=operationReference,yes,
+createElementInstanceVariables,PUT,/element-instances/{elementInstanceKey}/variables,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+createElementInstanceVariables,PUT,/element-instances/{elementInstanceKey}/variables,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+createElementInstanceVariables,PUT,/element-instances/{elementInstanceKey}/variables,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+createElementInstanceVariables,PUT,/element-instances/{elementInstanceKey}/variables,documented-500,response code 500 documented in spec,yes,
+createElementInstanceVariables,PUT,/element-instances/{elementInstanceKey}/variables,documented-503,response code 503 documented in spec,yes,
+createElementInstanceVariables,PUT,/element-instances/{elementInstanceKey}/variables,documented-504,response code 504 documented in spec,yes,
+evaluateExpression,POST,/expression/evaluation,happy-path,documented success response,yes,
+evaluateExpression,POST,/expression/evaluation,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+evaluateExpression,POST,/expression/evaluation,bad-request:missing-required,field=expression,yes,
+evaluateExpression,POST,/expression/evaluation,bad-request:type-mismatch,"field=expression, type=string",yes,
+evaluateExpression,POST,/expression/evaluation,bad-request:type-mismatch,"field=tenantId, type=string",yes,
+evaluateExpression,POST,/expression/evaluation,bad-request:type-mismatch,"field=variables, type=object",yes,
+evaluateExpression,POST,/expression/evaluation,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+evaluateExpression,POST,/expression/evaluation,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+evaluateExpression,POST,/expression/evaluation,documented-500,response code 500 documented in spec,yes,
+getFormByKey,GET,/forms/{formKey},happy-path,documented success response,yes,
+getFormByKey,GET,/forms/{formKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getFormByKey,GET,/forms/{formKey},404-not-found,"path param=formKey, type=string, format=FormKey",yes,
+getFormByKey,GET,/forms/{formKey},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getFormByKey,GET,/forms/{formKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getFormByKey,GET,/forms/{formKey},documented-500,response code 500 documented in spec,yes,
+createGlobalTaskListener,POST,/global-task-listeners,happy-path,documented success response,yes,
+createGlobalTaskListener,POST,/global-task-listeners,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createGlobalTaskListener,POST,/global-task-listeners,bad-request:missing-required,field=id,yes,
+createGlobalTaskListener,POST,/global-task-listeners,bad-request:missing-required,field=type,yes,
+createGlobalTaskListener,POST,/global-task-listeners,bad-request:missing-required,field=eventTypes,yes,
+createGlobalTaskListener,POST,/global-task-listeners,bad-request:format-invalid,"field=id, format=GlobalListenerId",yes,
+createGlobalTaskListener,POST,/global-task-listeners,bad-request:type-mismatch,"field=id, type=string",yes,
+createGlobalTaskListener,POST,/global-task-listeners,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+createGlobalTaskListener,POST,/global-task-listeners,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+createGlobalTaskListener,POST,/global-task-listeners,business-entity-lifecycle,409 documented on non-collection POST,no,lifecycle state machine for this entity
+createGlobalTaskListener,POST,/global-task-listeners,documented-500,response code 500 documented in spec,yes,
+createGlobalTaskListener,POST,/global-task-listeners,documented-503,response code 503 documented in spec,yes,
+getGlobalTaskListener,GET,/global-task-listeners/{id},happy-path,documented success response,yes,
+getGlobalTaskListener,GET,/global-task-listeners/{id},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getGlobalTaskListener,GET,/global-task-listeners/{id},404-not-found,"path param=id, type=string, format=GlobalListenerId",yes,
+getGlobalTaskListener,GET,/global-task-listeners/{id},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getGlobalTaskListener,GET,/global-task-listeners/{id},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getGlobalTaskListener,GET,/global-task-listeners/{id},documented-500,response code 500 documented in spec,yes,
+updateGlobalTaskListener,PUT,/global-task-listeners/{id},happy-path,documented success response,yes,
+updateGlobalTaskListener,PUT,/global-task-listeners/{id},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+updateGlobalTaskListener,PUT,/global-task-listeners/{id},404-not-found,"path param=id, type=string, format=GlobalListenerId",yes,
+updateGlobalTaskListener,PUT,/global-task-listeners/{id},bad-request:missing-required,field=type,yes,
+updateGlobalTaskListener,PUT,/global-task-listeners/{id},bad-request:missing-required,field=eventTypes,yes,
+updateGlobalTaskListener,PUT,/global-task-listeners/{id},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+updateGlobalTaskListener,PUT,/global-task-listeners/{id},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+updateGlobalTaskListener,PUT,/global-task-listeners/{id},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+updateGlobalTaskListener,PUT,/global-task-listeners/{id},documented-500,response code 500 documented in spec,yes,
+updateGlobalTaskListener,PUT,/global-task-listeners/{id},documented-503,response code 503 documented in spec,yes,
+deleteGlobalTaskListener,DELETE,/global-task-listeners/{id},happy-path,documented success response,yes,
+deleteGlobalTaskListener,DELETE,/global-task-listeners/{id},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+deleteGlobalTaskListener,DELETE,/global-task-listeners/{id},404-not-found,"path param=id, type=string, format=GlobalListenerId",yes,
+deleteGlobalTaskListener,DELETE,/global-task-listeners/{id},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+deleteGlobalTaskListener,DELETE,/global-task-listeners/{id},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+deleteGlobalTaskListener,DELETE,/global-task-listeners/{id},documented-500,response code 500 documented in spec,yes,
+deleteGlobalTaskListener,DELETE,/global-task-listeners/{id},documented-503,response code 503 documented in spec,yes,
+searchGlobalTaskListeners,POST,/global-task-listeners/search,happy-path,documented success response,yes,
+searchGlobalTaskListeners,POST,/global-task-listeners/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchGlobalTaskListeners,POST,/global-task-listeners/search,bad-request:additional-property,closed schema,yes,
+searchGlobalTaskListeners,POST,/global-task-listeners/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchGlobalTaskListeners,POST,/global-task-listeners/search,pagination-sort:request-shape,sort array in body,yes,
+searchGlobalTaskListeners,POST,/global-task-listeners/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchGlobalTaskListeners,POST,/global-task-listeners/search,filter:request-shape,filter object in body,yes,
+searchGlobalTaskListeners,POST,/global-task-listeners/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchGlobalTaskListeners,POST,/global-task-listeners/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchGlobalTaskListeners,POST,/global-task-listeners/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchGlobalTaskListeners,POST,/global-task-listeners/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchGlobalTaskListeners,POST,/global-task-listeners/search,documented-500,response code 500 documented in spec,yes,
+createGroup,POST,/groups,happy-path,documented success response,yes,
+createGroup,POST,/groups,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createGroup,POST,/groups,bad-request:missing-required,field=groupId,yes,
+createGroup,POST,/groups,bad-request:missing-required,field=name,yes,
+createGroup,POST,/groups,bad-request:additional-property,closed schema,yes,
+createGroup,POST,/groups,bad-request:type-mismatch,"field=name, type=string",yes,
+createGroup,POST,/groups,bad-request:type-mismatch,"field=description, type=string",yes,
+createGroup,POST,/groups,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+createGroup,POST,/groups,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+createGroup,POST,/groups,documented-500,response code 500 documented in spec,yes,
+createGroup,POST,/groups,documented-503,response code 503 documented in spec,yes,
+searchGroups,POST,/groups/search,happy-path,documented success response,yes,
+searchGroups,POST,/groups/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchGroups,POST,/groups/search,bad-request:additional-property,closed schema,yes,
+searchGroups,POST,/groups/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchGroups,POST,/groups/search,pagination-sort:request-shape,sort array in body,yes,
+searchGroups,POST,/groups/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchGroups,POST,/groups/search,filter:request-shape,filter object in body,yes,
+searchGroups,POST,/groups/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchGroups,POST,/groups/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchGroups,POST,/groups/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchGroups,POST,/groups/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchGroups,POST,/groups/search,documented-500,response code 500 documented in spec,yes,
+getGroup,GET,/groups/{groupId},happy-path,documented success response,yes,
+getGroup,GET,/groups/{groupId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getGroup,GET,/groups/{groupId},404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+getGroup,GET,/groups/{groupId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getGroup,GET,/groups/{groupId},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getGroup,GET,/groups/{groupId},documented-500,response code 500 documented in spec,yes,
+updateGroup,PUT,/groups/{groupId},happy-path,documented success response,yes,
+updateGroup,PUT,/groups/{groupId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+updateGroup,PUT,/groups/{groupId},404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+updateGroup,PUT,/groups/{groupId},bad-request:missing-required,field=name,yes,
+updateGroup,PUT,/groups/{groupId},bad-request:type-mismatch,"field=name, type=string",yes,
+updateGroup,PUT,/groups/{groupId},bad-request:type-mismatch,"field=description, type=string",yes,
+updateGroup,PUT,/groups/{groupId},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+updateGroup,PUT,/groups/{groupId},403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+updateGroup,PUT,/groups/{groupId},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+updateGroup,PUT,/groups/{groupId},documented-500,response code 500 documented in spec,yes,
+updateGroup,PUT,/groups/{groupId},documented-503,response code 503 documented in spec,yes,
+deleteGroup,DELETE,/groups/{groupId},happy-path,documented success response,yes,
+deleteGroup,DELETE,/groups/{groupId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+deleteGroup,DELETE,/groups/{groupId},404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+deleteGroup,DELETE,/groups/{groupId},403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+deleteGroup,DELETE,/groups/{groupId},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+deleteGroup,DELETE,/groups/{groupId},documented-500,response code 500 documented in spec,yes,
+deleteGroup,DELETE,/groups/{groupId},documented-503,response code 503 documented in spec,yes,
+searchClientsForGroup,POST,/groups/{groupId}/clients/search,happy-path,documented success response,yes,
+searchClientsForGroup,POST,/groups/{groupId}/clients/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchClientsForGroup,POST,/groups/{groupId}/clients/search,404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+searchClientsForGroup,POST,/groups/{groupId}/clients/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchClientsForGroup,POST,/groups/{groupId}/clients/search,pagination-sort:request-shape,sort array in body,yes,
+searchClientsForGroup,POST,/groups/{groupId}/clients/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchClientsForGroup,POST,/groups/{groupId}/clients/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchClientsForGroup,POST,/groups/{groupId}/clients/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchClientsForGroup,POST,/groups/{groupId}/clients/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchClientsForGroup,POST,/groups/{groupId}/clients/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchClientsForGroup,POST,/groups/{groupId}/clients/search,documented-500,response code 500 documented in spec,yes,
+assignClientToGroup,PUT,/groups/{groupId}/clients/{clientId},happy-path,documented success response,yes,
+assignClientToGroup,PUT,/groups/{groupId}/clients/{clientId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+assignClientToGroup,PUT,/groups/{groupId}/clients/{clientId},404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+assignClientToGroup,PUT,/groups/{groupId}/clients/{clientId},404-not-found,"path param=clientId, type=string, format=ClientId",yes,
+assignClientToGroup,PUT,/groups/{groupId}/clients/{clientId},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+assignClientToGroup,PUT,/groups/{groupId}/clients/{clientId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+assignClientToGroup,PUT,/groups/{groupId}/clients/{clientId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+assignClientToGroup,PUT,/groups/{groupId}/clients/{clientId},documented-500,response code 500 documented in spec,yes,
+assignClientToGroup,PUT,/groups/{groupId}/clients/{clientId},documented-503,response code 503 documented in spec,yes,
+unassignClientFromGroup,DELETE,/groups/{groupId}/clients/{clientId},happy-path,documented success response,yes,
+unassignClientFromGroup,DELETE,/groups/{groupId}/clients/{clientId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+unassignClientFromGroup,DELETE,/groups/{groupId}/clients/{clientId},404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+unassignClientFromGroup,DELETE,/groups/{groupId}/clients/{clientId},404-not-found,"path param=clientId, type=string, format=ClientId",yes,
+unassignClientFromGroup,DELETE,/groups/{groupId}/clients/{clientId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+unassignClientFromGroup,DELETE,/groups/{groupId}/clients/{clientId},business-entity-lifecycle,operationId prefix `unassign` implies state transition,no,lifecycle state machine for this entity
+unassignClientFromGroup,DELETE,/groups/{groupId}/clients/{clientId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+unassignClientFromGroup,DELETE,/groups/{groupId}/clients/{clientId},documented-500,response code 500 documented in spec,yes,
+unassignClientFromGroup,DELETE,/groups/{groupId}/clients/{clientId},documented-503,response code 503 documented in spec,yes,
+searchMappingRulesForGroup,POST,/groups/{groupId}/mapping-rules/search,happy-path,documented success response,yes,
+searchMappingRulesForGroup,POST,/groups/{groupId}/mapping-rules/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchMappingRulesForGroup,POST,/groups/{groupId}/mapping-rules/search,404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+searchMappingRulesForGroup,POST,/groups/{groupId}/mapping-rules/search,bad-request:additional-property,closed schema,yes,
+searchMappingRulesForGroup,POST,/groups/{groupId}/mapping-rules/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchMappingRulesForGroup,POST,/groups/{groupId}/mapping-rules/search,pagination-sort:request-shape,sort array in body,yes,
+searchMappingRulesForGroup,POST,/groups/{groupId}/mapping-rules/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchMappingRulesForGroup,POST,/groups/{groupId}/mapping-rules/search,filter:request-shape,filter object in body,yes,
+searchMappingRulesForGroup,POST,/groups/{groupId}/mapping-rules/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchMappingRulesForGroup,POST,/groups/{groupId}/mapping-rules/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchMappingRulesForGroup,POST,/groups/{groupId}/mapping-rules/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchMappingRulesForGroup,POST,/groups/{groupId}/mapping-rules/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchMappingRulesForGroup,POST,/groups/{groupId}/mapping-rules/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchMappingRulesForGroup,POST,/groups/{groupId}/mapping-rules/search,documented-500,response code 500 documented in spec,yes,
+assignMappingRuleToGroup,PUT,/groups/{groupId}/mapping-rules/{mappingRuleId},happy-path,documented success response,yes,
+assignMappingRuleToGroup,PUT,/groups/{groupId}/mapping-rules/{mappingRuleId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+assignMappingRuleToGroup,PUT,/groups/{groupId}/mapping-rules/{mappingRuleId},404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+assignMappingRuleToGroup,PUT,/groups/{groupId}/mapping-rules/{mappingRuleId},404-not-found,"path param=mappingRuleId, type=string, format=MappingRuleId",yes,
+assignMappingRuleToGroup,PUT,/groups/{groupId}/mapping-rules/{mappingRuleId},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+assignMappingRuleToGroup,PUT,/groups/{groupId}/mapping-rules/{mappingRuleId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+assignMappingRuleToGroup,PUT,/groups/{groupId}/mapping-rules/{mappingRuleId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+assignMappingRuleToGroup,PUT,/groups/{groupId}/mapping-rules/{mappingRuleId},documented-500,response code 500 documented in spec,yes,
+assignMappingRuleToGroup,PUT,/groups/{groupId}/mapping-rules/{mappingRuleId},documented-503,response code 503 documented in spec,yes,
+unassignMappingRuleFromGroup,DELETE,/groups/{groupId}/mapping-rules/{mappingRuleId},happy-path,documented success response,yes,
+unassignMappingRuleFromGroup,DELETE,/groups/{groupId}/mapping-rules/{mappingRuleId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+unassignMappingRuleFromGroup,DELETE,/groups/{groupId}/mapping-rules/{mappingRuleId},404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+unassignMappingRuleFromGroup,DELETE,/groups/{groupId}/mapping-rules/{mappingRuleId},404-not-found,"path param=mappingRuleId, type=string, format=MappingRuleId",yes,
+unassignMappingRuleFromGroup,DELETE,/groups/{groupId}/mapping-rules/{mappingRuleId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+unassignMappingRuleFromGroup,DELETE,/groups/{groupId}/mapping-rules/{mappingRuleId},business-entity-lifecycle,operationId prefix `unassign` implies state transition,no,lifecycle state machine for this entity
+unassignMappingRuleFromGroup,DELETE,/groups/{groupId}/mapping-rules/{mappingRuleId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+unassignMappingRuleFromGroup,DELETE,/groups/{groupId}/mapping-rules/{mappingRuleId},documented-500,response code 500 documented in spec,yes,
+unassignMappingRuleFromGroup,DELETE,/groups/{groupId}/mapping-rules/{mappingRuleId},documented-503,response code 503 documented in spec,yes,
+searchRolesForGroup,POST,/groups/{groupId}/roles/search,happy-path,documented success response,yes,
+searchRolesForGroup,POST,/groups/{groupId}/roles/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchRolesForGroup,POST,/groups/{groupId}/roles/search,404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+searchRolesForGroup,POST,/groups/{groupId}/roles/search,bad-request:additional-property,closed schema,yes,
+searchRolesForGroup,POST,/groups/{groupId}/roles/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchRolesForGroup,POST,/groups/{groupId}/roles/search,pagination-sort:request-shape,sort array in body,yes,
+searchRolesForGroup,POST,/groups/{groupId}/roles/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchRolesForGroup,POST,/groups/{groupId}/roles/search,filter:request-shape,filter object in body,yes,
+searchRolesForGroup,POST,/groups/{groupId}/roles/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchRolesForGroup,POST,/groups/{groupId}/roles/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchRolesForGroup,POST,/groups/{groupId}/roles/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchRolesForGroup,POST,/groups/{groupId}/roles/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchRolesForGroup,POST,/groups/{groupId}/roles/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchRolesForGroup,POST,/groups/{groupId}/roles/search,documented-500,response code 500 documented in spec,yes,
+searchUsersForGroup,POST,/groups/{groupId}/users/search,happy-path,documented success response,yes,
+searchUsersForGroup,POST,/groups/{groupId}/users/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchUsersForGroup,POST,/groups/{groupId}/users/search,404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+searchUsersForGroup,POST,/groups/{groupId}/users/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchUsersForGroup,POST,/groups/{groupId}/users/search,pagination-sort:request-shape,sort array in body,yes,
+searchUsersForGroup,POST,/groups/{groupId}/users/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchUsersForGroup,POST,/groups/{groupId}/users/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchUsersForGroup,POST,/groups/{groupId}/users/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchUsersForGroup,POST,/groups/{groupId}/users/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchUsersForGroup,POST,/groups/{groupId}/users/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchUsersForGroup,POST,/groups/{groupId}/users/search,documented-500,response code 500 documented in spec,yes,
+assignUserToGroup,PUT,/groups/{groupId}/users/{username},happy-path,documented success response,yes,
+assignUserToGroup,PUT,/groups/{groupId}/users/{username},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+assignUserToGroup,PUT,/groups/{groupId}/users/{username},404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+assignUserToGroup,PUT,/groups/{groupId}/users/{username},404-not-found,"path param=username, type=string, format=Username",yes,
+assignUserToGroup,PUT,/groups/{groupId}/users/{username},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+assignUserToGroup,PUT,/groups/{groupId}/users/{username},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+assignUserToGroup,PUT,/groups/{groupId}/users/{username},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+assignUserToGroup,PUT,/groups/{groupId}/users/{username},documented-500,response code 500 documented in spec,yes,
+assignUserToGroup,PUT,/groups/{groupId}/users/{username},documented-503,response code 503 documented in spec,yes,
+unassignUserFromGroup,DELETE,/groups/{groupId}/users/{username},happy-path,documented success response,yes,
+unassignUserFromGroup,DELETE,/groups/{groupId}/users/{username},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+unassignUserFromGroup,DELETE,/groups/{groupId}/users/{username},404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+unassignUserFromGroup,DELETE,/groups/{groupId}/users/{username},404-not-found,"path param=username, type=string, format=Username",yes,
+unassignUserFromGroup,DELETE,/groups/{groupId}/users/{username},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+unassignUserFromGroup,DELETE,/groups/{groupId}/users/{username},business-entity-lifecycle,operationId prefix `unassign` implies state transition,no,lifecycle state machine for this entity
+unassignUserFromGroup,DELETE,/groups/{groupId}/users/{username},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+unassignUserFromGroup,DELETE,/groups/{groupId}/users/{username},documented-500,response code 500 documented in spec,yes,
+unassignUserFromGroup,DELETE,/groups/{groupId}/users/{username},documented-503,response code 503 documented in spec,yes,
+searchIncidents,POST,/incidents/search,happy-path,documented success response,yes,
+searchIncidents,POST,/incidents/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchIncidents,POST,/incidents/search,bad-request:additional-property,closed schema,yes,
+searchIncidents,POST,/incidents/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchIncidents,POST,/incidents/search,pagination-sort:request-shape,sort array in body,yes,
+searchIncidents,POST,/incidents/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchIncidents,POST,/incidents/search,filter:request-shape,filter object in body,yes,
+searchIncidents,POST,/incidents/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchIncidents,POST,/incidents/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchIncidents,POST,/incidents/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchIncidents,POST,/incidents/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchIncidents,POST,/incidents/search,documented-500,response code 500 documented in spec,yes,
+getIncident,GET,/incidents/{incidentKey},happy-path,documented success response,yes,
+getIncident,GET,/incidents/{incidentKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getIncident,GET,/incidents/{incidentKey},404-not-found,"path param=incidentKey, type=string, format=IncidentKey",yes,
+getIncident,GET,/incidents/{incidentKey},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getIncident,GET,/incidents/{incidentKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getIncident,GET,/incidents/{incidentKey},documented-500,response code 500 documented in spec,yes,
+resolveIncident,POST,/incidents/{incidentKey}/resolution,happy-path,documented success response,yes,
+resolveIncident,POST,/incidents/{incidentKey}/resolution,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+resolveIncident,POST,/incidents/{incidentKey}/resolution,404-not-found,"path param=incidentKey, type=string, format=IncidentKey",yes,
+resolveIncident,POST,/incidents/{incidentKey}/resolution,bad-request:additional-property,closed schema,yes,
+resolveIncident,POST,/incidents/{incidentKey}/resolution,bad-request:format-invalid,"field=operationReference, format=int64",yes,
+resolveIncident,POST,/incidents/{incidentKey}/resolution,bad-request:type-mismatch,"field=operationReference, type=integer",yes,
+resolveIncident,POST,/incidents/{incidentKey}/resolution,bad-request:range-violation,field=operationReference,yes,
+resolveIncident,POST,/incidents/{incidentKey}/resolution,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+resolveIncident,POST,/incidents/{incidentKey}/resolution,business-entity-lifecycle,path has state-transition verb,no,lifecycle state machine for this entity
+resolveIncident,POST,/incidents/{incidentKey}/resolution,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+resolveIncident,POST,/incidents/{incidentKey}/resolution,documented-500,response code 500 documented in spec,yes,
+resolveIncident,POST,/incidents/{incidentKey}/resolution,documented-503,response code 503 documented in spec,yes,
+getProcessInstanceStatisticsByDefinition,POST,/incidents/statistics/process-instances-by-definition,happy-path,documented success response,yes,
+getProcessInstanceStatisticsByDefinition,POST,/incidents/statistics/process-instances-by-definition,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getProcessInstanceStatisticsByDefinition,POST,/incidents/statistics/process-instances-by-definition,bad-request:missing-required,field=filter,yes,
+getProcessInstanceStatisticsByDefinition,POST,/incidents/statistics/process-instances-by-definition,bad-request:type-mismatch,"field=sort, type=array",yes,
+getProcessInstanceStatisticsByDefinition,POST,/incidents/statistics/process-instances-by-definition,pagination-sort:request-shape,page object in body,yes,
+getProcessInstanceStatisticsByDefinition,POST,/incidents/statistics/process-instances-by-definition,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getProcessInstanceStatisticsByDefinition,POST,/incidents/statistics/process-instances-by-definition,pagination-sort:request-shape,sort array in body,yes,
+getProcessInstanceStatisticsByDefinition,POST,/incidents/statistics/process-instances-by-definition,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getProcessInstanceStatisticsByDefinition,POST,/incidents/statistics/process-instances-by-definition,filter:request-shape,filter object in body,yes,
+getProcessInstanceStatisticsByDefinition,POST,/incidents/statistics/process-instances-by-definition,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getProcessInstanceStatisticsByDefinition,POST,/incidents/statistics/process-instances-by-definition,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+getProcessInstanceStatisticsByDefinition,POST,/incidents/statistics/process-instances-by-definition,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getProcessInstanceStatisticsByDefinition,POST,/incidents/statistics/process-instances-by-definition,documented-500,response code 500 documented in spec,yes,
+getProcessInstanceStatisticsByError,POST,/incidents/statistics/process-instances-by-error,happy-path,documented success response,yes,
+getProcessInstanceStatisticsByError,POST,/incidents/statistics/process-instances-by-error,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getProcessInstanceStatisticsByError,POST,/incidents/statistics/process-instances-by-error,bad-request:additional-property,closed schema,yes,
+getProcessInstanceStatisticsByError,POST,/incidents/statistics/process-instances-by-error,bad-request:type-mismatch,"field=sort, type=array",yes,
+getProcessInstanceStatisticsByError,POST,/incidents/statistics/process-instances-by-error,pagination-sort:request-shape,page object in body,yes,
+getProcessInstanceStatisticsByError,POST,/incidents/statistics/process-instances-by-error,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getProcessInstanceStatisticsByError,POST,/incidents/statistics/process-instances-by-error,pagination-sort:request-shape,sort array in body,yes,
+getProcessInstanceStatisticsByError,POST,/incidents/statistics/process-instances-by-error,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getProcessInstanceStatisticsByError,POST,/incidents/statistics/process-instances-by-error,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+getProcessInstanceStatisticsByError,POST,/incidents/statistics/process-instances-by-error,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getProcessInstanceStatisticsByError,POST,/incidents/statistics/process-instances-by-error,documented-500,response code 500 documented in spec,yes,
+activateJobs,POST,/jobs/activation,happy-path,documented success response,yes,
+activateJobs,POST,/jobs/activation,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+activateJobs,POST,/jobs/activation,bad-request:missing-required,field=type,yes,
+activateJobs,POST,/jobs/activation,bad-request:missing-required,field=maxJobsToActivate,yes,
+activateJobs,POST,/jobs/activation,bad-request:missing-required,field=timeout,yes,
+activateJobs,POST,/jobs/activation,bad-request:additional-property,closed schema,yes,
+activateJobs,POST,/jobs/activation,bad-request:type-mismatch,"field=type, type=string",yes,
+activateJobs,POST,/jobs/activation,bad-request:type-mismatch,"field=worker, type=string",yes,
+activateJobs,POST,/jobs/activation,bad-request:format-invalid,"field=timeout, format=int64",yes,
+activateJobs,POST,/jobs/activation,bad-request:type-mismatch,"field=timeout, type=integer",yes,
+activateJobs,POST,/jobs/activation,bad-request:format-invalid,"field=maxJobsToActivate, format=int32",yes,
+activateJobs,POST,/jobs/activation,bad-request:type-mismatch,"field=maxJobsToActivate, type=integer",yes,
+activateJobs,POST,/jobs/activation,bad-request:type-mismatch,"field=fetchVariable, type=array",yes,
+activateJobs,POST,/jobs/activation,bad-request:format-invalid,"field=requestTimeout, format=int64",yes,
+activateJobs,POST,/jobs/activation,bad-request:type-mismatch,"field=requestTimeout, type=integer",yes,
+activateJobs,POST,/jobs/activation,bad-request:type-mismatch,"field=tenantIds, type=array",yes,
+activateJobs,POST,/jobs/activation,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+activateJobs,POST,/jobs/activation,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+activateJobs,POST,/jobs/activation,business-entity-lifecycle,path has state-transition verb,no,lifecycle state machine for this entity
+activateJobs,POST,/jobs/activation,documented-500,response code 500 documented in spec,yes,
+activateJobs,POST,/jobs/activation,documented-503,response code 503 documented in spec,yes,
+searchJobs,POST,/jobs/search,happy-path,documented success response,yes,
+searchJobs,POST,/jobs/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchJobs,POST,/jobs/search,bad-request:additional-property,closed schema,yes,
+searchJobs,POST,/jobs/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchJobs,POST,/jobs/search,pagination-sort:request-shape,sort array in body,yes,
+searchJobs,POST,/jobs/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchJobs,POST,/jobs/search,filter:request-shape,filter object in body,yes,
+searchJobs,POST,/jobs/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchJobs,POST,/jobs/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchJobs,POST,/jobs/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchJobs,POST,/jobs/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchJobs,POST,/jobs/search,documented-500,response code 500 documented in spec,yes,
+updateJob,PATCH,/jobs/{jobKey},happy-path,documented success response,yes,
+updateJob,PATCH,/jobs/{jobKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+updateJob,PATCH,/jobs/{jobKey},404-not-found,"path param=jobKey, type=string, format=JobKey",yes,
+updateJob,PATCH,/jobs/{jobKey},bad-request:missing-required,field=changeset,yes,
+updateJob,PATCH,/jobs/{jobKey},bad-request:additional-property,closed schema,yes,
+updateJob,PATCH,/jobs/{jobKey},bad-request:type-mismatch,"field=changeset, type=object",yes,
+updateJob,PATCH,/jobs/{jobKey},bad-request:format-invalid,"field=operationReference, format=int64",yes,
+updateJob,PATCH,/jobs/{jobKey},bad-request:type-mismatch,"field=operationReference, type=integer",yes,
+updateJob,PATCH,/jobs/{jobKey},bad-request:range-violation,field=operationReference,yes,
+updateJob,PATCH,/jobs/{jobKey},403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+updateJob,PATCH,/jobs/{jobKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+updateJob,PATCH,/jobs/{jobKey},documented-500,response code 500 documented in spec,yes,
+updateJob,PATCH,/jobs/{jobKey},documented-503,response code 503 documented in spec,yes,
+completeJob,POST,/jobs/{jobKey}/completion,happy-path,documented success response,yes,
+completeJob,POST,/jobs/{jobKey}/completion,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+completeJob,POST,/jobs/{jobKey}/completion,404-not-found,"path param=jobKey, type=string, format=JobKey",yes,
+completeJob,POST,/jobs/{jobKey}/completion,bad-request:additional-property,closed schema,yes,
+completeJob,POST,/jobs/{jobKey}/completion,bad-request:type-mismatch,"field=variables, type=object",yes,
+completeJob,POST,/jobs/{jobKey}/completion,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+completeJob,POST,/jobs/{jobKey}/completion,business-entity-lifecycle,path has state-transition verb,no,lifecycle state machine for this entity
+completeJob,POST,/jobs/{jobKey}/completion,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+completeJob,POST,/jobs/{jobKey}/completion,documented-500,response code 500 documented in spec,yes,
+completeJob,POST,/jobs/{jobKey}/completion,documented-503,response code 503 documented in spec,yes,
+throwJobError,POST,/jobs/{jobKey}/error,happy-path,documented success response,yes,
+throwJobError,POST,/jobs/{jobKey}/error,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+throwJobError,POST,/jobs/{jobKey}/error,404-not-found,"path param=jobKey, type=string, format=JobKey",yes,
+throwJobError,POST,/jobs/{jobKey}/error,bad-request:missing-required,field=errorCode,yes,
+throwJobError,POST,/jobs/{jobKey}/error,bad-request:additional-property,closed schema,yes,
+throwJobError,POST,/jobs/{jobKey}/error,bad-request:type-mismatch,"field=errorCode, type=string",yes,
+throwJobError,POST,/jobs/{jobKey}/error,bad-request:type-mismatch,"field=errorMessage, type=string",yes,
+throwJobError,POST,/jobs/{jobKey}/error,bad-request:type-mismatch,"field=variables, type=object",yes,
+throwJobError,POST,/jobs/{jobKey}/error,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+throwJobError,POST,/jobs/{jobKey}/error,business-entity-lifecycle,409 documented on non-collection POST,no,lifecycle state machine for this entity
+throwJobError,POST,/jobs/{jobKey}/error,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+throwJobError,POST,/jobs/{jobKey}/error,documented-500,response code 500 documented in spec,yes,
+throwJobError,POST,/jobs/{jobKey}/error,documented-503,response code 503 documented in spec,yes,
+failJob,POST,/jobs/{jobKey}/failure,happy-path,documented success response,yes,
+failJob,POST,/jobs/{jobKey}/failure,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+failJob,POST,/jobs/{jobKey}/failure,404-not-found,"path param=jobKey, type=string, format=JobKey",yes,
+failJob,POST,/jobs/{jobKey}/failure,bad-request:additional-property,closed schema,yes,
+failJob,POST,/jobs/{jobKey}/failure,bad-request:format-invalid,"field=retries, format=int32",yes,
+failJob,POST,/jobs/{jobKey}/failure,bad-request:type-mismatch,"field=retries, type=integer",yes,
+failJob,POST,/jobs/{jobKey}/failure,bad-request:type-mismatch,"field=errorMessage, type=string",yes,
+failJob,POST,/jobs/{jobKey}/failure,bad-request:format-invalid,"field=retryBackOff, format=int64",yes,
+failJob,POST,/jobs/{jobKey}/failure,bad-request:type-mismatch,"field=retryBackOff, type=integer",yes,
+failJob,POST,/jobs/{jobKey}/failure,bad-request:type-mismatch,"field=variables, type=object",yes,
+failJob,POST,/jobs/{jobKey}/failure,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+failJob,POST,/jobs/{jobKey}/failure,business-entity-lifecycle,operationId prefix `fail` implies state transition,no,lifecycle state machine for this entity
+failJob,POST,/jobs/{jobKey}/failure,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+failJob,POST,/jobs/{jobKey}/failure,documented-500,response code 500 documented in spec,yes,
+failJob,POST,/jobs/{jobKey}/failure,documented-503,response code 503 documented in spec,yes,
+getGlobalJobStatistics,GET,/jobs/statistics/global,happy-path,documented success response,yes,
+getGlobalJobStatistics,GET,/jobs/statistics/global,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getGlobalJobStatistics,GET,/jobs/statistics/global,pagination-sort:request-shape,query param=from,yes,
+getGlobalJobStatistics,GET,/jobs/statistics/global,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getGlobalJobStatistics,GET,/jobs/statistics/global,documented-500,response code 500 documented in spec,yes,
+getJobTypeStatistics,POST,/jobs/statistics/by-types,happy-path,documented success response,yes,
+getJobTypeStatistics,POST,/jobs/statistics/by-types,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getJobTypeStatistics,POST,/jobs/statistics/by-types,bad-request:type-mismatch,"field=filter, type=object",yes,
+getJobTypeStatistics,POST,/jobs/statistics/by-types,pagination-sort:request-shape,page object in body,yes,
+getJobTypeStatistics,POST,/jobs/statistics/by-types,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getJobTypeStatistics,POST,/jobs/statistics/by-types,filter:request-shape,filter object in body,yes,
+getJobTypeStatistics,POST,/jobs/statistics/by-types,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getJobTypeStatistics,POST,/jobs/statistics/by-types,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+getJobTypeStatistics,POST,/jobs/statistics/by-types,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getJobTypeStatistics,POST,/jobs/statistics/by-types,documented-500,response code 500 documented in spec,yes,
+getJobWorkerStatistics,POST,/jobs/statistics/by-workers,happy-path,documented success response,yes,
+getJobWorkerStatistics,POST,/jobs/statistics/by-workers,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getJobWorkerStatistics,POST,/jobs/statistics/by-workers,bad-request:missing-required,field=filter,yes,
+getJobWorkerStatistics,POST,/jobs/statistics/by-workers,bad-request:type-mismatch,"field=filter, type=object",yes,
+getJobWorkerStatistics,POST,/jobs/statistics/by-workers,pagination-sort:request-shape,page object in body,yes,
+getJobWorkerStatistics,POST,/jobs/statistics/by-workers,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getJobWorkerStatistics,POST,/jobs/statistics/by-workers,filter:request-shape,filter object in body,yes,
+getJobWorkerStatistics,POST,/jobs/statistics/by-workers,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getJobWorkerStatistics,POST,/jobs/statistics/by-workers,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+getJobWorkerStatistics,POST,/jobs/statistics/by-workers,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getJobWorkerStatistics,POST,/jobs/statistics/by-workers,documented-500,response code 500 documented in spec,yes,
+getJobTimeSeriesStatistics,POST,/jobs/statistics/time-series,happy-path,documented success response,yes,
+getJobTimeSeriesStatistics,POST,/jobs/statistics/time-series,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getJobTimeSeriesStatistics,POST,/jobs/statistics/time-series,bad-request:missing-required,field=filter,yes,
+getJobTimeSeriesStatistics,POST,/jobs/statistics/time-series,bad-request:type-mismatch,"field=filter, type=object",yes,
+getJobTimeSeriesStatistics,POST,/jobs/statistics/time-series,pagination-sort:request-shape,page object in body,yes,
+getJobTimeSeriesStatistics,POST,/jobs/statistics/time-series,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getJobTimeSeriesStatistics,POST,/jobs/statistics/time-series,filter:request-shape,filter object in body,yes,
+getJobTimeSeriesStatistics,POST,/jobs/statistics/time-series,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getJobTimeSeriesStatistics,POST,/jobs/statistics/time-series,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+getJobTimeSeriesStatistics,POST,/jobs/statistics/time-series,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getJobTimeSeriesStatistics,POST,/jobs/statistics/time-series,documented-500,response code 500 documented in spec,yes,
+getJobErrorStatistics,POST,/jobs/statistics/errors,happy-path,documented success response,yes,
+getJobErrorStatistics,POST,/jobs/statistics/errors,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getJobErrorStatistics,POST,/jobs/statistics/errors,bad-request:missing-required,field=filter,yes,
+getJobErrorStatistics,POST,/jobs/statistics/errors,bad-request:type-mismatch,"field=filter, type=object",yes,
+getJobErrorStatistics,POST,/jobs/statistics/errors,pagination-sort:request-shape,page object in body,yes,
+getJobErrorStatistics,POST,/jobs/statistics/errors,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getJobErrorStatistics,POST,/jobs/statistics/errors,filter:request-shape,filter object in body,yes,
+getJobErrorStatistics,POST,/jobs/statistics/errors,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getJobErrorStatistics,POST,/jobs/statistics/errors,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+getJobErrorStatistics,POST,/jobs/statistics/errors,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getJobErrorStatistics,POST,/jobs/statistics/errors,documented-500,response code 500 documented in spec,yes,
+getLicense,GET,/license,happy-path,documented success response,yes,
+getLicense,GET,/license,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getLicense,GET,/license,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+getLicense,GET,/license,documented-500,response code 500 documented in spec,yes,
+createMappingRule,POST,/mapping-rules,happy-path,documented success response,yes,
+createMappingRule,POST,/mapping-rules,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createMappingRule,POST,/mapping-rules,bad-request:missing-required,field=mappingRuleId,yes,
+createMappingRule,POST,/mapping-rules,bad-request:additional-property,closed schema,yes,
+createMappingRule,POST,/mapping-rules,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+createMappingRule,POST,/mapping-rules,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+createMappingRule,POST,/mapping-rules,documented-500,response code 500 documented in spec,yes,
+searchMappingRule,POST,/mapping-rules/search,happy-path,documented success response,yes,
+searchMappingRule,POST,/mapping-rules/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchMappingRule,POST,/mapping-rules/search,bad-request:additional-property,closed schema,yes,
+searchMappingRule,POST,/mapping-rules/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchMappingRule,POST,/mapping-rules/search,pagination-sort:request-shape,sort array in body,yes,
+searchMappingRule,POST,/mapping-rules/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchMappingRule,POST,/mapping-rules/search,filter:request-shape,filter object in body,yes,
+searchMappingRule,POST,/mapping-rules/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchMappingRule,POST,/mapping-rules/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchMappingRule,POST,/mapping-rules/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchMappingRule,POST,/mapping-rules/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchMappingRule,POST,/mapping-rules/search,documented-500,response code 500 documented in spec,yes,
+updateMappingRule,PUT,/mapping-rules/{mappingRuleId},happy-path,documented success response,yes,
+updateMappingRule,PUT,/mapping-rules/{mappingRuleId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+updateMappingRule,PUT,/mapping-rules/{mappingRuleId},404-not-found,"path param=mappingRuleId, type=string, format=MappingRuleId",yes,
+updateMappingRule,PUT,/mapping-rules/{mappingRuleId},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+updateMappingRule,PUT,/mapping-rules/{mappingRuleId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+updateMappingRule,PUT,/mapping-rules/{mappingRuleId},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+updateMappingRule,PUT,/mapping-rules/{mappingRuleId},documented-500,response code 500 documented in spec,yes,
+updateMappingRule,PUT,/mapping-rules/{mappingRuleId},documented-503,response code 503 documented in spec,yes,
+deleteMappingRule,DELETE,/mapping-rules/{mappingRuleId},happy-path,documented success response,yes,
+deleteMappingRule,DELETE,/mapping-rules/{mappingRuleId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+deleteMappingRule,DELETE,/mapping-rules/{mappingRuleId},404-not-found,"path param=mappingRuleId, type=string, format=MappingRuleId",yes,
+deleteMappingRule,DELETE,/mapping-rules/{mappingRuleId},403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+deleteMappingRule,DELETE,/mapping-rules/{mappingRuleId},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+deleteMappingRule,DELETE,/mapping-rules/{mappingRuleId},documented-500,response code 500 documented in spec,yes,
+deleteMappingRule,DELETE,/mapping-rules/{mappingRuleId},documented-503,response code 503 documented in spec,yes,
+getMappingRule,GET,/mapping-rules/{mappingRuleId},happy-path,documented success response,yes,
+getMappingRule,GET,/mapping-rules/{mappingRuleId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getMappingRule,GET,/mapping-rules/{mappingRuleId},404-not-found,"path param=mappingRuleId, type=string, format=MappingRuleId",yes,
+getMappingRule,GET,/mapping-rules/{mappingRuleId},403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+getMappingRule,GET,/mapping-rules/{mappingRuleId},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getMappingRule,GET,/mapping-rules/{mappingRuleId},documented-500,response code 500 documented in spec,yes,
+searchMessageSubscriptions,POST,/message-subscriptions/search,happy-path,documented success response,yes,
+searchMessageSubscriptions,POST,/message-subscriptions/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchMessageSubscriptions,POST,/message-subscriptions/search,bad-request:additional-property,closed schema,yes,
+searchMessageSubscriptions,POST,/message-subscriptions/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchMessageSubscriptions,POST,/message-subscriptions/search,pagination-sort:request-shape,sort array in body,yes,
+searchMessageSubscriptions,POST,/message-subscriptions/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchMessageSubscriptions,POST,/message-subscriptions/search,filter:request-shape,filter object in body,yes,
+searchMessageSubscriptions,POST,/message-subscriptions/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchMessageSubscriptions,POST,/message-subscriptions/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchMessageSubscriptions,POST,/message-subscriptions/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchMessageSubscriptions,POST,/message-subscriptions/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchMessageSubscriptions,POST,/message-subscriptions/search,documented-500,response code 500 documented in spec,yes,
+correlateMessage,POST,/messages/correlation,happy-path,documented success response,yes,
+correlateMessage,POST,/messages/correlation,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+correlateMessage,POST,/messages/correlation,bad-request:missing-required,field=name,yes,
+correlateMessage,POST,/messages/correlation,bad-request:additional-property,closed schema,yes,
+correlateMessage,POST,/messages/correlation,bad-request:type-mismatch,"field=name, type=string",yes,
+correlateMessage,POST,/messages/correlation,bad-request:type-mismatch,"field=correlationKey, type=string",yes,
+correlateMessage,POST,/messages/correlation,bad-request:type-mismatch,"field=variables, type=object",yes,
+correlateMessage,POST,/messages/correlation,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+correlateMessage,POST,/messages/correlation,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+correlateMessage,POST,/messages/correlation,business-entity-lifecycle,path has state-transition verb,no,lifecycle state machine for this entity
+correlateMessage,POST,/messages/correlation,documented-500,response code 500 documented in spec,yes,
+correlateMessage,POST,/messages/correlation,documented-503,response code 503 documented in spec,yes,
+publishMessage,POST,/messages/publication,happy-path,documented success response,yes,
+publishMessage,POST,/messages/publication,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+publishMessage,POST,/messages/publication,bad-request:missing-required,field=name,yes,
+publishMessage,POST,/messages/publication,bad-request:additional-property,closed schema,yes,
+publishMessage,POST,/messages/publication,bad-request:type-mismatch,"field=name, type=string",yes,
+publishMessage,POST,/messages/publication,bad-request:type-mismatch,"field=correlationKey, type=string",yes,
+publishMessage,POST,/messages/publication,bad-request:format-invalid,"field=timeToLive, format=int64",yes,
+publishMessage,POST,/messages/publication,bad-request:type-mismatch,"field=timeToLive, type=integer",yes,
+publishMessage,POST,/messages/publication,bad-request:type-mismatch,"field=messageId, type=string",yes,
+publishMessage,POST,/messages/publication,bad-request:type-mismatch,"field=variables, type=object",yes,
+publishMessage,POST,/messages/publication,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+publishMessage,POST,/messages/publication,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+publishMessage,POST,/messages/publication,business-entity-lifecycle,path has state-transition verb,no,lifecycle state machine for this entity
+publishMessage,POST,/messages/publication,documented-500,response code 500 documented in spec,yes,
+publishMessage,POST,/messages/publication,documented-503,response code 503 documented in spec,yes,
+searchProcessDefinitions,POST,/process-definitions/search,happy-path,documented success response,yes,
+searchProcessDefinitions,POST,/process-definitions/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchProcessDefinitions,POST,/process-definitions/search,bad-request:additional-property,closed schema,yes,
+searchProcessDefinitions,POST,/process-definitions/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchProcessDefinitions,POST,/process-definitions/search,pagination-sort:request-shape,sort array in body,yes,
+searchProcessDefinitions,POST,/process-definitions/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchProcessDefinitions,POST,/process-definitions/search,filter:request-shape,filter object in body,yes,
+searchProcessDefinitions,POST,/process-definitions/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchProcessDefinitions,POST,/process-definitions/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchProcessDefinitions,POST,/process-definitions/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchProcessDefinitions,POST,/process-definitions/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchProcessDefinitions,POST,/process-definitions/search,documented-500,response code 500 documented in spec,yes,
+getProcessDefinitionMessageSubscriptionStatistics,POST,/process-definitions/statistics/message-subscriptions,happy-path,documented success response,yes,
+getProcessDefinitionMessageSubscriptionStatistics,POST,/process-definitions/statistics/message-subscriptions,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getProcessDefinitionMessageSubscriptionStatistics,POST,/process-definitions/statistics/message-subscriptions,pagination-sort:request-shape,page object in body,yes,
+getProcessDefinitionMessageSubscriptionStatistics,POST,/process-definitions/statistics/message-subscriptions,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getProcessDefinitionMessageSubscriptionStatistics,POST,/process-definitions/statistics/message-subscriptions,filter:request-shape,filter object in body,yes,
+getProcessDefinitionMessageSubscriptionStatistics,POST,/process-definitions/statistics/message-subscriptions,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getProcessDefinitionMessageSubscriptionStatistics,POST,/process-definitions/statistics/message-subscriptions,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+getProcessDefinitionMessageSubscriptionStatistics,POST,/process-definitions/statistics/message-subscriptions,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getProcessDefinitionMessageSubscriptionStatistics,POST,/process-definitions/statistics/message-subscriptions,documented-500,response code 500 documented in spec,yes,
+getProcessDefinitionInstanceStatistics,POST,/process-definitions/statistics/process-instances,happy-path,documented success response,yes,
+getProcessDefinitionInstanceStatistics,POST,/process-definitions/statistics/process-instances,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getProcessDefinitionInstanceStatistics,POST,/process-definitions/statistics/process-instances,bad-request:type-mismatch,"field=sort, type=array",yes,
+getProcessDefinitionInstanceStatistics,POST,/process-definitions/statistics/process-instances,pagination-sort:request-shape,page object in body,yes,
+getProcessDefinitionInstanceStatistics,POST,/process-definitions/statistics/process-instances,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getProcessDefinitionInstanceStatistics,POST,/process-definitions/statistics/process-instances,pagination-sort:request-shape,sort array in body,yes,
+getProcessDefinitionInstanceStatistics,POST,/process-definitions/statistics/process-instances,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getProcessDefinitionInstanceStatistics,POST,/process-definitions/statistics/process-instances,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+getProcessDefinitionInstanceStatistics,POST,/process-definitions/statistics/process-instances,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getProcessDefinitionInstanceStatistics,POST,/process-definitions/statistics/process-instances,documented-500,response code 500 documented in spec,yes,
+getProcessDefinition,GET,/process-definitions/{processDefinitionKey},happy-path,documented success response,yes,
+getProcessDefinition,GET,/process-definitions/{processDefinitionKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getProcessDefinition,GET,/process-definitions/{processDefinitionKey},404-not-found,"path param=processDefinitionKey, type=string, format=ProcessDefinitionKey",yes,
+getProcessDefinition,GET,/process-definitions/{processDefinitionKey},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getProcessDefinition,GET,/process-definitions/{processDefinitionKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getProcessDefinition,GET,/process-definitions/{processDefinitionKey},documented-500,response code 500 documented in spec,yes,
+getStartProcessForm,GET,/process-definitions/{processDefinitionKey}/form,happy-path,documented success response,yes,
+getStartProcessForm,GET,/process-definitions/{processDefinitionKey}/form,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getStartProcessForm,GET,/process-definitions/{processDefinitionKey}/form,404-not-found,"path param=processDefinitionKey, type=string, format=ProcessDefinitionKey",yes,
+getStartProcessForm,GET,/process-definitions/{processDefinitionKey}/form,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getStartProcessForm,GET,/process-definitions/{processDefinitionKey}/form,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getStartProcessForm,GET,/process-definitions/{processDefinitionKey}/form,documented-500,response code 500 documented in spec,yes,
+getProcessDefinitionStatistics,POST,/process-definitions/{processDefinitionKey}/statistics/element-instances,happy-path,documented success response,yes,
+getProcessDefinitionStatistics,POST,/process-definitions/{processDefinitionKey}/statistics/element-instances,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getProcessDefinitionStatistics,POST,/process-definitions/{processDefinitionKey}/statistics/element-instances,404-not-found,"path param=processDefinitionKey, type=string, format=ProcessDefinitionKey",yes,
+getProcessDefinitionStatistics,POST,/process-definitions/{processDefinitionKey}/statistics/element-instances,bad-request:additional-property,closed schema,yes,
+getProcessDefinitionStatistics,POST,/process-definitions/{processDefinitionKey}/statistics/element-instances,filter:request-shape,filter object in body,yes,
+getProcessDefinitionStatistics,POST,/process-definitions/{processDefinitionKey}/statistics/element-instances,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getProcessDefinitionStatistics,POST,/process-definitions/{processDefinitionKey}/statistics/element-instances,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getProcessDefinitionStatistics,POST,/process-definitions/{processDefinitionKey}/statistics/element-instances,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getProcessDefinitionStatistics,POST,/process-definitions/{processDefinitionKey}/statistics/element-instances,documented-500,response code 500 documented in spec,yes,
+getProcessDefinitionXML,GET,/process-definitions/{processDefinitionKey}/xml,happy-path,documented success response,yes,
+getProcessDefinitionXML,GET,/process-definitions/{processDefinitionKey}/xml,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getProcessDefinitionXML,GET,/process-definitions/{processDefinitionKey}/xml,404-not-found,"path param=processDefinitionKey, type=string, format=ProcessDefinitionKey",yes,
+getProcessDefinitionXML,GET,/process-definitions/{processDefinitionKey}/xml,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getProcessDefinitionXML,GET,/process-definitions/{processDefinitionKey}/xml,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getProcessDefinitionXML,GET,/process-definitions/{processDefinitionKey}/xml,documented-500,response code 500 documented in spec,yes,
+getProcessDefinitionInstanceVersionStatistics,POST,/process-definitions/statistics/process-instances-by-version,happy-path,documented success response,yes,
+getProcessDefinitionInstanceVersionStatistics,POST,/process-definitions/statistics/process-instances-by-version,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getProcessDefinitionInstanceVersionStatistics,POST,/process-definitions/statistics/process-instances-by-version,bad-request:missing-required,field=filter,yes,
+getProcessDefinitionInstanceVersionStatistics,POST,/process-definitions/statistics/process-instances-by-version,bad-request:type-mismatch,"field=sort, type=array",yes,
+getProcessDefinitionInstanceVersionStatistics,POST,/process-definitions/statistics/process-instances-by-version,pagination-sort:request-shape,page object in body,yes,
+getProcessDefinitionInstanceVersionStatistics,POST,/process-definitions/statistics/process-instances-by-version,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getProcessDefinitionInstanceVersionStatistics,POST,/process-definitions/statistics/process-instances-by-version,pagination-sort:request-shape,sort array in body,yes,
+getProcessDefinitionInstanceVersionStatistics,POST,/process-definitions/statistics/process-instances-by-version,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getProcessDefinitionInstanceVersionStatistics,POST,/process-definitions/statistics/process-instances-by-version,filter:request-shape,filter object in body,yes,
+getProcessDefinitionInstanceVersionStatistics,POST,/process-definitions/statistics/process-instances-by-version,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+getProcessDefinitionInstanceVersionStatistics,POST,/process-definitions/statistics/process-instances-by-version,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+getProcessDefinitionInstanceVersionStatistics,POST,/process-definitions/statistics/process-instances-by-version,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getProcessDefinitionInstanceVersionStatistics,POST,/process-definitions/statistics/process-instances-by-version,documented-500,response code 500 documented in spec,yes,
+createProcessInstance,POST,/process-instances,happy-path,documented success response,yes,
+createProcessInstance,POST,/process-instances,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createProcessInstance,POST,/process-instances,bad-request:oneof-violation,oneOf branches=2,yes,
+createProcessInstance,POST,/process-instances,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+createProcessInstance,POST,/process-instances,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+createProcessInstance,POST,/process-instances,business-entity-lifecycle,409 documented on non-collection POST,no,lifecycle state machine for this entity
+createProcessInstance,POST,/process-instances,documented-500,response code 500 documented in spec,yes,
+createProcessInstance,POST,/process-instances,documented-503,response code 503 documented in spec,yes,
+createProcessInstance,POST,/process-instances,documented-504,response code 504 documented in spec,yes,
+cancelProcessInstancesBatchOperation,POST,/process-instances/cancellation,happy-path,documented success response,yes,
+cancelProcessInstancesBatchOperation,POST,/process-instances/cancellation,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+cancelProcessInstancesBatchOperation,POST,/process-instances/cancellation,bad-request:missing-required,field=filter,yes,
+cancelProcessInstancesBatchOperation,POST,/process-instances/cancellation,bad-request:additional-property,closed schema,yes,
+cancelProcessInstancesBatchOperation,POST,/process-instances/cancellation,bad-request:format-invalid,"field=operationReference, format=int64",yes,
+cancelProcessInstancesBatchOperation,POST,/process-instances/cancellation,bad-request:type-mismatch,"field=operationReference, type=integer",yes,
+cancelProcessInstancesBatchOperation,POST,/process-instances/cancellation,bad-request:range-violation,field=operationReference,yes,
+cancelProcessInstancesBatchOperation,POST,/process-instances/cancellation,filter:request-shape,filter object in body,yes,
+cancelProcessInstancesBatchOperation,POST,/process-instances/cancellation,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+cancelProcessInstancesBatchOperation,POST,/process-instances/cancellation,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+cancelProcessInstancesBatchOperation,POST,/process-instances/cancellation,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+cancelProcessInstancesBatchOperation,POST,/process-instances/cancellation,business-entity-lifecycle,path has state-transition verb,no,lifecycle state machine for this entity
+cancelProcessInstancesBatchOperation,POST,/process-instances/cancellation,documented-500,response code 500 documented in spec,yes,
+deleteProcessInstancesBatchOperation,POST,/process-instances/deletion,happy-path,documented success response,yes,
+deleteProcessInstancesBatchOperation,POST,/process-instances/deletion,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+deleteProcessInstancesBatchOperation,POST,/process-instances/deletion,bad-request:missing-required,field=filter,yes,
+deleteProcessInstancesBatchOperation,POST,/process-instances/deletion,bad-request:additional-property,closed schema,yes,
+deleteProcessInstancesBatchOperation,POST,/process-instances/deletion,bad-request:format-invalid,"field=operationReference, format=int64",yes,
+deleteProcessInstancesBatchOperation,POST,/process-instances/deletion,bad-request:type-mismatch,"field=operationReference, type=integer",yes,
+deleteProcessInstancesBatchOperation,POST,/process-instances/deletion,bad-request:range-violation,field=operationReference,yes,
+deleteProcessInstancesBatchOperation,POST,/process-instances/deletion,filter:request-shape,filter object in body,yes,
+deleteProcessInstancesBatchOperation,POST,/process-instances/deletion,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+deleteProcessInstancesBatchOperation,POST,/process-instances/deletion,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+deleteProcessInstancesBatchOperation,POST,/process-instances/deletion,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+deleteProcessInstancesBatchOperation,POST,/process-instances/deletion,documented-500,response code 500 documented in spec,yes,
+resolveIncidentsBatchOperation,POST,/process-instances/incident-resolution,happy-path,documented success response,yes,
+resolveIncidentsBatchOperation,POST,/process-instances/incident-resolution,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+resolveIncidentsBatchOperation,POST,/process-instances/incident-resolution,bad-request:missing-required,field=filter,yes,
+resolveIncidentsBatchOperation,POST,/process-instances/incident-resolution,bad-request:additional-property,closed schema,yes,
+resolveIncidentsBatchOperation,POST,/process-instances/incident-resolution,bad-request:format-invalid,"field=operationReference, format=int64",yes,
+resolveIncidentsBatchOperation,POST,/process-instances/incident-resolution,bad-request:type-mismatch,"field=operationReference, type=integer",yes,
+resolveIncidentsBatchOperation,POST,/process-instances/incident-resolution,bad-request:range-violation,field=operationReference,yes,
+resolveIncidentsBatchOperation,POST,/process-instances/incident-resolution,filter:request-shape,filter object in body,yes,
+resolveIncidentsBatchOperation,POST,/process-instances/incident-resolution,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+resolveIncidentsBatchOperation,POST,/process-instances/incident-resolution,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+resolveIncidentsBatchOperation,POST,/process-instances/incident-resolution,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+resolveIncidentsBatchOperation,POST,/process-instances/incident-resolution,business-entity-lifecycle,operationId prefix `resolve` implies state transition,no,lifecycle state machine for this entity
+resolveIncidentsBatchOperation,POST,/process-instances/incident-resolution,documented-500,response code 500 documented in spec,yes,
+migrateProcessInstancesBatchOperation,POST,/process-instances/migration,happy-path,documented success response,yes,
+migrateProcessInstancesBatchOperation,POST,/process-instances/migration,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+migrateProcessInstancesBatchOperation,POST,/process-instances/migration,bad-request:missing-required,field=filter,yes,
+migrateProcessInstancesBatchOperation,POST,/process-instances/migration,bad-request:missing-required,field=migrationPlan,yes,
+migrateProcessInstancesBatchOperation,POST,/process-instances/migration,bad-request:additional-property,closed schema,yes,
+migrateProcessInstancesBatchOperation,POST,/process-instances/migration,bad-request:format-invalid,"field=operationReference, format=int64",yes,
+migrateProcessInstancesBatchOperation,POST,/process-instances/migration,bad-request:type-mismatch,"field=operationReference, type=integer",yes,
+migrateProcessInstancesBatchOperation,POST,/process-instances/migration,bad-request:range-violation,field=operationReference,yes,
+migrateProcessInstancesBatchOperation,POST,/process-instances/migration,filter:request-shape,filter object in body,yes,
+migrateProcessInstancesBatchOperation,POST,/process-instances/migration,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+migrateProcessInstancesBatchOperation,POST,/process-instances/migration,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+migrateProcessInstancesBatchOperation,POST,/process-instances/migration,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+migrateProcessInstancesBatchOperation,POST,/process-instances/migration,business-entity-lifecycle,operationId prefix `migrate` implies state transition,no,lifecycle state machine for this entity
+migrateProcessInstancesBatchOperation,POST,/process-instances/migration,documented-500,response code 500 documented in spec,yes,
+modifyProcessInstancesBatchOperation,POST,/process-instances/modification,happy-path,documented success response,yes,
+modifyProcessInstancesBatchOperation,POST,/process-instances/modification,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+modifyProcessInstancesBatchOperation,POST,/process-instances/modification,bad-request:missing-required,field=filter,yes,
+modifyProcessInstancesBatchOperation,POST,/process-instances/modification,bad-request:missing-required,field=moveInstructions,yes,
+modifyProcessInstancesBatchOperation,POST,/process-instances/modification,bad-request:additional-property,closed schema,yes,
+modifyProcessInstancesBatchOperation,POST,/process-instances/modification,bad-request:type-mismatch,"field=moveInstructions, type=array",yes,
+modifyProcessInstancesBatchOperation,POST,/process-instances/modification,bad-request:format-invalid,"field=operationReference, format=int64",yes,
+modifyProcessInstancesBatchOperation,POST,/process-instances/modification,bad-request:type-mismatch,"field=operationReference, type=integer",yes,
+modifyProcessInstancesBatchOperation,POST,/process-instances/modification,bad-request:range-violation,field=operationReference,yes,
+modifyProcessInstancesBatchOperation,POST,/process-instances/modification,filter:request-shape,filter object in body,yes,
+modifyProcessInstancesBatchOperation,POST,/process-instances/modification,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+modifyProcessInstancesBatchOperation,POST,/process-instances/modification,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+modifyProcessInstancesBatchOperation,POST,/process-instances/modification,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+modifyProcessInstancesBatchOperation,POST,/process-instances/modification,business-entity-lifecycle,path has state-transition verb,no,lifecycle state machine for this entity
+modifyProcessInstancesBatchOperation,POST,/process-instances/modification,documented-500,response code 500 documented in spec,yes,
+searchProcessInstances,POST,/process-instances/search,happy-path,documented success response,yes,
+searchProcessInstances,POST,/process-instances/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchProcessInstances,POST,/process-instances/search,bad-request:additional-property,closed schema,yes,
+searchProcessInstances,POST,/process-instances/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchProcessInstances,POST,/process-instances/search,pagination-sort:request-shape,sort array in body,yes,
+searchProcessInstances,POST,/process-instances/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchProcessInstances,POST,/process-instances/search,filter:request-shape,filter object in body,yes,
+searchProcessInstances,POST,/process-instances/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchProcessInstances,POST,/process-instances/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchProcessInstances,POST,/process-instances/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchProcessInstances,POST,/process-instances/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchProcessInstances,POST,/process-instances/search,documented-500,response code 500 documented in spec,yes,
+getProcessInstance,GET,/process-instances/{processInstanceKey},happy-path,documented success response,yes,
+getProcessInstance,GET,/process-instances/{processInstanceKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getProcessInstance,GET,/process-instances/{processInstanceKey},404-not-found,"path param=processInstanceKey, type=string, format=ProcessInstanceKey",yes,
+getProcessInstance,GET,/process-instances/{processInstanceKey},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getProcessInstance,GET,/process-instances/{processInstanceKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getProcessInstance,GET,/process-instances/{processInstanceKey},documented-500,response code 500 documented in spec,yes,
+getProcessInstanceCallHierarchy,GET,/process-instances/{processInstanceKey}/call-hierarchy,happy-path,documented success response,yes,
+getProcessInstanceCallHierarchy,GET,/process-instances/{processInstanceKey}/call-hierarchy,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getProcessInstanceCallHierarchy,GET,/process-instances/{processInstanceKey}/call-hierarchy,404-not-found,"path param=processInstanceKey, type=string, format=ProcessInstanceKey",yes,
+getProcessInstanceCallHierarchy,GET,/process-instances/{processInstanceKey}/call-hierarchy,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getProcessInstanceCallHierarchy,GET,/process-instances/{processInstanceKey}/call-hierarchy,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getProcessInstanceCallHierarchy,GET,/process-instances/{processInstanceKey}/call-hierarchy,documented-500,response code 500 documented in spec,yes,
+cancelProcessInstance,POST,/process-instances/{processInstanceKey}/cancellation,happy-path,documented success response,yes,
+cancelProcessInstance,POST,/process-instances/{processInstanceKey}/cancellation,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+cancelProcessInstance,POST,/process-instances/{processInstanceKey}/cancellation,404-not-found,"path param=processInstanceKey, type=string, format=ProcessInstanceKey",yes,
+cancelProcessInstance,POST,/process-instances/{processInstanceKey}/cancellation,bad-request:additional-property,closed schema,yes,
+cancelProcessInstance,POST,/process-instances/{processInstanceKey}/cancellation,bad-request:format-invalid,"field=operationReference, format=int64",yes,
+cancelProcessInstance,POST,/process-instances/{processInstanceKey}/cancellation,bad-request:type-mismatch,"field=operationReference, type=integer",yes,
+cancelProcessInstance,POST,/process-instances/{processInstanceKey}/cancellation,bad-request:range-violation,field=operationReference,yes,
+cancelProcessInstance,POST,/process-instances/{processInstanceKey}/cancellation,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+cancelProcessInstance,POST,/process-instances/{processInstanceKey}/cancellation,business-entity-lifecycle,path has state-transition verb,no,lifecycle state machine for this entity
+cancelProcessInstance,POST,/process-instances/{processInstanceKey}/cancellation,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+cancelProcessInstance,POST,/process-instances/{processInstanceKey}/cancellation,documented-500,response code 500 documented in spec,yes,
+cancelProcessInstance,POST,/process-instances/{processInstanceKey}/cancellation,documented-503,response code 503 documented in spec,yes,
+cancelProcessInstance,POST,/process-instances/{processInstanceKey}/cancellation,documented-504,response code 504 documented in spec,yes,
+deleteProcessInstance,POST,/process-instances/{processInstanceKey}/deletion,happy-path,documented success response,yes,
+deleteProcessInstance,POST,/process-instances/{processInstanceKey}/deletion,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+deleteProcessInstance,POST,/process-instances/{processInstanceKey}/deletion,404-not-found,"path param=processInstanceKey, type=string, format=ProcessInstanceKey",yes,
+deleteProcessInstance,POST,/process-instances/{processInstanceKey}/deletion,bad-request:additional-property,closed schema,yes,
+deleteProcessInstance,POST,/process-instances/{processInstanceKey}/deletion,bad-request:format-invalid,"field=operationReference, format=int64",yes,
+deleteProcessInstance,POST,/process-instances/{processInstanceKey}/deletion,bad-request:type-mismatch,"field=operationReference, type=integer",yes,
+deleteProcessInstance,POST,/process-instances/{processInstanceKey}/deletion,bad-request:range-violation,field=operationReference,yes,
+deleteProcessInstance,POST,/process-instances/{processInstanceKey}/deletion,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+deleteProcessInstance,POST,/process-instances/{processInstanceKey}/deletion,business-entity-lifecycle,409 documented on non-collection POST,no,lifecycle state machine for this entity
+deleteProcessInstance,POST,/process-instances/{processInstanceKey}/deletion,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+deleteProcessInstance,POST,/process-instances/{processInstanceKey}/deletion,documented-500,response code 500 documented in spec,yes,
+deleteProcessInstance,POST,/process-instances/{processInstanceKey}/deletion,documented-503,response code 503 documented in spec,yes,
+resolveProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incident-resolution,happy-path,documented success response,yes,
+resolveProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incident-resolution,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+resolveProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incident-resolution,404-not-found,"path param=processInstanceKey, type=string, format=ProcessInstanceKey",yes,
+resolveProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incident-resolution,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+resolveProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incident-resolution,business-entity-lifecycle,operationId prefix `resolve` implies state transition,no,lifecycle state machine for this entity
+resolveProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incident-resolution,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+resolveProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incident-resolution,documented-500,response code 500 documented in spec,yes,
+resolveProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incident-resolution,documented-503,response code 503 documented in spec,yes,
+searchProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incidents/search,happy-path,documented success response,yes,
+searchProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incidents/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incidents/search,404-not-found,"path param=processInstanceKey, type=string, format=ProcessInstanceKey",yes,
+searchProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incidents/search,bad-request:additional-property,closed schema,yes,
+searchProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incidents/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incidents/search,pagination-sort:request-shape,sort array in body,yes,
+searchProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incidents/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incidents/search,filter:request-shape,filter object in body,yes,
+searchProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incidents/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incidents/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incidents/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incidents/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incidents/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchProcessInstanceIncidents,POST,/process-instances/{processInstanceKey}/incidents/search,documented-500,response code 500 documented in spec,yes,
+migrateProcessInstance,POST,/process-instances/{processInstanceKey}/migration,happy-path,documented success response,yes,
+migrateProcessInstance,POST,/process-instances/{processInstanceKey}/migration,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+migrateProcessInstance,POST,/process-instances/{processInstanceKey}/migration,404-not-found,"path param=processInstanceKey, type=string, format=ProcessInstanceKey",yes,
+migrateProcessInstance,POST,/process-instances/{processInstanceKey}/migration,bad-request:missing-required,field=targetProcessDefinitionKey,yes,
+migrateProcessInstance,POST,/process-instances/{processInstanceKey}/migration,bad-request:missing-required,field=mappingInstructions,yes,
+migrateProcessInstance,POST,/process-instances/{processInstanceKey}/migration,bad-request:additional-property,closed schema,yes,
+migrateProcessInstance,POST,/process-instances/{processInstanceKey}/migration,bad-request:type-mismatch,"field=mappingInstructions, type=array",yes,
+migrateProcessInstance,POST,/process-instances/{processInstanceKey}/migration,bad-request:format-invalid,"field=operationReference, format=int64",yes,
+migrateProcessInstance,POST,/process-instances/{processInstanceKey}/migration,bad-request:type-mismatch,"field=operationReference, type=integer",yes,
+migrateProcessInstance,POST,/process-instances/{processInstanceKey}/migration,bad-request:range-violation,field=operationReference,yes,
+migrateProcessInstance,POST,/process-instances/{processInstanceKey}/migration,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+migrateProcessInstance,POST,/process-instances/{processInstanceKey}/migration,business-entity-lifecycle,operationId prefix `migrate` implies state transition,no,lifecycle state machine for this entity
+migrateProcessInstance,POST,/process-instances/{processInstanceKey}/migration,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+migrateProcessInstance,POST,/process-instances/{processInstanceKey}/migration,documented-500,response code 500 documented in spec,yes,
+migrateProcessInstance,POST,/process-instances/{processInstanceKey}/migration,documented-503,response code 503 documented in spec,yes,
+modifyProcessInstance,POST,/process-instances/{processInstanceKey}/modification,happy-path,documented success response,yes,
+modifyProcessInstance,POST,/process-instances/{processInstanceKey}/modification,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+modifyProcessInstance,POST,/process-instances/{processInstanceKey}/modification,404-not-found,"path param=processInstanceKey, type=string, format=ProcessInstanceKey",yes,
+modifyProcessInstance,POST,/process-instances/{processInstanceKey}/modification,bad-request:additional-property,closed schema,yes,
+modifyProcessInstance,POST,/process-instances/{processInstanceKey}/modification,bad-request:format-invalid,"field=operationReference, format=int64",yes,
+modifyProcessInstance,POST,/process-instances/{processInstanceKey}/modification,bad-request:type-mismatch,"field=operationReference, type=integer",yes,
+modifyProcessInstance,POST,/process-instances/{processInstanceKey}/modification,bad-request:range-violation,field=operationReference,yes,
+modifyProcessInstance,POST,/process-instances/{processInstanceKey}/modification,bad-request:type-mismatch,"field=activateInstructions, type=array",yes,
+modifyProcessInstance,POST,/process-instances/{processInstanceKey}/modification,bad-request:type-mismatch,"field=moveInstructions, type=array",yes,
+modifyProcessInstance,POST,/process-instances/{processInstanceKey}/modification,bad-request:type-mismatch,"field=terminateInstructions, type=array",yes,
+modifyProcessInstance,POST,/process-instances/{processInstanceKey}/modification,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+modifyProcessInstance,POST,/process-instances/{processInstanceKey}/modification,business-entity-lifecycle,path has state-transition verb,no,lifecycle state machine for this entity
+modifyProcessInstance,POST,/process-instances/{processInstanceKey}/modification,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+modifyProcessInstance,POST,/process-instances/{processInstanceKey}/modification,documented-500,response code 500 documented in spec,yes,
+modifyProcessInstance,POST,/process-instances/{processInstanceKey}/modification,documented-503,response code 503 documented in spec,yes,
+getProcessInstanceSequenceFlows,GET,/process-instances/{processInstanceKey}/sequence-flows,happy-path,documented success response,yes,
+getProcessInstanceSequenceFlows,GET,/process-instances/{processInstanceKey}/sequence-flows,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getProcessInstanceSequenceFlows,GET,/process-instances/{processInstanceKey}/sequence-flows,404-not-found,"path param=processInstanceKey, type=string, format=ProcessInstanceKey",yes,
+getProcessInstanceSequenceFlows,GET,/process-instances/{processInstanceKey}/sequence-flows,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getProcessInstanceSequenceFlows,GET,/process-instances/{processInstanceKey}/sequence-flows,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getProcessInstanceSequenceFlows,GET,/process-instances/{processInstanceKey}/sequence-flows,documented-500,response code 500 documented in spec,yes,
+getProcessInstanceStatistics,GET,/process-instances/{processInstanceKey}/statistics/element-instances,happy-path,documented success response,yes,
+getProcessInstanceStatistics,GET,/process-instances/{processInstanceKey}/statistics/element-instances,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getProcessInstanceStatistics,GET,/process-instances/{processInstanceKey}/statistics/element-instances,404-not-found,"path param=processInstanceKey, type=string, format=ProcessInstanceKey",yes,
+getProcessInstanceStatistics,GET,/process-instances/{processInstanceKey}/statistics/element-instances,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getProcessInstanceStatistics,GET,/process-instances/{processInstanceKey}/statistics/element-instances,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getProcessInstanceStatistics,GET,/process-instances/{processInstanceKey}/statistics/element-instances,documented-500,response code 500 documented in spec,yes,
+searchResources,POST,/resources/search,happy-path,documented success response,yes,
+searchResources,POST,/resources/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchResources,POST,/resources/search,bad-request:additional-property,closed schema,yes,
+searchResources,POST,/resources/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchResources,POST,/resources/search,pagination-sort:request-shape,sort array in body,yes,
+searchResources,POST,/resources/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchResources,POST,/resources/search,filter:request-shape,filter object in body,yes,
+searchResources,POST,/resources/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchResources,POST,/resources/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchResources,POST,/resources/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchResources,POST,/resources/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchResources,POST,/resources/search,documented-500,response code 500 documented in spec,yes,
+getResource,GET,/resources/{resourceKey},happy-path,documented success response,yes,
+getResource,GET,/resources/{resourceKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getResource,GET,/resources/{resourceKey},404-not-found,"path param=resourceKey, type=string, format=ResourceKey",yes,
+getResource,GET,/resources/{resourceKey},403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+getResource,GET,/resources/{resourceKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getResource,GET,/resources/{resourceKey},documented-500,response code 500 documented in spec,yes,
+getResourceContent,GET,/resources/{resourceKey}/content,happy-path,documented success response,yes,
+getResourceContent,GET,/resources/{resourceKey}/content,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getResourceContent,GET,/resources/{resourceKey}/content,404-not-found,"path param=resourceKey, type=string, format=ResourceKey",yes,
+getResourceContent,GET,/resources/{resourceKey}/content,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+getResourceContent,GET,/resources/{resourceKey}/content,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getResourceContent,GET,/resources/{resourceKey}/content,documented-406,response code 406 documented in spec,yes,
+getResourceContent,GET,/resources/{resourceKey}/content,documented-500,response code 500 documented in spec,yes,
+getResourceContentBinary,GET,/resources/{resourceKey}/content/binary,happy-path,documented success response,yes,
+getResourceContentBinary,GET,/resources/{resourceKey}/content/binary,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getResourceContentBinary,GET,/resources/{resourceKey}/content/binary,404-not-found,"path param=resourceKey, type=string, format=ResourceKey",yes,
+getResourceContentBinary,GET,/resources/{resourceKey}/content/binary,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+getResourceContentBinary,GET,/resources/{resourceKey}/content/binary,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getResourceContentBinary,GET,/resources/{resourceKey}/content/binary,documented-500,response code 500 documented in spec,yes,
+deleteResource,POST,/resources/{resourceKey}/deletion,happy-path,documented success response,yes,
+deleteResource,POST,/resources/{resourceKey}/deletion,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+deleteResource,POST,/resources/{resourceKey}/deletion,404-not-found,"path param=resourceKey, type=string, format=ResourceKey",yes,
+deleteResource,POST,/resources/{resourceKey}/deletion,bad-request:additional-property,closed schema,yes,
+deleteResource,POST,/resources/{resourceKey}/deletion,bad-request:format-invalid,"field=operationReference, format=int64",yes,
+deleteResource,POST,/resources/{resourceKey}/deletion,bad-request:type-mismatch,"field=operationReference, type=integer",yes,
+deleteResource,POST,/resources/{resourceKey}/deletion,bad-request:range-violation,field=operationReference,yes,
+deleteResource,POST,/resources/{resourceKey}/deletion,bad-request:type-mismatch,"field=deleteHistory, type=boolean",yes,
+deleteResource,POST,/resources/{resourceKey}/deletion,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+deleteResource,POST,/resources/{resourceKey}/deletion,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+deleteResource,POST,/resources/{resourceKey}/deletion,documented-500,response code 500 documented in spec,yes,
+deleteResource,POST,/resources/{resourceKey}/deletion,documented-503,response code 503 documented in spec,yes,
+createRole,POST,/roles,happy-path,documented success response,yes,
+createRole,POST,/roles,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createRole,POST,/roles,bad-request:missing-required,field=roleId,yes,
+createRole,POST,/roles,bad-request:missing-required,field=name,yes,
+createRole,POST,/roles,bad-request:additional-property,closed schema,yes,
+createRole,POST,/roles,bad-request:type-mismatch,"field=name, type=string",yes,
+createRole,POST,/roles,bad-request:type-mismatch,"field=description, type=string",yes,
+createRole,POST,/roles,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+createRole,POST,/roles,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+createRole,POST,/roles,documented-500,response code 500 documented in spec,yes,
+createRole,POST,/roles,documented-503,response code 503 documented in spec,yes,
+searchRoles,POST,/roles/search,happy-path,documented success response,yes,
+searchRoles,POST,/roles/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchRoles,POST,/roles/search,bad-request:additional-property,closed schema,yes,
+searchRoles,POST,/roles/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchRoles,POST,/roles/search,pagination-sort:request-shape,sort array in body,yes,
+searchRoles,POST,/roles/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchRoles,POST,/roles/search,filter:request-shape,filter object in body,yes,
+searchRoles,POST,/roles/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchRoles,POST,/roles/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchRoles,POST,/roles/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchRoles,POST,/roles/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchRoles,POST,/roles/search,documented-500,response code 500 documented in spec,yes,
+getRole,GET,/roles/{roleId},happy-path,documented success response,yes,
+getRole,GET,/roles/{roleId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getRole,GET,/roles/{roleId},404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+getRole,GET,/roles/{roleId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getRole,GET,/roles/{roleId},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getRole,GET,/roles/{roleId},documented-500,response code 500 documented in spec,yes,
+updateRole,PUT,/roles/{roleId},happy-path,documented success response,yes,
+updateRole,PUT,/roles/{roleId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+updateRole,PUT,/roles/{roleId},404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+updateRole,PUT,/roles/{roleId},bad-request:missing-required,field=name,yes,
+updateRole,PUT,/roles/{roleId},bad-request:type-mismatch,"field=name, type=string",yes,
+updateRole,PUT,/roles/{roleId},bad-request:type-mismatch,"field=description, type=string",yes,
+updateRole,PUT,/roles/{roleId},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+updateRole,PUT,/roles/{roleId},403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+updateRole,PUT,/roles/{roleId},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+updateRole,PUT,/roles/{roleId},documented-500,response code 500 documented in spec,yes,
+updateRole,PUT,/roles/{roleId},documented-503,response code 503 documented in spec,yes,
+deleteRole,DELETE,/roles/{roleId},happy-path,documented success response,yes,
+deleteRole,DELETE,/roles/{roleId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+deleteRole,DELETE,/roles/{roleId},404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+deleteRole,DELETE,/roles/{roleId},403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+deleteRole,DELETE,/roles/{roleId},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+deleteRole,DELETE,/roles/{roleId},documented-500,response code 500 documented in spec,yes,
+deleteRole,DELETE,/roles/{roleId},documented-503,response code 503 documented in spec,yes,
+searchClientsForRole,POST,/roles/{roleId}/clients/search,happy-path,documented success response,yes,
+searchClientsForRole,POST,/roles/{roleId}/clients/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchClientsForRole,POST,/roles/{roleId}/clients/search,404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+searchClientsForRole,POST,/roles/{roleId}/clients/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchClientsForRole,POST,/roles/{roleId}/clients/search,pagination-sort:request-shape,sort array in body,yes,
+searchClientsForRole,POST,/roles/{roleId}/clients/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchClientsForRole,POST,/roles/{roleId}/clients/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchClientsForRole,POST,/roles/{roleId}/clients/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchClientsForRole,POST,/roles/{roleId}/clients/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchClientsForRole,POST,/roles/{roleId}/clients/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchClientsForRole,POST,/roles/{roleId}/clients/search,documented-500,response code 500 documented in spec,yes,
+assignRoleToClient,PUT,/roles/{roleId}/clients/{clientId},happy-path,documented success response,yes,
+assignRoleToClient,PUT,/roles/{roleId}/clients/{clientId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+assignRoleToClient,PUT,/roles/{roleId}/clients/{clientId},404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+assignRoleToClient,PUT,/roles/{roleId}/clients/{clientId},404-not-found,"path param=clientId, type=string, format=ClientId",yes,
+assignRoleToClient,PUT,/roles/{roleId}/clients/{clientId},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+assignRoleToClient,PUT,/roles/{roleId}/clients/{clientId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+assignRoleToClient,PUT,/roles/{roleId}/clients/{clientId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+assignRoleToClient,PUT,/roles/{roleId}/clients/{clientId},documented-500,response code 500 documented in spec,yes,
+assignRoleToClient,PUT,/roles/{roleId}/clients/{clientId},documented-503,response code 503 documented in spec,yes,
+unassignRoleFromClient,DELETE,/roles/{roleId}/clients/{clientId},happy-path,documented success response,yes,
+unassignRoleFromClient,DELETE,/roles/{roleId}/clients/{clientId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+unassignRoleFromClient,DELETE,/roles/{roleId}/clients/{clientId},404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+unassignRoleFromClient,DELETE,/roles/{roleId}/clients/{clientId},404-not-found,"path param=clientId, type=string, format=ClientId",yes,
+unassignRoleFromClient,DELETE,/roles/{roleId}/clients/{clientId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+unassignRoleFromClient,DELETE,/roles/{roleId}/clients/{clientId},business-entity-lifecycle,operationId prefix `unassign` implies state transition,no,lifecycle state machine for this entity
+unassignRoleFromClient,DELETE,/roles/{roleId}/clients/{clientId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+unassignRoleFromClient,DELETE,/roles/{roleId}/clients/{clientId},documented-500,response code 500 documented in spec,yes,
+unassignRoleFromClient,DELETE,/roles/{roleId}/clients/{clientId},documented-503,response code 503 documented in spec,yes,
+searchGroupsForRole,POST,/roles/{roleId}/groups/search,happy-path,documented success response,yes,
+searchGroupsForRole,POST,/roles/{roleId}/groups/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchGroupsForRole,POST,/roles/{roleId}/groups/search,404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+searchGroupsForRole,POST,/roles/{roleId}/groups/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchGroupsForRole,POST,/roles/{roleId}/groups/search,pagination-sort:request-shape,sort array in body,yes,
+searchGroupsForRole,POST,/roles/{roleId}/groups/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchGroupsForRole,POST,/roles/{roleId}/groups/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchGroupsForRole,POST,/roles/{roleId}/groups/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchGroupsForRole,POST,/roles/{roleId}/groups/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchGroupsForRole,POST,/roles/{roleId}/groups/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchGroupsForRole,POST,/roles/{roleId}/groups/search,documented-500,response code 500 documented in spec,yes,
+assignRoleToGroup,PUT,/roles/{roleId}/groups/{groupId},happy-path,documented success response,yes,
+assignRoleToGroup,PUT,/roles/{roleId}/groups/{groupId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+assignRoleToGroup,PUT,/roles/{roleId}/groups/{groupId},404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+assignRoleToGroup,PUT,/roles/{roleId}/groups/{groupId},404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+assignRoleToGroup,PUT,/roles/{roleId}/groups/{groupId},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+assignRoleToGroup,PUT,/roles/{roleId}/groups/{groupId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+assignRoleToGroup,PUT,/roles/{roleId}/groups/{groupId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+assignRoleToGroup,PUT,/roles/{roleId}/groups/{groupId},documented-500,response code 500 documented in spec,yes,
+assignRoleToGroup,PUT,/roles/{roleId}/groups/{groupId},documented-503,response code 503 documented in spec,yes,
+unassignRoleFromGroup,DELETE,/roles/{roleId}/groups/{groupId},happy-path,documented success response,yes,
+unassignRoleFromGroup,DELETE,/roles/{roleId}/groups/{groupId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+unassignRoleFromGroup,DELETE,/roles/{roleId}/groups/{groupId},404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+unassignRoleFromGroup,DELETE,/roles/{roleId}/groups/{groupId},404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+unassignRoleFromGroup,DELETE,/roles/{roleId}/groups/{groupId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+unassignRoleFromGroup,DELETE,/roles/{roleId}/groups/{groupId},business-entity-lifecycle,operationId prefix `unassign` implies state transition,no,lifecycle state machine for this entity
+unassignRoleFromGroup,DELETE,/roles/{roleId}/groups/{groupId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+unassignRoleFromGroup,DELETE,/roles/{roleId}/groups/{groupId},documented-500,response code 500 documented in spec,yes,
+unassignRoleFromGroup,DELETE,/roles/{roleId}/groups/{groupId},documented-503,response code 503 documented in spec,yes,
+searchMappingRulesForRole,POST,/roles/{roleId}/mapping-rules/search,happy-path,documented success response,yes,
+searchMappingRulesForRole,POST,/roles/{roleId}/mapping-rules/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchMappingRulesForRole,POST,/roles/{roleId}/mapping-rules/search,404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+searchMappingRulesForRole,POST,/roles/{roleId}/mapping-rules/search,bad-request:additional-property,closed schema,yes,
+searchMappingRulesForRole,POST,/roles/{roleId}/mapping-rules/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchMappingRulesForRole,POST,/roles/{roleId}/mapping-rules/search,pagination-sort:request-shape,sort array in body,yes,
+searchMappingRulesForRole,POST,/roles/{roleId}/mapping-rules/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchMappingRulesForRole,POST,/roles/{roleId}/mapping-rules/search,filter:request-shape,filter object in body,yes,
+searchMappingRulesForRole,POST,/roles/{roleId}/mapping-rules/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchMappingRulesForRole,POST,/roles/{roleId}/mapping-rules/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchMappingRulesForRole,POST,/roles/{roleId}/mapping-rules/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchMappingRulesForRole,POST,/roles/{roleId}/mapping-rules/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchMappingRulesForRole,POST,/roles/{roleId}/mapping-rules/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchMappingRulesForRole,POST,/roles/{roleId}/mapping-rules/search,documented-500,response code 500 documented in spec,yes,
+assignRoleToMappingRule,PUT,/roles/{roleId}/mapping-rules/{mappingRuleId},happy-path,documented success response,yes,
+assignRoleToMappingRule,PUT,/roles/{roleId}/mapping-rules/{mappingRuleId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+assignRoleToMappingRule,PUT,/roles/{roleId}/mapping-rules/{mappingRuleId},404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+assignRoleToMappingRule,PUT,/roles/{roleId}/mapping-rules/{mappingRuleId},404-not-found,"path param=mappingRuleId, type=string, format=MappingRuleId",yes,
+assignRoleToMappingRule,PUT,/roles/{roleId}/mapping-rules/{mappingRuleId},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+assignRoleToMappingRule,PUT,/roles/{roleId}/mapping-rules/{mappingRuleId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+assignRoleToMappingRule,PUT,/roles/{roleId}/mapping-rules/{mappingRuleId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+assignRoleToMappingRule,PUT,/roles/{roleId}/mapping-rules/{mappingRuleId},documented-500,response code 500 documented in spec,yes,
+assignRoleToMappingRule,PUT,/roles/{roleId}/mapping-rules/{mappingRuleId},documented-503,response code 503 documented in spec,yes,
+unassignRoleFromMappingRule,DELETE,/roles/{roleId}/mapping-rules/{mappingRuleId},happy-path,documented success response,yes,
+unassignRoleFromMappingRule,DELETE,/roles/{roleId}/mapping-rules/{mappingRuleId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+unassignRoleFromMappingRule,DELETE,/roles/{roleId}/mapping-rules/{mappingRuleId},404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+unassignRoleFromMappingRule,DELETE,/roles/{roleId}/mapping-rules/{mappingRuleId},404-not-found,"path param=mappingRuleId, type=string, format=MappingRuleId",yes,
+unassignRoleFromMappingRule,DELETE,/roles/{roleId}/mapping-rules/{mappingRuleId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+unassignRoleFromMappingRule,DELETE,/roles/{roleId}/mapping-rules/{mappingRuleId},business-entity-lifecycle,operationId prefix `unassign` implies state transition,no,lifecycle state machine for this entity
+unassignRoleFromMappingRule,DELETE,/roles/{roleId}/mapping-rules/{mappingRuleId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+unassignRoleFromMappingRule,DELETE,/roles/{roleId}/mapping-rules/{mappingRuleId},documented-500,response code 500 documented in spec,yes,
+unassignRoleFromMappingRule,DELETE,/roles/{roleId}/mapping-rules/{mappingRuleId},documented-503,response code 503 documented in spec,yes,
+searchUsersForRole,POST,/roles/{roleId}/users/search,happy-path,documented success response,yes,
+searchUsersForRole,POST,/roles/{roleId}/users/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchUsersForRole,POST,/roles/{roleId}/users/search,404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+searchUsersForRole,POST,/roles/{roleId}/users/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchUsersForRole,POST,/roles/{roleId}/users/search,pagination-sort:request-shape,sort array in body,yes,
+searchUsersForRole,POST,/roles/{roleId}/users/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchUsersForRole,POST,/roles/{roleId}/users/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchUsersForRole,POST,/roles/{roleId}/users/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchUsersForRole,POST,/roles/{roleId}/users/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchUsersForRole,POST,/roles/{roleId}/users/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchUsersForRole,POST,/roles/{roleId}/users/search,documented-500,response code 500 documented in spec,yes,
+assignRoleToUser,PUT,/roles/{roleId}/users/{username},happy-path,documented success response,yes,
+assignRoleToUser,PUT,/roles/{roleId}/users/{username},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+assignRoleToUser,PUT,/roles/{roleId}/users/{username},404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+assignRoleToUser,PUT,/roles/{roleId}/users/{username},404-not-found,"path param=username, type=string, format=Username",yes,
+assignRoleToUser,PUT,/roles/{roleId}/users/{username},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+assignRoleToUser,PUT,/roles/{roleId}/users/{username},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+assignRoleToUser,PUT,/roles/{roleId}/users/{username},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+assignRoleToUser,PUT,/roles/{roleId}/users/{username},documented-500,response code 500 documented in spec,yes,
+assignRoleToUser,PUT,/roles/{roleId}/users/{username},documented-503,response code 503 documented in spec,yes,
+unassignRoleFromUser,DELETE,/roles/{roleId}/users/{username},happy-path,documented success response,yes,
+unassignRoleFromUser,DELETE,/roles/{roleId}/users/{username},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+unassignRoleFromUser,DELETE,/roles/{roleId}/users/{username},404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+unassignRoleFromUser,DELETE,/roles/{roleId}/users/{username},404-not-found,"path param=username, type=string, format=Username",yes,
+unassignRoleFromUser,DELETE,/roles/{roleId}/users/{username},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+unassignRoleFromUser,DELETE,/roles/{roleId}/users/{username},business-entity-lifecycle,operationId prefix `unassign` implies state transition,no,lifecycle state machine for this entity
+unassignRoleFromUser,DELETE,/roles/{roleId}/users/{username},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+unassignRoleFromUser,DELETE,/roles/{roleId}/users/{username},documented-500,response code 500 documented in spec,yes,
+unassignRoleFromUser,DELETE,/roles/{roleId}/users/{username},documented-503,response code 503 documented in spec,yes,
+createAdminUser,POST,/setup/user,happy-path,documented success response,yes,
+createAdminUser,POST,/setup/user,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createAdminUser,POST,/setup/user,bad-request:missing-required,field=username,yes,
+createAdminUser,POST,/setup/user,bad-request:missing-required,field=password,yes,
+createAdminUser,POST,/setup/user,bad-request:additional-property,closed schema,yes,
+createAdminUser,POST,/setup/user,bad-request:type-mismatch,"field=password, type=string",yes,
+createAdminUser,POST,/setup/user,bad-request:type-mismatch,"field=name, type=string",yes,
+createAdminUser,POST,/setup/user,bad-request:type-mismatch,"field=email, type=string",yes,
+createAdminUser,POST,/setup/user,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+createAdminUser,POST,/setup/user,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+createAdminUser,POST,/setup/user,documented-500,response code 500 documented in spec,yes,
+createAdminUser,POST,/setup/user,documented-503,response code 503 documented in spec,yes,
+broadcastSignal,POST,/signals/broadcast,happy-path,documented success response,yes,
+broadcastSignal,POST,/signals/broadcast,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+broadcastSignal,POST,/signals/broadcast,bad-request:missing-required,field=signalName,yes,
+broadcastSignal,POST,/signals/broadcast,bad-request:additional-property,closed schema,yes,
+broadcastSignal,POST,/signals/broadcast,bad-request:type-mismatch,"field=signalName, type=string",yes,
+broadcastSignal,POST,/signals/broadcast,bad-request:type-mismatch,"field=variables, type=object",yes,
+broadcastSignal,POST,/signals/broadcast,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+broadcastSignal,POST,/signals/broadcast,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+broadcastSignal,POST,/signals/broadcast,business-entity-lifecycle,path has state-transition verb,no,lifecycle state machine for this entity
+broadcastSignal,POST,/signals/broadcast,documented-500,response code 500 documented in spec,yes,
+broadcastSignal,POST,/signals/broadcast,documented-503,response code 503 documented in spec,yes,
+getStatus,GET,/status,happy-path,documented success response,yes,
+getStatus,GET,/status,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getStatus,GET,/status,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+getStatus,GET,/status,documented-503,response code 503 documented in spec,yes,
+getUsageMetrics,GET,/system/usage-metrics,happy-path,documented success response,yes,
+getUsageMetrics,GET,/system/usage-metrics,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getUsageMetrics,GET,/system/usage-metrics,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getUsageMetrics,GET,/system/usage-metrics,documented-500,response code 500 documented in spec,yes,
+getSystemConfiguration,GET,/system/configuration,happy-path,documented success response,yes,
+getSystemConfiguration,GET,/system/configuration,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getSystemConfiguration,GET,/system/configuration,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+getSystemConfiguration,GET,/system/configuration,documented-500,response code 500 documented in spec,yes,
+createTenant,POST,/tenants,happy-path,documented success response,yes,
+createTenant,POST,/tenants,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createTenant,POST,/tenants,bad-request:missing-required,field=tenantId,yes,
+createTenant,POST,/tenants,bad-request:missing-required,field=name,yes,
+createTenant,POST,/tenants,bad-request:additional-property,closed schema,yes,
+createTenant,POST,/tenants,bad-request:type-mismatch,"field=name, type=string",yes,
+createTenant,POST,/tenants,bad-request:type-mismatch,"field=description, type=string",yes,
+createTenant,POST,/tenants,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+createTenant,POST,/tenants,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+createTenant,POST,/tenants,business-entity-lifecycle,409 documented on non-collection POST,no,lifecycle state machine for this entity
+createTenant,POST,/tenants,documented-500,response code 500 documented in spec,yes,
+createTenant,POST,/tenants,documented-503,response code 503 documented in spec,yes,
+searchTenants,POST,/tenants/search,happy-path,documented success response,yes,
+searchTenants,POST,/tenants/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchTenants,POST,/tenants/search,bad-request:additional-property,closed schema,yes,
+searchTenants,POST,/tenants/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchTenants,POST,/tenants/search,pagination-sort:request-shape,sort array in body,yes,
+searchTenants,POST,/tenants/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchTenants,POST,/tenants/search,filter:request-shape,filter object in body,yes,
+searchTenants,POST,/tenants/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchTenants,POST,/tenants/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchTenants,POST,/tenants/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchTenants,POST,/tenants/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchTenants,POST,/tenants/search,documented-500,response code 500 documented in spec,yes,
+getTenant,GET,/tenants/{tenantId},happy-path,documented success response,yes,
+getTenant,GET,/tenants/{tenantId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getTenant,GET,/tenants/{tenantId},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+getTenant,GET,/tenants/{tenantId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getTenant,GET,/tenants/{tenantId},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getTenant,GET,/tenants/{tenantId},documented-500,response code 500 documented in spec,yes,
+updateTenant,PUT,/tenants/{tenantId},happy-path,documented success response,yes,
+updateTenant,PUT,/tenants/{tenantId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+updateTenant,PUT,/tenants/{tenantId},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+updateTenant,PUT,/tenants/{tenantId},bad-request:missing-required,field=name,yes,
+updateTenant,PUT,/tenants/{tenantId},bad-request:additional-property,closed schema,yes,
+updateTenant,PUT,/tenants/{tenantId},bad-request:type-mismatch,"field=name, type=string",yes,
+updateTenant,PUT,/tenants/{tenantId},bad-request:type-mismatch,"field=description, type=string",yes,
+updateTenant,PUT,/tenants/{tenantId},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+updateTenant,PUT,/tenants/{tenantId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+updateTenant,PUT,/tenants/{tenantId},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+updateTenant,PUT,/tenants/{tenantId},documented-500,response code 500 documented in spec,yes,
+updateTenant,PUT,/tenants/{tenantId},documented-503,response code 503 documented in spec,yes,
+deleteTenant,DELETE,/tenants/{tenantId},happy-path,documented success response,yes,
+deleteTenant,DELETE,/tenants/{tenantId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+deleteTenant,DELETE,/tenants/{tenantId},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+deleteTenant,DELETE,/tenants/{tenantId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+deleteTenant,DELETE,/tenants/{tenantId},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+deleteTenant,DELETE,/tenants/{tenantId},documented-500,response code 500 documented in spec,yes,
+deleteTenant,DELETE,/tenants/{tenantId},documented-503,response code 503 documented in spec,yes,
+searchClientsForTenant,POST,/tenants/{tenantId}/clients/search,happy-path,documented success response,yes,
+searchClientsForTenant,POST,/tenants/{tenantId}/clients/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchClientsForTenant,POST,/tenants/{tenantId}/clients/search,404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+searchClientsForTenant,POST,/tenants/{tenantId}/clients/search,bad-request:additional-property,closed schema,yes,
+searchClientsForTenant,POST,/tenants/{tenantId}/clients/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchClientsForTenant,POST,/tenants/{tenantId}/clients/search,pagination-sort:request-shape,sort array in body,yes,
+searchClientsForTenant,POST,/tenants/{tenantId}/clients/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchClientsForTenant,POST,/tenants/{tenantId}/clients/search,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+searchClientsForTenant,POST,/tenants/{tenantId}/clients/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchClientsForTenant,POST,/tenants/{tenantId}/clients/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchClientsForTenant,POST,/tenants/{tenantId}/clients/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+assignClientToTenant,PUT,/tenants/{tenantId}/clients/{clientId},happy-path,documented success response,yes,
+assignClientToTenant,PUT,/tenants/{tenantId}/clients/{clientId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+assignClientToTenant,PUT,/tenants/{tenantId}/clients/{clientId},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+assignClientToTenant,PUT,/tenants/{tenantId}/clients/{clientId},404-not-found,"path param=clientId, type=string, format=ClientId",yes,
+assignClientToTenant,PUT,/tenants/{tenantId}/clients/{clientId},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+assignClientToTenant,PUT,/tenants/{tenantId}/clients/{clientId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+assignClientToTenant,PUT,/tenants/{tenantId}/clients/{clientId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+assignClientToTenant,PUT,/tenants/{tenantId}/clients/{clientId},documented-500,response code 500 documented in spec,yes,
+assignClientToTenant,PUT,/tenants/{tenantId}/clients/{clientId},documented-503,response code 503 documented in spec,yes,
+unassignClientFromTenant,DELETE,/tenants/{tenantId}/clients/{clientId},happy-path,documented success response,yes,
+unassignClientFromTenant,DELETE,/tenants/{tenantId}/clients/{clientId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+unassignClientFromTenant,DELETE,/tenants/{tenantId}/clients/{clientId},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+unassignClientFromTenant,DELETE,/tenants/{tenantId}/clients/{clientId},404-not-found,"path param=clientId, type=string, format=ClientId",yes,
+unassignClientFromTenant,DELETE,/tenants/{tenantId}/clients/{clientId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+unassignClientFromTenant,DELETE,/tenants/{tenantId}/clients/{clientId},business-entity-lifecycle,operationId prefix `unassign` implies state transition,no,lifecycle state machine for this entity
+unassignClientFromTenant,DELETE,/tenants/{tenantId}/clients/{clientId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+unassignClientFromTenant,DELETE,/tenants/{tenantId}/clients/{clientId},documented-500,response code 500 documented in spec,yes,
+unassignClientFromTenant,DELETE,/tenants/{tenantId}/clients/{clientId},documented-503,response code 503 documented in spec,yes,
+searchGroupIdsForTenant,POST,/tenants/{tenantId}/groups/search,happy-path,documented success response,yes,
+searchGroupIdsForTenant,POST,/tenants/{tenantId}/groups/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchGroupIdsForTenant,POST,/tenants/{tenantId}/groups/search,404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+searchGroupIdsForTenant,POST,/tenants/{tenantId}/groups/search,bad-request:additional-property,closed schema,yes,
+searchGroupIdsForTenant,POST,/tenants/{tenantId}/groups/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchGroupIdsForTenant,POST,/tenants/{tenantId}/groups/search,pagination-sort:request-shape,sort array in body,yes,
+searchGroupIdsForTenant,POST,/tenants/{tenantId}/groups/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchGroupIdsForTenant,POST,/tenants/{tenantId}/groups/search,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+searchGroupIdsForTenant,POST,/tenants/{tenantId}/groups/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchGroupIdsForTenant,POST,/tenants/{tenantId}/groups/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchGroupIdsForTenant,POST,/tenants/{tenantId}/groups/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+assignGroupToTenant,PUT,/tenants/{tenantId}/groups/{groupId},happy-path,documented success response,yes,
+assignGroupToTenant,PUT,/tenants/{tenantId}/groups/{groupId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+assignGroupToTenant,PUT,/tenants/{tenantId}/groups/{groupId},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+assignGroupToTenant,PUT,/tenants/{tenantId}/groups/{groupId},404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+assignGroupToTenant,PUT,/tenants/{tenantId}/groups/{groupId},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+assignGroupToTenant,PUT,/tenants/{tenantId}/groups/{groupId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+assignGroupToTenant,PUT,/tenants/{tenantId}/groups/{groupId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+assignGroupToTenant,PUT,/tenants/{tenantId}/groups/{groupId},documented-500,response code 500 documented in spec,yes,
+assignGroupToTenant,PUT,/tenants/{tenantId}/groups/{groupId},documented-503,response code 503 documented in spec,yes,
+unassignGroupFromTenant,DELETE,/tenants/{tenantId}/groups/{groupId},happy-path,documented success response,yes,
+unassignGroupFromTenant,DELETE,/tenants/{tenantId}/groups/{groupId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+unassignGroupFromTenant,DELETE,/tenants/{tenantId}/groups/{groupId},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+unassignGroupFromTenant,DELETE,/tenants/{tenantId}/groups/{groupId},404-not-found,"path param=groupId, type=string, format=GroupId",yes,
+unassignGroupFromTenant,DELETE,/tenants/{tenantId}/groups/{groupId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+unassignGroupFromTenant,DELETE,/tenants/{tenantId}/groups/{groupId},business-entity-lifecycle,operationId prefix `unassign` implies state transition,no,lifecycle state machine for this entity
+unassignGroupFromTenant,DELETE,/tenants/{tenantId}/groups/{groupId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+unassignGroupFromTenant,DELETE,/tenants/{tenantId}/groups/{groupId},documented-500,response code 500 documented in spec,yes,
+unassignGroupFromTenant,DELETE,/tenants/{tenantId}/groups/{groupId},documented-503,response code 503 documented in spec,yes,
+searchMappingRulesForTenant,POST,/tenants/{tenantId}/mapping-rules/search,happy-path,documented success response,yes,
+searchMappingRulesForTenant,POST,/tenants/{tenantId}/mapping-rules/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchMappingRulesForTenant,POST,/tenants/{tenantId}/mapping-rules/search,404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+searchMappingRulesForTenant,POST,/tenants/{tenantId}/mapping-rules/search,bad-request:additional-property,closed schema,yes,
+searchMappingRulesForTenant,POST,/tenants/{tenantId}/mapping-rules/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchMappingRulesForTenant,POST,/tenants/{tenantId}/mapping-rules/search,pagination-sort:request-shape,sort array in body,yes,
+searchMappingRulesForTenant,POST,/tenants/{tenantId}/mapping-rules/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchMappingRulesForTenant,POST,/tenants/{tenantId}/mapping-rules/search,filter:request-shape,filter object in body,yes,
+searchMappingRulesForTenant,POST,/tenants/{tenantId}/mapping-rules/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchMappingRulesForTenant,POST,/tenants/{tenantId}/mapping-rules/search,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+searchMappingRulesForTenant,POST,/tenants/{tenantId}/mapping-rules/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchMappingRulesForTenant,POST,/tenants/{tenantId}/mapping-rules/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchMappingRulesForTenant,POST,/tenants/{tenantId}/mapping-rules/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+assignMappingRuleToTenant,PUT,/tenants/{tenantId}/mapping-rules/{mappingRuleId},happy-path,documented success response,yes,
+assignMappingRuleToTenant,PUT,/tenants/{tenantId}/mapping-rules/{mappingRuleId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+assignMappingRuleToTenant,PUT,/tenants/{tenantId}/mapping-rules/{mappingRuleId},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+assignMappingRuleToTenant,PUT,/tenants/{tenantId}/mapping-rules/{mappingRuleId},404-not-found,"path param=mappingRuleId, type=string, format=MappingRuleId",yes,
+assignMappingRuleToTenant,PUT,/tenants/{tenantId}/mapping-rules/{mappingRuleId},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+assignMappingRuleToTenant,PUT,/tenants/{tenantId}/mapping-rules/{mappingRuleId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+assignMappingRuleToTenant,PUT,/tenants/{tenantId}/mapping-rules/{mappingRuleId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+assignMappingRuleToTenant,PUT,/tenants/{tenantId}/mapping-rules/{mappingRuleId},documented-500,response code 500 documented in spec,yes,
+assignMappingRuleToTenant,PUT,/tenants/{tenantId}/mapping-rules/{mappingRuleId},documented-503,response code 503 documented in spec,yes,
+unassignMappingRuleFromTenant,DELETE,/tenants/{tenantId}/mapping-rules/{mappingRuleId},happy-path,documented success response,yes,
+unassignMappingRuleFromTenant,DELETE,/tenants/{tenantId}/mapping-rules/{mappingRuleId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+unassignMappingRuleFromTenant,DELETE,/tenants/{tenantId}/mapping-rules/{mappingRuleId},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+unassignMappingRuleFromTenant,DELETE,/tenants/{tenantId}/mapping-rules/{mappingRuleId},404-not-found,"path param=mappingRuleId, type=string, format=MappingRuleId",yes,
+unassignMappingRuleFromTenant,DELETE,/tenants/{tenantId}/mapping-rules/{mappingRuleId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+unassignMappingRuleFromTenant,DELETE,/tenants/{tenantId}/mapping-rules/{mappingRuleId},business-entity-lifecycle,operationId prefix `unassign` implies state transition,no,lifecycle state machine for this entity
+unassignMappingRuleFromTenant,DELETE,/tenants/{tenantId}/mapping-rules/{mappingRuleId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+unassignMappingRuleFromTenant,DELETE,/tenants/{tenantId}/mapping-rules/{mappingRuleId},documented-500,response code 500 documented in spec,yes,
+unassignMappingRuleFromTenant,DELETE,/tenants/{tenantId}/mapping-rules/{mappingRuleId},documented-503,response code 503 documented in spec,yes,
+searchRolesForTenant,POST,/tenants/{tenantId}/roles/search,happy-path,documented success response,yes,
+searchRolesForTenant,POST,/tenants/{tenantId}/roles/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchRolesForTenant,POST,/tenants/{tenantId}/roles/search,404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+searchRolesForTenant,POST,/tenants/{tenantId}/roles/search,bad-request:additional-property,closed schema,yes,
+searchRolesForTenant,POST,/tenants/{tenantId}/roles/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchRolesForTenant,POST,/tenants/{tenantId}/roles/search,pagination-sort:request-shape,sort array in body,yes,
+searchRolesForTenant,POST,/tenants/{tenantId}/roles/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchRolesForTenant,POST,/tenants/{tenantId}/roles/search,filter:request-shape,filter object in body,yes,
+searchRolesForTenant,POST,/tenants/{tenantId}/roles/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchRolesForTenant,POST,/tenants/{tenantId}/roles/search,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+searchRolesForTenant,POST,/tenants/{tenantId}/roles/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchRolesForTenant,POST,/tenants/{tenantId}/roles/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchRolesForTenant,POST,/tenants/{tenantId}/roles/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+assignRoleToTenant,PUT,/tenants/{tenantId}/roles/{roleId},happy-path,documented success response,yes,
+assignRoleToTenant,PUT,/tenants/{tenantId}/roles/{roleId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+assignRoleToTenant,PUT,/tenants/{tenantId}/roles/{roleId},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+assignRoleToTenant,PUT,/tenants/{tenantId}/roles/{roleId},404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+assignRoleToTenant,PUT,/tenants/{tenantId}/roles/{roleId},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+assignRoleToTenant,PUT,/tenants/{tenantId}/roles/{roleId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+assignRoleToTenant,PUT,/tenants/{tenantId}/roles/{roleId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+assignRoleToTenant,PUT,/tenants/{tenantId}/roles/{roleId},documented-500,response code 500 documented in spec,yes,
+assignRoleToTenant,PUT,/tenants/{tenantId}/roles/{roleId},documented-503,response code 503 documented in spec,yes,
+unassignRoleFromTenant,DELETE,/tenants/{tenantId}/roles/{roleId},happy-path,documented success response,yes,
+unassignRoleFromTenant,DELETE,/tenants/{tenantId}/roles/{roleId},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+unassignRoleFromTenant,DELETE,/tenants/{tenantId}/roles/{roleId},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+unassignRoleFromTenant,DELETE,/tenants/{tenantId}/roles/{roleId},404-not-found,"path param=roleId, type=string, format=RoleId",yes,
+unassignRoleFromTenant,DELETE,/tenants/{tenantId}/roles/{roleId},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+unassignRoleFromTenant,DELETE,/tenants/{tenantId}/roles/{roleId},business-entity-lifecycle,operationId prefix `unassign` implies state transition,no,lifecycle state machine for this entity
+unassignRoleFromTenant,DELETE,/tenants/{tenantId}/roles/{roleId},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+unassignRoleFromTenant,DELETE,/tenants/{tenantId}/roles/{roleId},documented-500,response code 500 documented in spec,yes,
+unassignRoleFromTenant,DELETE,/tenants/{tenantId}/roles/{roleId},documented-503,response code 503 documented in spec,yes,
+searchUsersForTenant,POST,/tenants/{tenantId}/users/search,happy-path,documented success response,yes,
+searchUsersForTenant,POST,/tenants/{tenantId}/users/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchUsersForTenant,POST,/tenants/{tenantId}/users/search,404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+searchUsersForTenant,POST,/tenants/{tenantId}/users/search,bad-request:additional-property,closed schema,yes,
+searchUsersForTenant,POST,/tenants/{tenantId}/users/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchUsersForTenant,POST,/tenants/{tenantId}/users/search,pagination-sort:request-shape,sort array in body,yes,
+searchUsersForTenant,POST,/tenants/{tenantId}/users/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchUsersForTenant,POST,/tenants/{tenantId}/users/search,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+searchUsersForTenant,POST,/tenants/{tenantId}/users/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchUsersForTenant,POST,/tenants/{tenantId}/users/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchUsersForTenant,POST,/tenants/{tenantId}/users/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+assignUserToTenant,PUT,/tenants/{tenantId}/users/{username},happy-path,documented success response,yes,
+assignUserToTenant,PUT,/tenants/{tenantId}/users/{username},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+assignUserToTenant,PUT,/tenants/{tenantId}/users/{username},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+assignUserToTenant,PUT,/tenants/{tenantId}/users/{username},404-not-found,"path param=username, type=string, format=Username",yes,
+assignUserToTenant,PUT,/tenants/{tenantId}/users/{username},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+assignUserToTenant,PUT,/tenants/{tenantId}/users/{username},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+assignUserToTenant,PUT,/tenants/{tenantId}/users/{username},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+assignUserToTenant,PUT,/tenants/{tenantId}/users/{username},documented-500,response code 500 documented in spec,yes,
+assignUserToTenant,PUT,/tenants/{tenantId}/users/{username},documented-503,response code 503 documented in spec,yes,
+unassignUserFromTenant,DELETE,/tenants/{tenantId}/users/{username},happy-path,documented success response,yes,
+unassignUserFromTenant,DELETE,/tenants/{tenantId}/users/{username},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+unassignUserFromTenant,DELETE,/tenants/{tenantId}/users/{username},404-not-found,"path param=tenantId, type=string, format=TenantId",yes,
+unassignUserFromTenant,DELETE,/tenants/{tenantId}/users/{username},404-not-found,"path param=username, type=string, format=Username",yes,
+unassignUserFromTenant,DELETE,/tenants/{tenantId}/users/{username},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+unassignUserFromTenant,DELETE,/tenants/{tenantId}/users/{username},business-entity-lifecycle,operationId prefix `unassign` implies state transition,no,lifecycle state machine for this entity
+unassignUserFromTenant,DELETE,/tenants/{tenantId}/users/{username},prerequisite-resource,2 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+unassignUserFromTenant,DELETE,/tenants/{tenantId}/users/{username},documented-500,response code 500 documented in spec,yes,
+unassignUserFromTenant,DELETE,/tenants/{tenantId}/users/{username},documented-503,response code 503 documented in spec,yes,
+getTopology,GET,/topology,happy-path,documented success response,yes,
+getTopology,GET,/topology,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getTopology,GET,/topology,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+getTopology,GET,/topology,documented-500,response code 500 documented in spec,yes,
+createUser,POST,/users,happy-path,documented success response,yes,
+createUser,POST,/users,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+createUser,POST,/users,bad-request:missing-required,field=username,yes,
+createUser,POST,/users,bad-request:missing-required,field=password,yes,
+createUser,POST,/users,bad-request:additional-property,closed schema,yes,
+createUser,POST,/users,bad-request:type-mismatch,"field=password, type=string",yes,
+createUser,POST,/users,bad-request:type-mismatch,"field=name, type=string",yes,
+createUser,POST,/users,bad-request:type-mismatch,"field=email, type=string",yes,
+createUser,POST,/users,409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+createUser,POST,/users,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+createUser,POST,/users,business-entity-lifecycle,409 documented on non-collection POST,no,lifecycle state machine for this entity
+createUser,POST,/users,documented-500,response code 500 documented in spec,yes,
+createUser,POST,/users,documented-503,response code 503 documented in spec,yes,
+searchUsers,POST,/users/search,happy-path,documented success response,yes,
+searchUsers,POST,/users/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchUsers,POST,/users/search,bad-request:additional-property,closed schema,yes,
+searchUsers,POST,/users/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchUsers,POST,/users/search,pagination-sort:request-shape,sort array in body,yes,
+searchUsers,POST,/users/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchUsers,POST,/users/search,filter:request-shape,filter object in body,yes,
+searchUsers,POST,/users/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchUsers,POST,/users/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchUsers,POST,/users/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchUsers,POST,/users/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchUsers,POST,/users/search,documented-500,response code 500 documented in spec,yes,
+getUser,GET,/users/{username},happy-path,documented success response,yes,
+getUser,GET,/users/{username},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getUser,GET,/users/{username},404-not-found,"path param=username, type=string, format=Username",yes,
+getUser,GET,/users/{username},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getUser,GET,/users/{username},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getUser,GET,/users/{username},documented-500,response code 500 documented in spec,yes,
+updateUser,PUT,/users/{username},happy-path,documented success response,yes,
+updateUser,PUT,/users/{username},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+updateUser,PUT,/users/{username},404-not-found,"path param=username, type=string, format=Username",yes,
+updateUser,PUT,/users/{username},bad-request:type-mismatch,"field=password, type=string",yes,
+updateUser,PUT,/users/{username},bad-request:type-mismatch,"field=name, type=string",yes,
+updateUser,PUT,/users/{username},bad-request:type-mismatch,"field=email, type=string",yes,
+updateUser,PUT,/users/{username},409-conflict,create-or-replace with same identifier,no,duplicatePolicy per endpoint (idempotent | conflict | replace)
+updateUser,PUT,/users/{username},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+updateUser,PUT,/users/{username},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+updateUser,PUT,/users/{username},documented-500,response code 500 documented in spec,yes,
+updateUser,PUT,/users/{username},documented-503,response code 503 documented in spec,yes,
+deleteUser,DELETE,/users/{username},happy-path,documented success response,yes,
+deleteUser,DELETE,/users/{username},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+deleteUser,DELETE,/users/{username},404-not-found,"path param=username, type=string, format=Username",yes,
+deleteUser,DELETE,/users/{username},403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+deleteUser,DELETE,/users/{username},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+deleteUser,DELETE,/users/{username},documented-500,response code 500 documented in spec,yes,
+deleteUser,DELETE,/users/{username},documented-503,response code 503 documented in spec,yes,
+searchUserTasks,POST,/user-tasks/search,happy-path,documented success response,yes,
+searchUserTasks,POST,/user-tasks/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchUserTasks,POST,/user-tasks/search,bad-request:additional-property,closed schema,yes,
+searchUserTasks,POST,/user-tasks/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchUserTasks,POST,/user-tasks/search,pagination-sort:request-shape,sort array in body,yes,
+searchUserTasks,POST,/user-tasks/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchUserTasks,POST,/user-tasks/search,filter:request-shape,filter object in body,yes,
+searchUserTasks,POST,/user-tasks/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchUserTasks,POST,/user-tasks/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchUserTasks,POST,/user-tasks/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchUserTasks,POST,/user-tasks/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchUserTasks,POST,/user-tasks/search,documented-500,response code 500 documented in spec,yes,
+getUserTask,GET,/user-tasks/{userTaskKey},happy-path,documented success response,yes,
+getUserTask,GET,/user-tasks/{userTaskKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getUserTask,GET,/user-tasks/{userTaskKey},404-not-found,"path param=userTaskKey, type=string, format=UserTaskKey",yes,
+getUserTask,GET,/user-tasks/{userTaskKey},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getUserTask,GET,/user-tasks/{userTaskKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getUserTask,GET,/user-tasks/{userTaskKey},documented-500,response code 500 documented in spec,yes,
+updateUserTask,PATCH,/user-tasks/{userTaskKey},happy-path,documented success response,yes,
+updateUserTask,PATCH,/user-tasks/{userTaskKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+updateUserTask,PATCH,/user-tasks/{userTaskKey},404-not-found,"path param=userTaskKey, type=string, format=UserTaskKey",yes,
+updateUserTask,PATCH,/user-tasks/{userTaskKey},bad-request:additional-property,closed schema,yes,
+updateUserTask,PATCH,/user-tasks/{userTaskKey},bad-request:type-mismatch,"field=changeset, type=object",yes,
+updateUserTask,PATCH,/user-tasks/{userTaskKey},bad-request:type-mismatch,"field=action, type=string",yes,
+updateUserTask,PATCH,/user-tasks/{userTaskKey},403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+updateUserTask,PATCH,/user-tasks/{userTaskKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+updateUserTask,PATCH,/user-tasks/{userTaskKey},documented-500,response code 500 documented in spec,yes,
+updateUserTask,PATCH,/user-tasks/{userTaskKey},documented-503,response code 503 documented in spec,yes,
+updateUserTask,PATCH,/user-tasks/{userTaskKey},documented-504,response code 504 documented in spec,yes,
+unassignUserTask,DELETE,/user-tasks/{userTaskKey}/assignee,happy-path,documented success response,yes,
+unassignUserTask,DELETE,/user-tasks/{userTaskKey}/assignee,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+unassignUserTask,DELETE,/user-tasks/{userTaskKey}/assignee,404-not-found,"path param=userTaskKey, type=string, format=UserTaskKey",yes,
+unassignUserTask,DELETE,/user-tasks/{userTaskKey}/assignee,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+unassignUserTask,DELETE,/user-tasks/{userTaskKey}/assignee,business-entity-lifecycle,operationId prefix `unassign` implies state transition,no,lifecycle state machine for this entity
+unassignUserTask,DELETE,/user-tasks/{userTaskKey}/assignee,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+unassignUserTask,DELETE,/user-tasks/{userTaskKey}/assignee,documented-500,response code 500 documented in spec,yes,
+unassignUserTask,DELETE,/user-tasks/{userTaskKey}/assignee,documented-503,response code 503 documented in spec,yes,
+unassignUserTask,DELETE,/user-tasks/{userTaskKey}/assignee,documented-504,response code 504 documented in spec,yes,
+assignUserTask,POST,/user-tasks/{userTaskKey}/assignment,happy-path,documented success response,yes,
+assignUserTask,POST,/user-tasks/{userTaskKey}/assignment,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+assignUserTask,POST,/user-tasks/{userTaskKey}/assignment,404-not-found,"path param=userTaskKey, type=string, format=UserTaskKey",yes,
+assignUserTask,POST,/user-tasks/{userTaskKey}/assignment,bad-request:additional-property,closed schema,yes,
+assignUserTask,POST,/user-tasks/{userTaskKey}/assignment,bad-request:type-mismatch,"field=assignee, type=string",yes,
+assignUserTask,POST,/user-tasks/{userTaskKey}/assignment,bad-request:type-mismatch,"field=allowOverride, type=boolean",yes,
+assignUserTask,POST,/user-tasks/{userTaskKey}/assignment,bad-request:type-mismatch,"field=action, type=string",yes,
+assignUserTask,POST,/user-tasks/{userTaskKey}/assignment,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+assignUserTask,POST,/user-tasks/{userTaskKey}/assignment,business-entity-lifecycle,path has state-transition verb,no,lifecycle state machine for this entity
+assignUserTask,POST,/user-tasks/{userTaskKey}/assignment,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+assignUserTask,POST,/user-tasks/{userTaskKey}/assignment,documented-500,response code 500 documented in spec,yes,
+assignUserTask,POST,/user-tasks/{userTaskKey}/assignment,documented-503,response code 503 documented in spec,yes,
+assignUserTask,POST,/user-tasks/{userTaskKey}/assignment,documented-504,response code 504 documented in spec,yes,
+searchUserTaskAuditLogs,POST,/user-tasks/{userTaskKey}/audit-logs/search,happy-path,documented success response,yes,
+searchUserTaskAuditLogs,POST,/user-tasks/{userTaskKey}/audit-logs/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchUserTaskAuditLogs,POST,/user-tasks/{userTaskKey}/audit-logs/search,404-not-found,"path param=userTaskKey, type=string, format=UserTaskKey",yes,
+searchUserTaskAuditLogs,POST,/user-tasks/{userTaskKey}/audit-logs/search,bad-request:additional-property,closed schema,yes,
+searchUserTaskAuditLogs,POST,/user-tasks/{userTaskKey}/audit-logs/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchUserTaskAuditLogs,POST,/user-tasks/{userTaskKey}/audit-logs/search,bad-request:type-mismatch,"field=filter, type=object",yes,
+searchUserTaskAuditLogs,POST,/user-tasks/{userTaskKey}/audit-logs/search,pagination-sort:request-shape,sort array in body,yes,
+searchUserTaskAuditLogs,POST,/user-tasks/{userTaskKey}/audit-logs/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchUserTaskAuditLogs,POST,/user-tasks/{userTaskKey}/audit-logs/search,filter:request-shape,filter object in body,yes,
+searchUserTaskAuditLogs,POST,/user-tasks/{userTaskKey}/audit-logs/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchUserTaskAuditLogs,POST,/user-tasks/{userTaskKey}/audit-logs/search,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+searchUserTaskAuditLogs,POST,/user-tasks/{userTaskKey}/audit-logs/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchUserTaskAuditLogs,POST,/user-tasks/{userTaskKey}/audit-logs/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchUserTaskAuditLogs,POST,/user-tasks/{userTaskKey}/audit-logs/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchUserTaskAuditLogs,POST,/user-tasks/{userTaskKey}/audit-logs/search,documented-500,response code 500 documented in spec,yes,
+completeUserTask,POST,/user-tasks/{userTaskKey}/completion,happy-path,documented success response,yes,
+completeUserTask,POST,/user-tasks/{userTaskKey}/completion,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+completeUserTask,POST,/user-tasks/{userTaskKey}/completion,404-not-found,"path param=userTaskKey, type=string, format=UserTaskKey",yes,
+completeUserTask,POST,/user-tasks/{userTaskKey}/completion,bad-request:additional-property,closed schema,yes,
+completeUserTask,POST,/user-tasks/{userTaskKey}/completion,bad-request:type-mismatch,"field=variables, type=object",yes,
+completeUserTask,POST,/user-tasks/{userTaskKey}/completion,bad-request:type-mismatch,"field=action, type=string",yes,
+completeUserTask,POST,/user-tasks/{userTaskKey}/completion,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+completeUserTask,POST,/user-tasks/{userTaskKey}/completion,business-entity-lifecycle,path has state-transition verb,no,lifecycle state machine for this entity
+completeUserTask,POST,/user-tasks/{userTaskKey}/completion,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+completeUserTask,POST,/user-tasks/{userTaskKey}/completion,documented-500,response code 500 documented in spec,yes,
+completeUserTask,POST,/user-tasks/{userTaskKey}/completion,documented-503,response code 503 documented in spec,yes,
+completeUserTask,POST,/user-tasks/{userTaskKey}/completion,documented-504,response code 504 documented in spec,yes,
+searchUserTaskEffectiveVariables,POST,/user-tasks/{userTaskKey}/effective-variables/search,happy-path,documented success response,yes,
+searchUserTaskEffectiveVariables,POST,/user-tasks/{userTaskKey}/effective-variables/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchUserTaskEffectiveVariables,POST,/user-tasks/{userTaskKey}/effective-variables/search,404-not-found,"path param=userTaskKey, type=string, format=UserTaskKey",yes,
+searchUserTaskEffectiveVariables,POST,/user-tasks/{userTaskKey}/effective-variables/search,bad-request:additional-property,closed schema,yes,
+searchUserTaskEffectiveVariables,POST,/user-tasks/{userTaskKey}/effective-variables/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchUserTaskEffectiveVariables,POST,/user-tasks/{userTaskKey}/effective-variables/search,pagination-sort:request-shape,page object in body,yes,
+searchUserTaskEffectiveVariables,POST,/user-tasks/{userTaskKey}/effective-variables/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchUserTaskEffectiveVariables,POST,/user-tasks/{userTaskKey}/effective-variables/search,pagination-sort:request-shape,sort array in body,yes,
+searchUserTaskEffectiveVariables,POST,/user-tasks/{userTaskKey}/effective-variables/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchUserTaskEffectiveVariables,POST,/user-tasks/{userTaskKey}/effective-variables/search,filter:request-shape,filter object in body,yes,
+searchUserTaskEffectiveVariables,POST,/user-tasks/{userTaskKey}/effective-variables/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchUserTaskEffectiveVariables,POST,/user-tasks/{userTaskKey}/effective-variables/search,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+searchUserTaskEffectiveVariables,POST,/user-tasks/{userTaskKey}/effective-variables/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchUserTaskEffectiveVariables,POST,/user-tasks/{userTaskKey}/effective-variables/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchUserTaskEffectiveVariables,POST,/user-tasks/{userTaskKey}/effective-variables/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchUserTaskEffectiveVariables,POST,/user-tasks/{userTaskKey}/effective-variables/search,documented-500,response code 500 documented in spec,yes,
+getUserTaskForm,GET,/user-tasks/{userTaskKey}/form,happy-path,documented success response,yes,
+getUserTaskForm,GET,/user-tasks/{userTaskKey}/form,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getUserTaskForm,GET,/user-tasks/{userTaskKey}/form,404-not-found,"path param=userTaskKey, type=string, format=UserTaskKey",yes,
+getUserTaskForm,GET,/user-tasks/{userTaskKey}/form,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getUserTaskForm,GET,/user-tasks/{userTaskKey}/form,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getUserTaskForm,GET,/user-tasks/{userTaskKey}/form,documented-500,response code 500 documented in spec,yes,
+searchUserTaskVariables,POST,/user-tasks/{userTaskKey}/variables/search,happy-path,documented success response,yes,
+searchUserTaskVariables,POST,/user-tasks/{userTaskKey}/variables/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchUserTaskVariables,POST,/user-tasks/{userTaskKey}/variables/search,404-not-found,"path param=userTaskKey, type=string, format=UserTaskKey",yes,
+searchUserTaskVariables,POST,/user-tasks/{userTaskKey}/variables/search,bad-request:additional-property,closed schema,yes,
+searchUserTaskVariables,POST,/user-tasks/{userTaskKey}/variables/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchUserTaskVariables,POST,/user-tasks/{userTaskKey}/variables/search,pagination-sort:request-shape,sort array in body,yes,
+searchUserTaskVariables,POST,/user-tasks/{userTaskKey}/variables/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchUserTaskVariables,POST,/user-tasks/{userTaskKey}/variables/search,filter:request-shape,filter object in body,yes,
+searchUserTaskVariables,POST,/user-tasks/{userTaskKey}/variables/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchUserTaskVariables,POST,/user-tasks/{userTaskKey}/variables/search,403-forbidden,403 not documented; emitter needs to know if RBAC applies,no,RBAC: permissions required per endpoint
+searchUserTaskVariables,POST,/user-tasks/{userTaskKey}/variables/search,prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+searchUserTaskVariables,POST,/user-tasks/{userTaskKey}/variables/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchUserTaskVariables,POST,/user-tasks/{userTaskKey}/variables/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchUserTaskVariables,POST,/user-tasks/{userTaskKey}/variables/search,documented-500,response code 500 documented in spec,yes,
+searchVariables,POST,/variables/search,happy-path,documented success response,yes,
+searchVariables,POST,/variables/search,401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+searchVariables,POST,/variables/search,bad-request:additional-property,closed schema,yes,
+searchVariables,POST,/variables/search,bad-request:type-mismatch,"field=sort, type=array",yes,
+searchVariables,POST,/variables/search,pagination-sort:request-shape,sort array in body,yes,
+searchVariables,POST,/variables/search,pagination-sort:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchVariables,POST,/variables/search,filter:request-shape,filter object in body,yes,
+searchVariables,POST,/variables/search,filter:behaviour-assertion,"asserting result correctness, not just status",no,filter-field-semantics + sort-field-allowlist per entity
+searchVariables,POST,/variables/search,403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+searchVariables,POST,/variables/search,eventual-consistency,search may lag behind writes,no,consistency window per entity (or eventually-consistent flag)
+searchVariables,POST,/variables/search,scale-large-n,"behaviour at 10K+ entities; pagination limits, timeout, ordering stability",no,scale thresholds + expected response time per entity
+searchVariables,POST,/variables/search,documented-500,response code 500 documented in spec,yes,
+getVariable,GET,/variables/{variableKey},happy-path,documented success response,yes,
+getVariable,GET,/variables/{variableKey},401-unauthorized,spec declares securitySchemes but does not apply them,no,"spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec)"
+getVariable,GET,/variables/{variableKey},404-not-found,"path param=variableKey, type=string, format=VariableKey",yes,
+getVariable,GET,/variables/{variableKey},403-forbidden,403 documented in spec,no,RBAC: permissions required per endpoint
+getVariable,GET,/variables/{variableKey},prerequisite-resource,1 path param(s) imply a referenced resource,no,creation chain per identifier semantic-type
+getVariable,GET,/variables/{variableKey},documented-500,response code 500 documented in spec,yes,

--- a/spec-coverage-analyzer/plan.md
+++ b/spec-coverage-analyzer/plan.md
@@ -1,0 +1,2776 @@
+# Spec-derived test plan
+
+Total operations: **190**. Total plan items: **1817**.
+
+- Computable from spec alone: **1027**
+- Needs ABox / domain knowledge: **790**
+
+## Per-operation plan
+
+### `POST /element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation` — `activateAdHocSubProcessActivities` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=adHocSubProcessInstanceKey, type=string, format=ElementInstanceKey | ✓ | — |
+| bad-request:missing-required | field=elements | ✓ | — |
+| bad-request:type-mismatch | field=elements, type=array | ✓ | — |
+| bad-request:type-mismatch | field=cancelRemainingInstances, type=boolean | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | path has state-transition verb |  | lifecycle state machine for this entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /jobs/activation` — `activateJobs` (21 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=timeout, format=int64 | ✓ | — |
+| bad-request:format-invalid | field=maxJobsToActivate, format=int32 | ✓ | — |
+| bad-request:format-invalid | field=requestTimeout, format=int64 | ✓ | — |
+| bad-request:missing-required | field=type | ✓ | — |
+| bad-request:missing-required | field=maxJobsToActivate | ✓ | — |
+| bad-request:missing-required | field=timeout | ✓ | — |
+| bad-request:type-mismatch | field=type, type=string | ✓ | — |
+| bad-request:type-mismatch | field=worker, type=string | ✓ | — |
+| bad-request:type-mismatch | field=timeout, type=integer | ✓ | — |
+| bad-request:type-mismatch | field=maxJobsToActivate, type=integer | ✓ | — |
+| bad-request:type-mismatch | field=fetchVariable, type=array | ✓ | — |
+| bad-request:type-mismatch | field=requestTimeout, type=integer | ✓ | — |
+| bad-request:type-mismatch | field=tenantIds, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| business-entity-lifecycle | path has state-transition verb |  | lifecycle state machine for this entity |
+
+### `PUT /groups/{groupId}/clients/{clientId}` — `assignClientToGroup` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| 404-not-found | path param=clientId, type=string, format=ClientId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /tenants/{tenantId}/clients/{clientId}` — `assignClientToTenant` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| 404-not-found | path param=clientId, type=string, format=ClientId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /tenants/{tenantId}/groups/{groupId}` — `assignGroupToTenant` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /groups/{groupId}/mapping-rules/{mappingRuleId}` — `assignMappingRuleToGroup` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| 404-not-found | path param=mappingRuleId, type=string, format=MappingRuleId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /tenants/{tenantId}/mapping-rules/{mappingRuleId}` — `assignMappingRuleToTenant` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| 404-not-found | path param=mappingRuleId, type=string, format=MappingRuleId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /roles/{roleId}/clients/{clientId}` — `assignRoleToClient` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| 404-not-found | path param=clientId, type=string, format=ClientId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /roles/{roleId}/groups/{groupId}` — `assignRoleToGroup` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /roles/{roleId}/mapping-rules/{mappingRuleId}` — `assignRoleToMappingRule` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| 404-not-found | path param=mappingRuleId, type=string, format=MappingRuleId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /tenants/{tenantId}/roles/{roleId}` — `assignRoleToTenant` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /roles/{roleId}/users/{username}` — `assignRoleToUser` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| 404-not-found | path param=username, type=string, format=Username | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /user-tasks/{userTaskKey}/assignment` — `assignUserTask` (13 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=userTaskKey, type=string, format=UserTaskKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=assignee, type=string | ✓ | — |
+| bad-request:type-mismatch | field=allowOverride, type=boolean | ✓ | — |
+| bad-request:type-mismatch | field=action, type=string | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| documented-504 | response code 504 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | path has state-transition verb |  | lifecycle state machine for this entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /groups/{groupId}/users/{username}` — `assignUserToGroup` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| 404-not-found | path param=username, type=string, format=Username | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /tenants/{tenantId}/users/{username}` — `assignUserToTenant` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| 404-not-found | path param=username, type=string, format=Username | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /signals/broadcast` — `broadcastSignal` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:missing-required | field=signalName | ✓ | — |
+| bad-request:type-mismatch | field=signalName, type=string | ✓ | — |
+| bad-request:type-mismatch | field=variables, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| business-entity-lifecycle | path has state-transition verb |  | lifecycle state machine for this entity |
+
+### `POST /batch-operations/{batchOperationKey}/cancellation` — `cancelBatchOperation` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=batchOperationKey, type=string, format=BatchOperationKey \| uuid | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | path has state-transition verb |  | lifecycle state machine for this entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /process-instances/{processInstanceKey}/cancellation` — `cancelProcessInstance` (13 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=processInstanceKey, type=string, format=ProcessInstanceKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=operationReference, format=int64 | ✓ | — |
+| bad-request:range-violation | field=operationReference | ✓ | — |
+| bad-request:type-mismatch | field=operationReference, type=integer | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| documented-504 | response code 504 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | path has state-transition verb |  | lifecycle state machine for this entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /process-instances/cancellation` — `cancelProcessInstancesBatchOperation` (13 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=operationReference, format=int64 | ✓ | — |
+| bad-request:missing-required | field=filter | ✓ | — |
+| bad-request:range-violation | field=operationReference | ✓ | — |
+| bad-request:type-mismatch | field=operationReference, type=integer | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| business-entity-lifecycle | path has state-transition verb |  | lifecycle state machine for this entity |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+
+### `POST /jobs/{jobKey}/completion` — `completeJob` (10 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=jobKey, type=string, format=JobKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=variables, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | path has state-transition verb |  | lifecycle state machine for this entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /user-tasks/{userTaskKey}/completion` — `completeUserTask` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=userTaskKey, type=string, format=UserTaskKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=variables, type=object | ✓ | — |
+| bad-request:type-mismatch | field=action, type=string | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| documented-504 | response code 504 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | path has state-transition verb |  | lifecycle state machine for this entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /messages/correlation` — `correlateMessage` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:missing-required | field=name | ✓ | — |
+| bad-request:type-mismatch | field=name, type=string | ✓ | — |
+| bad-request:type-mismatch | field=correlationKey, type=string | ✓ | — |
+| bad-request:type-mismatch | field=variables, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| business-entity-lifecycle | path has state-transition verb |  | lifecycle state machine for this entity |
+
+### `POST /setup/user` — `createAdminUser` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:missing-required | field=username | ✓ | — |
+| bad-request:missing-required | field=password | ✓ | — |
+| bad-request:type-mismatch | field=password, type=string | ✓ | — |
+| bad-request:type-mismatch | field=name, type=string | ✓ | — |
+| bad-request:type-mismatch | field=email, type=string | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+
+### `POST /agent-instances` — `createAgentInstance` (8 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:missing-required | field=elementInstanceKey | ✓ | — |
+| bad-request:missing-required | field=definition | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+
+### `POST /authorizations` — `createAuthorization` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:oneof-violation | oneOf branches=2 | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+
+### `POST /deployments` — `createDeployment` (5 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+
+### `POST /documents` — `createDocument` (5 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| documented-415 | response code 415 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+
+### `POST /documents/{documentId}/links` — `createDocumentLink` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=documentId, type=string, format=DocumentId | ✓ | — |
+| bad-request:format-invalid | field=timeToLive, format=int64 | ✓ | — |
+| bad-request:type-mismatch | field=timeToLive, type=integer | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /documents/batch` — `createDocuments` (5 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| documented-415 | response code 415 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+
+### `PUT /element-instances/{elementInstanceKey}/variables` — `createElementInstanceVariables` (16 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=elementInstanceKey, type=string, format=ElementInstanceKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=operationReference, format=int64 | ✓ | — |
+| bad-request:missing-required | field=variables | ✓ | — |
+| bad-request:range-violation | field=operationReference | ✓ | — |
+| bad-request:type-mismatch | field=variables, type=object | ✓ | — |
+| bad-request:type-mismatch | field=local, type=boolean | ✓ | — |
+| bad-request:type-mismatch | field=operationReference, type=integer | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| documented-504 | response code 504 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /cluster-variables/global` — `createGlobalClusterVariable` (8 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:missing-required | field=name | ✓ | — |
+| bad-request:missing-required | field=value | ✓ | — |
+| bad-request:type-mismatch | field=value, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+
+### `POST /global-task-listeners` — `createGlobalTaskListener` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:format-invalid | field=id, format=GlobalListenerId | ✓ | — |
+| bad-request:missing-required | field=id | ✓ | — |
+| bad-request:missing-required | field=type | ✓ | — |
+| bad-request:missing-required | field=eventTypes | ✓ | — |
+| bad-request:type-mismatch | field=id, type=string | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| business-entity-lifecycle | 409 documented on non-collection POST |  | lifecycle state machine for this entity |
+
+### `POST /groups` — `createGroup` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:missing-required | field=groupId | ✓ | — |
+| bad-request:missing-required | field=name | ✓ | — |
+| bad-request:type-mismatch | field=name, type=string | ✓ | — |
+| bad-request:type-mismatch | field=description, type=string | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+
+### `POST /mapping-rules` — `createMappingRule` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:missing-required | field=mappingRuleId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+
+### `POST /process-instances` — `createProcessInstance` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:oneof-violation | oneOf branches=2 | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| documented-504 | response code 504 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| business-entity-lifecycle | 409 documented on non-collection POST |  | lifecycle state machine for this entity |
+
+### `POST /roles` — `createRole` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:missing-required | field=roleId | ✓ | — |
+| bad-request:missing-required | field=name | ✓ | — |
+| bad-request:type-mismatch | field=name, type=string | ✓ | — |
+| bad-request:type-mismatch | field=description, type=string | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+
+### `POST /tenants` — `createTenant` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:missing-required | field=tenantId | ✓ | — |
+| bad-request:missing-required | field=name | ✓ | — |
+| bad-request:type-mismatch | field=name, type=string | ✓ | — |
+| bad-request:type-mismatch | field=description, type=string | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| business-entity-lifecycle | 409 documented on non-collection POST |  | lifecycle state machine for this entity |
+
+### `POST /cluster-variables/tenants/{tenantId}` — `createTenantClusterVariable` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| bad-request:missing-required | field=name | ✓ | — |
+| bad-request:missing-required | field=value | ✓ | — |
+| bad-request:type-mismatch | field=value, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /users` — `createUser` (13 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:missing-required | field=username | ✓ | — |
+| bad-request:missing-required | field=password | ✓ | — |
+| bad-request:type-mismatch | field=password, type=string | ✓ | — |
+| bad-request:type-mismatch | field=name, type=string | ✓ | — |
+| bad-request:type-mismatch | field=email, type=string | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| business-entity-lifecycle | 409 documented on non-collection POST |  | lifecycle state machine for this entity |
+
+### `DELETE /authorizations/{authorizationKey}` — `deleteAuthorization` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=authorizationKey, type=string, format=AuthorizationKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /decision-instances/{decisionEvaluationKey}/deletion` — `deleteDecisionInstance` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=decisionEvaluationKey, type=string, format=DecisionEvaluationKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=operationReference, format=int64 | ✓ | — |
+| bad-request:range-violation | field=operationReference | ✓ | — |
+| bad-request:type-mismatch | field=operationReference, type=integer | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /decision-instances/deletion` — `deleteDecisionInstancesBatchOperation` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=operationReference, format=int64 | ✓ | — |
+| bad-request:missing-required | field=filter | ✓ | — |
+| bad-request:range-violation | field=operationReference | ✓ | — |
+| bad-request:type-mismatch | field=operationReference, type=integer | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+
+### `DELETE /documents/{documentId}` — `deleteDocument` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=documentId, type=string, format=DocumentId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /cluster-variables/global/{name}` — `deleteGlobalClusterVariable` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=name, type=string, format=ClusterVariableName | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /global-task-listeners/{id}` — `deleteGlobalTaskListener` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=id, type=string, format=GlobalListenerId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /groups/{groupId}` — `deleteGroup` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /mapping-rules/{mappingRuleId}` — `deleteMappingRule` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=mappingRuleId, type=string, format=MappingRuleId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /process-instances/{processInstanceKey}/deletion` — `deleteProcessInstance` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=processInstanceKey, type=string, format=ProcessInstanceKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=operationReference, format=int64 | ✓ | — |
+| bad-request:range-violation | field=operationReference | ✓ | — |
+| bad-request:type-mismatch | field=operationReference, type=integer | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | 409 documented on non-collection POST |  | lifecycle state machine for this entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /process-instances/deletion` — `deleteProcessInstancesBatchOperation` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=operationReference, format=int64 | ✓ | — |
+| bad-request:missing-required | field=filter | ✓ | — |
+| bad-request:range-violation | field=operationReference | ✓ | — |
+| bad-request:type-mismatch | field=operationReference, type=integer | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+
+### `POST /resources/{resourceKey}/deletion` — `deleteResource` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=resourceKey, type=string, format=ResourceKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=operationReference, format=int64 | ✓ | — |
+| bad-request:range-violation | field=operationReference | ✓ | — |
+| bad-request:type-mismatch | field=operationReference, type=integer | ✓ | — |
+| bad-request:type-mismatch | field=deleteHistory, type=boolean | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /roles/{roleId}` — `deleteRole` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /tenants/{tenantId}` — `deleteTenant` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /cluster-variables/tenants/{tenantId}/{name}` — `deleteTenantClusterVariable` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| 404-not-found | path param=name, type=string, format=ClusterVariableName | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /users/{username}` — `deleteUser` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=username, type=string, format=Username | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /conditionals/evaluation` — `evaluateConditionals` (8 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:missing-required | field=variables | ✓ | — |
+| bad-request:type-mismatch | field=variables, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+
+### `POST /decision-definitions/evaluation` — `evaluateDecision` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:oneof-violation | oneOf branches=2 | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+
+### `POST /expression/evaluation` — `evaluateExpression` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:missing-required | field=expression | ✓ | — |
+| bad-request:type-mismatch | field=expression, type=string | ✓ | — |
+| bad-request:type-mismatch | field=tenantId, type=string | ✓ | — |
+| bad-request:type-mismatch | field=variables, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+
+### `POST /jobs/{jobKey}/failure` — `failJob` (15 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=jobKey, type=string, format=JobKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=retries, format=int32 | ✓ | — |
+| bad-request:format-invalid | field=retryBackOff, format=int64 | ✓ | — |
+| bad-request:type-mismatch | field=retries, type=integer | ✓ | — |
+| bad-request:type-mismatch | field=errorMessage, type=string | ✓ | — |
+| bad-request:type-mismatch | field=retryBackOff, type=integer | ✓ | — |
+| bad-request:type-mismatch | field=variables, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `fail` implies state transition |  | lifecycle state machine for this entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /agent-instances/{agentInstanceKey}` — `getAgentInstance` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=agentInstanceKey, type=string, format=AgentInstanceKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /audit-logs/{auditLogKey}` — `getAuditLog` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=auditLogKey, type=string, format=AuditLogKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /authentication/me` — `getAuthentication` (4 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 401-unauthorized | per-op security; strip auth header | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+
+### `GET /authorizations/{authorizationKey}` — `getAuthorization` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=authorizationKey, type=string, format=AuthorizationKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /batch-operations/{batchOperationKey}` — `getBatchOperation` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=batchOperationKey, type=string, format=BatchOperationKey \| uuid | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /decision-definitions/{decisionDefinitionKey}` — `getDecisionDefinition` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=decisionDefinitionKey, type=string, format=DecisionDefinitionKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /decision-definitions/{decisionDefinitionKey}/xml` — `getDecisionDefinitionXML` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=decisionDefinitionKey, type=string, format=DecisionDefinitionKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /decision-instances/{decisionEvaluationInstanceKey}` — `getDecisionInstance` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=decisionEvaluationInstanceKey, type=string, format=DecisionEvaluationInstanceKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /decision-requirements/{decisionRequirementsKey}` — `getDecisionRequirements` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=decisionRequirementsKey, type=string, format=DecisionRequirementsKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /decision-requirements/{decisionRequirementsKey}/xml` — `getDecisionRequirementsXML` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=decisionRequirementsKey, type=string, format=DecisionRequirementsKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /documents/{documentId}` — `getDocument` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=documentId, type=string, format=DocumentId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /element-instances/{elementInstanceKey}` — `getElementInstance` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=elementInstanceKey, type=string, format=ElementInstanceKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /forms/{formKey}` — `getFormByKey` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=formKey, type=string, format=FormKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /cluster-variables/global/{name}` — `getGlobalClusterVariable` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=name, type=string, format=ClusterVariableName | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /jobs/statistics/global` — `getGlobalJobStatistics` (5 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | query param=from | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+
+### `GET /global-task-listeners/{id}` — `getGlobalTaskListener` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=id, type=string, format=GlobalListenerId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /groups/{groupId}` — `getGroup` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /incidents/{incidentKey}` — `getIncident` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=incidentKey, type=string, format=IncidentKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /jobs/statistics/errors` — `getJobErrorStatistics` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:missing-required | field=filter | ✓ | — |
+| bad-request:type-mismatch | field=filter, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | page object in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+
+### `POST /jobs/statistics/time-series` — `getJobTimeSeriesStatistics` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:missing-required | field=filter | ✓ | — |
+| bad-request:type-mismatch | field=filter, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | page object in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+
+### `POST /jobs/statistics/by-types` — `getJobTypeStatistics` (10 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:type-mismatch | field=filter, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | page object in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+
+### `POST /jobs/statistics/by-workers` — `getJobWorkerStatistics` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:missing-required | field=filter | ✓ | — |
+| bad-request:type-mismatch | field=filter, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | page object in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+
+### `GET /license` — `getLicense` (4 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+
+### `GET /mapping-rules/{mappingRuleId}` — `getMappingRule` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=mappingRuleId, type=string, format=MappingRuleId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /process-definitions/{processDefinitionKey}` — `getProcessDefinition` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=processDefinitionKey, type=string, format=ProcessDefinitionKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /process-definitions/statistics/process-instances` — `getProcessDefinitionInstanceStatistics` (10 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | page object in body | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+
+### `POST /process-definitions/statistics/process-instances-by-version` — `getProcessDefinitionInstanceVersionStatistics` (13 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:missing-required | field=filter | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | page object in body | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+
+### `POST /process-definitions/statistics/message-subscriptions` — `getProcessDefinitionMessageSubscriptionStatistics` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | page object in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+
+### `POST /process-definitions/{processDefinitionKey}/statistics/element-instances` — `getProcessDefinitionStatistics` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=processDefinitionKey, type=string, format=ProcessDefinitionKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /process-definitions/{processDefinitionKey}/xml` — `getProcessDefinitionXML` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=processDefinitionKey, type=string, format=ProcessDefinitionKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /process-instances/{processInstanceKey}` — `getProcessInstance` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=processInstanceKey, type=string, format=ProcessInstanceKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /process-instances/{processInstanceKey}/call-hierarchy` — `getProcessInstanceCallHierarchy` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=processInstanceKey, type=string, format=ProcessInstanceKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /process-instances/{processInstanceKey}/sequence-flows` — `getProcessInstanceSequenceFlows` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=processInstanceKey, type=string, format=ProcessInstanceKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /process-instances/{processInstanceKey}/statistics/element-instances` — `getProcessInstanceStatistics` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=processInstanceKey, type=string, format=ProcessInstanceKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /incidents/statistics/process-instances-by-definition` — `getProcessInstanceStatisticsByDefinition` (13 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:missing-required | field=filter | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | page object in body | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+
+### `POST /incidents/statistics/process-instances-by-error` — `getProcessInstanceStatisticsByError` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | page object in body | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+
+### `GET /resources/{resourceKey}` — `getResource` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=resourceKey, type=string, format=ResourceKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /resources/{resourceKey}/content` — `getResourceContent` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=resourceKey, type=string, format=ResourceKey | ✓ | — |
+| documented-406 | response code 406 documented in spec | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /resources/{resourceKey}/content/binary` — `getResourceContentBinary` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=resourceKey, type=string, format=ResourceKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /roles/{roleId}` — `getRole` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /process-definitions/{processDefinitionKey}/form` — `getStartProcessForm` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=processDefinitionKey, type=string, format=ProcessDefinitionKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /status` — `getStatus` (4 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+
+### `GET /system/configuration` — `getSystemConfiguration` (4 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+
+### `GET /tenants/{tenantId}` — `getTenant` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /cluster-variables/tenants/{tenantId}/{name}` — `getTenantClusterVariable` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| 404-not-found | path param=name, type=string, format=ClusterVariableName | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /topology` — `getTopology` (4 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+
+### `GET /system/usage-metrics` — `getUsageMetrics` (4 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+
+### `GET /users/{username}` — `getUser` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=username, type=string, format=Username | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /user-tasks/{userTaskKey}` — `getUserTask` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=userTaskKey, type=string, format=UserTaskKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /user-tasks/{userTaskKey}/form` — `getUserTaskForm` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=userTaskKey, type=string, format=UserTaskKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `GET /variables/{variableKey}` — `getVariable` (6 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=variableKey, type=string, format=VariableKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /process-instances/{processInstanceKey}/migration` — `migrateProcessInstance` (15 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=processInstanceKey, type=string, format=ProcessInstanceKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=operationReference, format=int64 | ✓ | — |
+| bad-request:missing-required | field=targetProcessDefinitionKey | ✓ | — |
+| bad-request:missing-required | field=mappingInstructions | ✓ | — |
+| bad-request:range-violation | field=operationReference | ✓ | — |
+| bad-request:type-mismatch | field=mappingInstructions, type=array | ✓ | — |
+| bad-request:type-mismatch | field=operationReference, type=integer | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `migrate` implies state transition |  | lifecycle state machine for this entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /process-instances/migration` — `migrateProcessInstancesBatchOperation` (14 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=operationReference, format=int64 | ✓ | — |
+| bad-request:missing-required | field=filter | ✓ | — |
+| bad-request:missing-required | field=migrationPlan | ✓ | — |
+| bad-request:range-violation | field=operationReference | ✓ | — |
+| bad-request:type-mismatch | field=operationReference, type=integer | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| business-entity-lifecycle | operationId prefix `migrate` implies state transition |  | lifecycle state machine for this entity |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+
+### `POST /process-instances/{processInstanceKey}/modification` — `modifyProcessInstance` (15 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=processInstanceKey, type=string, format=ProcessInstanceKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=operationReference, format=int64 | ✓ | — |
+| bad-request:range-violation | field=operationReference | ✓ | — |
+| bad-request:type-mismatch | field=operationReference, type=integer | ✓ | — |
+| bad-request:type-mismatch | field=activateInstructions, type=array | ✓ | — |
+| bad-request:type-mismatch | field=moveInstructions, type=array | ✓ | — |
+| bad-request:type-mismatch | field=terminateInstructions, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | path has state-transition verb |  | lifecycle state machine for this entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /process-instances/modification` — `modifyProcessInstancesBatchOperation` (15 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=operationReference, format=int64 | ✓ | — |
+| bad-request:missing-required | field=filter | ✓ | — |
+| bad-request:missing-required | field=moveInstructions | ✓ | — |
+| bad-request:range-violation | field=operationReference | ✓ | — |
+| bad-request:type-mismatch | field=moveInstructions, type=array | ✓ | — |
+| bad-request:type-mismatch | field=operationReference, type=integer | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| business-entity-lifecycle | path has state-transition verb |  | lifecycle state machine for this entity |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+
+### `PUT /clock` — `pinClock` (10 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=timestamp, format=int64 | ✓ | — |
+| bad-request:missing-required | field=timestamp | ✓ | — |
+| bad-request:type-mismatch | field=timestamp, type=integer | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `pin` implies state transition |  | lifecycle state machine for this entity |
+
+### `POST /messages/publication` — `publishMessage` (15 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=timeToLive, format=int64 | ✓ | — |
+| bad-request:missing-required | field=name | ✓ | — |
+| bad-request:type-mismatch | field=name, type=string | ✓ | — |
+| bad-request:type-mismatch | field=correlationKey, type=string | ✓ | — |
+| bad-request:type-mismatch | field=timeToLive, type=integer | ✓ | — |
+| bad-request:type-mismatch | field=messageId, type=string | ✓ | — |
+| bad-request:type-mismatch | field=variables, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| business-entity-lifecycle | path has state-transition verb |  | lifecycle state machine for this entity |
+
+### `POST /clock/reset` — `resetClock` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| business-entity-lifecycle | operationId prefix `reset` implies state transition |  | lifecycle state machine for this entity |
+
+### `POST /incidents/{incidentKey}/resolution` — `resolveIncident` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=incidentKey, type=string, format=IncidentKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=operationReference, format=int64 | ✓ | — |
+| bad-request:range-violation | field=operationReference | ✓ | — |
+| bad-request:type-mismatch | field=operationReference, type=integer | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | path has state-transition verb |  | lifecycle state machine for this entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /process-instances/incident-resolution` — `resolveIncidentsBatchOperation` (13 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=operationReference, format=int64 | ✓ | — |
+| bad-request:missing-required | field=filter | ✓ | — |
+| bad-request:range-violation | field=operationReference | ✓ | — |
+| bad-request:type-mismatch | field=operationReference, type=integer | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| business-entity-lifecycle | operationId prefix `resolve` implies state transition |  | lifecycle state machine for this entity |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+
+### `POST /process-instances/{processInstanceKey}/incident-resolution` — `resolveProcessInstanceIncidents` (8 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=processInstanceKey, type=string, format=ProcessInstanceKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `resolve` implies state transition |  | lifecycle state machine for this entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /batch-operations/{batchOperationKey}/resumption` — `resumeBatchOperation` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=batchOperationKey, type=string, format=BatchOperationKey \| uuid | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /agent-instances/search` — `searchAgentInstances` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /audit-logs/search` — `searchAuditLogs` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /authorizations/search` — `searchAuthorizations` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /batch-operation-items/search` — `searchBatchOperationItems` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /batch-operations/search` — `searchBatchOperations` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /groups/{groupId}/clients/search` — `searchClientsForGroup` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /roles/{roleId}/clients/search` — `searchClientsForRole` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /tenants/{tenantId}/clients/search` — `searchClientsForTenant` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /cluster-variables/search` — `searchClusterVariables` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /correlated-message-subscriptions/search` — `searchCorrelatedMessageSubscriptions` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /decision-definitions/search` — `searchDecisionDefinitions` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /decision-instances/search` — `searchDecisionInstances` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /decision-requirements/search` — `searchDecisionRequirements` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /element-instances/{elementInstanceKey}/incidents/search` — `searchElementInstanceIncidents` (14 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=elementInstanceKey, type=string, format=ElementInstanceKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /element-instances/search` — `searchElementInstances` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /global-task-listeners/search` — `searchGlobalTaskListeners` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /tenants/{tenantId}/groups/search` — `searchGroupIdsForTenant` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /groups/search` — `searchGroups` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /roles/{roleId}/groups/search` — `searchGroupsForRole` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /incidents/search` — `searchIncidents` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /jobs/search` — `searchJobs` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /mapping-rules/search` — `searchMappingRule` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /groups/{groupId}/mapping-rules/search` — `searchMappingRulesForGroup` (14 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /roles/{roleId}/mapping-rules/search` — `searchMappingRulesForRole` (14 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /tenants/{tenantId}/mapping-rules/search` — `searchMappingRulesForTenant` (13 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /message-subscriptions/search` — `searchMessageSubscriptions` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /process-definitions/search` — `searchProcessDefinitions` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /process-instances/{processInstanceKey}/incidents/search` — `searchProcessInstanceIncidents` (14 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=processInstanceKey, type=string, format=ProcessInstanceKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /process-instances/search` — `searchProcessInstances` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /resources/search` — `searchResources` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /roles/search` — `searchRoles` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /groups/{groupId}/roles/search` — `searchRolesForGroup` (14 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /tenants/{tenantId}/roles/search` — `searchRolesForTenant` (13 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /tenants/search` — `searchTenants` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /user-tasks/{userTaskKey}/audit-logs/search` — `searchUserTaskAuditLogs` (15 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=userTaskKey, type=string, format=UserTaskKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| bad-request:type-mismatch | field=filter, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /user-tasks/{userTaskKey}/effective-variables/search` — `searchUserTaskEffectiveVariables` (16 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=userTaskKey, type=string, format=UserTaskKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | page object in body | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /user-tasks/{userTaskKey}/variables/search` — `searchUserTaskVariables` (14 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=userTaskKey, type=string, format=UserTaskKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /user-tasks/search` — `searchUserTasks` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /users/search` — `searchUsers` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /groups/{groupId}/users/search` — `searchUsersForGroup` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /roles/{roleId}/users/search` — `searchUsersForRole` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /tenants/{tenantId}/users/search` — `searchUsersForTenant` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /variables/search` — `searchVariables` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=sort, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| filter:request-shape | filter object in body | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| pagination-sort:request-shape | sort array in body | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| eventual-consistency | search may lag behind writes |  | consistency window per entity (or eventually-consistent flag) |
+| filter:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| pagination-sort:behaviour-assertion | asserting result correctness, not just status |  | filter-field-semantics + sort-field-allowlist per entity |
+| scale-large-n | behaviour at 10K+ entities; pagination limits, timeout, ordering stability |  | scale thresholds + expected response time per entity |
+
+### `POST /batch-operations/{batchOperationKey}/suspension` — `suspendBatchOperation` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=batchOperationKey, type=string, format=BatchOperationKey \| uuid | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `POST /jobs/{jobKey}/error` — `throwJobError` (13 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=jobKey, type=string, format=JobKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:missing-required | field=errorCode | ✓ | — |
+| bad-request:type-mismatch | field=errorCode, type=string | ✓ | — |
+| bad-request:type-mismatch | field=errorMessage, type=string | ✓ | — |
+| bad-request:type-mismatch | field=variables, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | 409 documented on non-collection POST |  | lifecycle state machine for this entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /groups/{groupId}/clients/{clientId}` — `unassignClientFromGroup` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| 404-not-found | path param=clientId, type=string, format=ClientId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `unassign` implies state transition |  | lifecycle state machine for this entity |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /tenants/{tenantId}/clients/{clientId}` — `unassignClientFromTenant` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| 404-not-found | path param=clientId, type=string, format=ClientId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `unassign` implies state transition |  | lifecycle state machine for this entity |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /tenants/{tenantId}/groups/{groupId}` — `unassignGroupFromTenant` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `unassign` implies state transition |  | lifecycle state machine for this entity |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /groups/{groupId}/mapping-rules/{mappingRuleId}` — `unassignMappingRuleFromGroup` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| 404-not-found | path param=mappingRuleId, type=string, format=MappingRuleId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `unassign` implies state transition |  | lifecycle state machine for this entity |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /tenants/{tenantId}/mapping-rules/{mappingRuleId}` — `unassignMappingRuleFromTenant` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| 404-not-found | path param=mappingRuleId, type=string, format=MappingRuleId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `unassign` implies state transition |  | lifecycle state machine for this entity |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /roles/{roleId}/clients/{clientId}` — `unassignRoleFromClient` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| 404-not-found | path param=clientId, type=string, format=ClientId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `unassign` implies state transition |  | lifecycle state machine for this entity |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /roles/{roleId}/groups/{groupId}` — `unassignRoleFromGroup` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `unassign` implies state transition |  | lifecycle state machine for this entity |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /roles/{roleId}/mapping-rules/{mappingRuleId}` — `unassignRoleFromMappingRule` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| 404-not-found | path param=mappingRuleId, type=string, format=MappingRuleId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `unassign` implies state transition |  | lifecycle state machine for this entity |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /tenants/{tenantId}/roles/{roleId}` — `unassignRoleFromTenant` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `unassign` implies state transition |  | lifecycle state machine for this entity |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /roles/{roleId}/users/{username}` — `unassignRoleFromUser` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| 404-not-found | path param=username, type=string, format=Username | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `unassign` implies state transition |  | lifecycle state machine for this entity |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /groups/{groupId}/users/{username}` — `unassignUserFromGroup` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| 404-not-found | path param=username, type=string, format=Username | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `unassign` implies state transition |  | lifecycle state machine for this entity |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /tenants/{tenantId}/users/{username}` — `unassignUserFromTenant` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| 404-not-found | path param=username, type=string, format=Username | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `unassign` implies state transition |  | lifecycle state machine for this entity |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `DELETE /user-tasks/{userTaskKey}/assignee` — `unassignUserTask` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=userTaskKey, type=string, format=UserTaskKey | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| documented-504 | response code 504 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| business-entity-lifecycle | operationId prefix `unassign` implies state transition |  | lifecycle state machine for this entity |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PATCH /agent-instances/{agentInstanceKey}` — `updateAgentInstance` (7 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=agentInstanceKey, type=string, format=AgentInstanceKey | ✓ | — |
+| bad-request:type-mismatch | field=tools, type=array | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /authorizations/{authorizationKey}` — `updateAuthorization` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=authorizationKey, type=string, format=AuthorizationKey | ✓ | — |
+| bad-request:oneof-violation | oneOf branches=2 | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /cluster-variables/global/{name}` — `updateGlobalClusterVariable` (9 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=name, type=string, format=ClusterVariableName | ✓ | — |
+| bad-request:missing-required | field=value | ✓ | — |
+| bad-request:type-mismatch | field=value, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /global-task-listeners/{id}` — `updateGlobalTaskListener` (10 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=id, type=string, format=GlobalListenerId | ✓ | — |
+| bad-request:missing-required | field=type | ✓ | — |
+| bad-request:missing-required | field=eventTypes | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /groups/{groupId}` — `updateGroup` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=groupId, type=string, format=GroupId | ✓ | — |
+| bad-request:missing-required | field=name | ✓ | — |
+| bad-request:type-mismatch | field=name, type=string | ✓ | — |
+| bad-request:type-mismatch | field=description, type=string | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PATCH /jobs/{jobKey}` — `updateJob` (13 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=jobKey, type=string, format=JobKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:format-invalid | field=operationReference, format=int64 | ✓ | — |
+| bad-request:missing-required | field=changeset | ✓ | — |
+| bad-request:range-violation | field=operationReference | ✓ | — |
+| bad-request:type-mismatch | field=changeset, type=object | ✓ | — |
+| bad-request:type-mismatch | field=operationReference, type=integer | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /mapping-rules/{mappingRuleId}` — `updateMappingRule` (8 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=mappingRuleId, type=string, format=MappingRuleId | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /roles/{roleId}` — `updateRole` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=roleId, type=string, format=RoleId | ✓ | — |
+| bad-request:missing-required | field=name | ✓ | — |
+| bad-request:type-mismatch | field=name, type=string | ✓ | — |
+| bad-request:type-mismatch | field=description, type=string | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /tenants/{tenantId}` — `updateTenant` (12 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:missing-required | field=name | ✓ | — |
+| bad-request:type-mismatch | field=name, type=string | ✓ | — |
+| bad-request:type-mismatch | field=description, type=string | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /cluster-variables/tenants/{tenantId}/{name}` — `updateTenantClusterVariable` (10 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=tenantId, type=string, format=TenantId | ✓ | — |
+| 404-not-found | path param=name, type=string, format=ClusterVariableName | ✓ | — |
+| bad-request:missing-required | field=value | ✓ | — |
+| bad-request:type-mismatch | field=value, type=object | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 2 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PUT /users/{username}` — `updateUser` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=username, type=string, format=Username | ✓ | — |
+| bad-request:type-mismatch | field=password, type=string | ✓ | — |
+| bad-request:type-mismatch | field=name, type=string | ✓ | — |
+| bad-request:type-mismatch | field=email, type=string | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 documented in spec |  | RBAC: permissions required per endpoint |
+| 409-conflict | create-or-replace with same identifier |  | duplicatePolicy per endpoint (idempotent \| conflict \| replace) |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+
+### `PATCH /user-tasks/{userTaskKey}` — `updateUserTask` (11 items)
+
+| kind | detail | computable | needed ABox fact |
+|---|---|:-:|---|
+| 404-not-found | path param=userTaskKey, type=string, format=UserTaskKey | ✓ | — |
+| bad-request:additional-property | closed schema | ✓ | — |
+| bad-request:type-mismatch | field=changeset, type=object | ✓ | — |
+| bad-request:type-mismatch | field=action, type=string | ✓ | — |
+| documented-500 | response code 500 documented in spec | ✓ | — |
+| documented-503 | response code 503 documented in spec | ✓ | — |
+| documented-504 | response code 504 documented in spec | ✓ | — |
+| happy-path | documented success response | ✓ | — |
+| 401-unauthorized | spec declares securitySchemes but does not apply them |  | spec-gap: which endpoints actually require auth (currently encoded only in deployment, not the spec) |
+| 403-forbidden | 403 not documented; emitter needs to know if RBAC applies |  | RBAC: permissions required per endpoint |
+| prerequisite-resource | 1 path param(s) imply a referenced resource |  | creation chain per identifier semantic-type |
+


### PR DESCRIPTION
## Status

**Draft / spike for #277**. Not for merge as-is — the goal of this PR is to give @jwulf and the team something concrete to react to before deciding on the next step (ABox slice priorities, rule-table refinement, integration design).

## Summary

Adds `spec-coverage-analyzer/` — a Python analyzer that reads an OpenAPI spec and emits a per-endpoint test plan, tagging each plan item as either **computable from the spec alone** or **needs an ABox fact** (with the missing fact named in the output).

Runs by default against `spec/camunda-oca/bundled/rest-api.bundle.json`; designed to be re-run on Camunda Hub when that spec lands.

## How is this different from the generator?

Both tools read the spec **and** the ABox — the generator already integrates the ontology under `configs/<config>/ontology/` (that's how it knows e.g. process-instance needs a deployed process first). The analyzer-spike-as-shipped doesn't read the ABox yet — that's deferred to next-step #2 below.

The real difference is *what each tool produces*:

| | Generator | Analyzer (this PR) |
|---|---|---|
| Output | Real `.spec.ts` test files (executable code) | A checklist describing what tests should exist (no code) |
| Categories covered | Only the categories the emitter plugins know how to build (happy-path, request-validation negatives, edge + entity lifecycles, …) | **Every** category that should exist, including ones no emitter knows how to build yet |
| When a category isn't covered | Silent — those tests just don't exist | Listed in the plan, tagged with what's missing (an ABox slice, a new emitter plugin, or both) |
| ABox integration | Already wired | Not in this spike — deferred to step 2 of "Next steps" |
| Audience | The test runner (CI / dev machine) | Humans deciding what to build next |

**Concrete example for `POST /tenants`** —

What the generator currently produces (real `.spec.ts` files):
- ✅ A happy-path test
- ✅ ~15 schema-validation negative tests via the request-validation emitter
- ✅ A composite lifecycle test (`create → present → update → delete → absent`) from the EntityLifecycle template

What the analyzer says **should** exist for that endpoint:
- ✅ All of the above, **plus:**
- ⚠️ A 401 test — currently `needs-abox: spec-gap` (spec under-declares auth)
- ⚠️ A 403 test — `needs-abox: RBAC` (no slice yet)
- ⚠️ A 404 test against a fake tenant ID — `computable` ✓ (no emitter for it yet either, but the spec gives us enough)
- ⚠️ A 409 test for duplicate-create — `needs-abox: duplicatePolicy` (Josh's 8.8 design, not landed)
- ⚠️ Pagination + filter behaviour tests on `search` — `needs-abox: filter/sort semantics`

The ✅ items: generator already produces them.
The ⚠️ items: generator produces **zero** of them.

**Why this matters:** the analyzer is the *checklist the generator gets graded against*. Without it, "is the generator producing enough tests?" gets hand-counted against another suite. With it, every missing test is named, scoped, and tagged with exactly what's blocking it — usually a specific ABox slice or a specific emitter plugin.

## Snapshot against the OCA spec

| | count |
|---|---:|
| Operations | 190 |
| Plan items total | 1817 |
| Computable from spec alone | **1027** (56%) |
| Needs ABox / domain knowledge | **790** (44%) |

**Top missing ABox facts (by plan-item load):**

| missing fact | plan items |
|---|---:|
| RBAC: permissions required per endpoint | 190 |
| spec-gap: which endpoints actually require auth | 189 |
| creation chain per identifier semantic-type | 120 |
| filter-field-semantics + sort-field-allowlist per entity | 106 |
| `duplicatePolicy` per endpoint (idempotent / conflict / replace) | 59 |
| consistency window per entity | 43 |
| scale thresholds + expected response time per entity | 43 |
| lifecycle state machine for this entity | 40 |
| cross-field validation rules | (low — heuristic only catches paired `*Before`/`*After`) |

## Spec-gap finding

The OCA spec declares `securitySchemes` (BearerAuth, basicAuth) but only applies them on `getAuthentication`. The analyzer flags 189 ops with a `401-unauthorized` needs-ABox item (`spec-gap: which endpoints actually require auth, encoded only in deployment, not the spec`). That's a real spec/reality drift worth surfacing — relates to camunda/camunda#52511.

## Rule table

See `spec-coverage-analyzer/README.md` for the full rule table. Brief summary:

- **Computable rules** (14 kinds): `happy-path`, `bad-request:{missing-required, type-mismatch, format-invalid, enum-violation, range-violation, additional-property, oneof-violation}`, `404-not-found` (per path param), `401-unauthorized` (when security is declared on the op), `pagination-sort:request-shape`, `filter:request-shape`, `documented-XXX` (per documented non-2xx response).
- **Needs-ABox rules** (9 kinds): `401-unauthorized:spec-gap`, `403-forbidden`, `409-conflict`, `business-entity-lifecycle`, `prerequisite-resource`, `eventual-consistency`, `scale-large-n`, `cross-field-range`, `pagination-sort/filter:behaviour-assertion`.

## Outputs

- `plan.csv` — machine-readable, one row per `(operationId, plan-item)` tuple.
- `plan.md` — per-endpoint readable summary, formatted as upstream's coverage_breakdown.md.
- `needs-abox.md` — aggregated needs-ABox gaps grouped by missing fact.

## Test plan

- [ ] Run `python3 spec-coverage-analyzer/build_plan.py` and confirm it emits the 3 artifacts.
- [ ] Spot-check a few operations in `plan.md` — do the computable / needs-ABox tags match what you'd expect?
- [ ] Sanity-check `needs-abox.md` — are the 9 ABox-fact buckets the right axes? Anything missing?

## Open questions for review

1. **Rule-table coverage**: is the current 14-computable + 9-needs-ABox set the right shape, or are there obvious categories missing?
2. **ABox slice priority**: which of the 8 top ABox facts should land first? My read: `duplicatePolicy` (smallest, already designed in 8.8) is the cheapest unlock — would move 59 plan items from "needs ABox" to "computable" in a single shot.
3. **Integration design**: where does this tool live long-term? Standalone Python (current spike) or rewritten into the TypeScript `path-analyser/` stack (consistent with the rest of the generator codebase)?

## Next steps (once this spike is signed off)

In priority order, with dependencies:

1. **Land `duplicatePolicy` as the first ABox slice.** Cheapest unblock — Josh has already designed it (8.8); needs to be expressed as a new file under `configs/camunda-oca/ontology/duplicatePolicy.json` with `{ operationId → policy }` entries for the ~59 create-style endpoints flagged. **Independent of this PR's review outcome — could start in parallel.**
2. **Wire the analyzer to read the ABox.** After (1), update `build_plan.py` to consume `duplicatePolicy` and reclassify those 59 plan items from `needs-abox` to `computable`. Validates the analyzer ↔ ABox contract on the smallest slice before scaling to the bigger ones (RBAC, filter-semantics).
3. **Ship the 404 fake-ID emitter (#279).** First proof of the full loop: analyzer flags a plan item as computable → emitter generates the actual test → tests run. No dependency on any ABox slice; `ontology/semantics.json` already encodes the path-param identifier types. ~1 day's work, closes ~127 upstream-equivalent tests.
4. **Run the analyzer against the Camunda Hub spec.** Validates the rule table generalises beyond OCA. Will surface any OCA-specific assumptions baked into the heuristics (e.g. the business-entity-signal patterns).
5. **Repurpose `coverage-analysis/` (PR #278) as a verification check.** Currently it analyses what the generator emits. Once the analyzer exists, the two can be diffed: "does the generator emit what the analyzer says it should?". Becomes a CI check rather than a static snapshot.

## Out of scope for follow-up (defer)

- **RBAC ABox slice** (190 items) — biggest unlock but also biggest scoping effort. Defer until `duplicatePolicy` validates the analyzer↔ABox pattern.
- **Filter-semantics ABox slice** (106 items) — same reasoning; lots of per-field decisions.
- **Camunda Hub generalisation** — wait until OCA-side loop (analyzer + duplicatePolicy + 404 emitter) is stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



