### PR TITLE
feat: promote IncidentKey serverEmergent → runtimeEmission (#305 Phase 5a)

### DIFF
--- a/configs/camunda-oca/fixtures/bpmn/incident-script-task.bpmn
+++ b/configs/camunda-oca/fixtures/bpmn/incident-script-task.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_incident_script_task" targetNamespace="http://bpmn.io/schema/bpmn" exporter="api-test-generator" exporterVersion="1.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_incident_script_task" name="Incident-Emitting Script Task Process" isExecutable="true">
+    <bpmn:extensionElements />
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_to_scriptTask</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_to_scriptTask" sourceRef="StartEvent_1" targetRef="ScriptTask_1" />
+    <bpmn:scriptTask id="ScriptTask_1" name="Failing FEEL Assertion">
+      <bpmn:extensionElements>
+        <zeebe:script expression="assert(missingVariable, missingVariable != null)" resultVariable="scriptResult" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_to_scriptTask</bpmn:incoming>
+      <bpmn:outgoing>Flow_to_end</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_to_end" sourceRef="ScriptTask_1" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1" name="End">
+      <bpmn:incoming>Flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_incident_script_task">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ScriptTask_1_di" bpmnElement="ScriptTask_1">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_to_scriptTask_di" bpmnElement="Flow_to_scriptTask">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_to_end_di" bpmnElement="Flow_to_end">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/configs/camunda-oca/fixtures/deployment-artifacts.json
+++ b/configs/camunda-oca/fixtures/deployment-artifacts.json
@@ -30,6 +30,15 @@
       }
     },
     {
+      "kind": "bpmnProcess",
+      "path": "bpmn/incident-script-task.bpmn",
+      "description": "BPMN process with a script task whose FEEL expression `assert(missingVariable, missingVariable != null)` fails on every instance, emitting a single incident deterministically (no timing dependency). Selected for chains whose consumer ops require ModelEmitsIncident (e.g. getIncident discovered via searchIncidents). See #305 Phase 5a.",
+      "providesStates": ["ModelEmitsIncident"],
+      "providesValues": {
+        "ElementId": ["StartEvent_1", "ScriptTask_1", "EndEvent_1"]
+      }
+    },
+    {
       "kind": "form",
       "path": "forms/simple.form",
       "description": "Minimal Camunda form JSON"

--- a/configs/camunda-oca/ontology/artifact-kinds.json
+++ b/configs/camunda-oca/ontology/artifact-kinds.json
@@ -8,7 +8,7 @@
       "name": "bpmnProcess",
       "identifierType": "ProcessDefinitionId",
       "producesStates": ["ProcessDefinitionDeployed"],
-      "producibleStates": ["ModelHasServiceTaskType", "ModelHasUserTask", "ProcessInstanceCompleted"],
+      "producibleStates": ["ModelHasServiceTaskType", "ModelHasUserTask", "ModelEmitsIncident", "ProcessInstanceCompleted"],
       "producesSemantics": ["ProcessDefinitionKey"],
       "deploymentSlices": ["processDefinition"],
       "modelKind": "bpmn",

--- a/configs/camunda-oca/ontology/semantics.json
+++ b/configs/camunda-oca/ontology/semantics.json
@@ -76,15 +76,29 @@
     },
     {
       "name": "IncidentKey",
-      "kind": "serverEmergent",
-      "$comment": "Server-minted lifecycle key for an incident. Incidents emerge from runtime failures during process execution \u2014 no direct create API. Search-filter input only; planner mints a deterministic placeholder. See #162 PR 5."
+      "kind": "runtimeEmission",
+      "emittedBy": {
+        "predecessor": "ProcessInstanceExists",
+        "guardedBy": [
+          "ModelEmitsIncident"
+        ]
+      },
+      "discoveredVia": {
+        "operationId": "searchIncidents",
+        "filterBy": "processInstanceKey",
+        "extractKey": "incidentKey",
+        "consistency": "eventual"
+      },
+      "$comment": "Server-minted lifecycle key for an incident. Emitted after a deployment whose BPMN deterministically fails at runtime (ModelEmitsIncident) reaches the failing element during a process instance run. Discovered via searchIncidents filtered by processInstanceKey; eventually consistent (await-eventually). See #305 Phase 5a (promoted from serverEmergent)."
     },
     {
       "name": "UserTaskKey",
       "kind": "runtimeEmission",
       "emittedBy": {
         "predecessor": "ProcessInstanceExists",
-        "guardedBy": ["ModelHasUserTask"]
+        "guardedBy": [
+          "ModelHasUserTask"
+        ]
       },
       "discoveredVia": {
         "operationId": "searchUserTasks",
@@ -119,6 +133,16 @@
     {
       "name": "ModelHasUserTask",
       "parameter": "userTaskElementId",
+      "producedBy": [
+        "createDeployment"
+      ],
+      "dependsOn": [
+        "ProcessDefinitionDeployed"
+      ]
+    },
+    {
+      "name": "ModelEmitsIncident",
+      "parameter": "incidentEmittingElementId",
       "producedBy": [
         "createDeployment"
       ],

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1993,6 +1993,47 @@ describeForThisConfig('bundled-spec invariants: fixture selection by required st
     );
   });
 
+  it('getIncident.feature.spec.ts deploys bpmn/incident-script-task.bpmn and chains searchIncidents → getIncident (#305 Phase 5a)', () => {
+    // Phase 5a promoted IncidentKey serverEmergent → runtimeEmission, gated
+    // by the new ModelEmitsIncident capability. The selector must pick the
+    // new incident-script-task fixture (the only one declaring
+    // providesStates: ['ModelEmitsIncident']) for any chain that consumes
+    // IncidentKey in a required path-param. The chain must also include a
+    // searchIncidents discovery step, an extracted incidentKey binding, and
+    // a getIncident step that consumes the bound key — the same shape as
+    // the UserTaskKey pilot (#305 Phase 3) but for incidents.
+    //
+    // Without the ABox promotion + fixture, getIncident would dead-end on
+    // IncidentKey (synthetic seed only), the emitted spec would have a
+    // single getIncident step seeded with `seedBinding('incidentKeyVar')`,
+    // and the test would be a no-op against any real broker.
+    const spec = join(GENERATED_TESTS_DIR, 'getIncident.feature.spec.ts');
+    if (!existsSync(spec)) {
+      throw new Error(`expected emitted spec ${spec} not found — run 'npm run testsuite:generate'`);
+    }
+    const src = readFileSync(spec, 'utf8');
+    expect(src, 'getIncident must deploy the incident-emitting fixture').toContain(
+      '@@FILE:bpmn/incident-script-task.bpmn',
+    );
+    expect(src, 'getIncident must include searchIncidents discovery step').toContain(
+      "test.step('searchIncidents'",
+    );
+    expect(src, 'getIncident must include getIncident endpoint step').toContain(
+      "test.step('getIncident'",
+    );
+    expect(src, 'getIncident must extract incidentKey from searchIncidents response').toContain(
+      "extractInto(ctx, 'incidentKeyVar', json?.items?.[0]?.incidentKey)",
+    );
+    expect(src, 'getIncident must consume the runtime-discovered incidentKey').toContain(
+      '${ctx.incidentKeyVar',
+    );
+    // Negative: must NOT fall back to seeded-only resolution.
+    expect(
+      src,
+      'getIncident must NOT seed incidentKeyVar — the runtimeEmission chain supplies it',
+    ).not.toContain("seedBinding('incidentKeyVar')");
+  });
+
   it('createProcessInstance.feature.spec.ts deploys bpmn/simple.bpmn (chainCleanupRequires ProcessInstanceCompleted, #249)', () => {
     // #249: createProcessInstance declares
     // `chainCleanupRequires: ["ProcessInstanceCompleted"]` so the

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -874,3 +874,103 @@ describe('planner contracts: discoveryIntent stamped on inserted runtimeEmission
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Fixture: IncidentKey runtimeEmission produces deploy → instance → search
+// → getIncident chain (#305 Phase 5a)
+// ---------------------------------------------------------------------------
+//
+// Mirrors the UserTaskKey pilot fixture but for IncidentKey, gated by the
+// new ModelEmitsIncident capability and discovered via searchIncidents.
+// The L2 guards that the planner machinery applies generically to any
+// runtimeEmission key (not just UserTaskKey) and that #309 Phase A's
+// discoveryIntent stamping carries through with the IncidentKey extract
+// shape.
+const fixtureRuntimeEmissionIncidentKey: OperationGraph = (() => {
+  const graph = makeGraph([
+    makeOp('createDeployment', {
+      produces: ['ProcessDefinitionKey'],
+      providerMap: { ProcessDefinitionKey: true },
+      domainProduces: ['ProcessDefinitionDeployed', 'ModelEmitsIncident'],
+    }),
+    makeOp('createProcessInstance', {
+      required: ['ProcessDefinitionKey'],
+      produces: ['ProcessInstanceKey'],
+      providerMap: { ProcessInstanceKey: true },
+      domainRequiresAll: ['ProcessDefinitionDeployed'],
+      domainProduces: ['ProcessInstanceExists'],
+    }),
+    makeOp('searchIncidents', {
+      required: [],
+      produces: [],
+      requestBodySemantics: [
+        { semantic: 'ProcessInstanceKey', fieldPath: 'filter.processInstanceKey', required: false },
+      ],
+    }),
+    makeOp('getIncident', {
+      required: ['IncidentKey'],
+    }),
+  ]);
+  graph.domain = {
+    version: 1,
+    semanticTypes: {
+      IncidentKey: {
+        kind: 'runtimeEmission',
+        emittedBy: {
+          predecessor: 'ProcessInstanceExists',
+          guardedBy: ['ModelEmitsIncident'],
+        },
+        discoveredVia: {
+          operationId: 'searchIncidents',
+          filterBy: 'processInstanceKey',
+          extractKey: 'incidentKey',
+          consistency: 'eventual',
+        },
+      },
+    },
+    runtimeStates: {
+      ProcessDefinitionDeployed: { kind: 'state', producedBy: ['createDeployment'] },
+      ProcessInstanceExists: { kind: 'state', producedBy: ['createProcessInstance'] },
+    },
+    capabilities: {
+      ModelEmitsIncident: {
+        kind: 'capability',
+        parameter: 'incidentEmittingElementId',
+        producedBy: ['createDeployment'],
+        dependsOn: ['ProcessDefinitionDeployed'],
+      },
+    },
+    identifiers: {},
+  };
+  return graph;
+})();
+
+describe('planner contracts: IncidentKey runtimeEmission discover-and-bind chain (#305 Phase 5a)', () => {
+  it('plans deploy → createProcessInstance → searchIncidents → getIncident for an endpoint that consumes IncidentKey', () => {
+    const collection = plan(fixtureRuntimeEmissionIncidentKey, 'getIncident');
+    expect(collection.unsatisfied).not.toBe(true);
+    expect(collection.scenarios.length).toBeGreaterThan(0);
+    const ops = opIdsOf(collection.scenarios[0]);
+    expect(ops).toEqual([
+      'createDeployment',
+      'createProcessInstance',
+      'searchIncidents',
+      'getIncident',
+    ]);
+  });
+
+  it('stamps discoveryIntent on the searchIncidents OperationRef with IncidentKey extract shape', () => {
+    const collection = plan(fixtureRuntimeEmissionIncidentKey, 'getIncident');
+    const scenario = collection.scenarios[0];
+    const discoveryRef = scenario.operations.find((o) => o.operationId === 'searchIncidents');
+    expect(discoveryRef).toBeDefined();
+    expect(discoveryRef?.discoveryIntent).toEqual({
+      filterBy: 'processInstanceKey',
+      fromSemantic: 'ProcessInstanceKey',
+      fromBinding: 'processInstanceKeyVar',
+      extractKey: 'incidentKey',
+      extractInto: 'incidentKeyVar',
+      consistency: 'eventual',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Promotes `IncidentKey` from `serverEmergent` to `runtimeEmission` so the planner generates a real test chain for `getIncident` instead of a synthetic-seed no-op.

The emitted `getIncident.feature.spec.ts` now chains:

```
createDeployment(incident-script-task.bpmn)
  → createProcessInstance
  → searchIncidents (eventual, filter.processInstanceKey)
  → getIncident (consumes the extracted incidentKey)
```

This is the third runtime-emission key promoted under #305 (after UserTaskKey in Phase 3) and the first under Phase 5. It directly exercises the #305 Phase 3 machinery (`expandRuntimeEmission`) and the #309 Phase A intentional-discovery body wrapping; both apply generically and now flow through IncidentKey for free.

## Why not also `resolveIncident`?

`resolveIncident` is a state transition (POST that flips state to RESOLVED) and doesn't fit the existing `UpdatedFieldVisibleOnReadBack` template. It is deferred to **Phase 5d**, which will introduce a state-observed-after-action template covering `resolveIncident`, `completeJob`, `failJob`, and `throwJobError` (all already producerBound or runtimeEmission-discoverable; the gap is the assertion shape, not the chain).

For the same reason, **no `Incident` row is added to `entity-kinds.json`** — the schema requires `mutators` (minItems 1) and we don't have one yet. `getIncident` emits purely from the runtimeEmission ABox (same path `getUserTask` takes — entity-kinds.UserTask exists only because `updateUserTask` does).

## Changes

- **New BPMN fixture** `configs/camunda-oca/fixtures/bpmn/incident-script-task.bpmn`: start → script task with FEEL expression `assert(missingVariable, missingVariable != null)` → end. The assertion fails on every instance, emitting exactly one incident deterministically (no timing dependency, no external worker required).
- **`semantics.json`**: add `ModelEmitsIncident` capability (producedBy: createDeployment, dependsOn: ProcessDefinitionDeployed); promote `IncidentKey` to runtimeEmission mirroring UserTaskKey shape (emittedBy.predecessor=ProcessInstanceExists, guardedBy: [ModelEmitsIncident]; discoveredVia: searchIncidents/processInstanceKey/incidentKey/eventual).
- **`artifact-kinds.json`**: add `ModelEmitsIncident` to `bpmnProcess.producibleStates` so the chain-feasibility BFS knows some bpmn fixture can deliver it; per-fixture `providesStates` in `deployment-artifacts.json` narrows the selection at emission time.
- **`deployment-artifacts.json`**: register incident-script-task.bpmn with `providesStates: [ModelEmitsIncident]`.

## Tests (layered)

- **L2** (`tests/fixtures/planner/planner-contracts.test.ts`): asserts BFS chain for `getIncident` is `createDeployment → createProcessInstance → searchIncidents → getIncident` with the #309 Phase A `discoveryIntent` stamped (fromSemantic: ProcessInstanceKey, extractKey: incidentKey, extractInto: incidentKeyVar).
- **L3** (`configs/camunda-oca/regression-invariants.test.ts`): asserts the emitted `getIncident.feature.spec.ts` deploys `incident-script-task.bpmn`, chains through `searchIncidents`, extracts `incidentKey`, consumes `ctx.incidentKeyVar`, and does NOT fall back to `seedBinding('incidentKeyVar')` — fails closed on ABox regression.
- Existing class-scoped invariants (lines 362, 461) already exercise IncidentKey generically via the runtimeEmission ABox loop.

## Gate run

```
npm run lint                # clean
npx tsc --noEmit (all 6 tsconfigs)  # clean
npm run testsuite:generate
npm run generate:request-validation
npm test                    # 582 passed | 2 skipped
```

## Refs

- Closes a chunk of #305 (Phase 5a — first true serverEmergent → runtimeEmission promotion after JobKey was correctly ruled out as already producerBound via `activateJobs`).
- Builds on #311 (#305 Phase 4 — `UpdatedFieldVisibleOnReadBack`) and #312 (#309 Phase A — intentional discovery body wrapping). Both apply to the new IncidentKey chain with no further work.