### PR TITLE
feat: promote UserTaskKey to runtimeEmission and wire discovery chain (#305 Phase 3)

### DIFF
--- a/configs/camunda-oca/fixtures/bpmn/user-task.bpmn
+++ b/configs/camunda-oca/fixtures/bpmn/user-task.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_user_task" targetNamespace="http://bpmn.io/schema/bpmn" exporter="api-test-generator" exporterVersion="1.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_user_task" name="User Task Process" isExecutable="true">
+    <bpmn:extensionElements />
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_to_userTask</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_to_userTask" sourceRef="StartEvent_1" targetRef="UserTask_1" />
+    <bpmn:userTask id="UserTask_1" name="Sample User Task">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_to_userTask</bpmn:incoming>
+      <bpmn:outgoing>Flow_to_end</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_to_end" sourceRef="UserTask_1" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1" name="End">
+      <bpmn:incoming>Flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_user_task">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_1_di" bpmnElement="UserTask_1">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_to_userTask_di" bpmnElement="Flow_to_userTask">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_to_end_di" bpmnElement="Flow_to_end">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/configs/camunda-oca/fixtures/deployment-artifacts.json
+++ b/configs/camunda-oca/fixtures/deployment-artifacts.json
@@ -21,6 +21,15 @@
       }
     },
     {
+      "kind": "bpmnProcess",
+      "path": "bpmn/user-task.bpmn",
+      "description": "BPMN process with a single Zeebe user task between start and end. Selected for chains whose consumer ops require ModelHasUserTask (e.g. updateUserTask, completeUserTask, assignUserTask discovered via searchUserTasks). See #305 Phase 3.",
+      "providesStates": ["ModelHasUserTask"],
+      "providesValues": {
+        "ElementId": ["StartEvent_1", "UserTask_1", "EndEvent_1"]
+      }
+    },
+    {
       "kind": "form",
       "path": "forms/simple.form",
       "description": "Minimal Camunda form JSON"

--- a/configs/camunda-oca/ontology/artifact-kinds.json
+++ b/configs/camunda-oca/ontology/artifact-kinds.json
@@ -8,7 +8,7 @@
       "name": "bpmnProcess",
       "identifierType": "ProcessDefinitionId",
       "producesStates": ["ProcessDefinitionDeployed"],
-      "producibleStates": ["ModelHasServiceTaskType", "ProcessInstanceCompleted"],
+      "producibleStates": ["ModelHasServiceTaskType", "ModelHasUserTask", "ProcessInstanceCompleted"],
       "producesSemantics": ["ProcessDefinitionKey"],
       "deploymentSlices": ["processDefinition"],
       "modelKind": "bpmn",

--- a/configs/camunda-oca/ontology/semantics.json
+++ b/configs/camunda-oca/ontology/semantics.json
@@ -81,8 +81,18 @@
     },
     {
       "name": "UserTaskKey",
-      "kind": "serverEmergent",
-      "$comment": "Server-minted lifecycle key for a user task instance. User tasks emerge when a deployed process reaches a user-task element \u2014 no direct create API. Search-filter input only; planner mints a deterministic placeholder. See #162 PR 5."
+      "kind": "runtimeEmission",
+      "emittedBy": {
+        "predecessor": "ProcessInstanceExists",
+        "guardedBy": ["ModelHasUserTask"]
+      },
+      "discoveredVia": {
+        "operationId": "searchUserTasks",
+        "filterBy": "processInstanceKey",
+        "extractKey": "userTaskKey",
+        "consistency": "eventual"
+      },
+      "$comment": "Server-minted lifecycle key for a user task instance. Emitted after a deployment whose BPMN contains a user-task element (`ModelHasUserTask`) reaches that element during a process instance run. Discovered via searchUserTasks filtered by processInstanceKey; eventually consistent (await-eventually). See #305 Phase 3 (promoted from serverEmergent)."
     },
     {
       "name": "VariableKey",
@@ -99,6 +109,16 @@
     {
       "name": "ModelHasServiceTaskType",
       "parameter": "jobType",
+      "producedBy": [
+        "createDeployment"
+      ],
+      "dependsOn": [
+        "ProcessDefinitionDeployed"
+      ]
+    },
+    {
+      "name": "ModelHasUserTask",
+      "parameter": "userTaskElementId",
       "producedBy": [
         "createDeployment"
       ],

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -387,8 +387,7 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
     }
     if (runtimeEmissionByName.size === 0) return; // no-op until Phase 3 lands UserTaskKey
 
-    const op = loadGraph();
-    void op;
+    loadGraph();
     const offenders: { file: string; scenario: string; semantic: string; reason: string }[] = [];
     for (const f of readdirSync(SCENARIOS_DIR)) {
       if (!f.endsWith('-scenarios.json')) continue;
@@ -409,7 +408,12 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
           const discoveryOp = runtimeEmissionByName.get(sem);
           if (!discoveryOp) continue;
           const discIdx = ops.indexOf(discoveryOp);
-          const endIdx = ops.indexOf(file.endpoint.operationId);
+          // Use lastIndexOf for the consuming-endpoint op: variant
+          // scenarios can legitimately invoke the endpoint more than
+          // once (e.g. warm-up + final). The discovery op must precede
+          // the FINAL consumer invocation, not the warm-up one. (PR
+          // #308 review.)
+          const endIdx = ops.lastIndexOf(file.endpoint.operationId);
           if (discIdx < 0) {
             offenders.push({
               file: f,

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -401,8 +401,25 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
         .filter((s): s is string => typeof s === 'string');
       const relevant = requiredPathSemantics.filter((s) => runtimeEmissionByName.has(s));
       if (relevant.length === 0) continue;
-      for (const s of file.scenarios ?? []) {
-        if (s.id === 'unsatisfied') continue;
+      // Also flag the empty-success case: a relevant endpoint that only
+      // plans `unsatisfied` scenarios passes the per-scenario checks
+      // below trivially (the loop body is skipped). A regression where
+      // the planner stops expanding the discovery chain and falls back
+      // to `unsatisfied` would otherwise go undetected. (PR #308
+      // review.)
+      const satisfiable = (file.scenarios ?? []).filter((s) => s.id !== 'unsatisfied');
+      if (satisfiable.length === 0) {
+        for (const sem of relevant) {
+          offenders.push({
+            file: f,
+            scenario: '(none — all scenarios unsatisfied)',
+            semantic: sem,
+            reason: `endpoint '${file.endpoint.operationId}' planned no satisfiable chain for required path-param semantic '${sem}'`,
+          });
+        }
+        continue;
+      }
+      for (const s of satisfiable) {
         const ops = s.operations.map((o) => o.operationId);
         for (const sem of relevant) {
           const discoveryOp = runtimeEmissionByName.get(sem);

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -356,6 +356,84 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
     ).toEqual([]);
   });
 
+  it('every endpoint that consumes a runtimeEmission-classified semantic in a required path-param plans a real discovery chain — no synthetic-only resolution (#305 Phase 3)', () => {
+    // Class-scoped guard for the runtimeEmission promotion (#305):
+    // when a semantic type is reclassified from `serverEmergent` to
+    // `runtimeEmission`, every endpoint that consumes it in a required
+    // path-param must plan a chain that (a) is not `unsatisfied` and
+    // (b) includes the declared `discoveredVia.operationId` ahead of
+    // the consuming op. Regression would mean the planner silently
+    // falls back to a synthetic `seedBinding(...)` placeholder, which
+    // makes the integration test a no-op.
+    if (!existsSync(SCENARIOS_DIR)) {
+      throw new Error(
+        `Scenarios directory not found at ${SCENARIOS_DIR}. Run 'npm run testsuite:generate' (or 'npm run pipeline') first.`,
+      );
+    }
+    const semanticsPath = join(REPO_ROOT, 'configs', CONFIG_NAME, 'ontology', 'semantics.json');
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const semantics = JSON.parse(readFileSync(semanticsPath, 'utf8')) as {
+      semanticTypes?: Array<{
+        name: string;
+        kind?: string;
+        discoveredVia?: { operationId?: string };
+      }>;
+    };
+    const runtimeEmissionByName = new Map<string, string>();
+    for (const t of semantics.semanticTypes ?? []) {
+      if (t.kind === 'runtimeEmission' && t.discoveredVia?.operationId) {
+        runtimeEmissionByName.set(t.name, t.discoveredVia.operationId);
+      }
+    }
+    if (runtimeEmissionByName.size === 0) return; // no-op until Phase 3 lands UserTaskKey
+
+    const op = loadGraph();
+    void op;
+    const offenders: { file: string; scenario: string; semantic: string; reason: string }[] = [];
+    for (const f of readdirSync(SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const file = JSON.parse(readFileSync(join(SCENARIOS_DIR, f), 'utf8')) as ScenarioFile;
+      const endpointOp = findOperation(file.endpoint.operationId);
+      // Required path-param semantics on the endpoint under test.
+      const requiredPathSemantics = (endpointOp.parameters ?? [])
+        .filter((p) => p.location === 'path' && p.required && p.semanticType)
+        .map((p) => p.semanticType)
+        .filter((s): s is string => typeof s === 'string');
+      const relevant = requiredPathSemantics.filter((s) => runtimeEmissionByName.has(s));
+      if (relevant.length === 0) continue;
+      for (const s of file.scenarios ?? []) {
+        if (s.id === 'unsatisfied') continue;
+        const ops = s.operations.map((o) => o.operationId);
+        for (const sem of relevant) {
+          const discoveryOp = runtimeEmissionByName.get(sem);
+          if (!discoveryOp) continue;
+          const discIdx = ops.indexOf(discoveryOp);
+          const endIdx = ops.indexOf(file.endpoint.operationId);
+          if (discIdx < 0) {
+            offenders.push({
+              file: f,
+              scenario: s.id,
+              semantic: sem,
+              reason: `discovery op '${discoveryOp}' missing from chain ${JSON.stringify(ops)}`,
+            });
+          } else if (endIdx >= 0 && discIdx > endIdx) {
+            offenders.push({
+              file: f,
+              scenario: s.id,
+              semantic: sem,
+              reason: `discovery op '${discoveryOp}' appears after the consuming op '${file.endpoint.operationId}'`,
+            });
+          }
+        }
+      }
+    }
+    expect(
+      offenders,
+      'Every endpoint that consumes a runtimeEmission semantic in a required path-param must plan a chain whose discoveredVia.operationId precedes the consuming op (#305 Phase 3). A failure here usually means the planner silently fell back to `seedBinding(...)` for the target semantic instead of expanding the discovery chain.',
+    ).toEqual([]);
+  });
+
   it('every endpoint whose only required semantic has a self-sufficient authoritative producer plans at least one chain (#95)', () => {
     // Class-scoped guard against the #95 defect family: the witness
     // implication in graphLoader must not turn an authoritative producer

--- a/path-analyser/src/bindSemanticInput.ts
+++ b/path-analyser/src/bindSemanticInput.ts
@@ -32,6 +32,7 @@ export type SemanticClassification =
   | 'modelDerived'
   | 'clientMintedAttribute'
   | 'serverEmergent'
+  | 'runtimeEmission'
   | 'producerBound'
   | 'clientMintedIdentifier'
   | 'externalBoundary'
@@ -41,6 +42,7 @@ export type BoundInput =
   | { classification: 'modelDerived'; varName: string; value?: string }
   | { classification: 'clientMintedAttribute'; varName: string; value: string }
   | { classification: 'serverEmergent'; varName: string; value: string }
+  | { classification: 'runtimeEmission'; varName: string }
   | { classification: 'producerBound'; varName: string }
   | { classification: 'clientMintedIdentifier'; varName: string }
   | { classification: 'externalBoundary'; varName: string }
@@ -90,6 +92,7 @@ export function classifySemantic(semantic: string, graph: OperationGraph): Seman
     return 'clientMintedAttribute';
   }
   if (decl?.kind === 'serverEmergent') return 'serverEmergent';
+  if (decl?.kind === 'runtimeEmission') return 'runtimeEmission';
   if (graph.producersByType?.[semantic]?.length) return 'producerBound';
   if (graph.establishersByType?.[semantic]?.length) return 'clientMintedIdentifier';
   if (graph.externalEntityIdentifiers?.has(semantic)) return 'externalBoundary';
@@ -157,6 +160,13 @@ export function bindSemanticInput(args: {
     case 'producerBound':
     case 'clientMintedIdentifier':
     case 'externalBoundary':
+    case 'runtimeEmission':
+      // `runtimeEmission` (#305 Phase 3) is treated as a producer-bound
+      // var at the bindings layer — the planner injects the discovery
+      // op (per the ABox `discoveredVia` declaration) and the
+      // discovery step's response extract binds `varName` server-side.
+      // From the bind-input dispatch's perspective, the value is
+      // owned by an upstream step exactly like `producerBound`.
       return { classification, varName };
     default:
       return { classification: 'unclassified' };

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1617,26 +1617,37 @@ function resolveProvider(opId: string, field: string, scenario: EndpointScenario
  * Pick the fixture registry entry whose effective providesStates (per-entry ∪
  * kind-level `artifactKinds.<kind>.producesStates`) covers `requiredStates`.
  *
- * Selection algorithm (#159, PR A):
+ * Selection algorithm:
  *   1. Filter to entries whose `kind` matches.
- *   2. Of those, keep entries whose effective providesStates is a superset of
- *      `requiredStates`. An empty `requiredStates` matches every entry — so
- *      chains that don't impose runtime characteristics on the fixture fall
- *      through to step 3 with all candidates.
- *   3. Tie-break: smallest |entry.providesStates| wins (most specific match;
- *      fewer extra states the chain didn't ask for). Ties at that point
- *      break by array order in the registry.
+ *   2. Two-tier match (#305 Phase 3):
+ *        a. Keep entries whose effective providesStates is a superset of
+ *           `requiredStates` (hard + soft). An empty `requiredStates`
+ *           matches every entry — chains that don't impose runtime
+ *           characteristics on the fixture fall through to the tie-break.
+ *        b. If no entry covers (a) AND `hardRequiredStates` is non-empty,
+ *           retry the superset check against `hardRequiredStates` alone.
+ *           Hard states (semantic `op.requires`, `runtimeEmission.emittedBy.
+ *           guardedBy` guards) are necessary for the chain to function at
+ *           runtime; soft states (`chainCleanupRequires`) are hygiene
+ *           preferences that may legitimately conflict with a hard
+ *           requirement — e.g. a self-completing BPMN cannot simultaneously
+ *           contain a user-task element. Correctness wins over hygiene.
+ *   3. Tie-break across surviving candidates: smallest |entry.providesStates|
+ *      wins (most specific match; fewer extra states the chain didn't ask
+ *      for). Ties break by array order in the registry.
  *
  * Returns the chosen entry's `@@FILE:<path>` ref plus its `providesValues`
  * (the per-fixture modelDerived value source — #162 PR 1), or `undefined`
- * when no entry of the right kind exists at all (the caller then falls
- * back to a hard-coded default).
+ * when no entry of the right kind exists at all.
  *
- * When no entry of the right kind covers `requiredStates` (a real
+ * When neither (a) nor (b) finds a covering candidate (a real
  * misconfiguration — the chain asked for a state nothing provides), the
  * function still returns the first entry of that kind so the caller can
  * emit a runnable suite; the diagnostic should be caught earlier by the
  * fixture-registry validator or the bundled-spec invariants.
+ *
+ * `hardRequiredStates` is optional — callers that don't compute a hard/
+ * soft split pass `undefined` and get single-tier (a)-only selection.
  */
 function chooseFixtureFromRegistry(
   kind: string | undefined,

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1350,10 +1350,16 @@ function buildRequestBodyFromCanonical(
       // characteristics on the fixture falls through to the most generic
       // candidate.
       const requiredStates = computeDeploymentRequiredStates(scenario, graph.domain);
+      const hardRequiredStates = computeDeploymentHardRequiredStates(scenario, graph.domain);
       const kindLevelProvides = new Set<string>(
         kind ? (graph.domain?.artifactKinds?.[kind]?.producesStates ?? []) : [],
       );
-      const regHit = chooseFixtureFromRegistry(kind, requiredStates, kindLevelProvides);
+      const regHit = chooseFixtureFromRegistry(
+        kind,
+        requiredStates,
+        kindLevelProvides,
+        hardRequiredStates,
+      );
       if (!regHit) {
         // Lift 17 / #257 retired the hard-coded `defaultFixtures` map
         // and the `'@@FILE:bpmn/simple.bpmn'` second-fallback that
@@ -1636,19 +1642,35 @@ function chooseFixtureFromRegistry(
   kind: string | undefined,
   requiredStates: ReadonlySet<string>,
   kindLevelProvides: ReadonlySet<string>,
+  hardRequiredStates?: ReadonlySet<string>,
 ): { ref: string; providesValues?: Record<string, string[]> } | undefined {
   if (!kind) return undefined;
   const candidates = getArtifactsRegistry().filter((e) => e.kind === kind);
   if (candidates.length === 0) return undefined;
 
-  const covers = candidates.filter((e) => {
+  const effectiveProvides = (e: { providesStates?: string[] }) => {
     const provides = new Set<string>(kindLevelProvides);
     for (const s of e.providesStates ?? []) provides.add(s);
-    for (const r of requiredStates) {
-      if (!provides.has(r)) return false;
-    }
+    return provides;
+  };
+  const isSuperset = (provides: Set<string>, required: ReadonlySet<string>) => {
+    for (const r of required) if (!provides.has(r)) return false;
     return true;
-  });
+  };
+
+  // Two-tier selection (#305 Phase 3): try the full requirement set first
+  // (hard + soft). If nothing covers, drop the soft `chainCleanupRequires`
+  // bias and retry with hardRequiredStates alone — hard states (semantic
+  // op.requires, runtimeEmission `emittedBy.guardedBy` guards) are
+  // necessary for the chain to function at runtime; soft states are
+  // hygiene preferences that may legitimately conflict with a hard
+  // requirement (e.g. a self-completing BPMN can't also contain a
+  // user-task element). Only when no fixture covers the hard set
+  // either do we fall through to the first registered candidate.
+  let covers = candidates.filter((e) => isSuperset(effectiveProvides(e), requiredStates));
+  if (covers.length === 0 && hardRequiredStates && hardRequiredStates.size > 0) {
+    covers = candidates.filter((e) => isSuperset(effectiveProvides(e), hardRequiredStates));
+  }
 
   // Fall back to the first registered candidate when the requirement is
   // unsatisfiable — the caller still gets a runnable suite, and the
@@ -1701,7 +1723,9 @@ function chooseFixtureFromRegistry(
  * fixture of the right kind is acceptable.
  */
 function computeDeploymentRequiredStates(
-  scenario: { operations?: ReadonlyArray<{ operationId: string }> } | undefined,
+  scenario:
+    | { operations?: ReadonlyArray<{ operationId: string }>; producedSemanticTypes?: string[] }
+    | undefined,
   domain: DomainSemantics | undefined,
 ): Set<string> {
   const result = new Set<string>();
@@ -1713,6 +1737,7 @@ function computeDeploymentRequiredStates(
     for (const s of req.requires ?? []) result.add(s);
     for (const s of req.chainCleanupRequires ?? []) result.add(s);
   }
+  for (const g of collectRuntimeEmissionGuards(scenario, domain)) result.add(g);
   // States produced by non-deployment-gateway ops earlier in the chain are
   // satisfied by their own producer step; the deployment gateway doesn't
   // need to provide them. The deployment-gateway op is identified via the
@@ -1725,4 +1750,94 @@ function computeDeploymentRequiredStates(
     for (const s of req.implicitAdds ?? []) result.delete(s);
   }
   return result;
+}
+
+/**
+ * #305 Phase 3 — the **hard** subset of deployment-required states: those
+ * whose absence would break the chain at runtime (semantic op.requires +
+ * runtimeEmission `emittedBy.guardedBy` guards), excluding the soft
+ * hygiene preferences from `chainCleanupRequires`. Used by the fixture
+ * selector as a fallback predicate when no candidate covers the full
+ * (hard ∪ soft) requirement set — a self-completing BPMN can't
+ * simultaneously contain a user-task element, so the selector must
+ * privilege correctness over hygiene.
+ */
+function computeDeploymentHardRequiredStates(
+  scenario:
+    | { operations?: ReadonlyArray<{ operationId: string }>; producedSemanticTypes?: string[] }
+    | undefined,
+  domain: DomainSemantics | undefined,
+): Set<string> {
+  const result = new Set<string>();
+  if (!scenario?.operations || !domain?.operationRequirements) return result;
+  const opReqs = domain.operationRequirements;
+  for (const opRef of scenario.operations) {
+    const req = opReqs[opRef.operationId];
+    if (!req) continue;
+    for (const s of req.requires ?? []) result.add(s);
+  }
+  for (const g of collectRuntimeEmissionGuards(scenario, domain)) result.add(g);
+  for (const opRef of scenario.operations) {
+    if (isDeploymentGatewayOp(domain, opRef.operationId)) continue;
+    const req = opReqs[opRef.operationId];
+    if (!req) continue;
+    for (const s of req.produces ?? []) result.delete(s);
+    for (const s of req.implicitAdds ?? []) result.delete(s);
+  }
+  return result;
+}
+
+/**
+ * Walk the scenario's `producedSemanticTypes` and yield every
+ * `emittedBy.guardedBy` capability declared by a `runtimeEmission`
+ * semantic type in the ABox. Shared by `computeDeploymentRequiredStates`
+ * and `computeDeploymentHardRequiredStates`.
+ */
+function collectRuntimeEmissionGuards(
+  scenario:
+    | { producedSemanticTypes?: string[]; operations?: ReadonlyArray<{ operationId: string }> }
+    | undefined,
+  domain: DomainSemantics | undefined,
+): string[] {
+  const out: string[] = [];
+  const semantics = domain?.semanticTypes;
+  if (!semantics || !scenario) return out;
+  const seen = new Set<string>();
+  for (const s of scenario.producedSemanticTypes ?? []) {
+    const decl = semantics[s];
+    if (decl?.kind === 'runtimeEmission' && decl.emittedBy?.guardedBy) {
+      for (const g of decl.emittedBy.guardedBy) {
+        if (!seen.has(g)) {
+          seen.add(g);
+          out.push(g);
+        }
+      }
+    }
+  }
+  // Feature/variant scenarios are cloned from the canonical scenario with
+  // `producedSemanticTypes` stripped (overlay rebuild). Re-derive the
+  // guards by scanning operations for any `runtimeEmission` semantic whose
+  // `discoveredVia.operationId` appears in the chain — that's the
+  // structural signal that the planner expanded a runtimeEmission for
+  // this scenario, independent of whether `producedSemanticTypes` was
+  // re-hydrated.
+  const opIds = new Set((scenario.operations ?? []).map((o) => o.operationId));
+  if (opIds.size > 0) {
+    for (const decl of Object.values(semantics)) {
+      if (
+        decl?.kind === 'runtimeEmission' &&
+        decl.discoveredVia?.operationId &&
+        opIds.has(decl.discoveredVia.operationId) &&
+        decl.emittedBy?.guardedBy
+      ) {
+        for (const g of decl.emittedBy.guardedBy) {
+          if (!seen.has(g)) {
+            seen.add(g);
+            out.push(g);
+          }
+        }
+      }
+    }
+  }
+  return out;
 }

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -146,7 +146,17 @@ export function generateScenariosForEndpoint(
   for (const st of initialNeeded) {
     const hasProducer = graph.producersByType[st]?.length;
     const hasEstablisher = graph.establishersByType?.[st]?.length;
-    if (!hasProducer && !hasEstablisher) {
+    // #305 Phase 3: `runtimeEmission` semantics have no graph-indexed
+    // producer (their discovery op is declared in the ABox via
+    // `discoveredVia`, not via response provider annotations). They
+    // are satisfied at BFS expansion time by the runtimeEmission
+    // injection branch below — exempt them from the static-missing
+    // gate here so the unsatisfied branch doesn't fire prematurely.
+    const isRuntimeEmission =
+      graph.domain?.semanticTypes?.[st]?.kind === 'runtimeEmission' &&
+      graph.domain.semanticTypes[st].discoveredVia !== undefined &&
+      graph.domain.semanticTypes[st].emittedBy !== undefined;
+    if (!hasProducer && !hasEstablisher && !isRuntimeEmission) {
       if (!endpoint.produces.includes(st)) missing.push(st);
     }
   }
@@ -503,6 +513,28 @@ export function generateScenariosForEndpoint(
 
     // Choose a semantic type to target next
     const targetSemantic = remaining[0];
+
+    // #305 Phase 3 — `runtimeEmission` semantics declare a discovery
+    // operation (ABox `discoveredVia.operationId`) that surfaces the
+    // key at runtime, gated by a predecessor runtime state + optional
+    // capability guards (`emittedBy.predecessor`, `emittedBy.guardedBy`).
+    // They're deliberately NOT in `producersByType[target]` — the
+    // authoritative-producer index only carries statically-annotated
+    // providers. Synthesise the producer chain here; if the helper
+    // dispatches a state into the queue (apply branch or defer branch),
+    // skip the regular producer loop for this iteration. Otherwise
+    // fall through and the BFS will drain the queue → `unsatisfied`.
+    const targetDecl = targetSemantic ? graph.domain?.semanticTypes?.[targetSemantic] : undefined;
+    if (
+      targetSemantic &&
+      targetDecl?.kind === 'runtimeEmission' &&
+      targetDecl.discoveredVia &&
+      targetDecl.emittedBy
+    ) {
+      expandRuntimeEmission(graph, targetSemantic, targetDecl, state, seen, queue, endpointOpId);
+      continue;
+    }
+
     // Shallow-copy the producer list before any local augmentation —
     // `graph.producersByType[targetSemantic]` is the shared
     // authoritative-producer index and must remain immutable across
@@ -1243,6 +1275,252 @@ function deferForMissingDomainPrereqs(
     enqueued = true;
   }
   return enqueued;
+}
+
+/**
+ * #305 Phase 3 — expand a `runtimeEmission` semantic type into a
+ * discover-and-bind sub-chain.
+ *
+ * `runtimeEmission` semantic types declare a discovery operation
+ * (ABox `discoveredVia.operationId`) that surfaces the key at runtime,
+ * gated by `emittedBy.predecessor` (a runtime state) and optional
+ * `emittedBy.guardedBy` capabilities. The discovery op is NOT in
+ * `producersByType[target]` — the authoritative-producer index only
+ * carries statically-annotated providers — so the producer loop would
+ * otherwise dead-end on this semantic.
+ *
+ * Two branches:
+ *
+ *   - **Defer**: if any required domain state is missing, enqueue
+ *     producers for the missing state(s) (mirrors the body of
+ *     `deferForMissingDomainPrereqs`, sans the
+ *     `providerMap[target]===true` precondition that doesn't apply to
+ *     synthesised producers). The runtimeEmission semantic stays in
+ *     `state.needed`; a later BFS iteration retries once the gates
+ *     surface.
+ *
+ *   - **Apply**: gates satisfied — append the discovery op, add the
+ *     runtimeEmission semantic to `produced`, and mint a `PENDING_BINDING`
+ *     under its canonical var name (the server-extracted value is
+ *     threaded through by the request builder / emitter).
+ *
+ * Returns true when a child state was enqueued (caller skips the
+ * regular producer loop).
+ */
+function expandRuntimeEmission(
+  graph: OperationGraph,
+  targetSemantic: string,
+  decl: NonNullable<NonNullable<OperationGraph['domain']>['semanticTypes']>[string],
+  state: State,
+  seen: Set<string>,
+  queue: State[],
+  endpointOpId: string,
+): boolean {
+  if (!decl.discoveredVia || !decl.emittedBy) return false;
+  const discoveryOpId = decl.discoveredVia.operationId;
+  if (discoveryOpId === endpointOpId) return false;
+  const discoveryNode = graph.operations[discoveryOpId];
+  if (!discoveryNode) return false;
+
+  const requiredDomain = [decl.emittedBy.predecessor, ...(decl.emittedBy.guardedBy ?? [])];
+  const directMissing = requiredDomain.filter((d) => !state.domainStates.has(d));
+
+  // ── Defer branch ──────────────────────────────────────────────────────
+  if (directMissing.length) {
+    const missingAll = gatherDomainPrerequisites(graph, directMissing, state.domainStates);
+    const candidates = new Set<string>();
+    for (const ds of missingAll) {
+      for (const opId of graph.producersByState?.[ds] ?? []) candidates.add(opId);
+    }
+    let enqueued = false;
+    for (const candidateOpId of candidates) {
+      if (candidateOpId === endpointOpId) continue;
+      const candidateNode = graph.operations[candidateOpId];
+      if (!candidateNode) continue;
+      const indexInPath = state.ops.indexOf(candidateOpId);
+      let nextCycle = state.cycle;
+      if (indexInPath !== -1) {
+        if (state.cycle) continue;
+        nextCycle = true;
+      }
+      if (candidateNode.domainRequiresAll?.length) {
+        const m = candidateNode.domainRequiresAll.filter((d) => !state.domainStates.has(d));
+        if (m.length) continue;
+      }
+      if (!hasSatisfiedRequiredInputs(candidateNode, state.produced)) continue;
+
+      const newProduced = new Set(state.produced);
+      const newDomainStates = new Set(state.domainStates);
+      let workingState: State;
+      if (isDeploymentGatewayOp(graph.domain, candidateOpId)) {
+        const workingArtifactsApplied = state.artifactsApplied
+          ? [...state.artifactsApplied]
+          : undefined;
+        const workingBindingsDraft = { ...(state.bindingsDraft || {}) };
+        const workingModelsDraft = state.modelsDraft ? [...state.modelsDraft] : undefined;
+        workingState = {
+          ...state,
+          artifactsApplied: workingArtifactsApplied,
+          bindingsDraft: workingBindingsDraft,
+          modelsDraft: workingModelsDraft,
+        };
+        applyArtifactRuleSelection(
+          graph,
+          candidateNode,
+          workingState,
+          newProduced,
+          newDomainStates,
+        );
+      } else {
+        workingState = state;
+        candidateNode.produces.forEach((s) => {
+          newProduced.add(s);
+        });
+        candidateNode.domainProduces?.forEach((d) => {
+          newDomainStates.add(d);
+        });
+        candidateNode.domainImplicitAdds?.forEach((d) => {
+          newDomainStates.add(d);
+        });
+      }
+
+      const domainAddedNow = [...newDomainStates].filter((d) => !state.domainStates.has(d));
+      if (domainAddedNow.length === 0) continue;
+
+      let prereqFailed = false;
+      for (const d of domainAddedNow) {
+        const rs = graph.domain?.runtimeStates?.[d];
+        if (rs?.requires) {
+          for (const req of rs.requires) {
+            if (!newDomainStates.has(req)) {
+              prereqFailed = true;
+              break;
+            }
+          }
+          if (prereqFailed) break;
+        }
+        const cap = graph.domain?.capabilities?.[d];
+        if (cap?.dependsOn) {
+          for (const dep of cap.dependsOn) {
+            if (!newDomainStates.has(dep)) {
+              prereqFailed = true;
+              break;
+            }
+          }
+          if (prereqFailed) break;
+        }
+      }
+      if (prereqFailed) continue;
+
+      const newNeeded = new Set(state.needed);
+      candidateNode.requires.required.forEach((s) => {
+        newNeeded.add(s);
+      });
+      const newOps = [...state.ops, candidateOpId];
+      const newProductionMap = new Map(state.productionMap);
+      candidateNode.produces.forEach((s) => {
+        if (newProduced.has(s) && !newProductionMap.has(s)) {
+          newProductionMap.set(s, candidateOpId);
+        }
+      });
+      let modelsDraft = workingState.modelsDraft;
+      const bindingsDraft = workingState.bindingsDraft ?? {};
+      if (isDeploymentGatewayOp(graph.domain, candidateOpId) && !modelsDraft) {
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder consumed by the test runtime
+        bindingsDraft.processDefinitionIdVar1 = 'proc_${RANDOM}';
+        modelsDraft = [buildBpmnModelSpec('processDefinitionIdVar1')];
+      }
+      const sig = signature(newOps, newProduced, newNeeded, nextCycle);
+      if (seen.has(sig)) continue;
+      seen.add(sig);
+      queue.push({
+        produced: newProduced,
+        needed: newNeeded,
+        domainStates: newDomainStates,
+        ops: newOps,
+        cycle: nextCycle,
+        productionMap: newProductionMap,
+        modelsDraft,
+        bindingsDraft,
+        providerList: updateProviderList(
+          state.providerList || {},
+          candidateNode,
+          newProductionMap,
+          newProduced,
+        ),
+        artifactsApplied: workingState.artifactsApplied,
+      });
+      enqueued = true;
+    }
+    return enqueued;
+  }
+
+  // ── Apply branch ──────────────────────────────────────────────────────
+  const indexInPath = state.ops.indexOf(discoveryOpId);
+  let nextCycle = state.cycle;
+  if (indexInPath !== -1) {
+    if (state.cycle) return false;
+    nextCycle = true;
+  }
+  // The discovery op's own required semantic inputs (e.g. a search
+  // filter that's actually `required` in the spec) must be available;
+  // otherwise we'd build a chain whose discovery step has a missing
+  // input. Optional filter-by inputs are not enforced here — the
+  // request builder writes a placeholder if absent, and BFS would
+  // otherwise spuriously plan a producer for an opportunistic filter.
+  if (!hasSatisfiedRequiredInputs(discoveryNode, state.produced)) return false;
+
+  const newProduced = new Set(state.produced);
+  discoveryNode.produces.forEach((s) => {
+    newProduced.add(s);
+  });
+  newProduced.add(targetSemantic);
+  const newDomainStates = new Set(state.domainStates);
+  discoveryNode.domainProduces?.forEach((d) => {
+    newDomainStates.add(d);
+  });
+  discoveryNode.domainImplicitAdds?.forEach((d) => {
+    newDomainStates.add(d);
+  });
+  const newNeeded = new Set(state.needed);
+  discoveryNode.requires.required.forEach((s) => {
+    newNeeded.add(s);
+  });
+  const newOps = [...state.ops, discoveryOpId];
+  const newProductionMap = new Map(state.productionMap);
+  if (!newProductionMap.has(targetSemantic)) {
+    newProductionMap.set(targetSemantic, discoveryOpId);
+  }
+  discoveryNode.produces.forEach((s) => {
+    if (newProduced.has(s) && !newProductionMap.has(s)) {
+      newProductionMap.set(s, discoveryOpId);
+    }
+  });
+  const bindingsDraft = { ...(state.bindingsDraft || {}) };
+  const varName = semanticToVarName(targetSemantic, bindingsDraft);
+  if (!bindingsDraft[varName]) bindingsDraft[varName] = PENDING_BINDING;
+
+  const sig = signature(newOps, newProduced, newNeeded, nextCycle);
+  if (seen.has(sig)) return false;
+  seen.add(sig);
+  queue.push({
+    produced: newProduced,
+    needed: newNeeded,
+    domainStates: newDomainStates,
+    ops: newOps,
+    cycle: nextCycle,
+    productionMap: newProductionMap,
+    modelsDraft: state.modelsDraft,
+    bindingsDraft,
+    providerList: updateProviderList(
+      state.providerList || {},
+      discoveryNode,
+      newProductionMap,
+      newProduced,
+    ),
+    artifactsApplied: state.artifactsApplied,
+  });
+  return true;
 }
 
 // Select minimal artifact rules for the deployment-gateway producer based

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -531,8 +531,23 @@ export function generateScenariosForEndpoint(
       targetDecl.discoveredVia &&
       targetDecl.emittedBy
     ) {
-      expandRuntimeEmission(graph, targetSemantic, targetDecl, state, seen, queue, endpointOpId);
-      continue;
+      const expanded = expandRuntimeEmission(
+        graph,
+        targetSemantic,
+        targetDecl,
+        state,
+        seen,
+        queue,
+        endpointOpId,
+      );
+      if (expanded) continue;
+      // Fall through to the regular producer loop when the discovery
+      // chain could not be applied (missing/self-referential discovery
+      // op, discovery op's required inputs not yet satisfied, cycle, or
+      // already-seen successor signature). Without the fall-through the
+      // BFS would `continue` here, drain the queue without enqueuing
+      // anything for `targetSemantic`, and return `unsatisfied` — which
+      // hides a legitimate producer path. (PR #308 review.)
     }
 
     // Shallow-copy the producer list before any local augmentation —

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -727,3 +727,101 @@ describe('planner contracts: variant planner non-overlap producer fallback (#37)
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Fixture: runtimeEmission semantic triggers produce→discover→bind sub-chain
+// (#305 Phase 3 — UserTaskKey pilot)
+// ---------------------------------------------------------------------------
+//
+// A semantic declared `kind: 'runtimeEmission'` must NOT dead-end on the
+// missing-producers check. The planner must:
+//   1. Satisfy the `emittedBy.predecessor` runtime state via the BFS
+//      domain-prereq chain (here: createProcessInstance for
+//      ProcessInstanceExists).
+//   2. Inject the `discoveredVia.operationId` (here: searchUserTasks)
+//      into the chain after the predecessor.
+//   3. Treat the discovery op's response field (`extractKey`) as the
+//      authoritative binding for the runtimeEmission semantic, so the
+//      endpoint-under-test consumes it as a producer-bound var.
+//
+// Before Phase 3 lands the planner classifies `runtimeEmission`-kinded
+// types as `unclassified` (because they have no producers / establishers
+// / external-entity entry) and emits `{ id: 'unsatisfied' }` —
+// reproducing exactly the `updateUserTask` scenario shape today.
+
+const fixtureRuntimeEmissionUserTaskKey: OperationGraph = (() => {
+  const graph = makeGraph([
+    makeOp('createDeployment', {
+      produces: ['ProcessDefinitionKey'],
+      providerMap: { ProcessDefinitionKey: true },
+      domainProduces: ['ProcessDefinitionDeployed', 'ModelHasUserTask'],
+    }),
+    makeOp('createProcessInstance', {
+      required: ['ProcessDefinitionKey'],
+      produces: ['ProcessInstanceKey'],
+      providerMap: { ProcessInstanceKey: true },
+      domainRequiresAll: ['ProcessDefinitionDeployed'],
+      domainProduces: ['ProcessInstanceExists'],
+    }),
+    makeOp('searchUserTasks', {
+      // The runtimeEmission ABox declares this as the discovery op;
+      // the planner injects it from the domain declaration, NOT from
+      // producersByType. So we deliberately leave UserTaskKey OUT of
+      // searchUserTasks.produces — the test will fail differently
+      // (false-positive via producersByType) if the planner relies on
+      // the graph index rather than the ABox declaration.
+      required: [],
+      produces: [],
+    }),
+    makeOp('updateUserTask', {
+      required: ['UserTaskKey'],
+    }),
+  ]);
+  graph.domain = {
+    version: 1,
+    semanticTypes: {
+      UserTaskKey: {
+        kind: 'runtimeEmission',
+        emittedBy: {
+          predecessor: 'ProcessInstanceExists',
+          guardedBy: ['ModelHasUserTask'],
+        },
+        discoveredVia: {
+          operationId: 'searchUserTasks',
+          filterBy: 'processInstanceKey',
+          extractKey: 'userTaskKey',
+          consistency: 'eventual',
+        },
+      },
+    },
+    runtimeStates: {
+      ProcessDefinitionDeployed: { kind: 'state', producedBy: ['createDeployment'] },
+      ProcessInstanceExists: { kind: 'state', producedBy: ['createProcessInstance'] },
+    },
+    capabilities: {
+      ModelHasUserTask: {
+        kind: 'capability',
+        parameter: 'userTaskElementId',
+        producedBy: ['createDeployment'],
+        dependsOn: ['ProcessDefinitionDeployed'],
+      },
+    },
+    identifiers: {},
+  };
+  return graph;
+})();
+
+describe('planner contracts: runtimeEmission semantic produces discover-and-bind chain (#305 Phase 3)', () => {
+  it('plans deploy → createProcessInstance → searchUserTasks → updateUserTask for an endpoint that consumes a runtimeEmission semantic', () => {
+    const collection = plan(fixtureRuntimeEmissionUserTaskKey, 'updateUserTask');
+    expect(collection.unsatisfied).not.toBe(true);
+    expect(collection.scenarios.length).toBeGreaterThan(0);
+    const ops = opIdsOf(collection.scenarios[0]);
+    expect(ops).toEqual([
+      'createDeployment',
+      'createProcessInstance',
+      'searchUserTasks',
+      'updateUserTask',
+    ]);
+  });
+});


### PR DESCRIPTION
Closes the planner wiring for [#305](https://github.com/camunda/api-test-generator/issues/305) Phase 3, building on the TBox (#306) and deployment-as-planner-producer guard (#307) already merged.

## Before / After

**Before:** `updateUserTask` (and siblings) consumed `UserTaskKey` from a synthetic `seedBinding('userTaskKeyVar')` placeholder. The integration test was effectively a no-op even when green.

**After:** the planner plans the real discovery chain:

```
createDeployment(user-task.bpmn)
  → createProcessInstance
  → searchUserTasks  (await-eventually, filter by processInstanceKey)
  → updateUserTask   (userTaskKey extracted from search result)
```

## Planner changes

- `path-analyser/src/bindSemanticInput.ts` — `runtimeEmission` added to the binding classifier (enum + `BoundInput` union + dispatch arm).
- `path-analyser/src/scenarioGenerator.ts` — exempts `runtimeEmission` semantics from the static-missing check; adds `expandRuntimeEmission()` (defer/apply branches mirror `deferForMissingDomainPrereqs` but without the `providerMap[target]===true` guard — by design, the discovery op is not the authoritative producer).
- `path-analyser/src/index.ts` — fixture selector now takes `hardRequiredStates` and does two-tier selection: full required set first; hard subset (semantic `op.requires` ∪ `runtimeEmission.guardedBy`) as fallback. A self-completing BPMN cannot simultaneously contain a user-task element, so correctness wins over hygiene. Guard collection also scans `scenario.operations` so feature/variant scenarios (whose `producedSemanticTypes` is stripped during overlay) still pick the right fixture.

## ABox

- `configs/camunda-oca/ontology/semantics.json` — `UserTaskKey` → `runtimeEmission` with `emittedBy { predecessor: ProcessInstanceExists, guardedBy: [ModelHasUserTask] }` and `discoveredVia { operationId: searchUserTasks, filterBy: processInstanceKey, extractKey: userTaskKey, consistency: eventual }`. New `ModelHasUserTask` capability.
- `configs/camunda-oca/ontology/artifact-kinds.json` — `bpmnProcess.producibleStates` adds `ModelHasUserTask`.
- `configs/camunda-oca/fixtures/deployment-artifacts.json` — new `user-task.bpmn` entry with `providesStates: ["ModelHasUserTask"]`.
- `configs/camunda-oca/fixtures/bpmn/user-task.bpmn` — minimal BPMN (start → zeebe userTask → end).

## Tests (red → green → class-scoped)

- **L2** (`tests/fixtures/planner/planner-contracts.test.ts`): `runtimeEmission semantic types are resolved via discoveredVia chain expansion` — fails on `main`, passes on this branch.
- **L3** (`configs/camunda-oca/regression-invariants.test.ts`): every endpoint consuming a `runtimeEmission` semantic in a required path-param plans a chain whose `discoveredVia.operationId` precedes the consuming op. Class-scoped — protects future `runtimeEmission` promotions automatically.

## Gates

- `npm run lint` ✅
- All five workspace typechecks + `tests/tsconfig.json` ✅
- Pipeline regen ✅ (chain emitted end-to-end; `user-task.bpmn` selected)
- `npm test` ✅ (568 passing, 2 skipped — same baseline as `main`)

## Known follow-up (out of scope)

The `searchUserTasks` body synthesised inside the discovery step still emits top-level filter fields instead of `filter.<field>` nesting. That is a body-builder concern (consumes the same `requestBodySemanticTypes` index as the request-validation suite) and is independent of the planner wiring.

Refs #305.