### PR TITLE
feat: intentional discovery body wrapping (#309 Phase A)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -455,6 +455,157 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
     ).toEqual([]);
   });
 
+  it('every planner-inserted runtimeEmission discovery step has a discoveryIntent and a body shaped exactly { filter: { [filterBy]: <bound> } } (#309 Phase A)', () => {
+    // Class-scoped guard for #309 Phase A. The pre-Phase-A planner
+    // emitted a flat top-level body for the inserted discovery step
+    // (every filter field as a placeholder), so the chain ran but
+    // queried for the wrong entity and the test passed for the wrong
+    // reason. Phase A stamps `discoveryIntent` on the OperationRef
+    // and the body builder emits ONLY the forward-bound filter wrapper.
+    //
+    // What this guards (per the issue #309 design table):
+    //   - The intentional-discovery regime must NEVER share the
+    //     exploratory-search regime's body shape — `{ filter: {
+    //       processInstanceKey: '${processInstanceKeyVar}' } }`, not
+    //     `{ processInstanceKey: '${processInstanceKeyVar}', state: ... }`.
+    //   - `filterBy` MUST resolve to the upstream producer's binding
+    //     (forward-bind), not a synthetic placeholder.
+    //   - User-authored search tests (no discoveryIntent stamped) are
+    //     untouched — they keep whatever shape the generic body builder
+    //     produces (today `{}` for a base-feature scenario).
+    if (!existsSync(FEATURE_SCENARIOS_DIR)) {
+      throw new Error(
+        `Feature-output scenarios directory not found at ${FEATURE_SCENARIOS_DIR}. Run 'npm run testsuite:generate' (or 'npm run pipeline') first.`,
+      );
+    }
+    interface DiscoveryIntentLite {
+      filterBy: string;
+      fromBinding: string;
+      extractKey: string;
+      extractInto: string;
+      consistency: 'eventual' | 'strong';
+    }
+    interface OpRefLite {
+      operationId: string;
+      discoveryIntent?: DiscoveryIntentLite;
+    }
+    interface RequestStepLite {
+      operationId: string;
+      bodyTemplate?: unknown;
+      discoveryIntent?: DiscoveryIntentLite;
+    }
+    interface ScenarioLite {
+      id: string;
+      operations: OpRefLite[];
+      requestPlan?: RequestStepLite[];
+    }
+    interface FileLite {
+      endpoint: { operationId: string };
+      scenarios: ScenarioLite[];
+    }
+    const offenders: { file: string; scenario: string; op: string; reason: string }[] = [];
+    let intentCount = 0;
+    for (const f of readdirSync(FEATURE_SCENARIOS_DIR)) {
+      if (!f.endsWith('-scenarios.json')) continue;
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const file = JSON.parse(readFileSync(join(FEATURE_SCENARIOS_DIR, f), 'utf8')) as FileLite;
+      for (const s of file.scenarios) {
+        for (const op of s.operations) {
+          if (!op.discoveryIntent) continue;
+          intentCount++;
+          const intent = op.discoveryIntent;
+          // Find the matching requestPlan step (must exist; body builder
+          // skips ops without a plan only for GET/DELETE — discovery
+          // ops are POST searches).
+          const step = (s.requestPlan ?? []).find((st) => st.operationId === op.operationId);
+          if (!step) {
+            offenders.push({
+              file: f,
+              scenario: s.id,
+              op: op.operationId,
+              reason: 'discoveryIntent stamped but no matching requestPlan step found',
+            });
+            continue;
+          }
+          if (!step.discoveryIntent) {
+            offenders.push({
+              file: f,
+              scenario: s.id,
+              op: op.operationId,
+              reason:
+                'requestPlan step missing discoveryIntent — body builder bypassed the Phase A branch',
+            });
+            continue;
+          }
+          const body = step.bodyTemplate;
+          if (!body || typeof body !== 'object' || Array.isArray(body)) {
+            offenders.push({
+              file: f,
+              scenario: s.id,
+              op: op.operationId,
+              reason: `bodyTemplate must be a plain object, got ${typeof body}`,
+            });
+            continue;
+          }
+          const bodyObj: Record<string, unknown> = body;
+          const topKeys = Object.keys(bodyObj);
+          if (topKeys.length !== 1 || topKeys[0] !== 'filter') {
+            offenders.push({
+              file: f,
+              scenario: s.id,
+              op: op.operationId,
+              reason: `bodyTemplate must have exactly one top-level key 'filter', got [${topKeys.join(', ')}]`,
+            });
+            continue;
+          }
+          const filterRaw = bodyObj.filter;
+          if (!filterRaw || typeof filterRaw !== 'object' || Array.isArray(filterRaw)) {
+            offenders.push({
+              file: f,
+              scenario: s.id,
+              op: op.operationId,
+              reason: `bodyTemplate.filter must be a plain object, got ${typeof filterRaw}`,
+            });
+            continue;
+          }
+          const filter: Record<string, unknown> = filterRaw;
+          const filterKeys = Object.keys(filter);
+          if (filterKeys.length !== 1 || filterKeys[0] !== intent.filterBy) {
+            offenders.push({
+              file: f,
+              scenario: s.id,
+              op: op.operationId,
+              reason: `bodyTemplate.filter must have exactly one key '${intent.filterBy}', got [${filterKeys.join(', ')}]`,
+            });
+            continue;
+          }
+          const value = filter[intent.filterBy];
+          const expected = `\${${intent.fromBinding}}`;
+          if (value !== expected) {
+            offenders.push({
+              file: f,
+              scenario: s.id,
+              op: op.operationId,
+              reason: `bodyTemplate.filter.${intent.filterBy} must equal '${expected}', got ${JSON.stringify(value)}`,
+            });
+          }
+        }
+      }
+    }
+    // Sanity: this invariant is a no-op without runtimeEmission ABox
+    // entries; with the camunda-oca config there must be at least one
+    // (UserTaskKey × searchUserTasks). A zero here means either the
+    // ABox regressed or the planner stopped stamping the intent.
+    expect(
+      intentCount,
+      'expected at least one stamped discoveryIntent (UserTaskKey via searchUserTasks)',
+    ).toBeGreaterThan(0);
+    expect(
+      offenders,
+      "Every planner-inserted runtimeEmission discovery step must carry a discoveryIntent and a body shaped exactly { filter: { [filterBy]: '${fromBinding}' } }. Per the #309 design table, this is the intentional-discovery regime — it MUST NOT share the exploratory-search regime's flat top-level body shape, and it MUST forward-bind to the upstream producer's binding.",
+    ).toEqual([]);
+  });
+
   it('every endpoint whose only required semantic has a self-sufficient authoritative producer plans at least one chain (#95)', () => {
     // Class-scoped guard against the #95 defect family: the witness
     // implication in graphLoader must not turn an authoritative producer

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -481,8 +481,31 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
         `Feature-output scenarios directory not found at ${FEATURE_SCENARIOS_DIR}. Run 'npm run testsuite:generate' (or 'npm run pipeline') first.`,
       );
     }
