### PR TITLE
feat(ontology): add runtimeEmission semantic-type kind to TBox (#305 Phase 1)

### DIFF
--- a/ontology/vocabulary/semantics.schema.json
+++ b/ontology/vocabulary/semantics.schema.json
@@ -92,7 +92,7 @@
             "predecessor": {
               "type": "string",
               "minLength": 1,
-              "description": "Name of a runtime state (`runtimeStates`) that must hold before this key can be discovered. Resolution against `domain.runtimeStates` is checked at load time. Typically the post-condition of a `createXxx` operation that triggers the key emission (e.g. `ProcessInstanceExists` for `UserTaskKey`)."
+              "description": "Name of a runtime state (`runtimeStates`) that must hold before this key can be discovered. Typically the post-condition of a `createXxx` operation that triggers the key emission (e.g. `ProcessInstanceExists` for `UserTaskKey`). Cross-ref against `domain.runtimeStates` is not yet enforced; the resolver lands with the planner support in Phase 2/3."
             },
             "guardedBy": {
               "type": "array",
@@ -100,7 +100,7 @@
                 "type": "string",
                 "minLength": 1
               },
-              "description": "Capability names whose presence is required for the predecessor to actually emit a key of this type — e.g. `ProcessInstanceExists` alone is not enough to emit a `UserTaskKey`; the deployed BPMN must contain a user-task element (`ModelHasUserTask`). Each entry must resolve against `domain.capabilities` (cross-sub-tree check enforced at load time). Empty/omitted = no capability guard."
+              "description": "Capability names whose presence is required for the predecessor to actually emit a key of this type — e.g. `ProcessInstanceExists` alone is not enough to emit a `UserTaskKey`; the deployed BPMN must contain a user-task element (`ModelHasUserTask`). Empty/omitted = no capability guard. Cross-ref against `domain.capabilities` is not yet enforced; the resolver lands with the planner support in Phase 2/3."
             }
           }
         },
@@ -116,7 +116,7 @@
             "operationId": {
               "type": "string",
               "minLength": 1,
-              "description": "OperationId of the search/get endpoint that surfaces the emitted key (e.g. `searchUserTasks`). Must reference an op present in the bundled graph — checked as an L3 abox-vs-graph invariant."
+              "description": "OperationId of the search/get endpoint that surfaces the emitted key (e.g. `searchUserTasks`). Graph cross-ref (op must exist in the bundled spec) is not yet enforced; the L3 abox-vs-graph invariant lands with the planner support in Phase 3 alongside the first ABox entry that uses `runtimeEmission`."
             },
             "filterBy": {
               "type": "string",

--- a/ontology/vocabulary/semantics.schema.json
+++ b/ontology/vocabulary/semantics.schema.json
@@ -72,13 +72,70 @@
           "enum": [
             "modelDerived",
             "attribute",
-            "serverEmergent"
+            "serverEmergent",
+            "runtimeEmission"
           ],
-          "description": "How the planner obtains a value for this semantic type (#162). `modelDerived` reads from a deployment artifact in the same chain. `attribute` is a free-form label minted by the planner; requires `clientMinted: true`. `serverEmergent` is a server-minted lifecycle key the client cannot pre-mint. Absent `kind` falls back to the existing planner classification chain."
+          "description": "How the planner obtains a value for this semantic type. `modelDerived` (#162) reads from a deployment artifact in the same chain. `attribute` (#162) is a free-form label minted by the planner; requires `clientMinted: true`. `serverEmergent` (#162) is a server-minted lifecycle key the client cannot pre-mint and has no discovery surface — the planner falls through to a placeholder. `runtimeEmission` (#305) is a server-minted key that *is* discoverable via a search endpoint after a known producing side-effect; requires both `emittedBy` (producing predecessor + capability guards) and `discoveredVia` (search-op + extraction + consistency model) so the planner can plan the `produce → discover → bind` chain. Absent `kind` falls back to the existing planner classification chain."
         },
         "clientMinted": {
           "type": "boolean",
           "description": "When true, values are minted by the planner / client rather than returned by a producer endpoint. Required when `kind === \"attribute\"` (loader-enforced)."
+        },
+        "emittedBy": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "predecessor"
+          ],
+          "description": "Required when `kind === \"runtimeEmission\"` (#305 Phase 1). Declares how the key comes into existence at runtime: the producing predecessor that must run before the key is observable, and any capability guards the predecessor's deployment artefact must satisfy (e.g. the BPMN must contain a user-task element for `UserTaskKey` to be emitted).",
+          "properties": {
+            "predecessor": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Name of a runtime state (`runtimeStates`) that must hold before this key can be discovered. Resolution against `domain.runtimeStates` is checked at load time. Typically the post-condition of a `createXxx` operation that triggers the key emission (e.g. `ProcessInstanceExists` for `UserTaskKey`)."
+            },
+            "guardedBy": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": "Capability names whose presence is required for the predecessor to actually emit a key of this type — e.g. `ProcessInstanceExists` alone is not enough to emit a `UserTaskKey`; the deployed BPMN must contain a user-task element (`ModelHasUserTask`). Each entry must resolve against `domain.capabilities` (cross-sub-tree check enforced at load time). Empty/omitted = no capability guard."
+            }
+          }
+        },
+        "discoveredVia": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "operationId",
+            "extractKey"
+          ],
+          "description": "Required when `kind === \"runtimeEmission\"` (#305 Phase 1). Declares how the planner reads the emitted key back from the system after the predecessor has run.",
+          "properties": {
+            "operationId": {
+              "type": "string",
+              "minLength": 1,
+              "description": "OperationId of the search/get endpoint that surfaces the emitted key (e.g. `searchUserTasks`). Must reference an op present in the bundled graph — checked as an L3 abox-vs-graph invariant."
+            },
+            "filterBy": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Request filter field on the discovery operation that the planner populates with an upstream-known key (typically `processInstanceKey` or `scopeKey`) to scope the result set to the producing predecessor's emissions. Omitted when the discovery op is unfiltered (rare; only sensible when fixture isolation makes a single global result the right one)."
+            },
+            "extractKey": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Response field name on each discovery-op result item whose value the planner binds as a value of this semantic type (e.g. `userTaskKey`). Documentary at the ABox layer; the planner reads it at scenario-generation time."
+            },
+            "consistency": {
+              "enum": [
+                "eventual",
+                "strong"
+              ],
+              "description": "Whether the discovery op returns the emitted key strongly-consistently (`strong` — read after producer returns succeeds first time) or only eventually (`eventual` — the planner must poll until the item appears, via the existing `await-eventually` helper). Mirrors the `runtimeStates.eventual` flag's intent. Defaults to `eventual` if omitted, matching Camunda's general consistency model for emitted entities."
+            }
+          }
         },
         "$comment": {
           "type": "string",

--- a/ontology/vocabulary/semantics.schema.json
+++ b/ontology/vocabulary/semantics.schema.json
@@ -133,7 +133,7 @@
                 "eventual",
                 "strong"
               ],
