### PR TITLE
feat: state-transition act+verify template (resolveIncident) — #189 / #305 Phase 5d-1

### DIFF
--- a/configs/camunda-oca/ontology/entity-kinds.json
+++ b/configs/camunda-oca/ontology/entity-kinds.json
@@ -144,6 +144,24 @@
       ],
       "fetcher": "getUserTask",
       "description": "#305 Phase 4 — a runtime-emitted user task, identified by its server-minted userTaskKey. UserTasks are not created via a client-facing endpoint; they are emitted as a side-effect of process-instance progression (when a user-task service-task activates). Discovered at planning time via the UserTaskKey runtimeEmission entry (discoveredVia searchUserTasks, post-#308). Mutated in place by updateUserTask (and, in future phases, assignUserTask/unassignUserTask/completeUserTask) and read back via getUserTask. Consumed by the UpdatedFieldVisibleOnReadBack scenario template (#305 Phase 4)."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "Incident",
+      "shape": "runtime-entity",
+      "identifiers": [
+        "IncidentKey"
+      ],
+      "fetcher": "getIncident",
+      "stateField": "state",
+      "transitions": [
+        {
+          "op": "resolveIncident",
+          "from": "ACTIVE",
+          "to": "RESOLVED"
+        }
+      ],
+      "description": "#305 Phase 5d / #189 — a runtime-emitted incident, identified by its server-minted incidentKey. Incidents are not created via a client-facing endpoint; they are emitted as a side-effect of a process instance whose BPMN deterministically fails at runtime (e.g. incident-script-task.bpmn). Discovered at planning time via the IncidentKey runtimeEmission entry (discoveredVia searchIncidents, #305 Phase 5a). The only client-facing state transition on the OCA API is resolveIncident (ACTIVE → RESOLVED); read back via getIncident. Consumed by the StateTransitionVisibleAfterAction scenario template (#305 Phase 5d / #189). No mutators[] today — Incidents do not expose per-field mutators on the public API."
     }
   ]
 }

--- a/configs/camunda-oca/ontology/scenario-templates.json
+++ b/configs/camunda-oca/ontology/scenario-templates.json
@@ -64,6 +64,17 @@
         { "kind": "Invoke", "op": "mutator" },
         { "kind": "Observe", "op": "fetcher", "expect": "fieldEquals" }
       ]
+    },
+    {
+      "@type": "ScenarioTemplate",
+      "name": "StateTransitionVisibleAfterAction",
+      "appliesTo": { "kind": "RuntimeEntity" },
+      "description": "#305 Phase 5d / #189 — for every runtime-emitted entity that declares one or more `transitions[]` and a `stateField` (shape: 'runtime-entity'), emit one scenario per transition that: (1) establishes the prerequisite chain for the transition op (which includes discovering the runtime entity via its runtimeEmission, e.g. IncidentKey via searchIncidents), (2) invokes the transition op (whose request body carries no per-field update — the post-state is implicit in the op semantics, e.g. resolveIncident flips Incident.state from ACTIVE to RESOLVED), (3) re-reads the entity via the fetcher (GET-by-id) and asserts a single equality `body.<stateField> === transition.to`. The expected value comes from the ABox row's `transitions[].to`; the state field is named explicitly by `stateField`. Pre-state (`transition.from`) is informational only — the planner's chain guarantees the entity is in `from` at invoke time (e.g. searchIncidents only ever surfaces ACTIVE incidents). Closes the state-machine-transition test gap for runtime entities whose only client-facing mutation is a state flip (no per-field mutator).",
+      "steps": [
+        { "kind": "PrereqChain", "for": "transition" },
+        { "kind": "Invoke", "op": "transition" },
+        { "kind": "Observe", "op": "fetcher", "expect": "stateEquals" }
+      ]
     }
   ]
 }

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -4804,7 +4804,7 @@ describeForThisConfig('bundled-spec invariants: entity-kinds ABox cross-referenc
     // (e.g. server-minted resources whose existence is only implied by
     // path-param conventions). These are deliberate ABox-only entries
     // and must not trip the spec-vs-abox drift check.
-    const ABOX_AUTHORITATIVE_KINDS = new Set(['Authorization', 'Document', 'UserTask']);
+    const ABOX_AUTHORITATIVE_KINDS = new Set(['Authorization', 'Document', 'UserTask', 'Incident']);
     const unaccounted = aboxOnly.filter((n) => !ABOX_AUTHORITATIVE_KINDS.has(n));
     expect(
       unaccounted,
@@ -7057,8 +7057,11 @@ describeForThisConfig(
       // against the runtime-entity ABox fields `mutators[]` (plural,
       // referenced symbolically as `mutator` from steps) and
       // `fetcher`. The compiler fans `mutator` out to one scenario
-      // per entry at instantiation time.
-      const RUNTIME_ENTITY_ROLES = new Set(['mutator', 'fetcher']);
+      // per entry at instantiation time. #305 Phase 5d / #189 adds
+      // `transition` for the StateTransitionVisibleAfterAction
+      // template, which fans `transition` out to one scenario per
+      // `transitions[]` entry.
+      const RUNTIME_ENTITY_ROLES = new Set(['mutator', 'fetcher', 'transition']);
       const offenders: string[] = [];
       for (const tpl of templates.templates) {
         const validRoles =
@@ -7084,7 +7087,7 @@ describeForThisConfig(
         `Every template step's role reference must resolve to a known field on its appliesTo subject ABox. ` +
           `For 'Edge' subjects, valid roles are: establishedBy, revokedBy, observableVia. ` +
           `For 'Entity' subjects, valid roles are: establishedBy, revokedBy, observableVia. ` +
-          `For 'RuntimeEntity' subjects, valid roles are: mutator, fetcher.`,
+          `For 'RuntimeEntity' subjects, valid roles are: mutator, fetcher, transition.`,
       ).toEqual([]);
     });
 
@@ -8034,6 +8037,162 @@ describeForThisConfig(
         }
       }
       expect(offenders).toEqual([]);
+    });
+  },
+);
+
+// ===========================================================================
+// #305 Phase 5d / #189 — StateTransitionVisibleAfterAction RuntimeEntity
+// scenarios.
+//
+// Same shape as the Phase 4 readback invariants above: skip when the
+// template emitted nothing for this config (no runtime-entity ABox row
+// with transitions[]), otherwise assert structural well-formedness of
+// the compiled scenarios AND the emitted Playwright spec for the
+// `resolveIncident` first-slice. Future transitions (completeJob,
+// completeUserTask, cancelProcessInstance, …) drop into the same
+// guard as soon as their ABox rows land.
+// ===========================================================================
+describeForThisConfig(
+  'bundled-spec invariants: StateTransitionVisibleAfterAction scenarios (#305 Phase 5d / #189)',
+  () => {
+    const STATE_TRANSITION_DIR = join(
+      SCENARIOS_DIR,
+      'templates',
+      'StateTransitionVisibleAfterAction',
+    );
+
+    interface StateTransitionFile {
+      templateName: string;
+      subjectName: string;
+      subjectKind: string;
+      scenario: {
+        steps: Array<{
+          kind: string;
+          operationId?: string;
+          assertion?: {
+            kind: string;
+            responseBodyPath?: string[];
+            expectedState?: string;
+            fromState?: string;
+            transitionOp?: string;
+          };
+        }>;
+      };
+    }
+
+    function loadAll(): { file: string; data: StateTransitionFile }[] {
+      if (!existsSync(STATE_TRANSITION_DIR)) return [];
+      const out: { file: string; data: StateTransitionFile }[] = [];
+      for (const f of readdirSync(STATE_TRANSITION_DIR)) {
+        if (!f.endsWith('.json')) continue;
+        // biome-ignore lint/plugin: runtime contract boundary for parsed pipeline JSON
+        const data = JSON.parse(
+          readFileSync(join(STATE_TRANSITION_DIR, f), 'utf8'),
+        ) as StateTransitionFile;
+        out.push({ file: f, data });
+      }
+      return out;
+    }
+
+    it('every emitted scenario has the canonical 3-step shape (prereqChain → invoke → observe.stateEquals)', () => {
+      const all = loadAll();
+      if (all.length === 0) return;
+      const offenders: string[] = [];
+      for (const { file, data } of all) {
+        const kinds = data.scenario.steps.map((s) => s.kind);
+        if (
+          kinds.length !== 3 ||
+          kinds[0] !== 'prereqChain' ||
+          kinds[1] !== 'invoke' ||
+          kinds[2] !== 'observe'
+        ) {
+          offenders.push(
+            `${file}: expected [prereqChain, invoke, observe], got ${JSON.stringify(kinds)}`,
+          );
+          continue;
+        }
+        const observe = data.scenario.steps[2];
+        if (observe.assertion?.kind !== 'stateEquals') {
+          offenders.push(
+            `${file}: observe.assertion.kind expected 'stateEquals', got '${observe.assertion?.kind}'`,
+          );
+        }
+      }
+      expect(offenders).toEqual([]);
+    });
+
+    it("every stateEquals assertion's responseBodyPath is a live 200-response leaf of the fetcher", () => {
+      const all = loadAll();
+      if (all.length === 0) return;
+      // biome-ignore lint/plugin: runtime contract boundary for parsed pipeline JSON
+      const graph = JSON.parse(readFileSync(GRAPH_PATH, 'utf8')) as {
+        operationsById?: Record<string, { responseLeafPaths?: Record<string, string[]> }>;
+      };
+      const opsById = graph.operationsById ?? {};
+      const offenders: string[] = [];
+      for (const { file, data } of all) {
+        const observe = data.scenario.steps[2];
+        const fetcherOpId = observe.operationId;
+        if (typeof fetcherOpId !== 'string') {
+          offenders.push(`${file}: observe.operationId missing`);
+          continue;
+        }
+        const liveLeaves = new Set(opsById[fetcherOpId]?.responseLeafPaths?.['200'] ?? []);
+        if (liveLeaves.size === 0) {
+          offenders.push(
+            `${file}: fetcher='${fetcherOpId}' has no 2xx responseLeafPaths in the graph`,
+          );
+          continue;
+        }
+        const path = observe.assertion?.responseBodyPath;
+        if (!Array.isArray(path) || path.length === 0) {
+          offenders.push(`${file}: stateEquals.responseBodyPath must be non-empty`);
+          continue;
+        }
+        const dotted = path.join('.');
+        if (!liveLeaves.has(dotted)) {
+          offenders.push(
+            `${file}: stateEquals.responseBodyPath '${dotted}' is not a live 200-response leaf of '${fetcherOpId}'`,
+          );
+        }
+      }
+      expect(offenders).toEqual([]);
+    });
+
+    it('every stateEquals assertion carries non-empty fromState, expectedState, and transitionOp', () => {
+      const all = loadAll();
+      if (all.length === 0) return;
+      const offenders: string[] = [];
+      for (const { file, data } of all) {
+        const a = data.scenario.steps[2].assertion;
+        if (a?.kind !== 'stateEquals') continue;
+        if (!a.fromState) offenders.push(`${file}: stateEquals.fromState missing`);
+        if (!a.expectedState) offenders.push(`${file}: stateEquals.expectedState missing`);
+        if (!a.transitionOp) offenders.push(`${file}: stateEquals.transitionOp missing`);
+      }
+      expect(offenders).toEqual([]);
+    });
+
+    it('Incident.resolveIncident slice: emitted Playwright spec asserts state === RESOLVED via getIncident read-back', () => {
+      const specPath = join(
+        GENERATED_TESTS_DIR,
+        'state-transitions',
+        'Incident.resolveIncident.lifecycle.spec.ts',
+      );
+      if (!existsSync(specPath)) {
+        return;
+      }
+      const src = readFileSync(specPath, 'utf8');
+      const required = [
+        "operationId: 'getIncident'",
+        "operationId: 'searchIncidents'",
+        '/resolution',
+        ".state).toEqual('RESOLVED')",
+        'incident-script-task.bpmn',
+      ];
+      const missing = required.filter((needle) => !src.includes(needle));
+      expect(missing).toEqual([]);
     });
   },
 );

