### PR TITLE
fix(materializer): drop broken responses:regenerate script from shipped suite

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1409,16 +1409,15 @@ describeForThisConfig('bundled-spec invariants: emitted Playwright suite', () =>
     ).toEqual([]);
   });
 
-  it('generated package.json has no script that points at a file the codegen does not ship', () => {
+  it('generated package.json has no script that references `./openapi.json`', () => {
     // The pre-fix `responses:regenerate` script pointed at
     // `./openapi.json`, which the codegen never wrote next to the
     // suite's package.json. Running `npm run responses:regenerate`
     // out of the box failed with "Local spec file not found". This
     // invariant rejects any script in the generated package.json
-    // whose command-line references a literal `./openapi.json` (or
-    // any other file the codegen does not materialise alongside
-    // package.json). Class-scoped: any reintroduction of the same
-    // dead-on-arrival shape — under any script name — fails.
+    // whose command-line references the literal `./openapi.json`.
+    // Class-scoped: any reintroduction of that dead-on-arrival
+    // shape — under any script name — fails.
     const pkgPath = join(GENERATED_TESTS_DIR, 'package.json');
     if (!existsSync(pkgPath)) {
       throw new Error(

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1409,6 +1409,41 @@ describeForThisConfig('bundled-spec invariants: emitted Playwright suite', () =>
     ).toEqual([]);
   });
 
+  it('generated package.json has no script that points at a file the codegen does not ship', () => {
+    // The pre-fix `responses:regenerate` script pointed at
+    // `./openapi.json`, which the codegen never wrote next to the
+    // suite's package.json. Running `npm run responses:regenerate`
+    // out of the box failed with "Local spec file not found". This
+    // invariant rejects any script in the generated package.json
+    // whose command-line references a literal `./openapi.json` (or
+    // any other file the codegen does not materialise alongside
+    // package.json). Class-scoped: any reintroduction of the same
+    // dead-on-arrival shape — under any script name — fails.
+    const pkgPath = join(GENERATED_TESTS_DIR, 'package.json');
+    if (!existsSync(pkgPath)) {
+      throw new Error(
+        `Generated package.json not found at ${pkgPath}. Run 'npm run testsuite:generate' first.`,
+      );
+    }
+    const pkgRaw = readFileSync(pkgPath, 'utf8');
+    const pkgParsed: unknown = JSON.parse(pkgRaw);
+    function isRecord(v: unknown): v is Record<string, unknown> {
+      return typeof v === 'object' && v !== null && !Array.isArray(v);
+    }
+    const scripts = isRecord(pkgParsed) && isRecord(pkgParsed.scripts) ? pkgParsed.scripts : {};
+    const offenders: { name: string; command: string }[] = [];
+    for (const [name, raw] of Object.entries(scripts)) {
+      if (typeof raw !== 'string') continue;
+      if (/(^|\s|=)\.\/(openapi\.json)(\s|$)/.test(raw)) {
+        offenders.push({ name, command: raw });
+      }
+    }
+    expect(
+      offenders,
+      'No script in the generated package.json may reference `./openapi.json` — the codegen does not materialise that file next to the suite, so any such script fails on first invocation. To regenerate `responses.json` against a different spec, use the npx command documented in README.md instead.',
+    ).toEqual([]);
+  });
+
   it('no generated test contains a stray __invalidEnum sentinel object (#39)', () => {
     // Layer-3 mirror of the targeted enum-violation test in
     // tests/request-validation/. Catches any future analyser that

--- a/materializer/templates/README.md
+++ b/materializer/templates/README.md
@@ -28,15 +28,11 @@ Each test that expects a success response calls `validateResponse(...)` from [`a
 
 ### Regenerating `responses.json` against a different spec
 
-If you want to validate against a different OpenAPI spec, place it next to this `package.json` (for example as `openapi.json`) and run:
-
-```bash
-npm run responses:regenerate
-```
-
-The default script targets `./openapi.json` and writes to `./json-body-assertions/`. To use a different path, invoke the CLI directly:
+`responses.json` is produced by the api-test-generator codegen step from the bundled Camunda OpenAPI spec, then shipped here. If you want to validate against a different spec (for example, an unreleased build) without re-running the upstream codegen, invoke the [`assert-json-body`](https://www.npmjs.com/package/assert-json-body) CLI directly against your spec:
 
 ```bash
 npx assert-json-body extract --specFile=path/to/spec.json --outputDir=./json-body-assertions
 ```
+
+There is intentionally no `npm run` wrapper for this — the regenerator's input (the spec) is not part of the suite, so a default-arg script would be misleading. The next codegen run will overwrite any local regeneration.
 

--- a/materializer/templates/package.json
+++ b/materializer/templates/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "description": "Generated Playwright integration suite produced by the api-test-generator path-analyser.",
   "scripts": {
-    "test": "playwright test",
-    "responses:regenerate": "assert-json-body extract --specFile=./openapi.json --outputDir=./json-body-assertions"
+    "test": "playwright test"
   },
   "dependencies": {
     "assert-json-body": "^1.7.1"


### PR DESCRIPTION
## Problem

In the generated Playwright suite for camunda-oca, `npm run responses:regenerate` fails out of the box:

```
assert-json-body extract --specFile=./openapi.json --outputDir=./json-body-assertions
Error: Local spec file not found: ./openapi.json
```

The script in `materializer/templates/package.json` targets `./openapi.json`, but the codegen never copies an OpenAPI spec next to the suite's `package.json`. `responses.json` is produced during codegen by `materializeResponseSchemas()` (`materializer/src/playwright/materialize-support.ts:527`), which spawns `assert-json-body` against the bundled Camunda spec — not via this script.

The script has never worked since the suite shipped.

## Fix

- Drop the script from the shipped `package.json` template.
- Rewrite the README's "Regenerating responses.json against a different spec" section to document the direct `npx assert-json-body extract --specFile=path/to/spec.json` invocation, and explain why no `npm run` wrapper is provided: the script's input (the spec) is not part of the suite, so a default-arg wrapper would be misleading.

## Class-scoped guard

Added an L3 invariant in `configs/camunda-oca/regression-invariants.test.ts` that rejects any script in the generated `package.json` whose command-line references `./openapi.json`. This catches the same dead-on-arrival shape under any future script name.

## Verification

- `npm run lint` ✅
- Full TC chain (extractor + path-analyser + emitter-sdk + materializer + request-validation + tests) ✅
- Regen pipeline + `npm test`: 561 pass / 2 skip ✅
- Inspected `generated/camunda-oca/playwright/package.json` — only `test` script remains; `assert-json-body` stays in `dependencies` because the suite imports `validateResponse` from it at runtime.