### PR TITLE
chore(planner): lock down createDeployment chain wiring before #305 Phase 3

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -279,6 +279,76 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
     expect(offenders).toEqual([]);
   });
 
+  it('every scenario whose chain consumes a createDeployment-authoritative semantic includes createDeployment as a producer step (#305 Phase 2 — deployment-as-planner-producer guard)', () => {
+    // Class-scoped pin of the property #305's Phase 3 must preserve:
+    // the `deploymentGateway` codegen role is a per-test call-site
+    // helper, NOT a semantic substitute for the planner step. If a
+    // chain references an operation that requires a semantic
+    // createDeployment authoritatively produces (e.g.
+    // ProcessDefinitionKey on createProcessInstance, FormKey on
+    // updateUserTaskForm, etc.), then createDeployment must appear in
+    // the same chain as a real producer step. The scenario JSON is
+    // the planner's output contract; this invariant fails if a future
+    // refactor lets the role hook short-circuit deployment planning.
+    //
+    // Defect class: any chain in which a deployment-derived key is
+    // sourced from a placeholder seedBinding or from an unrelated
+    // ancestor instead of an in-chain createDeployment.
+    //
+    // The "authoritative" set comes from the #34/#137 invariant above
+    // and matches createDeployment's response provider:true semantics:
+    // ProcessDefinitionKey/Id, DecisionDefinitionKey/Id,
+    // DecisionRequirementsKey, FormKey.
+    if (!existsSync(SCENARIOS_DIR)) {
+      throw new Error(
+        `Scenarios directory not found at ${SCENARIOS_DIR}. Run 'npm run testsuite:generate' (or 'npm run pipeline') first.`,
+      );
+    }
+    loadGraph();
+    const deploymentDerivedSemantics = new Set([
+      'ProcessDefinitionKey',
+      'ProcessDefinitionId',
+      'DecisionDefinitionKey',
+      'DecisionDefinitionId',
+      'DecisionRequirementsKey',
+      'FormKey',
+    ]);
+    function consumesDeploymentDerived(opId: string): boolean {
+      const op = cachedOperationById?.get(opId);
+      if (!op) return false;
+      for (const e of op.requestBodySemanticTypes ?? []) {
+        if (e.required && deploymentDerivedSemantics.has(e.semanticType)) return true;
+      }
+      return false;
+    }
+    const offenders: { file: string; scenario: string; ops: string[] }[] = [];
+    for (const f of readdirSync(SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const file = JSON.parse(readFileSync(join(SCENARIOS_DIR, f), 'utf8')) as ScenarioFile;
+      for (const s of file.scenarios ?? []) {
+        if (s.id === 'unsatisfied') continue;
+        const ops = s.operations.map((o) => o.operationId);
+        if (ops.length <= 1) continue;
+        // Exclude createDeployment itself from the chain when checking
+        // who consumes deployment-derived semantics — we want the
+        // *downstream* consumers' transitive need to be satisfied by
+        // an in-chain createDeployment.
+        const downstreamConsumers = ops.filter(
+          (o) => o !== 'createDeployment' && consumesDeploymentDerived(o),
+        );
+        if (downstreamConsumers.length === 0) continue;
+        if (!ops.includes('createDeployment')) {
+          offenders.push({ file: f, scenario: s.id, ops });
+        }
+      }
+    }
+    expect(
+      offenders,
+      'Every chain that consumes a deployment-derived semantic (ProcessDefinitionKey/Id, DecisionDefinitionKey/Id, DecisionRequirementsKey, FormKey) must include createDeployment as a producer step. The deploymentGateway codegen role is an emitter call-site helper, not a planner substitute (#305 corrected acceptance criterion #3).',
+    ).toEqual([]);
+  });
+
   it('every endpoint whose only required semantic has a self-sufficient authoritative producer plans at least one chain (#95)', () => {
     // Class-scoped guard against the #95 defect family: the witness
     // implication in graphLoader must not turn an authoritative producer

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -314,10 +314,17 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
       'FormKey',
     ]);
     function consumesDeploymentDerived(opId: string): boolean {
-      const op = cachedOperationById?.get(opId);
-      if (!op) return false;
+      // Use findOperation so unknown opIds throw rather than silently
+      // making the invariant a no-op (which would mask drift between
+      // the scenarios and the graph).
+      const op = findOperation(opId);
       for (const e of op.requestBodySemanticTypes ?? []) {
         if (e.required && deploymentDerivedSemantics.has(e.semanticType)) return true;
+      }
+      for (const p of op.parameters ?? []) {
+        if (p.required && p.semanticType && deploymentDerivedSemantics.has(p.semanticType)) {
+          return true;
+        }
       }
       return false;
     }


### PR DESCRIPTION
Part of #305 — Phase 2 of 6.

## Context

The #305 issue body claims `createDeployment` escaped the prereq chain
via the `deploymentGateway` codegen role. On inspection that framing
is inaccurate — `createDeployment` is already wired as a planner step
wherever `bpmnProcess.producesStates` is required (verified against
`generated/camunda-oca/scenarios/get--process-instances--{processInstanceKey}-scenarios.json`,
which plans `createDeployment → createProcessInstance → getProcessInstance`).
The `deploymentGateway` role is a per-test call-site helper for DRY-ness
at emission time, **not** a planner replacement. jwulf's clarifying
comment on the issue partially walks this back already.

The real root cause for the broken `updateUserTask`-style scenarios
is that `UserTaskKey` and friends are classified `serverEmergent`,
which is what Phase 3 (`runtimeEmission` classifier) actually fixes.

## What this PR does

Per AGENTS.md's green/green coverage-audit mandate, add an L3 invariant
that pins the **current** deployment wiring before Phase 3 touches
`scenarioGenerator.ts`. It walks every `*-scenarios.json` and fails
if any non-`unsatisfied` scenario whose chain consumes a
deployment-derived semantic (`ProcessDefinitionKey`/`Id`,
`DecisionDefinitionKey`/`Id`, `DecisionRequirementsKey`, `FormKey`)
is planned without `createDeployment` as a producer step.

This is **class-scoped** — the existing invariant at line 259 only
pins `createProcessInstance` (#32/#35). The new one catches every
deployment-derived consumer chain, defending against any future
refactor that lets the role hook short-circuit deployment planning.

## Verification

Green on main:
```
✓ configs/camunda-oca/regression-invariants.test.ts (150 tests | 2 skipped) 1347ms
 Test Files  54 passed (54)
      Tests  562 passed | 2 skipped (564)
```

No behavioural changes — invariants only.

## Phase status (#305)

- ✅ Phase 0 — audit (session artifact)
- 🟡 Phase 1 — TBox schema (#306, in review)
- 🟢 **Phase 2 — this PR** (green/green guard)
- ⏳ Phase 3 — UserTaskKey runtimeEmission pilot
- ⏳ Phase 4 — `UpdatedFieldVisibleOnReadBack` scenario template
- ⏳ Phase 5 — remaining keys roll-out
- ⏳ Phase 6 — umbrella runtimeEmission L3 invariant