--- a/materializer/src/index.ts
+++ b/materializer/src/index.ts
@@ -557,6 +557,21 @@ async function run() {
         globalContextSeeds: seedsArg,
       });
       lifecycleCount += runtimeWritten.length;
+
+      // #305 Phase 5d / #189 — StateTransitionVisibleAfterAction
+      // (RuntimeEntity). Sibling subdir to runtime-entities/ so the
+      // two RuntimeEntity-scoped templates don't fight over file
+      // names (Incident.resolveIncident is a state-transition;
+      // future Incident.mutateIncident — if ever — would be a
+      // readback, separate file in runtime-entities/).
+      const stateTransitionOutDir = path.join(outDir, 'state-transitions');
+      await fs.rm(stateTransitionOutDir, { recursive: true, force: true });
+      const stateTransitionWritten = await emitTemplateSuites({
+        scenariosDir: getTemplateScenariosDir(repoRoot, 'StateTransitionVisibleAfterAction'),
+        outDir: stateTransitionOutDir,
+        globalContextSeeds: seedsArg,
+      });
+      lifecycleCount += stateTransitionWritten.length;
     }
     console.log(
       `Generated test suites for ${count} endpoints (+${variantCount} variant suites, +${lifecycleCount} lifecycle suites) in ${outDir} (target: ${emitter.id})`,

--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -146,7 +146,31 @@ function renderLifecycleSuite(
   // a syntactically valid spec that secretly elides a step.
   const subjectKind = file.subjectKind;
   if (subjectKind === 'RuntimeEntity') {
-    return renderReadBackSuite(file, globalContextSeeds);
+    // RuntimeEntity templates share the 3-step shape but differ on the
+    // observe step's assertion kind: `fieldEquals` (#305 Phase 4,
+    // UpdatedFieldVisibleOnReadBack) vs `stateEquals` (#305 Phase 5d /
+    // #189, StateTransitionVisibleAfterAction). Dispatch on the third
+    // step's assertion kind so each render path is self-contained.
+    if (steps.length !== 3) {
+      throw new Error(
+        `RuntimeEntity template ${file.subjectName} must have exactly 3 steps; got ${steps.length}.`,
+      );
+    }
+    const observe = steps[2];
+    if (observe.kind !== 'observe') {
+      throw new Error(
+        `RuntimeEntity template ${file.subjectName} step 2 must be an observe step (got '${observe.kind}').`,
+      );
+    }
+    if (observe.assertion.kind === 'fieldEquals') {
+      return renderReadBackSuite(file, globalContextSeeds);
+    }
+    if (observe.assertion.kind === 'stateEquals') {
+      return renderStateTransitionSuite(file, globalContextSeeds);
+    }
+    throw new Error(
+      `RuntimeEntity template ${file.subjectName} observe.assertion.kind must be 'fieldEquals' or 'stateEquals' (got '${observe.assertion.kind}').`,
+    );
   }
   if (subjectKind !== 'Edge' && subjectKind !== 'Entity') {
     throw new Error(
@@ -169,6 +193,7 @@ function renderLifecycleSuite(
   if (
     observePresent.kind !== 'observe' ||
     observePresent.assertion.kind === 'fieldEquals' ||
+    observePresent.assertion.kind === 'stateEquals' ||
     observePresent.assertion.expect !== 'present'
   ) {
     throw new Error(`Step 2 of ${file.subjectName} must be a present-observe step.`);
@@ -179,6 +204,7 @@ function renderLifecycleSuite(
   if (
     observeAbsent.kind !== 'observe' ||
     observeAbsent.assertion.kind === 'fieldEquals' ||
+    observeAbsent.assertion.kind === 'stateEquals' ||
     observeAbsent.assertion.expect !== 'absent'
   ) {
     throw new Error(`Step 4 of ${file.subjectName} must be an absent-observe step.`);
@@ -753,6 +779,182 @@ function appendObserveFieldEqualsStep(
   }
 }
 
+// ---------------------------------------------------------------------------
+// #305 Phase 5d / #189 — StateTransitionVisibleAfterAction render path
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a 3-step `StateTransitionVisibleAfterAction` template
+ * scenario (per Incident.resolveIncident, etc.):
+ *   1. prereqChain inline (establish the runtime entity + bind its id,
+ *      typically deploy → createProcessInstance → searchIncidents)
+ *   2. invoke (transition op, e.g. resolveIncident)
+ *   3. observe (fetcher; assert body.<stateField> === expectedState)
+ *
+ * Parallel to {@link renderReadBackSuite}; differs only in the
+ * observe step's assertion shape — `stateEquals` reads the expected
+ * value from the assertion itself rather than the mutator body.
+ */
+function renderStateTransitionSuite(
+  file: TemplateScenarioFile,
+  globalContextSeeds: readonly TemplateGlobalContextSeed[],
+): string {
+  const scenario = file.scenario;
+  const steps = scenario.steps;
+  if (steps.length !== 3) {
+    throw new Error(
+      `StateTransitionVisibleAfterAction template ${file.subjectName} must have exactly 3 steps; got ${steps.length}.`,
+    );
+  }
+  const [prereq, transition, observe] = steps;
+  if (prereq.kind !== 'prereqChain') {
+    throw new Error(`Step 0 of ${file.subjectName} must be a prereqChain step.`);
+  }
+  if (transition.kind !== 'invoke') {
+    throw new Error(`Step 1 of ${file.subjectName} must be an invoke step.`);
+  }
+  if (observe.kind !== 'observe' || observe.assertion.kind !== 'stateEquals') {
+    throw new Error(
+      `Step 2 of ${file.subjectName} must be an observe step with assertion.kind='stateEquals'.`,
+    );
+  }
+  const allRequestSteps: RequestStep[] = [
+    ...prereq.requestPlan,
+    transition.requestPlan,
+    observe.requestPlan,
+  ];
+  const ecOps = new Set<string>(scenario.eventuallyConsistentOps ?? []);
+  const needsExtractInto = allRequestSteps.some((rp) => (rp.extract?.length ?? 0) > 0);
+  const needsAwaitEventually =
+    allRequestSteps.some((rp) => (rp.eventualWaitsAfter?.length ?? 0) > 0) ||
+    allRequestSteps.some((rp) => stepNeedsAwaitForOp(rp, ecOps)) ||
+    ecOps.has(observe.operationId);
+  const needsResolveFixture = allRequestSteps.some(
+    (rp) => rp.bodyKind === 'multipart' && !!rp.multipartTemplate,
+  );
+
+  const lines: string[] = [];
+  lines.push("import { expect, test } from '@playwright/test';");
+  lines.push("import { authHeaders, buildBaseUrl } from '../support/env';");
+  const seedingImports = ['initSpecSalt', 'seedBinding'];
+  if (needsExtractInto) seedingImports.push('extractInto');
+  lines.push(`import { ${seedingImports.join(', ')} } from '../support/seeding';`);
+  if (needsAwaitEventually) {
+    lines.push("import { awaitEventually } from '../support/await-eventually';");
+  }
+  if (needsResolveFixture) {
+    lines.push("import { resolveFixture } from '../support/fixtures';");
+  }
+  lines.push('');
+  lines.push(`initSpecSalt('${file.subjectName}.state-transition');`);
+  lines.push('');
+  const fromTo = `${observe.assertion.fromState} → ${observe.assertion.expectedState}`;
+  lines.push(`test.describe('${file.subjectName} state transition (${fromTo})', () => {`);
+  lines.push(
+    `  test('invoke ${transition.operationId}, observe state=${observe.assertion.expectedState} on read-back', async ({ request }) => {`,
+  );
+  lines.push('    const baseUrl = buildBaseUrl();');
+  lines.push('    const ctx: Record<string, unknown> = {};');
+
+  lines.push(
+    ...emitCtxSeeding({
+      indent: '    ',
+      bindings: prereq.bindings,
+      seedBindings: prereq.seedBindings,
+      globalContextSeeds,
+    }),
+  );
+
+  let stepIdx = 0;
+  for (const rp of prereq.requestPlan) {
+    lines.push('');
+    appendInlineRequestStep(lines, rp, stepIdx, `prereq: ${rp.operationId}`, ecOps);
+    stepIdx++;
+  }
+
+  lines.push('');
+  appendInlineRequestStep(
+    lines,
+    transition.requestPlan,
+    stepIdx,
+    `invoke (transition): ${transition.operationId}`,
+    ecOps,
+  );
+  stepIdx++;
+
+  lines.push('');
+  appendObserveStateEqualsStep(
+    lines,
+    observe,
+    stepIdx,
+    `observe (read-back): ${observe.operationId}`,
+    ecOps,
+  );
+
+  lines.push('  });');
+  lines.push('});');
+  lines.push('');
+  return lines.join('\n');
+}
+
+/**
+ * Render an observe step whose assertion is `stateEquals`. Reads the
+ * fetcher's 200 response and asserts a single equality on the named
+ * state field against the literal `expectedState` from the assertion.
+ */
+function appendObserveStateEqualsStep(
+  lines: string[],
+  step: ObserveStep,
+  idx: number,
+  label: string,
+  ecOps: ReadonlySet<string>,
+): void {
+  if (step.assertion.kind !== 'stateEquals') {
+    throw new Error(
+      `appendObserveStateEqualsStep called with assertion.kind='${step.assertion.kind}'`,
+    );
+  }
+  const respVar = `resp${idx + 1}`;
+  const urlExpr = buildUrlExpression(step.requestPlan.pathTemplate);
+  const method = step.requestPlan.method.toLowerCase();
+  const isEC = ecOps.has(step.operationId);
+  lines.push(`    await test.step('${escapeQuotes(label)}', async () => {`);
+  if (isEC) {
+    lines.push(`      const url = baseUrl + ${urlExpr};`);
+    lines.push(`      const ${respVar} = await awaitEventually(`);
+    lines.push(`        async () => request.${method}(url, { headers: await authHeaders() }),`);
+    lines.push(`        {`);
+    lines.push(`          method: '${step.requestPlan.method.toUpperCase()}',`);
+    lines.push(`          operationId: '${step.operationId}',`);
+    lines.push(`        },`);
+    lines.push(`      );`);
+  } else {
+    const inline = renderInlineStepLines({
+      step: step.requestPlan,
+      idx,
+      varName: respVar,
+      urlExpr,
+      method,
+      shouldAwaitEventually: false,
+    });
+    for (const line of reindent(inline, EXTRA_INDENT)) lines.push(line);
+  }
+  lines.push(`      if (${respVar}.status() !== 200) {`);
+  lines.push(`        try { console.error('Response body:', await ${respVar}.text()); } catch {}`);
+  lines.push('      }');
+  lines.push(`      expect(${respVar}.status()).toBe(200);`);
+  lines.push(`      const __body = await ${respVar}.json();`);
+  const accessExpr = buildOptionalAccessChain(
+    '__body',
+    stripArrayMarkers(step.assertion.responseBodyPath),
+  );
+  const literal = JSON.stringify(step.assertion.expectedState);
+  lines.push(`      expect(${accessExpr}).toEqual(${literal});`);
+  lines.push('    });');
+  for (const wait of step.requestPlan.eventualWaitsAfter ?? []) {
+    appendEventualWait(lines, wait, idx);
+  }
+}
 /**
  * Walk `body` along `path` (object property names) and return the
  * primitive/array value at that leaf, or `undefined` if any segment

--- a/ontology/vocabulary/entity-kinds.schema.json
+++ b/ontology/vocabulary/entity-kinds.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://camunda.github.io/api-test-generator/ns/v1/entity-kinds.schema.json",
   "title": "Entity-kinds ABox (api-test-generator ontology, v1)",
-  "description": "TBox JSON Schema for an ABox file describing the entity kinds (the domain nouns) of a single API. Each entry asserts: an entity kind exists; it has one of three shapes (`entity` for in-API-managed with full CRUD, `external-entity` for identifiers minted outside the API, `runtime-entity` for entities emitted by the runtime as a side-effect of other operations); and a list of semantic identifier-type names that identify it. `shape: \"entity\"` kinds carry an all-or-nothing CRUD triple (`establishedBy`/`observableVia`/`revokedBy`) consumed by the EntityLifecycle scenario template (#280) — asymmetric subsets surface as ABox-load validation errors. `shape: \"external-entity\"` kinds (e.g. Client) must NOT carry the CRUD triple. `shape: \"runtime-entity\"` kinds (#305 Phase 4, e.g. UserTask) carry `mutators[]` plus a single `fetcher` consumed by the `UpdatedFieldVisibleOnReadBack` template; the if/then/else below enforces that runtime-entity kinds carry mutators+fetcher and that entity/external-entity kinds do NOT. The schema is intentionally agnostic to which API ships the kinds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/entity-kinds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (kind names appearing in operation `produces[]`/`requires[]`, identifier types being live, CRUD op methods being POST/GET/DELETE, etc.) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them.",
+  "description": "TBox JSON Schema for an ABox file describing the entity kinds (the domain nouns) of a single API. Each entry asserts: an entity kind exists; it has one of three shapes (`entity` for in-API-managed with full CRUD, `external-entity` for identifiers minted outside the API, `runtime-entity` for entities emitted by the runtime as a side-effect of other operations); and a list of semantic identifier-type names that identify it. `shape: \"entity\"` kinds carry an all-or-nothing CRUD triple (`establishedBy`/`observableVia`/`revokedBy`) consumed by the EntityLifecycle scenario template (#280) — asymmetric subsets surface as ABox-load validation errors. `shape: \"external-entity\"` kinds (e.g. Client) must NOT carry the CRUD triple. `shape: \"runtime-entity\"` kinds (#305 Phase 4 / Phase 5d, e.g. UserTask, Incident) carry a `fetcher` plus at least one of `mutators[]` (consumed by `UpdatedFieldVisibleOnReadBack`) or `transitions[]` + `stateField` (consumed by `StateTransitionVisibleAfterAction`, #189); the if/then/else below enforces that runtime-entity kinds carry the required combination and that entity/external-entity kinds carry none of these. The schema is intentionally agnostic to which API ships the kinds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/entity-kinds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (kind names appearing in operation `produces[]`/`requires[]`, identifier types being live, CRUD op methods being POST/GET/DELETE, etc.) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -61,7 +61,7 @@
             "external-entity",
             "runtime-entity"
           ],
-          "description": "`entity`: in-API-managed (producer + consumer ops both inside the API). `external-entity`: identifier minted outside the API; planner treats `identifiers[]` as `externalBoundary` (client-mintable, no upstream producer required). `runtime-entity` (#305 Phase 4): entity emitted by the runtime as a side-effect of another operation (e.g. UserTask from a process instance); discovered via runtimeEmission, mutated in place, and re-read via `mutators[]` + `fetcher` consumed by the `UpdatedFieldVisibleOnReadBack` template."
+          "description": "`entity`: in-API-managed (producer + consumer ops both inside the API). `external-entity`: identifier minted outside the API; planner treats `identifiers[]` as `externalBoundary` (client-mintable, no upstream producer required). `runtime-entity` (#305 Phase 4 / Phase 5d): entity emitted by the runtime as a side-effect of another operation (e.g. UserTask from a process instance, Incident from a failing process instance); discovered via runtimeEmission and re-read via `fetcher`. Carries `mutators[]` (consumed by `UpdatedFieldVisibleOnReadBack`) and/or `transitions[]`+`stateField` (consumed by `StateTransitionVisibleAfterAction`, #189)."
         },
         "identifiers": {
           "type": "array",
@@ -94,12 +94,25 @@
             "type": "string",
             "minLength": 1
           },
-          "description": "#305 Phase 4 — operationIds of operations that mutate the runtime entity in place (e.g. `updateUserTask`, `assignUserTask`, `completeUserTask` for `UserTask`). Conventionally a `PATCH`/`POST`/`DELETE` on a sub-resource of the entity's identifier (`/{id}/...`). Required on `shape: \"runtime-entity\"`; forbidden on `shape: \"entity\"` and `shape: \"external-entity\"`. The `UpdatedFieldVisibleOnReadBack` template emits one scenario per mutator."
+          "description": "#305 Phase 4 — operationIds of operations that mutate the runtime entity in place (e.g. `updateUserTask`, `assignUserTask`, `completeUserTask` for `UserTask`). Conventionally a `PATCH`/`POST`/`DELETE` on a sub-resource of the entity's identifier (`/{id}/...`). Optional on `shape: \"runtime-entity\"` (the row must carry `mutators[]` or `transitions[]` or both — see the runtime-entity branch of the allOf below); forbidden on `shape: \"entity\"` and `shape: \"external-entity\"`. The `UpdatedFieldVisibleOnReadBack` template emits one scenario per mutator."
+        },
+        "transitions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/StateTransition"
+          },
+          "description": "#305 Phase 5d / #189 — server-driven state transitions for this runtime entity. Each entry names the operationId of a transition op (e.g. `resolveIncident`), the state the entity is expected to be in *before* the transition is invoked (e.g. `ACTIVE`), and the state it is expected to be in *after* (e.g. `RESOLVED`). Transition ops are distinguished from mutators by carrying no per-field update in the request body — the post-state is implicit in the operation semantics. Consumed by the `StateTransitionVisibleAfterAction` scenario template (one scenario per transition: prereqChain → invoke transition → re-fetch via `fetcher` → assert `<stateField>` equals `to`). Optional on `shape: \"runtime-entity\"` (the row must carry `mutators[]` or `transitions[]` or both); when present, `stateField` is required so the template knows which response leaf to read."
+        },
+        "stateField": {
+          "type": "string",
+          "minLength": 1,
+          "description": "#305 Phase 5d / #189 — name of the leaf in the `fetcher`'s 200 response that carries this entity's current state (almost always `\"state\"`). Required when `transitions[]` is present (the `StateTransitionVisibleAfterAction` template asserts `body.<stateField> === transition.to`). Forbidden when `transitions[]` is absent (would have no consumer). The L3 invariant verifies the named leaf actually appears in the fetcher's `responseLeafPaths[\"200\"]`."
         },
         "fetcher": {
           "type": "string",
           "minLength": 1,
-          "description": "#305 Phase 4 — operationId of the canonical read-back operation for this runtime entity (e.g. `getUserTask` for `UserTask`). Conventionally a `GET` returning 200, accepting the entity's identifier(s) as path parameters. Required on `shape: \"runtime-entity\"`; forbidden on `shape: \"entity\"` and `shape: \"external-entity\"`."
+          "description": "#305 Phase 4 — operationId of the canonical read-back operation for this runtime entity (e.g. `getUserTask` for `UserTask`, `getIncident` for `Incident`). Conventionally a `GET` returning 200, accepting the entity's identifier(s) as path parameters. Required on `shape: \"runtime-entity\"`; forbidden on `shape: \"entity\"` and `shape: \"external-entity\"`."
         },
         "description": {
           "type": "string",
@@ -126,6 +139,16 @@
                 {
                   "required": [
                     "mutators"
+                  ]
+                },
+                {
+                  "required": [
+                    "transitions"
+                  ]
+                },
+                {
+                  "required": [
+                    "stateField"
                   ]
                 },
                 {
@@ -170,6 +193,16 @@
                 },
                 {
                   "required": [
+                    "transitions"
+                  ]
+                },
+                {
+                  "required": [
+                    "stateField"
+                  ]
+                },
+                {
+                  "required": [
                     "fetcher"
                   ]
                 }
@@ -187,8 +220,19 @@
           },
           "then": {
             "required": [
-              "mutators",
               "fetcher"
+            ],
+            "anyOf": [
+              {
+                "required": [
+                  "mutators"
+                ]
+              },
+              {
+                "required": [
+                  "transitions"
+                ]
+              }
             ],
             "not": {
               "anyOf": [
@@ -210,8 +254,58 @@
               ]
             }
           }
+        },
+        {
+          "if": {
+            "required": [
+              "transitions"
+            ]
+          },
+          "then": {
+            "required": [
+              "stateField"
+            ]
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "stateField"
+            ]
+          },
+          "then": {
+            "required": [
+              "transitions"
+            ]
+          }
         }
       ]
+    },
+    "StateTransition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "op",
+        "from",
+        "to"
+      ],
+      "properties": {
+        "op": {
+          "type": "string",
+          "minLength": 1,
+          "description": "OperationId of the transition op (e.g. `resolveIncident`). Conventionally a `POST` on a sub-resource of the entity (`/{id}/resolution`) whose request body carries no new field value — the post-state is implicit in the operation semantics. At instantiation time the planner resolves this to its canonical scenario and uses the final RequestStep as the invoke step."
+        },
+        "from": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Entity state expected *before* the transition is invoked (e.g. `ACTIVE`). Currently informational — the template trusts the chain to deliver the entity in this state (e.g. `searchIncidents` only ever surfaces ACTIVE incidents on the OCA API). Recorded explicitly so future tightening (an explicit pre-state witness step) is a template change, not an ABox migration."
+        },
+        "to": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Entity state expected *after* the transition is invoked (e.g. `RESOLVED`). Compiled into the `stateEquals` assertion on the read-back step: `expect(body.<stateField>).toBe(<to>)`."
+        }
+      }
     }
   }
 }

--- a/ontology/vocabulary/scenario-template.schema.json
+++ b/ontology/vocabulary/scenario-template.schema.json
@@ -72,7 +72,7 @@
       }
     },
     "AppliesTo": {
-      "description": "Discriminator naming the subject ABox the template is instantiated against. `Edge` instantiates against the edges ABox (#269 Phase 1). `Entity` (#280) instantiates against the entity-kinds ABox, restricted to `shape: \"entity\"` rows (those carry the required `establishedBy`/`observableVia`/`revokedBy` triple). `RuntimeEntity` (#305 Phase 4) also instantiates against the entity-kinds ABox, but restricted to `shape: \"runtime-entity\"` rows (which carry `mutators[]` + `fetcher` instead of the CRUD triple). Extending the union is how future subject ABoxes (resources, state-transitions, …) opt in to template-driven scenario emission.",
+      "description": "Discriminator naming the subject ABox the template is instantiated against. `Edge` instantiates against the edges ABox (#269 Phase 1). `Entity` (#280) instantiates against the entity-kinds ABox, restricted to `shape: \"entity\"` rows (those carry the required `establishedBy`/`observableVia`/`revokedBy` triple). `RuntimeEntity` (#305 Phase 4 / Phase 5d) also instantiates against the entity-kinds ABox, but restricted to `shape: \"runtime-entity\"` rows (which carry `fetcher` plus `mutators[]` and/or `transitions[]` instead of the CRUD triple). Extending the union is how future subject ABoxes (resources, …) opt in to template-driven scenario emission.",
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -118,7 +118,7 @@
         "for": {
           "type": "string",
           "minLength": 1,
-          "description": "Subject-role name (e.g. `establishedBy`). At instantiation time the planner resolves this to the subject's operationId and runs its existing BFS targeted at that operation, materializing all upstream producers as preceding steps."
+          "description": "Subject-role name (e.g. `establishedBy`, `mutator`, `transition`). At instantiation time the planner resolves this to the subject's operationId and runs its existing BFS targeted at that operation, materializing all upstream producers as preceding steps."
         }
       }
     },
@@ -137,7 +137,7 @@
         "op": {
           "type": "string",
           "minLength": 1,
-          "description": "Subject-role name (e.g. `establishedBy` or `revokedBy`). At instantiation time the planner resolves this to the subject's operationId and emits an invocation whose inputs are drawn from the scenario binding context built up by any preceding PrereqChain step."
+          "description": "Subject-role name (e.g. `establishedBy`, `revokedBy`, `mutator`, `transition`). At instantiation time the planner resolves this to the subject's operationId and emits an invocation whose inputs are drawn from the scenario binding context built up by any preceding PrereqChain step."
         }
       }
     },
@@ -157,16 +157,17 @@
         "op": {
           "type": "string",
           "minLength": 1,
-          "description": "Subject-role name (e.g. `observableVia`, `fetcher`). At instantiation time the planner resolves this to the subject's observation operationId, invokes it, and asserts on the response per `expect`. The concrete assertion shape is chosen by `appliesTo.kind` × `expect`: for `Edge` + `present|absent` it is a projection-search membership check (`toContain` / `not.toContain` on the configured array path); for `Entity` (#280) + `present|absent` it is a get-by-id status check (`expect: 'present'` → status 200; `expect: 'absent'` → status 404); for `RuntimeEntity` (#305 Phase 4) + `fieldEquals` it is a per-field equality check on the fetcher 200 response against the values emitted by the preceding mutator request body."
+          "description": "Subject-role name (e.g. `observableVia`, `fetcher`). At instantiation time the planner resolves this to the subject's observation operationId, invokes it, and asserts on the response per `expect`. The concrete assertion shape is chosen by `appliesTo.kind` × `expect`: for `Edge` + `present|absent` it is a projection-search membership check (`toContain` / `not.toContain` on the configured array path); for `Entity` (#280) + `present|absent` it is a get-by-id status check (`expect: 'present'` → status 200; `expect: 'absent'` → status 404); for `RuntimeEntity` (#305 Phase 4) + `fieldEquals` it is a per-field equality check on the fetcher 200 response against the values emitted by the preceding mutator request body; for `RuntimeEntity` (#305 Phase 5d / #189) + `stateEquals` it is a single equality check `body.<stateField> === transition.to` after a state-transition invoke."
         },
         "expect": {
           "type": "string",
           "enum": [
             "present",
             "absent",
-            "fieldEquals"
+            "fieldEquals",
+            "stateEquals"
           ],
-          "description": "High-level observation predicate. `present`/`absent` assert the subject instance is/is not visible to the observer (compiled to membership or status assertions per `appliesTo.kind`). `fieldEquals` (#305 Phase 4) asserts that every field present in the preceding mutator's emitted request body is reflected unchanged in the fetcher's 200 response; only valid for `appliesTo.kind: \"RuntimeEntity\"` templates that include an Observe-after-Invoke pattern. The concrete list of fields is derived at instantiation time by intersecting the mutator request body's leaves with the fetcher's `responseLeafPaths['200']`, bridged by **last-segment leaf name** (not `semanticType` — changeset fields typically lack `x-semantic-type` upstream). Mutator-body leaves with no matching fetcher leaf are skipped silently; the instantiator errors only if the intersection is empty. No field selector lives in the template ABox."
+          "description": "High-level observation predicate. `present`/`absent` assert the subject instance is/is not visible to the observer (compiled to membership or status assertions per `appliesTo.kind`). `fieldEquals` (#305 Phase 4) asserts that every field present in the preceding mutator's emitted request body is reflected unchanged in the fetcher's 200 response; only valid for `appliesTo.kind: \"RuntimeEntity\"` templates that include an Observe-after-Invoke pattern. The concrete list of fields is derived at instantiation time by intersecting the mutator request body's leaves with the fetcher's `responseLeafPaths['200']`, bridged by **last-segment leaf name** (not `semanticType` — changeset fields typically lack `x-semantic-type` upstream). Mutator-body leaves with no matching fetcher leaf are skipped silently; the instantiator errors only if the intersection is empty. No field selector lives in the template ABox. `stateEquals` (#305 Phase 5d / #189) asserts that the fetcher's 200 response carries `<stateField> === transition.to`, where `stateField` and `transition.to` come from the entity-kinds ABox row's `transitions[]` and `stateField` fields. Only valid for `appliesTo.kind: \"RuntimeEntity\"` templates."
         }
       }
     }

--- a/path-analyser/src/ontology/entityKindsSchema.ts
+++ b/path-analyser/src/ontology/entityKindsSchema.ts
@@ -49,16 +49,30 @@
 // service-task activates inside a process instance) rather than being
 // directly created by a client-facing endpoint. Runtime entities have
 // no `establishedBy`/`observableVia`/`revokedBy` triple; instead they
-// carry `mutators[]` (one-or-more opIds that mutate the entity in
-// place — e.g. `updateUserTask`, `assignUserTask`, `completeUserTask`)
-// and a `fetcher` (single opId, conventionally a GET-by-id). The pair
-// is consumed by the `UpdatedFieldVisibleOnReadBack` scenario template,
-// which emits one "mutate → re-fetch and assert the mutated field
-// equals the request value" scenario per mutator. Discovery of the
-// pre-existing entity (e.g. `searchUserTasks` to find an active
-// user-task key) is the planner's job via the runtimeEmission
-// machinery shipped in Phase 3 (#308) — the ABox itself only declares
-// the mutator/fetcher catalogue.
+// carry a `fetcher` (single opId, conventionally a GET-by-id) plus
+// **at least one** of:
+//
+//   - `mutators[]`   — opIds that mutate the entity in place
+//                       (e.g. `updateUserTask`, `assignUserTask`).
+//                       Consumed by the `UpdatedFieldVisibleOnReadBack`
+//                       scenario template (one scenario per mutator).
+//   - `transitions[]` — server-driven state transitions invoked by a
+//                       transition op whose request body carries no
+//                       new field value (e.g. `resolveIncident` flips
+//                       Incident.state from ACTIVE → RESOLVED). #305
+//                       Phase 5d / #189. Consumed by the
+//                       `StateTransitionVisibleAfterAction` scenario
+//                       template (one scenario per transition). When
+//                       `transitions[]` is present, `stateField` is
+//                       required: it names the leaf in the fetcher's
+//                       200 response that carries the entity's current
+//                       state (almost always `"state"`).
+//
+// Discovery of the pre-existing entity (e.g. `searchUserTasks` to find
+// an active user-task key, `searchIncidents` to find an active
+// incident) is the planner's job via the runtimeEmission machinery
+// shipped in Phase 3 (#308) — the ABox itself only declares the
+// mutator/transition/fetcher catalogue.
 //
 // JSON-LD (`@context`, `@type`) is accepted and preserved verbatim but
 // not interpreted by the loader — same convention as `edgeSchema.ts`.
@@ -68,7 +82,7 @@ export const entityKindsSchema = {
   $id: 'https://camunda.github.io/api-test-generator/ns/v1/entity-kinds.schema.json',
   title: 'Entity-kinds ABox (api-test-generator ontology, v1)',
   description:
-    'TBox JSON Schema for an ABox file describing the entity kinds (the domain nouns) of a single API. Each entry asserts: an entity kind exists; it has one of three shapes (`entity` for in-API-managed with full CRUD, `external-entity` for identifiers minted outside the API, `runtime-entity` for entities emitted by the runtime as a side-effect of other operations); and a list of semantic identifier-type names that identify it. `shape: "entity"` kinds carry an all-or-nothing CRUD triple (`establishedBy`/`observableVia`/`revokedBy`) consumed by the EntityLifecycle scenario template (#280) — asymmetric subsets surface as ABox-load validation errors. `shape: "external-entity"` kinds (e.g. Client) must NOT carry the CRUD triple. `shape: "runtime-entity"` kinds (#305 Phase 4, e.g. UserTask) carry `mutators[]` plus a single `fetcher` consumed by the `UpdatedFieldVisibleOnReadBack` template; the if/then/else below enforces that runtime-entity kinds carry mutators+fetcher and that entity/external-entity kinds do NOT. The schema is intentionally agnostic to which API ships the kinds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/entity-kinds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (kind names appearing in operation `produces[]`/`requires[]`, identifier types being live, CRUD op methods being POST/GET/DELETE, etc.) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them.',
+    'TBox JSON Schema for an ABox file describing the entity kinds (the domain nouns) of a single API. Each entry asserts: an entity kind exists; it has one of three shapes (`entity` for in-API-managed with full CRUD, `external-entity` for identifiers minted outside the API, `runtime-entity` for entities emitted by the runtime as a side-effect of other operations); and a list of semantic identifier-type names that identify it. `shape: "entity"` kinds carry an all-or-nothing CRUD triple (`establishedBy`/`observableVia`/`revokedBy`) consumed by the EntityLifecycle scenario template (#280) — asymmetric subsets surface as ABox-load validation errors. `shape: "external-entity"` kinds (e.g. Client) must NOT carry the CRUD triple. `shape: "runtime-entity"` kinds (#305 Phase 4 / Phase 5d, e.g. UserTask, Incident) carry a `fetcher` plus at least one of `mutators[]` (consumed by `UpdatedFieldVisibleOnReadBack`) or `transitions[]` + `stateField` (consumed by `StateTransitionVisibleAfterAction`, #189); the if/then/else below enforces that runtime-entity kinds carry the required combination and that entity/external-entity kinds carry none of these. The schema is intentionally agnostic to which API ships the kinds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/entity-kinds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (kind names appearing in operation `produces[]`/`requires[]`, identifier types being live, CRUD op methods being POST/GET/DELETE, etc.) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them.',
   type: 'object',
   additionalProperties: false,
   required: ['version', 'kinds'],
@@ -110,7 +124,7 @@ export const entityKindsSchema = {
           type: 'string',
           enum: ['entity', 'external-entity', 'runtime-entity'],
           description:
-            '`entity`: in-API-managed (producer + consumer ops both inside the API). `external-entity`: identifier minted outside the API; planner treats `identifiers[]` as `externalBoundary` (client-mintable, no upstream producer required). `runtime-entity` (#305 Phase 4): entity emitted by the runtime as a side-effect of another operation (e.g. UserTask from a process instance); discovered via runtimeEmission, mutated in place, and re-read via `mutators[]` + `fetcher` consumed by the `UpdatedFieldVisibleOnReadBack` template.',
+            '`entity`: in-API-managed (producer + consumer ops both inside the API). `external-entity`: identifier minted outside the API; planner treats `identifiers[]` as `externalBoundary` (client-mintable, no upstream producer required). `runtime-entity` (#305 Phase 4 / Phase 5d): entity emitted by the runtime as a side-effect of another operation (e.g. UserTask from a process instance, Incident from a failing process instance); discovered via runtimeEmission and re-read via `fetcher`. Carries `mutators[]` (consumed by `UpdatedFieldVisibleOnReadBack`) and/or `transitions[]`+`stateField` (consumed by `StateTransitionVisibleAfterAction`, #189).',
         },
         identifiers: {
           type: 'array',
@@ -148,13 +162,26 @@ export const entityKindsSchema = {
             minLength: 1,
           },
           description:
-            '#305 Phase 4 — operationIds of operations that mutate the runtime entity in place (e.g. `updateUserTask`, `assignUserTask`, `completeUserTask` for `UserTask`). Conventionally a `PATCH`/`POST`/`DELETE` on a sub-resource of the entity\'s identifier (`/{id}/...`). Required on `shape: "runtime-entity"`; forbidden on `shape: "entity"` and `shape: "external-entity"`. The `UpdatedFieldVisibleOnReadBack` template emits one scenario per mutator.',
+            '#305 Phase 4 — operationIds of operations that mutate the runtime entity in place (e.g. `updateUserTask`, `assignUserTask`, `completeUserTask` for `UserTask`). Conventionally a `PATCH`/`POST`/`DELETE` on a sub-resource of the entity\'s identifier (`/{id}/...`). Optional on `shape: "runtime-entity"` (the row must carry `mutators[]` or `transitions[]` or both — see the runtime-entity branch of the allOf below); forbidden on `shape: "entity"` and `shape: "external-entity"`. The `UpdatedFieldVisibleOnReadBack` template emits one scenario per mutator.',
+        },
+        transitions: {
+          type: 'array',
+          minItems: 1,
+          items: { $ref: '#/definitions/StateTransition' },
+          description:
+            '#305 Phase 5d / #189 — server-driven state transitions for this runtime entity. Each entry names the operationId of a transition op (e.g. `resolveIncident`), the state the entity is expected to be in *before* the transition is invoked (e.g. `ACTIVE`), and the state it is expected to be in *after* (e.g. `RESOLVED`). Transition ops are distinguished from mutators by carrying no per-field update in the request body — the post-state is implicit in the operation semantics. Consumed by the `StateTransitionVisibleAfterAction` scenario template (one scenario per transition: prereqChain → invoke transition → re-fetch via `fetcher` → assert `<stateField>` equals `to`). Optional on `shape: "runtime-entity"` (the row must carry `mutators[]` or `transitions[]` or both); when present, `stateField` is required so the template knows which response leaf to read.',
+        },
+        stateField: {
+          type: 'string',
+          minLength: 1,
+          description:
+            '#305 Phase 5d / #189 — name of the leaf in the `fetcher`\'s 200 response that carries this entity\'s current state (almost always `"state"`). Required when `transitions[]` is present (the `StateTransitionVisibleAfterAction` template asserts `body.<stateField> === transition.to`). Forbidden when `transitions[]` is absent (would have no consumer). The L3 invariant verifies the named leaf actually appears in the fetcher\'s `responseLeafPaths["200"]`.',
         },
         fetcher: {
           type: 'string',
           minLength: 1,
           description:
-            '#305 Phase 4 — operationId of the canonical read-back operation for this runtime entity (e.g. `getUserTask` for `UserTask`). Conventionally a `GET` returning 200, accepting the entity\'s identifier(s) as path parameters. Required on `shape: "runtime-entity"`; forbidden on `shape: "entity"` and `shape: "external-entity"`.',
+            '#305 Phase 4 — operationId of the canonical read-back operation for this runtime entity (e.g. `getUserTask` for `UserTask`, `getIncident` for `Incident`). Conventionally a `GET` returning 200, accepting the entity\'s identifier(s) as path parameters. Required on `shape: "runtime-entity"`; forbidden on `shape: "entity"` and `shape: "external-entity"`.',
         },
         description: {
           type: 'string',
@@ -163,9 +190,13 @@ export const entityKindsSchema = {
       },
       // All-or-nothing CRUD triple / runtime-entity pair gated by shape.
       //   - shape=entity (#280):           all three of establishedBy/observableVia/revokedBy required;
-      //                                    mutators/fetcher forbidden.
-      //   - shape=external-entity (#280):  none of the CRUD triple, no mutators/fetcher.
-      //   - shape=runtime-entity (#305-4): mutators+fetcher required; CRUD triple forbidden.
+      //                                    mutators/transitions/stateField/fetcher forbidden.
+      //   - shape=external-entity (#280):  none of the CRUD triple, no mutators/transitions/stateField/fetcher.
+      //   - shape=runtime-entity (#305-4 / Phase 5d):
+      //                                    fetcher required; at least one of mutators[] or transitions[]
+      //                                    must be present (a runtime-entity row with neither is dead
+      //                                    weight — nothing instantiates against it); if transitions[]
+      //                                    is present, stateField is required; CRUD triple forbidden.
       // Draft-07 if/then/else: the `if` clause matches by `shape` only
       // (no extra `required`), then branches set the all-or-nothing
       // constraint on the same instance.
@@ -176,7 +207,12 @@ export const entityKindsSchema = {
           then: {
             required: ['establishedBy', 'observableVia', 'revokedBy'],
             not: {
-              anyOf: [{ required: ['mutators'] }, { required: ['fetcher'] }],
+              anyOf: [
+                { required: ['mutators'] },
+                { required: ['transitions'] },
+                { required: ['stateField'] },
+                { required: ['fetcher'] },
+              ],
             },
           },
         },
@@ -190,6 +226,8 @@ export const entityKindsSchema = {
                 { required: ['observableVia'] },
                 { required: ['revokedBy'] },
                 { required: ['mutators'] },
+                { required: ['transitions'] },
+                { required: ['stateField'] },
                 { required: ['fetcher'] },
               ],
             },
@@ -199,7 +237,8 @@ export const entityKindsSchema = {
           if: { properties: { shape: { const: 'runtime-entity' } } },
           // biome-ignore lint/suspicious/noThenProperty: JSON Schema Draft-07 `then` keyword (paired with `if`), not a Promise-like.
           then: {
-            required: ['mutators', 'fetcher'],
+            required: ['fetcher'],
+            anyOf: [{ required: ['mutators'] }, { required: ['transitions'] }],
             not: {
               anyOf: [
                 { required: ['establishedBy'] },
@@ -209,7 +248,46 @@ export const entityKindsSchema = {
             },
           },
         },
+        {
+          // Cross-field: `stateField` exists iff `transitions` exists.
+          // Split into two if/then arms because Draft-07 if/then doesn't
+          // gracefully express "X required iff Y present" in a single
+          // branch.
+          if: { required: ['transitions'] },
+          // biome-ignore lint/suspicious/noThenProperty: JSON Schema Draft-07 `then` keyword (paired with `if`), not a Promise-like.
+          then: { required: ['stateField'] },
+        },
+        {
+          if: { required: ['stateField'] },
+          // biome-ignore lint/suspicious/noThenProperty: JSON Schema Draft-07 `then` keyword (paired with `if`), not a Promise-like.
+          then: { required: ['transitions'] },
+        },
       ],
+    },
+    StateTransition: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['op', 'from', 'to'],
+      properties: {
+        op: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'OperationId of the transition op (e.g. `resolveIncident`). Conventionally a `POST` on a sub-resource of the entity (`/{id}/resolution`) whose request body carries no new field value — the post-state is implicit in the operation semantics. At instantiation time the planner resolves this to its canonical scenario and uses the final RequestStep as the invoke step.',
+        },
+        from: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Entity state expected *before* the transition is invoked (e.g. `ACTIVE`). Currently informational — the template trusts the chain to deliver the entity in this state (e.g. `searchIncidents` only ever surfaces ACTIVE incidents on the OCA API). Recorded explicitly so future tightening (an explicit pre-state witness step) is a template change, not an ABox migration.',
+        },
+        to: {
+          type: 'string',
+          minLength: 1,
+          description:
+            'Entity state expected *after* the transition is invoked (e.g. `RESOLVED`). Compiled into the `stateEquals` assertion on the read-back step: `expect(body.<stateField>).toBe(<to>)`.',
+        },
+      },
     },
   },
 } as const;

--- a/path-analyser/src/ontology/scenarioTemplateSchema.ts
+++ b/path-analyser/src/ontology/scenarioTemplateSchema.ts
@@ -109,7 +109,7 @@ export const scenarioTemplateSchema = {
     },
     AppliesTo: {
       description:
-        'Discriminator naming the subject ABox the template is instantiated against. `Edge` instantiates against the edges ABox (#269 Phase 1). `Entity` (#280) instantiates against the entity-kinds ABox, restricted to `shape: "entity"` rows (those carry the required `establishedBy`/`observableVia`/`revokedBy` triple). `RuntimeEntity` (#305 Phase 4) also instantiates against the entity-kinds ABox, but restricted to `shape: "runtime-entity"` rows (which carry `mutators[]` + `fetcher` instead of the CRUD triple). Extending the union is how future subject ABoxes (resources, state-transitions, …) opt in to template-driven scenario emission.',
+        'Discriminator naming the subject ABox the template is instantiated against. `Edge` instantiates against the edges ABox (#269 Phase 1). `Entity` (#280) instantiates against the entity-kinds ABox, restricted to `shape: "entity"` rows (those carry the required `establishedBy`/`observableVia`/`revokedBy` triple). `RuntimeEntity` (#305 Phase 4 / Phase 5d) also instantiates against the entity-kinds ABox, but restricted to `shape: "runtime-entity"` rows (which carry `fetcher` plus `mutators[]` and/or `transitions[]` instead of the CRUD triple). Extending the union is how future subject ABoxes (resources, …) opt in to template-driven scenario emission.',
       type: 'object',
       additionalProperties: false,
       required: ['kind'],
@@ -139,7 +139,7 @@ export const scenarioTemplateSchema = {
           type: 'string',
           minLength: 1,
           description:
-            "Subject-role name (e.g. `establishedBy`). At instantiation time the planner resolves this to the subject's operationId and runs its existing BFS targeted at that operation, materializing all upstream producers as preceding steps.",
+            "Subject-role name (e.g. `establishedBy`, `mutator`, `transition`). At instantiation time the planner resolves this to the subject's operationId and runs its existing BFS targeted at that operation, materializing all upstream producers as preceding steps.",
         },
       },
     },
@@ -153,7 +153,7 @@ export const scenarioTemplateSchema = {
           type: 'string',
           minLength: 1,
           description:
-            "Subject-role name (e.g. `establishedBy` or `revokedBy`). At instantiation time the planner resolves this to the subject's operationId and emits an invocation whose inputs are drawn from the scenario binding context built up by any preceding PrereqChain step.",
+            "Subject-role name (e.g. `establishedBy`, `revokedBy`, `mutator`, `transition`). At instantiation time the planner resolves this to the subject's operationId and emits an invocation whose inputs are drawn from the scenario binding context built up by any preceding PrereqChain step.",
         },
       },
     },
@@ -167,13 +167,13 @@ export const scenarioTemplateSchema = {
           type: 'string',
           minLength: 1,
           description:
-            "Subject-role name (e.g. `observableVia`, `fetcher`). At instantiation time the planner resolves this to the subject's observation operationId, invokes it, and asserts on the response per `expect`. The concrete assertion shape is chosen by `appliesTo.kind` × `expect`: for `Edge` + `present|absent` it is a projection-search membership check (`toContain` / `not.toContain` on the configured array path); for `Entity` (#280) + `present|absent` it is a get-by-id status check (`expect: 'present'` → status 200; `expect: 'absent'` → status 404); for `RuntimeEntity` (#305 Phase 4) + `fieldEquals` it is a per-field equality check on the fetcher 200 response against the values emitted by the preceding mutator request body.",
+            "Subject-role name (e.g. `observableVia`, `fetcher`). At instantiation time the planner resolves this to the subject's observation operationId, invokes it, and asserts on the response per `expect`. The concrete assertion shape is chosen by `appliesTo.kind` × `expect`: for `Edge` + `present|absent` it is a projection-search membership check (`toContain` / `not.toContain` on the configured array path); for `Entity` (#280) + `present|absent` it is a get-by-id status check (`expect: 'present'` → status 200; `expect: 'absent'` → status 404); for `RuntimeEntity` (#305 Phase 4) + `fieldEquals` it is a per-field equality check on the fetcher 200 response against the values emitted by the preceding mutator request body; for `RuntimeEntity` (#305 Phase 5d / #189) + `stateEquals` it is a single equality check `body.<stateField> === transition.to` after a state-transition invoke.",
         },
         expect: {
           type: 'string',
-          enum: ['present', 'absent', 'fieldEquals'],
+          enum: ['present', 'absent', 'fieldEquals', 'stateEquals'],
           description:
-            "High-level observation predicate. `present`/`absent` assert the subject instance is/is not visible to the observer (compiled to membership or status assertions per `appliesTo.kind`). `fieldEquals` (#305 Phase 4) asserts that every field present in the preceding mutator's emitted request body is reflected unchanged in the fetcher's 200 response; only valid for `appliesTo.kind: \"RuntimeEntity\"` templates that include an Observe-after-Invoke pattern. The concrete list of fields is derived at instantiation time by intersecting the mutator request body's leaves with the fetcher's `responseLeafPaths['200']`, bridged by **last-segment leaf name** (not `semanticType` — changeset fields typically lack `x-semantic-type` upstream). Mutator-body leaves with no matching fetcher leaf are skipped silently; the instantiator errors only if the intersection is empty. No field selector lives in the template ABox.",
+            "High-level observation predicate. `present`/`absent` assert the subject instance is/is not visible to the observer (compiled to membership or status assertions per `appliesTo.kind`). `fieldEquals` (#305 Phase 4) asserts that every field present in the preceding mutator's emitted request body is reflected unchanged in the fetcher's 200 response; only valid for `appliesTo.kind: \"RuntimeEntity\"` templates that include an Observe-after-Invoke pattern. The concrete list of fields is derived at instantiation time by intersecting the mutator request body's leaves with the fetcher's `responseLeafPaths['200']`, bridged by **last-segment leaf name** (not `semanticType` — changeset fields typically lack `x-semantic-type` upstream). Mutator-body leaves with no matching fetcher leaf are skipped silently; the instantiator errors only if the intersection is empty. No field selector lives in the template ABox. `stateEquals` (#305 Phase 5d / #189) asserts that the fetcher's 200 response carries `<stateField> === transition.to`, where `stateField` and `transition.to` come from the entity-kinds ABox row's `transitions[]` and `stateField` fields. Only valid for `appliesTo.kind: \"RuntimeEntity\"` templates.",
         },
       },
     },

--- a/path-analyser/src/scenarioTemplateInstantiator.ts
+++ b/path-analyser/src/scenarioTemplateInstantiator.ts
@@ -728,6 +728,209 @@ function compileUpdatedFieldVisibleOnReadBack(
 }
 
 /**
+ * #305 Phase 5d / #189 — Produce one {@link TemplateScenario} per
+ * (runtime-entity × transition) pair. Parallel to
+ * {@link compileUpdatedFieldVisibleOnReadBack}, but tailored for
+ * state-transition ops (e.g. `resolveIncident`) whose request body
+ * carries no per-field update — the post-state is implicit in the op
+ * semantics and asserted via a single equality on the fetcher's
+ * `<stateField>` response leaf.
+ *
+ * Differences from the readback compiler:
+ *   - The expected value is a string literal read from
+ *     `transition.to` in the ABox, not plucked from the mutator body.
+ *   - The state field is named explicitly by `kind.stateField` (not
+ *     inferred from the body / response intersection).
+ *   - The emitted assertion is `stateEquals`, not `fieldEquals`.
+ *
+ * Returns one scenario per `kind.transitions[]` entry. Pairs that fail
+ * (missing canonical, fetcher missing `stateField`, etc.) are surfaced
+ * as `errors` so the caller can fail the whole instantiation loudly
+ * with the full list of broken pairs.
+ */
+function compileStateTransitionVisibleAfterAction(
+  template: ScenarioTemplate,
+  kind: EntityKind,
+  graph: OperationGraph,
+  canonical: CanonicalScenarioMap,
+): {
+  scenarios: Array<{ transitionOp: string; scenario: TemplateScenario }>;
+  errors: string[];
+} {
+  const scenarios: Array<{ transitionOp: string; scenario: TemplateScenario }> = [];
+  const errors: string[] = [];
+
+  if (kind.shape !== 'runtime-entity') {
+    errors.push(
+      `${template.name} × ${kind.name}: appliesTo RuntimeEntity templates only apply to shape: "runtime-entity" kinds, got shape: "${kind.shape}"`,
+    );
+    return { scenarios, errors };
+  }
+  const fetcherOpId = kind.fetcher;
+  const transitions = kind.transitions;
+  const stateField = kind.stateField;
+  if (
+    typeof fetcherOpId !== 'string' ||
+    !Array.isArray(transitions) ||
+    transitions.length === 0 ||
+    typeof stateField !== 'string' ||
+    stateField.length === 0
+  ) {
+    errors.push(
+      `${template.name} × ${kind.name}: missing fetcher, transitions[], or stateField on shape: "runtime-entity" kind (schema bug?)`,
+    );
+    return { scenarios, errors };
+  }
+
+  const fetcherScenario = canonical.get(fetcherOpId);
+  if (!fetcherScenario) {
+    errors.push(
+      `${template.name} × ${kind.name}: no canonical scenario for fetcher='${fetcherOpId}'`,
+    );
+    return { scenarios, errors };
+  }
+  const fetcherPlan = fetcherScenario.requestPlan;
+  if (!fetcherPlan?.length) {
+    errors.push(`${template.name} × ${kind.name}: fetcher scenario has no requestPlan`);
+    return { scenarios, errors };
+  }
+
+  // Verify the named stateField is actually a live leaf in the
+  // fetcher's 2xx response. The L3 invariant repeats this guard
+  // against the on-disk graph; doing it here means a misconfigured
+  // ABox fails at planning time with a precise message rather than
+  // emitting a spec that asserts against a non-existent field.
+  const fetcherOp = graph.operations[fetcherOpId];
+  const fetcherLeaves =
+    fetcherOp?.responseLeafPaths?.['200'] ??
+    Object.entries(fetcherOp?.responseLeafPaths ?? {}).find(([s]) => /^2\d\d$/.test(s))?.[1] ??
+    [];
+  if (!fetcherLeaves.includes(stateField)) {
+    errors.push(
+      `${template.name} × ${kind.name}: stateField='${stateField}' is not a 2xx response leaf of fetcher='${fetcherOpId}' (available leaves: ${fetcherLeaves.join(', ') || '<none>'})`,
+    );
+    return { scenarios, errors };
+  }
+
+  const lastOf = (plan: RequestStep[]): RequestStep => plan[plan.length - 1];
+
+  for (const transition of transitions) {
+    const transitionOpId = transition.op;
+    const transitionScenario = canonical.get(transitionOpId);
+    if (!transitionScenario) {
+      errors.push(
+        `${template.name} × ${kind.name} × ${transitionOpId}: no canonical scenario for transition op`,
+      );
+      continue;
+    }
+    const transitionPlan = transitionScenario.requestPlan;
+    if (!transitionPlan?.length) {
+      errors.push(
+        `${template.name} × ${kind.name} × ${transitionOpId}: transition scenario has no requestPlan`,
+      );
+      continue;
+    }
+    const transitionOps = transitionScenario.operations;
+    if (transitionOps.length !== transitionPlan.length) {
+      errors.push(
+        `${template.name} × ${kind.name} × ${transitionOpId}: transition scenario operations.length (${transitionOps.length}) ≠ requestPlan.length (${transitionPlan.length}); duplicate invocation on a transition is unsupported`,
+      );
+      continue;
+    }
+
+    const prereqOps: OperationRef[] = transitionOps.slice(0, -1).map((o) => ({ ...o }));
+    const prereqPlan: RequestStep[] = transitionPlan.slice(0, -1);
+
+    const bindings: Record<string, string> = {};
+    const aggregateBindingNames = new Set<string>([
+      ...Object.keys(transitionScenario.bindings ?? {}),
+      ...(transitionScenario.seedBindings ?? []),
+    ]);
+    for (const bindName of aggregateBindingNames) {
+      const sem = bindName.endsWith('Var')
+        ? bindName.slice(0, -3).charAt(0).toUpperCase() + bindName.slice(0, -3).slice(1)
+        : bindName;
+      bindings[sem] = bindName;
+    }
+
+    const inputsFor = (opId: string): Record<string, string> => {
+      const op = graph.operations[opId];
+      const result: Record<string, string> = {};
+      for (const sem of op?.requires.required ?? []) {
+        result[sem] = bindingNameFor(sem);
+      }
+      return result;
+    };
+    const producesFor = (opId: string): Record<string, string> => {
+      const op = graph.operations[opId];
+      const result: Record<string, string> = {};
+      for (const leaf of op?.responseSemanticLeaves ?? []) {
+        if (!leaf.provider) continue;
+        result[leaf.semantic] = bindingNameFor(leaf.semantic);
+      }
+      return result;
+    };
+
+    const allOpIds = new Set<string>([
+      ...prereqOps.map((o) => o.operationId),
+      transitionOpId,
+      fetcherOpId,
+    ]);
+    const eventuallyConsistentOps: string[] = [];
+    for (const opId of allOpIds) {
+      const op = graph.operations[opId];
+      if (op?.eventuallyConsistent) eventuallyConsistentOps.push(opId);
+    }
+    eventuallyConsistentOps.sort();
+
+    const steps: TemplateStep[] = [
+      {
+        kind: 'prereqChain',
+        targetOperationId: transitionOpId,
+        operations: prereqOps,
+        bindings: { ...(transitionScenario.bindings ?? {}) },
+        seedBindings: [...(transitionScenario.seedBindings ?? [])],
+        requestPlan: prereqPlan,
+      },
+      {
+        kind: 'invoke',
+        operationId: transitionOpId,
+        inputs: inputsFor(transitionOpId),
+        produces: producesFor(transitionOpId),
+        requestPlan: lastOf(transitionPlan),
+      },
+      {
+        kind: 'observe',
+        operationId: fetcherOpId,
+        inputs: inputsFor(fetcherOpId),
+        requestPlan: lastOf(fetcherPlan),
+        assertion: {
+          kind: 'stateEquals',
+          responseBodyPath: [stateField],
+          expectedState: transition.to,
+          fromState: transition.from,
+          transitionOp: transitionOpId,
+        },
+      },
+    ];
+
+    scenarios.push({
+      transitionOp: transitionOpId,
+      scenario: {
+        templateName: template.name,
+        subjectName: `${kind.name}.${transitionOpId}`,
+        subjectKind: 'RuntimeEntity',
+        steps,
+        bindings,
+        eventuallyConsistentOps,
+      },
+    });
+  }
+
+  return { scenarios, errors };
+}
+
+/**
  * Walk an emitted request body template (object/array/primitive),
  * yielding every primitive (or array-of-primitive) leaf with its
  * dotted path. Array indices are skipped — we only care about the
@@ -838,30 +1041,56 @@ export function instantiateAllTemplates(
     }
     if (tpl.appliesTo.kind === 'RuntimeEntity') {
       // #305 Phase 4 — UpdatedFieldVisibleOnReadBack template.
-      // Compiler implementation lands in a follow-up commit on the same
-      // branch; this dispatch arm exists so the TBox + ABox changes can
-      // typecheck and the ontology drift gates can run.
-      if (tpl.name !== 'UpdatedFieldVisibleOnReadBack') {
+      // #305 Phase 5d / #189 — StateTransitionVisibleAfterAction template.
+      // Refuse-by-default for any other template name so unrecognised
+      // entries fail loudly rather than silently re-running an existing
+      // compiler against the wrong vocabulary.
+      if (
+        tpl.name !== 'UpdatedFieldVisibleOnReadBack' &&
+        tpl.name !== 'StateTransitionVisibleAfterAction'
+      ) {
         throw new Error(
           `No compiler registered for scenario template '${tpl.name}'. ` +
-            `#305 Phase 4 only ships the UpdatedFieldVisibleOnReadBack ` +
-            `compiler; additional RuntimeEntity-scoped templates need ` +
-            `their own dispatch in instantiateAllTemplates.`,
+            `RuntimeEntity-scoped templates currently shipped: ` +
+            `UpdatedFieldVisibleOnReadBack (#305 Phase 4), ` +
+            `StateTransitionVisibleAfterAction (#305 Phase 5d / #189). ` +
+            `Additional templates need their own dispatch in instantiateAllTemplates.`,
         );
       }
       if (entityKinds === null) continue;
       for (const kind of entityKinds.kinds) {
         if (kind.shape !== 'runtime-entity') continue;
-        const compiled = compileUpdatedFieldVisibleOnReadBack(tpl, kind, graph, canonical);
-        for (const result of compiled.scenarios) {
-          out.push({
-            templateName: tpl.name,
-            subjectName: `${kind.name}.${result.mutatorOpId}`,
-            subjectKind: 'RuntimeEntity',
-            scenario: result.scenario,
-          });
+        if (tpl.name === 'UpdatedFieldVisibleOnReadBack') {
+          // Skip rows that don't declare mutators — runtime-entity rows
+          // are now allowed to carry transitions[] only (Phase 5d
+          // schema relaxation). A row with no mutators is not an error
+          // for *this* template, just out of scope.
+          if (!Array.isArray(kind.mutators) || kind.mutators.length === 0) continue;
+          const compiled = compileUpdatedFieldVisibleOnReadBack(tpl, kind, graph, canonical);
+          for (const result of compiled.scenarios) {
+            out.push({
+              templateName: tpl.name,
+              subjectName: `${kind.name}.${result.mutatorOpId}`,
+              subjectKind: 'RuntimeEntity',
+              scenario: result.scenario,
+            });
+          }
+          for (const err of compiled.errors) errors.push(err);
+        } else {
+          // StateTransitionVisibleAfterAction. Skip rows with no
+          // transitions[] — same reasoning as above.
+          if (!Array.isArray(kind.transitions) || kind.transitions.length === 0) continue;
+          const compiled = compileStateTransitionVisibleAfterAction(tpl, kind, graph, canonical);
+          for (const result of compiled.scenarios) {
+            out.push({
+              templateName: tpl.name,
+              subjectName: `${kind.name}.${result.transitionOp}`,
+              subjectKind: 'RuntimeEntity',
+              scenario: result.scenario,
+            });
+          }
+          for (const err of compiled.errors) errors.push(err);
         }
-        for (const err of compiled.errors) errors.push(err);
       }
       continue;
     }

--- a/path-analyser/src/scenarioTemplateInstantiator.ts
+++ b/path-analyser/src/scenarioTemplateInstantiator.ts
@@ -812,6 +812,22 @@ function compileStateTransitionVisibleAfterAction(
     return { scenarios, errors };
   }
 
+  // Split the (possibly dotted) stateField into segments for the
+  // emitter's array-based `pluckByPath`. responseLeafPaths stores
+  // dotted leaves (`metadata.state`, `process.status`, …), so a
+  // single-element wrapper would coerce the emitter into reading
+  // `body['metadata.state']` instead of `body.metadata.state`.
+  // Empty segments (leading dot, double dot, trailing dot) are
+  // never valid leaves — reject so the ABox author sees a clear
+  // error rather than a malformed assertion.
+  const stateFieldSegments = stateField.split('.');
+  if (stateFieldSegments.some((seg) => seg.length === 0)) {
+    errors.push(
+      `${template.name} × ${kind.name}: stateField='${stateField}' has empty path segments (leading, trailing, or double dot)`,
+    );
+    return { scenarios, errors };
+  }
+
   const lastOf = (plan: RequestStep[]): RequestStep => plan[plan.length - 1];
 
   for (const transition of transitions) {
@@ -906,7 +922,7 @@ function compileStateTransitionVisibleAfterAction(
         requestPlan: lastOf(fetcherPlan),
         assertion: {
           kind: 'stateEquals',
-          responseBodyPath: [stateField],
+          responseBodyPath: stateFieldSegments,
           expectedState: transition.to,
           fromState: transition.from,
           transitionOp: transitionOpId,

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -1075,6 +1075,44 @@ export interface ObserveStep {
           /** Path into the fetcher's 200-response body where the actual value should appear. */
           responseBodyPath: string[];
         }>;
+      }
+    | {
+        /**
+         * #305 Phase 5d / #189 — state-transition read-back assertion.
+         * Emitted by the `StateTransitionVisibleAfterAction` template
+         * compiler for `shape: "runtime-entity"` subjects that declare
+         * `transitions[]` + `stateField`. The preceding `InvokeStep`
+         * is a state-transition op whose request body carries no per-
+         * field update (e.g. `resolveIncident` — the post-state is
+         * implicit in the op semantics). The observation fetches the
+         * entity by id and asserts a single equality on the named
+         * state field. Compiled to
+         * `expect(body.<stateField>).toBe(<expectedState>)`.
+         *
+         * `fromState` is carried purely for traceability (so the
+         * emitted suite's test name and the L3 invariant can mention
+         * the transition direction); the assertion itself does not
+         * re-witness the pre-state — the planner's chain guarantees
+         * the entity is in `fromState` at invoke time (e.g.
+         * `searchIncidents` only surfaces ACTIVE incidents on the
+         * OCA API).
+         */
+        kind: 'stateEquals';
+        /**
+         * Top-level (or dotted) response leaf carrying the entity's
+         * current state on the fetcher's 200 response. Almost always
+         * a single segment (`['state']`); recorded as a path for
+         * symmetry with `fieldEquals.responseBodyPath` so a future
+         * nested-state response can be modelled without an emitter
+         * change.
+         */
+        responseBodyPath: string[];
+        /** Expected state value after the transition (e.g. `'RESOLVED'`). */
+        expectedState: string;
+        /** State the entity is expected to be in before the transition (e.g. `'ACTIVE'`). Informational; not re-asserted. */
+        fromState: string;
+        /** OperationId of the transition op that drove the state change. Recorded for traceability. */
+        transitionOp: string;
       };
 }
 

--- a/tests/fixtures/planner/state-transition-visible-after-action.test.ts
+++ b/tests/fixtures/planner/state-transition-visible-after-action.test.ts
@@ -191,4 +191,77 @@ describe('StateTransitionVisibleAfterAction compiler — Layer 2 contract', () =
       instantiateAllTemplates(graph, templates, edges, badCanonical, entityKinds),
     ).toThrow(/no canonical scenario for transition op/);
   });
+
+  it('splits a dotted stateField into responseBodyPath segments (so the emitter walks the object, not a bracket access)', () => {
+    const dottedGraph: OperationGraph = {
+      operations: {
+        resolveThing: graph.operations.resolveThing,
+        getThing: makeOp('getThing', {
+          method: 'GET',
+          path: '/things/{thingKey}',
+          requires: { required: ['ThingKey'], optional: [] },
+          responseLeafPaths: {
+            '200': ['thingKey', 'metadata.state'],
+          },
+        }),
+      },
+      producersByType: {},
+      establishersByType: {},
+    };
+    const dottedKinds = {
+      version: 1,
+      kinds: [
+        {
+          '@type': 'EntityKind' as const,
+          name: 'Thing',
+          shape: 'runtime-entity' as const,
+          identifiers: ['ThingKey'],
+          fetcher: 'getThing',
+          stateField: 'metadata.state',
+          transitions: [{ op: 'resolveThing', from: 'ACTIVE', to: 'RESOLVED' }],
+          description: 'test',
+        },
+      ],
+    };
+    const out = instantiateAllTemplates(dottedGraph, templates, edges, canonical, dottedKinds);
+    const observe = out[0].scenario.steps[2];
+    if (observe.kind !== 'observe' || observe.assertion.kind !== 'stateEquals') {
+      throw new Error('expected observe.stateEquals');
+    }
+    expect(observe.assertion.responseBodyPath).toEqual(['metadata', 'state']);
+  });
+
+  it('throws (loud failure) when stateField has empty path segments (leading/trailing/double dot)', () => {
+    const emptySegmentGraph: OperationGraph = {
+      operations: {
+        resolveThing: graph.operations.resolveThing,
+        getThing: makeOp('getThing', {
+          method: 'GET',
+          path: '/things/{thingKey}',
+          requires: { required: ['ThingKey'], optional: [] },
+          responseLeafPaths: { '200': ['thingKey', '.state'] },
+        }),
+      },
+      producersByType: {},
+      establishersByType: {},
+    };
+    const emptySegmentKinds = {
+      version: 1,
+      kinds: [
+        {
+          '@type': 'EntityKind' as const,
+          name: 'Thing',
+          shape: 'runtime-entity' as const,
+          identifiers: ['ThingKey'],
+          fetcher: 'getThing',
+          stateField: '.state',
+          transitions: [{ op: 'resolveThing', from: 'ACTIVE', to: 'RESOLVED' }],
+          description: 'test',
+        },
+      ],
+    };
+    expect(() =>
+      instantiateAllTemplates(emptySegmentGraph, templates, edges, canonical, emptySegmentKinds),
+    ).toThrow(/empty path segments/);
+  });
 });