-              "description": "Whether the discovery op returns the emitted key strongly-consistently (`strong` — read after producer returns succeeds first time) or only eventually (`eventual` — the planner must poll until the item appears, via the existing `await-eventually` helper). Mirrors the `runtimeStates.eventual` flag's intent. Defaults to `eventual` if omitted, matching Camunda's general consistency model for emitted entities."
+              "description": "Whether the discovery op returns the emitted key strongly-consistently (`strong` — read after producer returns succeeds first time) or only eventually (`eventual` — the planner must poll until the item appears, via the existing `await-eventually` helper). Mirrors the `runtimeStates.eventual` flag's intent. Defaults to `strong` if omitted — most Camunda read-after-write surfaces are strongly consistent; `eventual` is the explicit opt-in for emitters that need polling."
             }
           }
         },

--- a/ontology/vocabulary/semantics.schema.json
+++ b/ontology/vocabulary/semantics.schema.json
@@ -75,7 +75,7 @@
             "serverEmergent",
             "runtimeEmission"
           ],
-          "description": "How the planner obtains a value for this semantic type. `modelDerived` (#162) reads from a deployment artifact in the same chain. `attribute` (#162) is a free-form label minted by the planner; requires `clientMinted: true`. `serverEmergent` (#162) is a server-minted lifecycle key the client cannot pre-mint and has no discovery surface — the planner falls through to a placeholder. `runtimeEmission` (#305) is a server-minted key that *is* discoverable via a search endpoint after a known producing side-effect; requires both `emittedBy` (producing predecessor + capability guards) and `discoveredVia` (search-op + extraction + consistency model) so the planner can plan the `produce → discover → bind` chain. Absent `kind` falls back to the existing planner classification chain."
+          "description": "How the planner obtains a value for this semantic type. `modelDerived` (#162) reads from a deployment artifact in the same chain. `attribute` (#162) is a free-form label minted by the planner; requires `clientMinted: true`. `serverEmergent` (#162) is a server-minted lifecycle key the client cannot pre-mint and has no discovery surface — the planner falls through to a placeholder. `runtimeEmission` (#305) is a server-minted key that *is* discoverable via a search endpoint after a known producing side-effect; the entry declares both `emittedBy` (producing predecessor + capability guards) and `discoveredVia` (search-op + extraction + consistency model). As of #305 Phase 1 the planner does not yet consume these fields — the produce → discover → bind chain is planned in Phase 3. Absent `kind` falls back to the existing planner classification chain."
         },
         "clientMinted": {
           "type": "boolean",
@@ -92,7 +92,7 @@
             "predecessor": {
               "type": "string",
               "minLength": 1,
-              "description": "Name of a runtime state (`runtimeStates`) that must hold before this key can be discovered. Typically the post-condition of a `createXxx` operation that triggers the key emission (e.g. `ProcessInstanceExists` for `UserTaskKey`). Cross-ref against `domain.runtimeStates` is not yet enforced; the resolver lands with the planner support in Phase 2/3."
+              "description": "Name of a runtime state (`runtimeStates`) that must hold before this key can be discovered. Typically the post-condition of a `createXxx` operation that triggers the key emission (e.g. `ProcessInstanceExists` for `UserTaskKey`). No cross-ABox validation is performed at load time as of #305 Phase 1; the resolver is intended to land alongside the planner support in Phase 3."
             },
             "guardedBy": {
               "type": "array",
@@ -100,7 +100,7 @@
                 "type": "string",
                 "minLength": 1
               },
-              "description": "Capability names whose presence is required for the predecessor to actually emit a key of this type — e.g. `ProcessInstanceExists` alone is not enough to emit a `UserTaskKey`; the deployed BPMN must contain a user-task element (`ModelHasUserTask`). Empty/omitted = no capability guard. Cross-ref against `domain.capabilities` is not yet enforced; the resolver lands with the planner support in Phase 2/3."
+              "description": "Capability names whose presence is required for the predecessor to actually emit a key of this type — e.g. `ProcessInstanceExists` alone is not enough to emit a `UserTaskKey`; the deployed BPMN must contain a user-task element (`ModelHasUserTask`). Empty/omitted = no capability guard. No cross-ABox validation is performed at load time as of #305 Phase 1; the resolver is intended to land alongside the planner support in Phase 3."
             }
           }
         },