+    // Independently identify the runtimeEmission discovery ops from the
+    // ABox so this invariant can fail when a discovery op appears in a
+    // chain *without* the planner having stamped a DiscoveryIntent on
+    // it. Looking only at already-stamped intents would only validate
+    // the body shape — not catch the regression where the stamp itself
+    // is missing.
+    const semanticsPath = join(REPO_ROOT, 'configs', CONFIG_NAME, 'ontology', 'semantics.json');
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const semantics = JSON.parse(readFileSync(semanticsPath, 'utf8')) as {
+      semanticTypes?: Array<{
+        name: string;
+        kind?: string;
+        discoveredVia?: { operationId?: string };
+      }>;
+    };
+    const discoveryOpIds = new Set<string>();
+    for (const t of semantics.semanticTypes ?? []) {
+      if (t.kind === 'runtimeEmission' && t.discoveredVia?.operationId) {
+        discoveryOpIds.add(t.discoveredVia.operationId);
+      }
+    }
+    if (discoveryOpIds.size === 0) return; // no-op until an ABox declares one
     interface DiscoveryIntentLite {
       filterBy: string;
+      fromSemantic: string;
       fromBinding: string;
       extractKey: string;
       extractInto: string;
@@ -512,9 +535,26 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
       if (!f.endsWith('-scenarios.json')) continue;
       // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
       const file = JSON.parse(readFileSync(join(FEATURE_SCENARIOS_DIR, f), 'utf8')) as FileLite;
+      const endpointOpId = file.endpoint.operationId;
       for (const s of file.scenarios) {
         for (const op of s.operations) {
-          if (!op.discoveryIntent) continue;
+          // Phase A only governs planner-inserted discovery steps —
+          // i.e. an ABox runtimeEmission op appearing as a prereq, not
+          // as the endpoint under test (which is the exploratory regime
+          // and uses the generic body builder).
+          const isInsertedDiscovery =
+            discoveryOpIds.has(op.operationId) && op.operationId !== endpointOpId;
+          if (!isInsertedDiscovery) continue;
+          if (!op.discoveryIntent) {
+            offenders.push({
+              file: f,
+              scenario: s.id,
+              op: op.operationId,
+              reason:
+                'planner-inserted runtimeEmission discovery op is missing discoveryIntent stamp — body would fall through to the generic builder (wrong regime)',
+            });
+            continue;
+          }
           intentCount++;
           const intent = op.discoveryIntent;
           // Find the matching requestPlan step (must exist; body builder

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -114,6 +114,9 @@ interface VariantScenarioFile {
 
 let cachedGraph: DependencyGraph | undefined;
 let cachedOperationById: Map<string, OperationNode> | undefined;
+function isPlainRecord(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
 function loadGraph(): DependencyGraph {
   if (cachedGraph) return cachedGraph;
   if (!existsSync(GRAPH_PATH)) {
@@ -538,7 +541,7 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
             continue;
           }
           const body = step.bodyTemplate;
-          if (!body || typeof body !== 'object' || Array.isArray(body)) {
+          if (!isPlainRecord(body)) {
             offenders.push({
               file: f,
               scenario: s.id,
@@ -547,7 +550,7 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
             });
             continue;
           }
-          const bodyObj: Record<string, unknown> = body;
+          const bodyObj = body;
           const topKeys = Object.keys(bodyObj);
           if (topKeys.length !== 1 || topKeys[0] !== 'filter') {
             offenders.push({
@@ -559,7 +562,7 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
             continue;
           }
           const filterRaw = bodyObj.filter;
-          if (!filterRaw || typeof filterRaw !== 'object' || Array.isArray(filterRaw)) {
+          if (!isPlainRecord(filterRaw)) {
             offenders.push({
               file: f,
               scenario: s.id,
@@ -568,7 +571,7 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
             });
             continue;
           }
-          const filter: Record<string, unknown> = filterRaw;
+          const filter = filterRaw;
           const filterKeys = Object.keys(filter);
           if (filterKeys.length !== 1 || filterKeys[0] !== intent.filterBy) {
             offenders.push({

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -662,21 +662,40 @@ function buildRequestPlan(
     // identifier echoes for downstream filters.)
     // Canonical request body synthesis for POST/PUT/PATCH using requestByMediaType
     if (['POST', 'PUT', 'PATCH'].includes(opRef.method)) {
-      const plan = buildRequestBodyFromCanonical(
-        opRef.operationId,
-        scenario,
-        graph,
-        canonical,
-        requestGroupsIndex,
-        isFinal,
-      );
-      if (plan?.kind === 'json') {
-        step.bodyTemplate = plan.template;
+      // #309 Phase A — intentional discovery body wrapping. When the
+      // planner stamped a `discoveryIntent` on this opRef (it's the
+      // inserted runtimeEmission discovery step, e.g. searchUserTasks
+      // for UserTaskKey), emit ONLY the structurally-correct filter
+      // wrapper `{ filter: { [filterBy]: '${fromBinding}' } }` and
+      // skip the generic semantics synthesis pass. The intent guarantees
+      // the upstream producer's binding name (`fromBinding`) was already
+      // bound by an earlier step's extract; this step must therefore
+      // query for *that exact* runtime-emitted entity, not throw a flat
+      // bag of placeholder filters at the server.
+      if (opRef.discoveryIntent) {
+        const intent = opRef.discoveryIntent;
+        step.bodyTemplate = {
+          filter: { [intent.filterBy]: `\${${intent.fromBinding}}` },
+        };
         step.bodyKind = 'json';
-      } else if (plan?.kind === 'multipart') {
-        step.multipartTemplate = plan.template;
-        step.bodyKind = 'multipart';
-        step.expectedDeploymentSlices = plan.expectedSlices;
+        step.discoveryIntent = intent;
+      } else {
+        const plan = buildRequestBodyFromCanonical(
+          opRef.operationId,
+          scenario,
+          graph,
+          canonical,
+          requestGroupsIndex,
+          isFinal,
+        );
+        if (plan?.kind === 'json') {
+          step.bodyTemplate = plan.template;
+          step.bodyKind = 'json';
+        } else if (plan?.kind === 'multipart') {
+          step.multipartTemplate = plan.template;
+          step.bodyKind = 'multipart';
+          step.expectedDeploymentSlices = plan.expectedSlices;
+        }
       }
     }
     if (isFinal && resp?.fields?.length) {

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -9,6 +9,7 @@ import {
 } from './ontology/operationRoles.js';
 import type {
   ArtifactRule,
+  DiscoveryIntent,
   EndpointScenario,
   EndpointScenarioCollection,
   ExtendedGenerationOpts,
@@ -78,6 +79,14 @@ interface State {
   establisherAliasSemantics?: Record<string, string>;
   providerList?: Record<string, string[]>; // semantic -> all providers
   artifactsApplied?: string[]; // artifact rule ids used so far
+  /**
+   * #309 Phase A — opId → DiscoveryIntent stamped by
+   * `expandRuntimeEmission` on the apply branch. Propagated through
+   * every `queue.push` site so the intent survives to scenario
+   * finalisation, where it is attached to the matching `OperationRef`
+   * for downstream body-builder consumption.
+   */
+  discoveryIntents?: Record<string, DiscoveryIntent>;
 }
 
 /*
@@ -329,6 +338,15 @@ export function generateScenariosForEndpoint(
         ...state.ops.map((id) => toRef(graph.operations[id])),
         toRef(endpoint),
       ];
+      // #309 Phase A — attach stamped discovery intents to matching
+      // OperationRefs so downstream materialisation can recognise the
+      // intentional-discovery shape.
+      if (state.discoveryIntents) {
+        for (const ref of opRefs) {
+          const intent = state.discoveryIntents[ref.operationId];
+          if (intent) ref.discoveryIntent = intent;
+        }
+      }
       const producedSemanticTypes = new Set<string>([...state.produced]);
       endpoint.produces.forEach((s) => {
         producedSemanticTypes.add(s);
@@ -506,6 +524,7 @@ export function generateScenariosForEndpoint(
           productionMap: newProductionMap,
           modelsDraft: state.modelsDraft,
           bindingsDraft: state.bindingsDraft,
+          discoveryIntents: state.discoveryIntents,
         });
       }
       continue;
@@ -953,6 +972,7 @@ export function generateScenariosForEndpoint(
           newProduced,
         ),
         artifactsApplied: workingState.artifactsApplied,
+        discoveryIntents: state.discoveryIntents,
       });
     }
   }
@@ -1286,6 +1306,7 @@ function deferForMissingDomainPrereqs(
         newProduced,
       ),
       artifactsApplied: workingState.artifactsApplied,
+      discoveryIntents: state.discoveryIntents,
     });
     enqueued = true;
   }
@@ -1464,6 +1485,7 @@ function expandRuntimeEmission(
           newProduced,
         ),
         artifactsApplied: workingState.artifactsApplied,
+        discoveryIntents: state.discoveryIntents,
       });
       enqueued = true;
     }
@@ -1515,6 +1537,35 @@ function expandRuntimeEmission(
   const varName = semanticToVarName(targetSemantic, bindingsDraft);
   if (!bindingsDraft[varName]) bindingsDraft[varName] = PENDING_BINDING;
 
+  // #309 Phase A — stamp DiscoveryIntent so the body builder emits
+  // `{ filter: { [filterBy]: '${fromBinding}' } }` for this inserted
+  // discovery step instead of the generic top-level scalar shape.
+  // `fromBinding` is resolved by finding the filterBy field's
+  // `requestBodySemantics` entry and converting its semantic to the
+  // standard `<camelLower(sem)>Var` binding name (the same convention
+  // every producer extract / URL-placeholder rewrite uses). Absent
+  // `filterBy` (allowed by the schema) → no intent; falls back to the
+  // generic body builder (rare; Phase A's invariant skips those).
+  let newDiscoveryIntents = state.discoveryIntents;
+  if (decl.discoveredVia.filterBy) {
+    const filterBy = decl.discoveredVia.filterBy;
+    const filterPaths = [`filter.${filterBy}`, filterBy];
+    const filterEntry = (discoveryNode.requestBodySemantics ?? []).find((rb) =>
+      filterPaths.includes(rb.fieldPath),
+    );
+    if (filterEntry) {
+      const fromBinding = `${camelLower(filterEntry.semantic)}Var`;
+      const intent: DiscoveryIntent = {
+        filterBy,
+        fromBinding,
+        extractKey: decl.discoveredVia.extractKey,
+        extractInto: varName,
+        consistency: decl.discoveredVia.consistency ?? 'strong',
+      };
+      newDiscoveryIntents = { ...(state.discoveryIntents ?? {}), [discoveryOpId]: intent };
+    }
+  }
+
   const sig = signature(newOps, newProduced, newNeeded, nextCycle);
   if (seen.has(sig)) return false;
   seen.add(sig);
@@ -1534,6 +1585,7 @@ function expandRuntimeEmission(
       newProduced,
     ),
     artifactsApplied: state.artifactsApplied,
+    discoveryIntents: newDiscoveryIntents,
   });
   return true;
 }

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -338,13 +338,28 @@ export function generateScenariosForEndpoint(
         ...state.ops.map((id) => toRef(graph.operations[id])),
         toRef(endpoint),
       ];
-      // #309 Phase A — attach stamped discovery intents to matching
-      // OperationRefs so downstream materialisation can recognise the
-      // intentional-discovery shape.
+      // #309 Phase A — resolve `fromBinding` from the chain's final
+      // bindings (mirroring `semanticToVarName`'s suffixing convention),
+      // and attach the resolved intent to the matching OperationRef so
+      // downstream materialisation can recognise the intentional-
+      // discovery shape. When multiple producers of the same semantic
+      // are bound in the chain, this picks the latest (`Var2`, `Var3`,
+      // …) rather than the un-suffixed base — matching the var name
+      // the producer auto-derive at `path-analyser/src/index.ts` will
+      // actually allocate for that producer. When the producer is
+      // enqueued via a defer path (which doesn't run the identifier-
+      // heuristic, so bindingsDraft has no entry yet), fall back to
+      // the un-suffixed base — the producer auto-derive will allocate
+      // exactly that name at code-emission time.
       if (state.discoveryIntents) {
+        const finalBindings = state.bindingsDraft ?? {};
         for (const ref of opRefs) {
           const intent = state.discoveryIntents[ref.operationId];
-          if (intent) ref.discoveryIntent = intent;
+          if (!intent) continue;
+          const resolved =
+            findLatestBindingForSemantic(intent.fromSemantic, finalBindings) ??
+            `${camelLower(intent.fromSemantic)}Var`;
+          ref.discoveryIntent = { ...intent, fromBinding: resolved };
         }
       }
       const producedSemanticTypes = new Set<string>([...state.produced]);
@@ -1540,12 +1555,14 @@ function expandRuntimeEmission(
   // #309 Phase A — stamp DiscoveryIntent so the body builder emits
   // `{ filter: { [filterBy]: '${fromBinding}' } }` for this inserted
   // discovery step instead of the generic top-level scalar shape.
-  // `fromBinding` is resolved by finding the filterBy field's
-  // `requestBodySemantics` entry and converting its semantic to the
-  // standard `<camelLower(sem)>Var` binding name (the same convention
-  // every producer extract / URL-placeholder rewrite uses). Absent
-  // `filterBy` (allowed by the schema) → no intent; falls back to the
-  // generic body builder (rare; Phase A's invariant skips those).
+  // Stamping is *eager* here (without resolving `fromBinding`) because
+  // the upstream producer may not have populated bindingsDraft yet at
+  // this BFS frontier. `fromBinding` is resolved later, at scenario
+  // finalisation, using `findLatestBindingForSemantic` against the
+  // final chain's bindings — that mirrors `semanticToVarName`'s
+  // suffixing convention (`Var`, `Var2`, …) so chains with multiple
+  // producers of the same semantic bind to the latest producer rather
+  // than the first.
   let newDiscoveryIntents = state.discoveryIntents;
   if (decl.discoveredVia.filterBy) {
     const filterBy = decl.discoveredVia.filterBy;
@@ -1554,10 +1571,10 @@ function expandRuntimeEmission(
       filterPaths.includes(rb.fieldPath),
     );
     if (filterEntry) {
-      const fromBinding = `${camelLower(filterEntry.semantic)}Var`;
       const intent: DiscoveryIntent = {
         filterBy,
-        fromBinding,
+        fromSemantic: filterEntry.semantic,
+        fromBinding: '', // resolved at finalisation (see attachDiscoveryIntents)
         extractKey: decl.discoveredVia.extractKey,
         extractInto: varName,
         consistency: decl.discoveredVia.consistency ?? 'strong',
@@ -1861,6 +1878,26 @@ function semanticToVarName(semantic: string, existing: Record<string, string>): 
   let i = 2;
   while (existing[base + i]) i++;
   return base + i;
+}
+
+// Mirror of `semanticToVarName` for the *consumer* side: given a semantic
+// for which a binding has already been allocated upstream in the chain,
+// return the latest-allocated var name (`Var`, `Var2`, `Var3`, …) so the
+// discovery step's filter binds to the most recent producer rather than
+// the first. Returns undefined if no binding exists for the semantic.
+function findLatestBindingForSemantic(
+  semantic: string,
+  bindings: Record<string, string>,
+): string | undefined {
+  const base = `${camelLower(semantic)}Var`;
+  if (!(base in bindings)) return undefined;
+  let latest = base;
+  let i = 2;
+  while (base + i in bindings) {
+    latest = base + i;
+    i++;
+  }
+  return latest;
 }
 
 function camelLower(s: string): string {

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -30,6 +30,35 @@ export interface OperationRef {
   method: string;
   path: string;
   eventuallyConsistent?: boolean;
+  /**
+   * #309 Phase A — stamped by `expandRuntimeEmission` on the inserted
+   * runtimeEmission discovery step (e.g. `searchUserTasks` when the
+   * chain is discovering `UserTaskKey`). Carries everything the body
+   * builder needs to emit the structurally-correct filter wrapper —
+   * `{ filter: { [filterBy]: '${fromBinding}' } }` — bound forward
+   * from the upstream producer's binding name. Absent on every other
+   * step (the generic body builder handles those).
+   */
+  discoveryIntent?: DiscoveryIntent;
+}
+
+/**
+ * #309 Phase A — describes a planner-inserted runtimeEmission
+ * discovery step: the upstream producer-binding the filter must
+ * forward-bind to, and the response field that surfaces the
+ * runtime-emitted key. The body builder reads `filterBy` + `fromBinding`
+ * to emit `{ filter: { [filterBy]: '${fromBinding}' } }`; the emitter
+ * reads `extractKey` + `extractInto` (today already derived from
+ * `discoveredVia.extractKey` via the producer auto-derive at
+ * `path-analyser/src/index.ts` ~714, so this field is currently
+ * documentary — Phase A only consumes filterBy + fromBinding).
+ */
+export interface DiscoveryIntent {
+  filterBy: string;
+  fromBinding: string;
+  extractKey: string;
+  extractInto: string;
+  consistency: 'eventual' | 'strong';
 }
 
 export interface OperationNode extends OperationRef {
@@ -420,6 +449,15 @@ export interface RequestStep {
    * graph or the domain sidecar.
    */
   eventualWaitsAfter?: EventualWaitSpec[];
+  /**
+   * #309 Phase A — present on planner-inserted runtimeEmission
+   * discovery steps. When set, `bodyTemplate` was synthesised by the
+   * forward-bind branch (`{ filter: { [filterBy]: '${fromBinding}' } }`),
+   * NOT by `buildRequestBodyFromCanonical`. Carried explicitly so L3
+   * invariants and downstream tooling can recognise the intentional-
+   * discovery shape without re-deriving it.
+   */
+  discoveryIntent?: DiscoveryIntent;
 }
 
 /**

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -52,9 +52,18 @@ export interface OperationRef {
  * `discoveredVia.extractKey` via the producer auto-derive at
  * `path-analyser/src/index.ts` ~714, so this field is currently
  * documentary — Phase A only consumes filterBy + fromBinding).
+ *
+ * `fromSemantic` records which upstream semantic the filter is bound
+ * to (e.g. `ProcessInstanceKey`). The planner stamps it eagerly during
+ * BFS expansion and uses it at scenario finalisation to resolve the
+ * actual `fromBinding` var name from the chain's allocated bindings —
+ * mirroring `semanticToVarName`'s suffixing convention so chains with
+ * multiple producers of the same semantic bind to the latest one
+ * rather than always assuming the un-suffixed base name.
  */
 export interface DiscoveryIntent {
   filterBy: string;
+  fromSemantic: string;
   fromBinding: string;
   extractKey: string;
   extractInto: string;

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -854,6 +854,7 @@ describe('planner contracts: discoveryIntent stamped on inserted runtimeEmission
     expect(discoveryRef).toBeDefined();
     expect(discoveryRef?.discoveryIntent).toEqual({
       filterBy: 'processInstanceKey',
+      fromSemantic: 'ProcessInstanceKey',
       fromBinding: 'processInstanceKeyVar',
       extractKey: 'userTaskKey',
       extractInto: 'userTaskKeyVar',

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -32,6 +32,7 @@ interface NodeOpts {
   optionalSubShapes?: OperationNode['optionalSubShapes'];
   responseSemanticLeaves?: OperationNode['responseSemanticLeaves'];
   eventuallyConsistent?: boolean;
+  requestBodySemantics?: OperationNode['requestBodySemantics'];
 }
 
 function makeOp(operationId: string, opts: NodeOpts = {}): OperationNode {
@@ -50,6 +51,7 @@ function makeOp(operationId: string, opts: NodeOpts = {}): OperationNode {
     optionalSubShapes: opts.optionalSubShapes,
     responseSemanticLeaves: opts.responseSemanticLeaves,
     eventuallyConsistent: opts.eventuallyConsistent,
+    requestBodySemantics: opts.requestBodySemantics,
   };
 }
 
@@ -772,6 +774,13 @@ const fixtureRuntimeEmissionUserTaskKey: OperationGraph = (() => {
       // the graph index rather than the ABox declaration.
       required: [],
       produces: [],
+      // #309 Phase A — the body builder resolves `fromBinding` by
+      // looking up which semantic the `filterBy` field carries; the
+      // BFS needs that index on the discovery node to stamp a
+      // discoveryIntent on the inserted step.
+      requestBodySemantics: [
+        { semantic: 'ProcessInstanceKey', fieldPath: 'filter.processInstanceKey', required: false },
+      ],
     }),
     makeOp('updateUserTask', {
       required: ['UserTaskKey'],
@@ -823,5 +832,44 @@ describe('planner contracts: runtimeEmission semantic produces discover-and-bind
       'searchUserTasks',
       'updateUserTask',
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture extension: discoveryIntent stamped on the inserted discovery step
+// (#309 Phase A — intentional discovery body wrapping)
+// ---------------------------------------------------------------------------
+//
+// Once Phase 3 puts the discovery op in the chain, Phase A must stamp a
+// `discoveryIntent` on the OperationRef for that step. The body builder
+// reads the intent to emit `{ filter: { [filterBy]: '${fromBinding}' } }`
+// instead of the generic top-level scalar shape — without this the
+// chain runs but the discovery filter is wrong and the test passes for
+// the wrong reason (see #309 issue context).
+describe('planner contracts: discoveryIntent stamped on inserted runtimeEmission discovery step (#309 Phase A)', () => {
+  it('stamps discoveryIntent on the searchUserTasks OperationRef with filterBy + fromBinding + extractKey + consistency', () => {
+    const collection = plan(fixtureRuntimeEmissionUserTaskKey, 'updateUserTask');
+    const scenario = collection.scenarios[0];
+    const discoveryRef = scenario.operations.find((o) => o.operationId === 'searchUserTasks');
+    expect(discoveryRef).toBeDefined();
+    expect(discoveryRef?.discoveryIntent).toEqual({
+      filterBy: 'processInstanceKey',
+      fromBinding: 'processInstanceKeyVar',
+      extractKey: 'userTaskKey',
+      extractInto: 'userTaskKeyVar',
+      consistency: 'eventual',
+    });
+  });
+
+  it('does NOT stamp discoveryIntent on the upstream producer or the endpoint-under-test', () => {
+    const collection = plan(fixtureRuntimeEmissionUserTaskKey, 'updateUserTask');
+    const scenario = collection.scenarios[0];
+    for (const op of scenario.operations) {
+      if (op.operationId === 'searchUserTasks') continue;
+      expect(
+        op.discoveryIntent,
+        `${op.operationId} must not carry discoveryIntent`,
+      ).toBeUndefined();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Planner-inserted `runtimeEmission` discovery steps now emit a structurally-correct filter body bound forward from the upstream producer. For the #305 Phase 3 `UserTask` chain, `searchUserTasks` now emits

```json
{ "filter": { "processInstanceKey": "${processInstanceKeyVar}" } }
```

— the exact entity just produced upstream — instead of a flat bag of placeholders. **Before this change the chain ran but queried for the wrong entity and the test passed for the wrong reason.**

Required for the #305 Phase 4 `UserTask.updateUserTask` read-back suite to actually pass against a live OCA broker (all OCA endpoints reject unknown top-level fields).

## Design

Per the #309 design table, this separates the two structurally-different filter regimes that previously shared the body-builder code path:

|  | Exploratory search (unchanged) | **Intentional discovery (this PR)** |
|---|---|---|
| Origin | User-authored test against `searchUserTasks` | Planner inserted it inside another chain via `discoveredVia` |
| Body shape | Generic builder (today `{}`) | Exactly `{ filter: { [filterBy]: '${fromBinding}' } }` |
| Binding direction | n/a | Forward-bound to upstream producer |

### Implementation

1. **New types**: `DiscoveryIntent` on `OperationRef` and `RequestStep` (`path-analyser/src/types.ts`).
2. **Stamp in planner**: `expandRuntimeEmission` (`scenarioGenerator.ts`) resolves `fromBinding` by looking up the filter field's `requestBodySemantics` entry and converting its semantic to the standard `<camelLower(sem)>Var` binding name (same convention every other binder uses). Intent rides through BFS State on a new `discoveryIntents` map; attached to matching opRef at scenario finalisation.
3. **Body builder branch**: `buildRequestPlan` (`index.ts`) — if `opRef.discoveryIntent` is present, emit the wrapped filter body and skip the generic `buildRequestBodyFromCanonical` synthesis pass. Intent is also stamped on the emitted RequestStep.

## Tests (layered)

- **L2** (`tests/fixtures/planner/planner-contracts.test.ts`): the existing #305 Phase 3 fixture is extended with the filter field's `requestBodySemantics` entry; two new assertions verify the `searchUserTasks` opRef carries the full DiscoveryIntent and no other op in the chain does.
- **L3** (`configs/camunda-oca/regression-invariants.test.ts`): every feature-output scenario whose opRefs include a stamped `discoveryIntent` must have a matching requestPlan step whose `bodyTemplate` is shaped exactly `{ filter: { [filterBy]: '${fromBinding}' } }` — no other top-level keys, no other filter keys, exact var ref. Sanity assertion: at least one stamped intent exists.

All 579 tests pass; lint + typecheck across all 6 workspace tsconfigs clean.

## Out of scope (deferred)

- **Phase B** — extractor filter-site model (operator alternatives `$eq` / `$in[]` / scalar, etc.).
- **Phase C / #168** — setter-chain reuse for user-authored search filter consumers (`clientMintedAttribute` Tag, BusinessId, etc.).
- Advanced filter operators (`$lt`, `$gt`, `$exists`, regex).

Closes #309 Phase A. Sets up Phases B + C as separate PRs.