--- a/tests/fixtures/planner/state-transition-visible-after-action.test.ts
+++ b/tests/fixtures/planner/state-transition-visible-after-action.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import { instantiateAllTemplates } from '../../../path-analyser/src/scenarioTemplateInstantiator.ts';
+import type {
+  EndpointScenario,
+  OperationGraph,
+  OperationNode,
+  RequestStep,
+} from '../../../path-analyser/src/types.ts';
+
+/**
+ * #305 Phase 5d / #189 — Layer-2 fixtures for the
+ * `StateTransitionVisibleAfterAction` compiler. Each `it` is one chain
+ * statement about how a `runtime-entity` ABox row + transition op +
+ * fetcher canonical pair flows through `instantiateAllTemplates`.
+ *
+ * The fixture hand-builds a minimal `OperationGraph` (transition op +
+ * fetcher) and a minimal canonical map (one EndpointScenario per op),
+ * then asserts on the emitted TemplateScenario's step list and
+ * stateEquals assertion shape.
+ */
+
+function makeOp(operationId: string, opts: Partial<OperationNode>): OperationNode {
+  return {
+    operationId,
+    method: 'POST',
+    path: `/${operationId}`,
+    requires: { required: [], optional: [] },
+    produces: [],
+    ...opts,
+  };
+}
+
+function makeStep(operationId: string, opts: Partial<RequestStep>): RequestStep {
+  return {
+    operationId,
+    method: 'POST',
+    pathTemplate: `/${operationId}`,
+    expect: { status: 200 },
+    ...opts,
+  };
+}
+
+function makeScenario(operationId: string, plan: RequestStep[]): EndpointScenario {
+  return {
+    id: `s:${operationId}`,
+    operations: plan.map((s) => ({
+      operationId: s.operationId,
+      method: s.method,
+      path: s.pathTemplate,
+    })),
+    producedSemanticTypes: [],
+    satisfiedSemanticTypes: [],
+    requestPlan: plan,
+    bindings: {},
+    seedBindings: [],
+  };
+}
+
+describe('StateTransitionVisibleAfterAction compiler — Layer 2 contract', () => {
+  const graph: OperationGraph = {
+    operations: {
+      resolveThing: makeOp('resolveThing', {
+        method: 'POST',
+        path: '/things/{thingKey}/resolution',
+        requires: { required: ['ThingKey'], optional: [] },
+      }),
+      getThing: makeOp('getThing', {
+        method: 'GET',
+        path: '/things/{thingKey}',
+        requires: { required: ['ThingKey'], optional: [] },
+        responseLeafPaths: {
+          '200': ['thingKey', 'state', 'createdAt'],
+        },
+      }),
+    },
+    producersByType: {},
+    establishersByType: {},
+  };
+
+  const canonical = new Map<string, EndpointScenario>([
+    [
+      'resolveThing',
+      makeScenario('resolveThing', [
+        makeStep('resolveThing', {
+          method: 'POST',
+          pathTemplate: '/things/{thingKey}/resolution',
+          bodyTemplate: {},
+          expect: { status: 204 },
+        }),
+      ]),
+    ],
+    [
+      'getThing',
+      makeScenario('getThing', [
+        makeStep('getThing', { method: 'GET', pathTemplate: '/things/{thingKey}' }),
+      ]),
+    ],
+  ]);
+
+  const templates = {
+    version: 1,
+    templates: [
+      {
+        '@type': 'ScenarioTemplate' as const,
+        name: 'StateTransitionVisibleAfterAction',
+        appliesTo: { kind: 'RuntimeEntity' as const },
+        description: 'test',
+        steps: [],
+      },
+    ],
+  };
+  const entityKinds = {
+    version: 1,
+    kinds: [
+      {
+        '@type': 'EntityKind' as const,
+        name: 'Thing',
+        shape: 'runtime-entity' as const,
+        identifiers: ['ThingKey'],
+        fetcher: 'getThing',
+        stateField: 'state',
+        transitions: [{ op: 'resolveThing', from: 'ACTIVE', to: 'RESOLVED' }],
+        description: 'test',
+      },
+    ],
+  };
+  const edges = { version: 1, edges: [] };
+
+  const result = instantiateAllTemplates(graph, templates, edges, canonical, entityKinds);
+
+  it('emits exactly one scenario per (runtime-entity × transition) pair', () => {
+    expect(result).toHaveLength(1);
+    expect(result[0].subjectKind).toBe('RuntimeEntity');
+    expect(result[0].subjectName).toBe('Thing.resolveThing');
+  });
+
+  it('emits the 3-step shape (prereqChain → invoke → observe)', () => {
+    const steps = result[0].scenario.steps;
+    expect(steps.map((s) => s.kind)).toEqual(['prereqChain', 'invoke', 'observe']);
+  });
+
+  it('emits a stateEquals assertion with expectedState from transitions[].to and responseBodyPath from stateField', () => {
+    const observe = result[0].scenario.steps[2];
+    if (observe.kind !== 'observe' || observe.assertion.kind !== 'stateEquals') {
+      throw new Error('expected observe.stateEquals');
+    }
+    expect(observe.assertion.responseBodyPath).toEqual(['state']);
+    expect(observe.assertion.expectedState).toBe('RESOLVED');
+    expect(observe.assertion.fromState).toBe('ACTIVE');
+    expect(observe.assertion.transitionOp).toBe('resolveThing');
+  });
+
+  it('targets the fetcher operation on the observe step', () => {
+    const observe = result[0].scenario.steps[2];
+    if (observe.kind !== 'observe') throw new Error('expected observe step');
+    expect(observe.operationId).toBe('getThing');
+  });
+
+  it('throws (loud failure) when stateField is not a 2xx response leaf of the fetcher', () => {
+    const badEntityKinds = {
+      version: 1,
+      kinds: [
+        {
+          '@type': 'EntityKind' as const,
+          name: 'Thing',
+          shape: 'runtime-entity' as const,
+          identifiers: ['ThingKey'],
+          fetcher: 'getThing',
+          stateField: 'phase',
+          transitions: [{ op: 'resolveThing', from: 'ACTIVE', to: 'RESOLVED' }],
+          description: 'test',
+        },
+      ],
+    };
+    expect(() =>
+      instantiateAllTemplates(graph, templates, edges, canonical, badEntityKinds),
+    ).toThrow(/stateField='phase' is not a 2xx response leaf/);
+  });
+
+  it('throws (loud failure) when the transition op has no canonical scenario', () => {
+    const badCanonical = new Map<string, EndpointScenario>([
+      // Only getThing in canonical — resolveThing missing.
+      [
+        'getThing',
+        makeScenario('getThing', [
+          makeStep('getThing', { method: 'GET', pathTemplate: '/things/{thingKey}' }),
+        ]),
+      ],
+    ]);
+    expect(() =>
+      instantiateAllTemplates(graph, templates, edges, badCanonical, entityKinds),
+    ).toThrow(/no canonical scenario for transition op/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `StateTransitionVisibleAfterAction` scenario template — a `RuntimeEntity`-scoped template that compiles to a 3-step Playwright suite per (entity-kind × transition):

1. **prereq chain** — establish the entity in its `from` state
2. **invoke** the transition op (resolveIncident, completeJob, …)
3. **observe** — re-fetch via the fetcher and assert `<stateField> === transition.to`

This is the architectural sibling of Phase 4's `UpdatedFieldVisibleOnReadBack`, but for state-machine transitions whose only client-facing mutation is a state flip (no per-field body).

First slice ships **`Incident.resolveIncident`** (ACTIVE → RESOLVED). The emitted spec ([state-transitions/Incident.resolveIncident.lifecycle.spec.ts](generated/camunda-oca/playwright/state-transitions/Incident.resolveIncident.lifecycle.spec.ts)):

```
createDeployment(incident-script-task.bpmn)
  → createProcessInstance
  → searchIncidents          (discovers incidentKey via IncidentKey runtimeEmission — Phase 5a / #313)
  → resolveIncident(incidentKey)
  → getIncident(incidentKey) → expect(state).toEqual('RESOLVED')
```

Future transitions (`completeJob`, `completeUserTask`, `cancelProcessInstance`, …) drop in as additional `entity-kinds.json` rows once each one's pre-state and fetcher state-field are vetted (see Phase 5d-2/3/4 in the plan).

## Schema

- Relax `runtime-entity` row to require `fetcher` + (`mutators` OR `transitions`).
- Add `transitions[] {op, from, to}` and `stateField` (with iff cross-field constraint via two Draft-07 if/then arms).
- Add `'stateEquals'` to `ObserveStep.expect` enum.
- Regenerated `ontology/vocabulary/{entity-kinds,scenario-template}.schema.json` via `npm run build:ontology`.

## Compiler + emitter

- `compileStateTransitionVisibleAfterAction` in `scenarioTemplateInstantiator.ts` (loud failure on missing canonical / stateField not a live 2xx leaf).
- `ObserveStep.assertion` `stateEquals` variant in `path-analyser/types.ts`.
- `renderStateTransitionSuite` + `appendObserveStateEqualsStep` in `materializer/playwright/templateEmitter.ts`.
- `materializer/index.ts` wires the new template into a `state-transitions/` sibling subdir alongside `runtime-entities/` (one Playwright suite per `<Entity>.<transitionOp>.lifecycle.spec.ts`).

## ABox

- New `Incident` runtime-entity row (`fetcher: getIncident`, `stateField: state`, `transitions: [{ resolveIncident, ACTIVE, RESOLVED }]`).
- New `StateTransitionVisibleAfterAction` template entry.

## Tests

- **L2** (`tests/fixtures/planner/state-transition-visible-after-action.test.ts`, 6 assertions): one scenario per (kind × transition), 3-step shape, stateEquals fields populated, observe targets fetcher, loud failure when stateField isn't a fetcher leaf, loud failure when transition has no canonical.
- **L3** (4 new invariants in `configs/camunda-oca/regression-invariants.test.ts`): canonical 3-step shape per emitted scenario, stateField is a live 200-response leaf, fromState/expectedState/transitionOp populated, emitted `Incident.resolveIncident` Playwright spec contains the expected substrings.
- Updated #210 ABox allowlist to include `Incident` (ABox-authoritative ahead of upstream `x-semantic-kind` annotation).
- Updated #268 Phase 1 RuntimeEntity role set to include `transition`.

All 592 tests pass; all 6 workspace typechecks clean; Biome clean.

Closes #189 (first slice — additional transitions land as ABox-only follow-ups).
Continues #305 Phase 5d.