@@ -116,7 +116,7 @@
             "operationId": {
               "type": "string",
               "minLength": 1,
-              "description": "OperationId of the search/get endpoint that surfaces the emitted key (e.g. `searchUserTasks`). Graph cross-ref (op must exist in the bundled spec) is not yet enforced; the L3 abox-vs-graph invariant lands with the planner support in Phase 3 alongside the first ABox entry that uses `runtimeEmission`."
+              "description": "OperationId of the search/get endpoint that surfaces the emitted key (e.g. `searchUserTasks`). No graph cross-ref (that the op exists in the bundled spec) is performed at load time as of #305 Phase 1; an L3 abox-vs-graph invariant is intended to land alongside the first ABox entry that uses `runtimeEmission` in Phase 3."
             },
             "filterBy": {
               "type": "string",

--- a/path-analyser/src/ontology/loader.ts
+++ b/path-analyser/src/ontology/loader.ts
@@ -757,14 +757,14 @@ export function deriveSemanticsViews(repoRoot: string): SemanticsViews | null {
     if (t.kind !== undefined) entry.kind = t.kind;
     if (t.clientMinted !== undefined) entry.clientMinted = t.clientMinted;
     if (t.emittedBy !== undefined) {
-      const eb: SemanticsViews['semanticTypes'][string]['emittedBy'] = {
+      const eb: NonNullable<SemanticsViews['semanticTypes'][string]['emittedBy']> = {
         predecessor: t.emittedBy.predecessor,
       };
       if (t.emittedBy.guardedBy !== undefined) eb.guardedBy = [...t.emittedBy.guardedBy];
       entry.emittedBy = eb;
     }
     if (t.discoveredVia !== undefined) {
-      const dv: SemanticsViews['semanticTypes'][string]['discoveredVia'] = {
+      const dv: NonNullable<SemanticsViews['semanticTypes'][string]['discoveredVia']> = {
         operationId: t.discoveredVia.operationId,
         extractKey: t.discoveredVia.extractKey,
       };

--- a/path-analyser/src/ontology/loader.ts
+++ b/path-analyser/src/ontology/loader.ts
@@ -767,9 +767,13 @@ export function deriveSemanticsViews(repoRoot: string): SemanticsViews | null {
       const dv: NonNullable<SemanticsViews['semanticTypes'][string]['discoveredVia']> = {
         operationId: t.discoveredVia.operationId,
         extractKey: t.discoveredVia.extractKey,
+        // Normalize the documented default here so every downstream
+        // consumer can rely on a concrete value rather than each
+        // re-implementing the fallback. Mirrors the `defaults to
+        // 'eventual'` claim in the TBox docs (#305 Phase 1 review).
+        consistency: t.discoveredVia.consistency ?? 'eventual',
       };
       if (t.discoveredVia.filterBy !== undefined) dv.filterBy = t.discoveredVia.filterBy;
-      if (t.discoveredVia.consistency !== undefined) dv.consistency = t.discoveredVia.consistency;
       entry.discoveredVia = dv;
     }
     semanticTypes[t.name] = entry;

--- a/path-analyser/src/ontology/loader.ts
+++ b/path-analyser/src/ontology/loader.ts
@@ -769,9 +769,11 @@ export function deriveSemanticsViews(repoRoot: string): SemanticsViews | null {
         extractKey: t.discoveredVia.extractKey,
         // Normalize the documented default here so every downstream
         // consumer can rely on a concrete value rather than each
-        // re-implementing the fallback. Mirrors the `defaults to
-        // 'eventual'` claim in the TBox docs (#305 Phase 1 review).
-        consistency: t.discoveredVia.consistency ?? 'eventual',
+        // re-implementing the fallback. Defaults to 'strong' — most
+        // Camunda read-after-write surfaces are strongly consistent;
+        // 'eventual' is the explicit exception that opts in to the
+        // poll-with-await helper (#305 Phase 1 review).
+        consistency: t.discoveredVia.consistency ?? 'strong',
       };
       if (t.discoveredVia.filterBy !== undefined) dv.filterBy = t.discoveredVia.filterBy;
       entry.discoveredVia = dv;

--- a/path-analyser/src/ontology/loader.ts
+++ b/path-analyser/src/ontology/loader.ts
@@ -679,6 +679,25 @@ export function loadSemanticsAbox(repoRoot: string): SemanticsAbox | null {
         `Semantics ABox at ${aboxPath} semanticTypes '${t.name}' has kind: 'attribute' but clientMinted is not true — attribute-shaped semantic types must declare clientMinted: true so the planner mints values rather than waiting for a producer`,
       );
     }
+    // Cross-property invariant: `kind: 'runtimeEmission'` ⇒ both
+    // `emittedBy` and `discoveredVia` present (#305 Phase 1). The whole
+    // point of `runtimeEmission` is to carry the planning information
+    // that distinguishes it from plain `serverEmergent`; without both
+    // sub-objects the planner has nothing to act on and the entry would
+    // silently behave like `serverEmergent` (a placeholder seedBinding),
+    // which is the bug #305 fixes.
+    if (t.kind === 'runtimeEmission') {
+      if (t.emittedBy === undefined) {
+        throw new Error(
+          `Semantics ABox at ${aboxPath} semanticTypes '${t.name}' has kind: 'runtimeEmission' but no emittedBy — runtimeEmission types must declare the producing predecessor (and any capability guards) so the planner can plan the produce → discover → bind chain`,
+        );
+      }
+      if (t.discoveredVia === undefined) {
+        throw new Error(
+          `Semantics ABox at ${aboxPath} semanticTypes '${t.name}' has kind: 'runtimeEmission' but no discoveredVia — runtimeEmission types must declare the discovery operation (operationId, optional filterBy, extractKey, optional consistency) so the planner knows how to read the emitted key back from the system`,
+        );
+      }
+    }
   }
   return parsed;
 }
@@ -693,8 +712,18 @@ export interface SemanticsViews {
     string,
     {
       witnesses?: string;
-      kind?: 'modelDerived' | 'attribute' | 'serverEmergent';
+      kind?: 'modelDerived' | 'attribute' | 'serverEmergent' | 'runtimeEmission';
       clientMinted?: boolean;
+      emittedBy?: {
+        predecessor: string;
+        guardedBy?: string[];
+      };
+      discoveredVia?: {
+        operationId: string;
+        filterBy?: string;
+        extractKey: string;
+        consistency?: 'eventual' | 'strong';
+      };
     }
   >;
   capabilities: Record<
@@ -727,6 +756,22 @@ export function deriveSemanticsViews(repoRoot: string): SemanticsViews | null {
     if (t.witnesses !== undefined) entry.witnesses = t.witnesses;
     if (t.kind !== undefined) entry.kind = t.kind;
     if (t.clientMinted !== undefined) entry.clientMinted = t.clientMinted;
+    if (t.emittedBy !== undefined) {
+      const eb: SemanticsViews['semanticTypes'][string]['emittedBy'] = {
+        predecessor: t.emittedBy.predecessor,
+      };
+      if (t.emittedBy.guardedBy !== undefined) eb.guardedBy = [...t.emittedBy.guardedBy];
+      entry.emittedBy = eb;
+    }
+    if (t.discoveredVia !== undefined) {
+      const dv: SemanticsViews['semanticTypes'][string]['discoveredVia'] = {
+        operationId: t.discoveredVia.operationId,
+        extractKey: t.discoveredVia.extractKey,
+      };
+      if (t.discoveredVia.filterBy !== undefined) dv.filterBy = t.discoveredVia.filterBy;
+      if (t.discoveredVia.consistency !== undefined) dv.consistency = t.discoveredVia.consistency;
+      entry.discoveredVia = dv;
+    }
     semanticTypes[t.name] = entry;
   }
   const capabilities: SemanticsViews['capabilities'] = {};

--- a/path-analyser/src/ontology/semanticsSchema.ts
+++ b/path-analyser/src/ontology/semanticsSchema.ts
@@ -40,9 +40,13 @@
 //                       state or capability the value witnesses
 //                       (`witnesses`); the value-source classification
 //                       (`kind`: `modelDerived` | `attribute` |
-//                       `serverEmergent`); whether values are minted
-//                       client-side rather than returned by a producer
-//                       (`clientMinted`).
+//                       `serverEmergent` | `runtimeEmission`); whether
+//                       values are minted client-side rather than
+//                       returned by a producer (`clientMinted`);
+//                       and — for `runtimeEmission` types only —
+//                       `emittedBy` (producing predecessor + capability
+//                       guards) and `discoveredVia` (search-op +
+//                       extraction + consistency model) (#305 Phase 1).
 //
 //   - `capabilities`  — per-capability metadata: a parameter name
 //                       (`parameter`); which ops produce the
@@ -61,6 +65,11 @@
 // express them):
 //
 //   - `kind: 'attribute'` ⇒ `clientMinted: true` (#162 PR 2 coupling).
+//   - `kind: 'runtimeEmission'` ⇒ both `emittedBy` and `discoveredVia`
+//     present (#305 Phase 1 — the whole point of `runtimeEmission` is
+//     to carry the planning information that distinguishes it from
+//     plain `serverEmergent`; without both sub-objects the planner has
+//     nothing to act on).
 //   - duplicate `name` rejected within each of the three sub-trees.
 //
 // JSON-LD (`@context`, `@type`) is accepted and preserved verbatim
@@ -126,14 +135,67 @@ export const semanticsSchema = {
             'Name of a runtime state (`runtimeStates`) or a capability (`capabilities`) that producing a value of this semantic type implies the existence of. The cross-reference is checked at load time against the post-overlay `domain.runtimeStates` / `domain.capabilities` views.',
         },
         kind: {
-          enum: ['modelDerived', 'attribute', 'serverEmergent'],
+          enum: ['modelDerived', 'attribute', 'serverEmergent', 'runtimeEmission'],
           description:
-            'How the planner obtains a value for this semantic type (#162). `modelDerived` reads from a deployment artifact in the same chain. `attribute` is a free-form label minted by the planner; requires `clientMinted: true`. `serverEmergent` is a server-minted lifecycle key the client cannot pre-mint. Absent `kind` falls back to the existing planner classification chain.',
+            'How the planner obtains a value for this semantic type. `modelDerived` (#162) reads from a deployment artifact in the same chain. `attribute` (#162) is a free-form label minted by the planner; requires `clientMinted: true`. `serverEmergent` (#162) is a server-minted lifecycle key the client cannot pre-mint and has no discovery surface — the planner falls through to a placeholder. `runtimeEmission` (#305) is a server-minted key that *is* discoverable via a search endpoint after a known producing side-effect; requires both `emittedBy` (producing predecessor + capability guards) and `discoveredVia` (search-op + extraction + consistency model) so the planner can plan the `produce → discover → bind` chain. Absent `kind` falls back to the existing planner classification chain.',
         },
         clientMinted: {
           type: 'boolean',
           description:
             'When true, values are minted by the planner / client rather than returned by a producer endpoint. Required when `kind === "attribute"` (loader-enforced).',
+        },
+        emittedBy: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['predecessor'],
+          description:
+            'Required when `kind === "runtimeEmission"` (#305 Phase 1). Declares how the key comes into existence at runtime: the producing predecessor that must run before the key is observable, and any capability guards the predecessor\'s deployment artefact must satisfy (e.g. the BPMN must contain a user-task element for `UserTaskKey` to be emitted).',
+          properties: {
+            predecessor: {
+              type: 'string',
+              minLength: 1,
+              description:
+                'Name of a runtime state (`runtimeStates`) that must hold before this key can be discovered. Resolution against `domain.runtimeStates` is checked at load time. Typically the post-condition of a `createXxx` operation that triggers the key emission (e.g. `ProcessInstanceExists` for `UserTaskKey`).',
+            },
+            guardedBy: {
+              type: 'array',
+              items: { type: 'string', minLength: 1 },
+              description:
+                'Capability names whose presence is required for the predecessor to actually emit a key of this type — e.g. `ProcessInstanceExists` alone is not enough to emit a `UserTaskKey`; the deployed BPMN must contain a user-task element (`ModelHasUserTask`). Each entry must resolve against `domain.capabilities` (cross-sub-tree check enforced at load time). Empty/omitted = no capability guard.',
+            },
+          },
+        },
+        discoveredVia: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['operationId', 'extractKey'],
+          description:
+            'Required when `kind === "runtimeEmission"` (#305 Phase 1). Declares how the planner reads the emitted key back from the system after the predecessor has run.',
+          properties: {
+            operationId: {
+              type: 'string',
+              minLength: 1,
+              description:
+                'OperationId of the search/get endpoint that surfaces the emitted key (e.g. `searchUserTasks`). Must reference an op present in the bundled graph — checked as an L3 abox-vs-graph invariant.',
+            },
+            filterBy: {
+              type: 'string',
+              minLength: 1,
+              description:
+                "Request filter field on the discovery operation that the planner populates with an upstream-known key (typically `processInstanceKey` or `scopeKey`) to scope the result set to the producing predecessor's emissions. Omitted when the discovery op is unfiltered (rare; only sensible when fixture isolation makes a single global result the right one).",
+            },
+            extractKey: {
+              type: 'string',
+              minLength: 1,
+              description:
+                'Response field name on each discovery-op result item whose value the planner binds as a value of this semantic type (e.g. `userTaskKey`). Documentary at the ABox layer; the planner reads it at scenario-generation time.',
+            },
+            consistency: {
+              enum: ['eventual', 'strong'],
+              description:
+                "Whether the discovery op returns the emitted key strongly-consistently (`strong` — read after producer returns succeeds first time) or only eventually (`eventual` — the planner must poll until the item appears, via the existing `await-eventually` helper). Mirrors the `runtimeStates.eventual` flag's intent. Defaults to `eventual` if omitted, matching Camunda's general consistency model for emitted entities.",
+            },
+          },
         },
         $comment: {
           type: 'string',

--- a/path-analyser/src/ontology/semanticsSchema.ts
+++ b/path-analyser/src/ontology/semanticsSchema.ts
@@ -155,13 +155,13 @@ export const semanticsSchema = {
               type: 'string',
               minLength: 1,
               description:
-                'Name of a runtime state (`runtimeStates`) that must hold before this key can be discovered. Resolution against `domain.runtimeStates` is checked at load time. Typically the post-condition of a `createXxx` operation that triggers the key emission (e.g. `ProcessInstanceExists` for `UserTaskKey`).',
+                'Name of a runtime state (`runtimeStates`) that must hold before this key can be discovered. Typically the post-condition of a `createXxx` operation that triggers the key emission (e.g. `ProcessInstanceExists` for `UserTaskKey`). Cross-ref against `domain.runtimeStates` is not yet enforced; the resolver lands with the planner support in Phase 2/3.',
             },
             guardedBy: {
               type: 'array',
               items: { type: 'string', minLength: 1 },
               description:
-                'Capability names whose presence is required for the predecessor to actually emit a key of this type — e.g. `ProcessInstanceExists` alone is not enough to emit a `UserTaskKey`; the deployed BPMN must contain a user-task element (`ModelHasUserTask`). Each entry must resolve against `domain.capabilities` (cross-sub-tree check enforced at load time). Empty/omitted = no capability guard.',
+                'Capability names whose presence is required for the predecessor to actually emit a key of this type — e.g. `ProcessInstanceExists` alone is not enough to emit a `UserTaskKey`; the deployed BPMN must contain a user-task element (`ModelHasUserTask`). Empty/omitted = no capability guard. Cross-ref against `domain.capabilities` is not yet enforced; the resolver lands with the planner support in Phase 2/3.',
             },
           },
         },
