### PR TITLE
feat: add UserTask.completeUserTask state transition (CREATED → COMPLETED) — #305 Phase 5d-2

### DIFF
--- a/configs/camunda-oca/ontology/entity-kinds.json
+++ b/configs/camunda-oca/ontology/entity-kinds.json
@@ -151,7 +151,7 @@
           "to": "COMPLETED"
         }
       ],
-      "description": "#305 Phase 4 + Phase 5d-2 — a runtime-emitted user task, identified by its server-minted userTaskKey. UserTasks are not created via a client-facing endpoint; they are emitted as a side-effect of process-instance progression (when a user-task service-task activates). Discovered at planning time via the UserTaskKey runtimeEmission entry (discoveredVia searchUserTasks, post-#308). Mutated in place by updateUserTask (and, in future phases, assignUserTask/unassignUserTask) and read back via getUserTask. State transition: completeUserTask flips state CREATED → COMPLETED (Phase 5d-2 / #189). Consumed by both UpdatedFieldVisibleOnReadBack (mutators) and StateTransitionVisibleAfterAction (transitions)."
+      "description": "#305 Phase 4 + Phase 5d-2 — a runtime-emitted user task, identified by its server-minted userTaskKey. UserTasks are not created via a client-facing endpoint; they are emitted as a side-effect of process-instance progression (when a BPMN user-task element is activated). Discovered at planning time via the UserTaskKey runtimeEmission entry (discoveredVia searchUserTasks, post-#308). Mutated in place by updateUserTask (and, in future phases, assignUserTask/unassignUserTask) and read back via getUserTask. State transition: completeUserTask flips state CREATED → COMPLETED (Phase 5d-2 / #189). Consumed by both UpdatedFieldVisibleOnReadBack (mutators) and StateTransitionVisibleAfterAction (transitions)."
     },
     {
       "@type": "EntityKind",

--- a/configs/camunda-oca/ontology/entity-kinds.json
+++ b/configs/camunda-oca/ontology/entity-kinds.json
@@ -143,7 +143,15 @@
         "updateUserTask"
       ],
       "fetcher": "getUserTask",
-      "description": "#305 Phase 4 — a runtime-emitted user task, identified by its server-minted userTaskKey. UserTasks are not created via a client-facing endpoint; they are emitted as a side-effect of process-instance progression (when a user-task service-task activates). Discovered at planning time via the UserTaskKey runtimeEmission entry (discoveredVia searchUserTasks, post-#308). Mutated in place by updateUserTask (and, in future phases, assignUserTask/unassignUserTask/completeUserTask) and read back via getUserTask. Consumed by the UpdatedFieldVisibleOnReadBack scenario template (#305 Phase 4)."
+      "stateField": "state",
+      "transitions": [
+        {
+          "op": "completeUserTask",
+          "from": "CREATED",
+          "to": "COMPLETED"
+        }
+      ],
+      "description": "#305 Phase 4 + Phase 5d-2 — a runtime-emitted user task, identified by its server-minted userTaskKey. UserTasks are not created via a client-facing endpoint; they are emitted as a side-effect of process-instance progression (when a user-task service-task activates). Discovered at planning time via the UserTaskKey runtimeEmission entry (discoveredVia searchUserTasks, post-#308). Mutated in place by updateUserTask (and, in future phases, assignUserTask/unassignUserTask) and read back via getUserTask. State transition: completeUserTask flips state CREATED → COMPLETED (Phase 5d-2 / #189). Consumed by both UpdatedFieldVisibleOnReadBack (mutators) and StateTransitionVisibleAfterAction (transitions)."
     },
     {
       "@type": "EntityKind",

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -8194,5 +8194,26 @@ describeForThisConfig(
       const missing = required.filter((needle) => !src.includes(needle));
       expect(missing).toEqual([]);
     });
+
+    it('UserTask.completeUserTask slice (#305 Phase 5d-2): emitted Playwright spec asserts state === COMPLETED via getUserTask read-back', () => {
+      const specPath = join(
+        GENERATED_TESTS_DIR,
+        'state-transitions',
+        'UserTask.completeUserTask.lifecycle.spec.ts',
+      );
+      if (!existsSync(specPath)) {
+        return;
+      }
+      const src = readFileSync(specPath, 'utf8');
+      const required = [
+        "operationId: 'getUserTask'",
+        "operationId: 'searchUserTasks'",
+        '/completion',
+        ".state).toEqual('COMPLETED')",
+        'user-task.bpmn',
+      ];
+      const missing = required.filter((needle) => !src.includes(needle));
+      expect(missing).toEqual([]);
+    });
   },
 );


### PR DESCRIPTION
## Summary

Second slice of the `StateTransitionVisibleAfterAction` template landed in #314 (Phase 5d-1). **Pure ABox addition** — no code changes — extending the existing `UserTask` runtime-entity row with:

```json
"stateField": "state",
"transitions": [{ "op": "completeUserTask", "from": "CREATED", "to": "COMPLETED" }]
```

UserTask now feeds **both** RuntimeEntity-scoped templates:
- `UpdatedFieldVisibleOnReadBack` (mutators: `updateUserTask`)
- `StateTransitionVisibleAfterAction` (transitions: `completeUserTask`)

## Emitted spec

`generated/camunda-oca/playwright/state-transitions/UserTask.completeUserTask.lifecycle.spec.ts`:

```
createDeployment(user-task.bpmn)
  → createProcessInstance
  → searchUserTasks            (discovers userTaskKey via UserTaskKey runtimeEmission — Phase 5a)
  → completeUserTask(userTaskKey)
  → getUserTask(userTaskKey) → expect(state).toEqual('COMPLETED')
```

## Tests

- L3: 1 new invariant pinning the emitted spec's required substrings (mirrors the `Incident.resolveIncident` invariant from #314).
- The class-scoped L3 invariants (3-step shape, stateField is a live response leaf, fromState/expectedState/transitionOp populated) automatically cover the new scenario without changes.
- All gates green: lint, 6 typechecks, 595 tests passing.

Closes a follow-up slice of #189. Continues #305 Phase 5d.