@@ -176,7 +176,7 @@ export const semanticsSchema = {
               type: 'string',
               minLength: 1,
               description:
-                'OperationId of the search/get endpoint that surfaces the emitted key (e.g. `searchUserTasks`). Must reference an op present in the bundled graph — checked as an L3 abox-vs-graph invariant.',
+                'OperationId of the search/get endpoint that surfaces the emitted key (e.g. `searchUserTasks`). Graph cross-ref (op must exist in the bundled spec) is not yet enforced; the L3 abox-vs-graph invariant lands with the planner support in Phase 3 alongside the first ABox entry that uses `runtimeEmission`.',
             },
             filterBy: {
               type: 'string',

--- a/path-analyser/src/ontology/semanticsSchema.ts
+++ b/path-analyser/src/ontology/semanticsSchema.ts
@@ -137,7 +137,7 @@ export const semanticsSchema = {
         kind: {
           enum: ['modelDerived', 'attribute', 'serverEmergent', 'runtimeEmission'],
           description:
-            'How the planner obtains a value for this semantic type. `modelDerived` (#162) reads from a deployment artifact in the same chain. `attribute` (#162) is a free-form label minted by the planner; requires `clientMinted: true`. `serverEmergent` (#162) is a server-minted lifecycle key the client cannot pre-mint and has no discovery surface — the planner falls through to a placeholder. `runtimeEmission` (#305) is a server-minted key that *is* discoverable via a search endpoint after a known producing side-effect; requires both `emittedBy` (producing predecessor + capability guards) and `discoveredVia` (search-op + extraction + consistency model) so the planner can plan the `produce → discover → bind` chain. Absent `kind` falls back to the existing planner classification chain.',
+            'How the planner obtains a value for this semantic type. `modelDerived` (#162) reads from a deployment artifact in the same chain. `attribute` (#162) is a free-form label minted by the planner; requires `clientMinted: true`. `serverEmergent` (#162) is a server-minted lifecycle key the client cannot pre-mint and has no discovery surface — the planner falls through to a placeholder. `runtimeEmission` (#305) is a server-minted key that *is* discoverable via a search endpoint after a known producing side-effect; the entry declares both `emittedBy` (producing predecessor + capability guards) and `discoveredVia` (search-op + extraction + consistency model). As of #305 Phase 1 the planner does not yet consume these fields — the produce → discover → bind chain is planned in Phase 3. Absent `kind` falls back to the existing planner classification chain.',
         },
         clientMinted: {
           type: 'boolean',
@@ -155,13 +155,13 @@ export const semanticsSchema = {
               type: 'string',
               minLength: 1,
               description:
-                'Name of a runtime state (`runtimeStates`) that must hold before this key can be discovered. Typically the post-condition of a `createXxx` operation that triggers the key emission (e.g. `ProcessInstanceExists` for `UserTaskKey`). Cross-ref against `domain.runtimeStates` is not yet enforced; the resolver lands with the planner support in Phase 2/3.',
+                'Name of a runtime state (`runtimeStates`) that must hold before this key can be discovered. Typically the post-condition of a `createXxx` operation that triggers the key emission (e.g. `ProcessInstanceExists` for `UserTaskKey`). No cross-ABox validation is performed at load time as of #305 Phase 1; the resolver is intended to land alongside the planner support in Phase 3.',
             },
             guardedBy: {
               type: 'array',
               items: { type: 'string', minLength: 1 },
               description:
-                'Capability names whose presence is required for the predecessor to actually emit a key of this type — e.g. `ProcessInstanceExists` alone is not enough to emit a `UserTaskKey`; the deployed BPMN must contain a user-task element (`ModelHasUserTask`). Empty/omitted = no capability guard. Cross-ref against `domain.capabilities` is not yet enforced; the resolver lands with the planner support in Phase 2/3.',
+                'Capability names whose presence is required for the predecessor to actually emit a key of this type — e.g. `ProcessInstanceExists` alone is not enough to emit a `UserTaskKey`; the deployed BPMN must contain a user-task element (`ModelHasUserTask`). Empty/omitted = no capability guard. No cross-ABox validation is performed at load time as of #305 Phase 1; the resolver is intended to land alongside the planner support in Phase 3.',
             },
           },
         },
@@ -176,7 +176,7 @@ export const semanticsSchema = {
               type: 'string',
               minLength: 1,
               description:
-                'OperationId of the search/get endpoint that surfaces the emitted key (e.g. `searchUserTasks`). Graph cross-ref (op must exist in the bundled spec) is not yet enforced; the L3 abox-vs-graph invariant lands with the planner support in Phase 3 alongside the first ABox entry that uses `runtimeEmission`.',
+                'OperationId of the search/get endpoint that surfaces the emitted key (e.g. `searchUserTasks`). No graph cross-ref (that the op exists in the bundled spec) is performed at load time as of #305 Phase 1; an L3 abox-vs-graph invariant is intended to land alongside the first ABox entry that uses `runtimeEmission` in Phase 3.',
             },
             filterBy: {
               type: 'string',

--- a/path-analyser/src/ontology/semanticsSchema.ts
+++ b/path-analyser/src/ontology/semanticsSchema.ts
@@ -193,7 +193,7 @@ export const semanticsSchema = {
             consistency: {
               enum: ['eventual', 'strong'],
               description:
-                "Whether the discovery op returns the emitted key strongly-consistently (`strong` — read after producer returns succeeds first time) or only eventually (`eventual` — the planner must poll until the item appears, via the existing `await-eventually` helper). Mirrors the `runtimeStates.eventual` flag's intent. Defaults to `eventual` if omitted, matching Camunda's general consistency model for emitted entities.",
+                "Whether the discovery op returns the emitted key strongly-consistently (`strong` — read after producer returns succeeds first time) or only eventually (`eventual` — the planner must poll until the item appears, via the existing `await-eventually` helper). Mirrors the `runtimeStates.eventual` flag's intent. Defaults to `strong` if omitted — most Camunda read-after-write surfaces are strongly consistent; `eventual` is the explicit opt-in for emitters that need polling.",
             },
           },
         },

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -518,18 +518,31 @@ export interface SemanticTypeSpec {
    *     `attribute` is a structural shape, `clientMinted` says where the
    *     value originates. Examples: `Tag`, `BusinessId`.
    *
+   *   - `serverEmergent` (#162 PR 5): server-minted lifecycle identifiers
+   *     that no client API directly mints with a returned value (e.g.
+   *     `IncidentKey`, `AuditLogKey`, `MessageSubscriptionKey`) AND for
+   *     which the planner has no path to discover the emitted value
+   *     post-hoc. The planner binds a deterministic placeholder so
+   *     search-filter request shapes validate; an empty search result is
+   *     acceptable because the value is a fabricated placeholder for a
+   *     key the client could not have known.
+   *
+   *   - `runtimeEmission` (#305 Phase 1): a server-minted lifecycle key
+   *     that the planner *can* discover after a known producing
+   *     side-effect (e.g. `UserTaskKey` is emitted when a process
+   *     instance executes a user-task element, and is discoverable via
+   *     `searchUserTasks(processInstanceKey)`). Distinct from
+   *     `serverEmergent` precisely because the discovery path is
+   *     declarable. Requires both `emittedBy` and `discoveredVia` on the
+   *     same entry — without them the planner has nothing to act on and
+   *     the entry would degrade to a placeholder. The loader enforces
+   *     this coupling.
+   *
    * Absent `kind` means the planner falls back to its existing
    * classification chain (producersByType / establishersByType /
    * external-entity / synthetic).
-   *
-   * `serverEmergent` (#162 PR 5): server-minted lifecycle identifiers
-   * that no client API directly mints with a returned value (e.g.
-   * `IncidentKey`, `AuditLogKey`, `MessageSubscriptionKey`). The planner
-   * binds a deterministic placeholder so search-filter request shapes
-   * validate; an empty search result is acceptable because the value is
-   * a fabricated placeholder for a key the client could not have known.
    */
-  kind?: 'modelDerived' | 'attribute' | 'serverEmergent';
+  kind?: 'modelDerived' | 'attribute' | 'serverEmergent' | 'runtimeEmission';
   /**
    * Whether values of this semantic are minted by the planner / client
    * rather than returned by a producer endpoint (#162 PR 2). Only
@@ -537,6 +550,29 @@ export interface SemanticTypeSpec {
    * client-minted semantics to identifier-shaped types as well.
    */
   clientMinted?: boolean;
+  /**
+   * Required when `kind === 'runtimeEmission'` (#305 Phase 1). Declares
+   * how a value of this type comes into existence at runtime — the
+   * producing predecessor that must run, plus any capability guards the
+   * predecessor's deployment artefact must satisfy. See
+   * `path-analyser/src/ontology/semanticsSchema.ts` for the field-level
+   * docs; this interface mirrors the ABox shape for the planner views.
+   */
+  emittedBy?: {
+    predecessor: string;
+    guardedBy?: string[];
+  };
+  /**
+   * Required when `kind === 'runtimeEmission'` (#305 Phase 1). Declares
+   * how the planner reads the emitted value back from the system after
+   * the predecessor has run.
+   */
+  discoveredVia?: {
+    operationId: string;
+    filterBy?: string;
+    extractKey: string;
+    consistency?: 'eventual' | 'strong';
+  };
 }
 
 export interface IdentifierSpec {

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -527,16 +527,24 @@ export interface SemanticTypeSpec {
    *     acceptable because the value is a fabricated placeholder for a
    *     key the client could not have known.
    *
-   *   - `runtimeEmission` (#305 Phase 1): a server-minted lifecycle key
-   *     that the planner *can* discover after a known producing
-   *     side-effect (e.g. `UserTaskKey` is emitted when a process
-   *     instance executes a user-task element, and is discoverable via
-   *     `searchUserTasks(processInstanceKey)`). Distinct from
-   *     `serverEmergent` precisely because the discovery path is
-   *     declarable. Requires both `emittedBy` and `discoveredVia` on the
-   *     same entry — without them the planner has nothing to act on and
-   *     the entry would degrade to a placeholder. The loader enforces
-   *     this coupling.
+   *   - `runtimeEmission` (#305 Phase 1, schema-only): a server-minted
+   *     lifecycle key that the planner *will be able to* discover after
+   *     a known producing side-effect (e.g. `UserTaskKey` is emitted
+   *     when a process instance executes a user-task element, and is
+   *     discoverable via `searchUserTasks(processInstanceKey)`).
+   *     Distinct from `serverEmergent` precisely because the discovery
+   *     path is declarable. Requires both `emittedBy` and
+   *     `discoveredVia` on the same entry — without them the planner
+   *     would have nothing to act on and the entry would degrade to a
+   *     placeholder. The loader enforces this coupling.
+   *
+   *     **Phase-1 scope note:** as of #305 Phase 1 (this commit) no
+   *     planner code reads `kind === 'runtimeEmission'`. The
+   *     classifier, BFS chain planner, and value-binder all behave as
+   *     if the entry were classified `serverEmergent` (falls through
+   *     to a placeholder `seedBinding`). The vocabulary is landed
+   *     first so Phase 3's ABox edits can validate cleanly against the
+   *     published TBox; planner support follows in Phase 3 of #305.
    *
    * Absent `kind` means the planner falls back to its existing
    * classification chain (producersByType / establishersByType /

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -534,17 +534,24 @@ export interface SemanticTypeSpec {
    *     discoverable via `searchUserTasks(processInstanceKey)`).
    *     Distinct from `serverEmergent` precisely because the discovery
    *     path is declarable. Requires both `emittedBy` and
-   *     `discoveredVia` on the same entry — without them the planner
-   *     would have nothing to act on and the entry would degrade to a
-   *     placeholder. The loader enforces this coupling.
+   *     `discoveredVia` on the same entry — without them the entry
+   *     would carry no actionable information for the future planner.
+   *     The loader enforces this coupling.
    *
    *     **Phase-1 scope note:** as of #305 Phase 1 (this commit) no
    *     planner code reads `kind === 'runtimeEmission'`. The
-   *     classifier, BFS chain planner, and value-binder all behave as
-   *     if the entry were classified `serverEmergent` (falls through
-   *     to a placeholder `seedBinding`). The vocabulary is landed
-   *     first so Phase 3's ABox edits can validate cleanly against the
-   *     published TBox; planner support follows in Phase 3 of #305.
+   *     `classifySemantic` dispatch in `bindSemanticInput.ts` only
+   *     special-cases `modelDerived` / `clientMintedAttribute` /
+   *     `serverEmergent`; a `runtimeEmission` declaration therefore
+   *     falls through to the producer/establisher/external-entity
+   *     chain and most commonly classifies as `unclassified` (the
+   *     keys we plan to migrate in Phase 3 — `UserTaskKey`,
+   *     `JobKey`, … — have no producer or establisher today, which
+   *     is exactly why they need `runtimeEmission` in the first
+   *     place). The vocabulary is landed first so Phase 3's ABox
+   *     edits can validate cleanly against the published TBox;
+   *     classifier + chain-planner support follows in Phase 3 of
+   *     #305.
    *
    * Absent `kind` means the planner falls back to its existing
    * classification chain (producersByType / establishersByType /

--- a/tests/fixtures/loader/semantics-abox-loader.test.ts
+++ b/tests/fixtures/loader/semantics-abox-loader.test.ts
@@ -313,6 +313,29 @@ describe('deriveSemanticsViews: record-shaped views', () => {
     });
   });
 
+  it("normalizes omitted `discoveredVia.consistency` to 'eventual' in derived views (#305 Phase 1)", () => {
+    // The TBox documents `consistency` as defaulting to `'eventual'`
+    // when omitted. Normalize in deriveSemanticsViews so downstream
+    // consumers (Phase 3+ planner code) can rely on a concrete value
+    // rather than each re-implementing the fallback.
+    writeAbox(
+      minimalAbox({
+        semanticTypes: [
+          { name: 'S', witnesses: 'Some' },
+          {
+            name: 'EmittedKey',
+            kind: 'runtimeEmission',
+            emittedBy: { predecessor: 'PS' },
+            // Intentionally omit `consistency`.
+            discoveredVia: { operationId: 'searchOp', extractKey: 'emittedKey' },
+          },
+        ],
+      }),
+    );
+    const views = deriveSemanticsViews(workdir);
+    expect(views?.semanticTypes.EmittedKey?.discoveredVia?.consistency).toBe('eventual');
+  });
+
   it('deep-clones array fields so callers cannot mutate the cached parse', () => {
     writeAbox(
       minimalAbox({

--- a/tests/fixtures/loader/semantics-abox-loader.test.ts
+++ b/tests/fixtures/loader/semantics-abox-loader.test.ts
@@ -313,11 +313,14 @@ describe('deriveSemanticsViews: record-shaped views', () => {
     });
   });
 
-  it("normalizes omitted `discoveredVia.consistency` to 'eventual' in derived views (#305 Phase 1)", () => {
-    // The TBox documents `consistency` as defaulting to `'eventual'`
-    // when omitted. Normalize in deriveSemanticsViews so downstream
-    // consumers (Phase 3+ planner code) can rely on a concrete value
-    // rather than each re-implementing the fallback.
+  it("normalizes omitted `discoveredVia.consistency` to 'strong' in derived views (#305 Phase 1)", () => {
+    // The TBox documents `consistency` as defaulting to `'strong'`
+    // when omitted (most Camunda read-after-write surfaces are
+    // strongly consistent; `'eventual'` is the explicit opt-in for
+    // emitters that need the poll-with-await helper). Normalize in
+    // deriveSemanticsViews so downstream consumers (Phase 3+ planner
+    // code) can rely on a concrete value rather than each
+    // re-implementing the fallback.
     writeAbox(
       minimalAbox({
         semanticTypes: [
@@ -333,7 +336,7 @@ describe('deriveSemanticsViews: record-shaped views', () => {
       }),
     );
     const views = deriveSemanticsViews(workdir);
-    expect(views?.semanticTypes.EmittedKey?.discoveredVia?.consistency).toBe('eventual');
+    expect(views?.semanticTypes.EmittedKey?.discoveredVia?.consistency).toBe('strong');
   });
 
   it('deep-clones array fields so callers cannot mutate the cached parse', () => {

--- a/tests/fixtures/loader/semantics-abox-loader.test.ts
+++ b/tests/fixtures/loader/semantics-abox-loader.test.ts
@@ -9,7 +9,8 @@
  *   4. Schema-invalid content → throws with a "failed TBox validation" diagnostic.
  *   5. Duplicate name in any sub-tree → throws.
  *   6. `kind: 'attribute'` without `clientMinted: true` → throws (cross-property invariant, #162 PR 2).
- *   7. Happy path → returns the parsed ABox.
+ *   7. `kind: 'runtimeEmission'` without `emittedBy` or without `discoveredVia` → throws (cross-property invariant, #305 Phase 1).
+ *   8. Happy path → returns the parsed ABox.
  *
  * Plus the `deriveSemanticsViews` accessor returns record-shaped views
  * that match what `graph.domain.{semanticTypes,capabilities,identifiers}`
@@ -136,6 +137,67 @@ describe('loadSemanticsAbox: documented branches', () => {
     expect(abox?.semanticTypes[0]?.clientMinted).toBe(true);
   });
 
+  it("throws when `kind: 'runtimeEmission'` is set without `emittedBy` (#305 Phase 1 coupling)", () => {
+    writeAbox(
+      minimalAbox({
+        semanticTypes: [
+          {
+            name: 'UserTaskKey',
+            kind: 'runtimeEmission',
+            discoveredVia: {
+              operationId: 'searchUserTasks',
+              filterBy: 'processInstanceKey',
+              extractKey: 'userTaskKey',
+              consistency: 'eventual',
+            },
+          },
+        ],
+      }),
+    );
+    expect(() => loadSemanticsAbox(workdir)).toThrow(
+      /UserTaskKey.*kind: 'runtimeEmission' but no emittedBy/,
+    );
+  });
+
+  it("throws when `kind: 'runtimeEmission'` is set without `discoveredVia` (#305 Phase 1 coupling)", () => {
+    writeAbox(
+      minimalAbox({
+        semanticTypes: [
+          {
+            name: 'UserTaskKey',
+            kind: 'runtimeEmission',
+            emittedBy: { predecessor: 'ProcessInstanceExists', guardedBy: ['ModelHasUserTask'] },
+          },
+        ],
+      }),
+    );
+    expect(() => loadSemanticsAbox(workdir)).toThrow(
+      /UserTaskKey.*kind: 'runtimeEmission' but no discoveredVia/,
+    );
+  });
+
+  it("accepts `kind: 'runtimeEmission'` with both `emittedBy` and `discoveredVia` (#305 Phase 1)", () => {
+    writeAbox(
+      minimalAbox({
+        semanticTypes: [
+          {
+            name: 'UserTaskKey',
+            kind: 'runtimeEmission',
+            emittedBy: { predecessor: 'ProcessInstanceExists', guardedBy: ['ModelHasUserTask'] },
+            discoveredVia: {
+              operationId: 'searchUserTasks',
+              filterBy: 'processInstanceKey',
+              extractKey: 'userTaskKey',
+              consistency: 'eventual',
+            },
+          },
+        ],
+      }),
+    );
+    const abox = loadSemanticsAbox(workdir);
+    expect(abox?.semanticTypes[0]?.kind).toBe('runtimeEmission');
+  });
+
   it('returns the parsed ABox on the happy path', () => {
     writeAbox(
       minimalAbox({
@@ -189,6 +251,17 @@ describe('deriveSemanticsViews: record-shaped views', () => {
           { name: 'ProcessDefinitionKey', witnesses: 'ProcessDefinitionDeployed' },
           { name: 'Tag', kind: 'attribute', clientMinted: true },
           { name: 'IncidentKey', kind: 'serverEmergent' },
+          {
+            name: 'UserTaskKey',
+            kind: 'runtimeEmission',
+            emittedBy: { predecessor: 'ProcessInstanceExists', guardedBy: ['ModelHasUserTask'] },
+            discoveredVia: {
+              operationId: 'searchUserTasks',
+              filterBy: 'processInstanceKey',
+              extractKey: 'userTaskKey',
+              consistency: 'eventual',
+            },
+          },
         ],
         capabilities: [
           {
@@ -213,9 +286,20 @@ describe('deriveSemanticsViews: record-shaped views', () => {
       'IncidentKey',
       'ProcessDefinitionKey',
       'Tag',
+      'UserTaskKey',
     ]);
     expect(views.semanticTypes.Tag).toEqual({ kind: 'attribute', clientMinted: true });
     expect(views.semanticTypes.IncidentKey).toEqual({ kind: 'serverEmergent' });
+    expect(views.semanticTypes.UserTaskKey).toEqual({
+      kind: 'runtimeEmission',
+      emittedBy: { predecessor: 'ProcessInstanceExists', guardedBy: ['ModelHasUserTask'] },
+      discoveredVia: {
+        operationId: 'searchUserTasks',
+        filterBy: 'processInstanceKey',
+        extractKey: 'userTaskKey',
+        consistency: 'eventual',
+      },
+    });
     expect(views.capabilities.ModelHasServiceTaskType).toEqual({
       kind: 'capability',
       parameter: 'jobType',
@@ -232,7 +316,15 @@ describe('deriveSemanticsViews: record-shaped views', () => {
   it('deep-clones array fields so callers cannot mutate the cached parse', () => {
     writeAbox(
       minimalAbox({
-        semanticTypes: [{ name: 'T', witnesses: 'S' }],
+        semanticTypes: [
+          { name: 'T', witnesses: 'S' },
+          {
+            name: 'EmittedKey',
+            kind: 'runtimeEmission',
+            emittedBy: { predecessor: 'PS', guardedBy: ['Cap'] },
+            discoveredVia: { operationId: 'searchOp', extractKey: 'emittedKey' },
+          },
+        ],
         capabilities: [
           {
             name: 'Cap',
@@ -257,11 +349,13 @@ describe('deriveSemanticsViews: record-shaped views', () => {
     v1.capabilities.Cap?.dependsOn?.push('mutated');
     v1.identifiers.Id?.boundBy?.push('mutated');
     v1.identifiers.Id?.fieldPaths?.push('mutated');
+    v1.semanticTypes.EmittedKey?.emittedBy?.guardedBy?.push('mutated');
     const v2 = deriveSemanticsViews(workdir);
     expect(v2?.capabilities.Cap?.producedBy).toEqual(['op1']);
     expect(v2?.capabilities.Cap?.dependsOn).toEqual(['S']);
     expect(v2?.identifiers.Id?.boundBy).toEqual(['op1']);
     expect(v2?.identifiers.Id?.fieldPaths).toEqual(['a.b']);
+    expect(v2?.semanticTypes.EmittedKey?.emittedBy?.guardedBy).toEqual(['Cap']);
   });
 
   it("propagates the loader's validation failure (does not silently swallow malformed ABox)", () => {


### PR DESCRIPTION
Part of #305 — Phase 1 (schema-only).

## What

Adds a fourth value-source classification — `runtimeEmission` — alongside the existing `modelDerived` / `attribute` / `serverEmergent` kinds in the semantics TBox. Carries the planning information (`emittedBy` + `discoveredVia`) that distinguishes "server-minted AND discoverable" from plain `serverEmergent` ("server-minted AND no discovery surface").

## Why

#305 fixes the long tail of `updateXxx` / `assignXxx` / `completeUserTask` tests being effectively no-ops. The planner classifies every emergent key as `serverEmergent` and falls through to a placeholder `seedBinding` — the PATCH/POST under test is dispatched against a synthetic key. Several of those keys are in fact reachable: `searchUserTasks` filters by `processInstanceKey`, etc. The planner just isn't allowed to plan the discovery chain because "discoverable via search after side-effect" isn't modelled.

This PR is the schema half. Later phases (Phase 3 onward) reclassify ABox entries and teach the planner to consume them.

## Scope split (deliberate)

- ✅ TBox: new `kind` enum member, `emittedBy { predecessor, guardedBy[] }`, `discoveredVia { operationId, filterBy, extractKey, consistency }`
- ✅ Loader: cross-property invariant — `kind === 'runtimeEmission'` requires both sub-objects
- ✅ Views: `deriveSemanticsViews` plumbs the new fields through with defensive array copies
- ✅ `SemanticTypeSpec` updated; published `ontology/vocabulary/semantics.schema.json` regenerated
- ❌ No ABox edits (those land in Phase 3+)
- ❌ No planner support (Phase 3+)
- ❌ No new fixtures/capabilities (Phase 3+)

Splitting the schema in first lets Phase 3's ABox edits validate cleanly against the published TBox without a partial-merge window.

## Tests

`tests/fixtures/loader/semantics-abox-loader.test.ts` gains three new L1 cases:

1. Missing `emittedBy` → loader throws with the type name in the diagnostic.
2. Missing `discoveredVia` → ditto.
3. Both present → happy path.

The view-shape and deep-clone tests are extended to assert the new fields propagate through `deriveSemanticsViews` and that array fields (`emittedBy.guardedBy`) are defensively copied.

## Validation

- `npm run lint` ✅
- Full TC chain (extractor + path-analyser + emitter-sdk + materializer + request-validation + tests) ✅
- `npm run build:ontology` regen, then full pipeline regen + `npm test`: **564 passed | 2 skipped** (+4 new tests vs Phase 0 baseline of 560) ✅
- No behaviour drift in `generated/` (verified: ABox is unchanged, so all consumers see identical `SemanticTypeSpec` data)