### PR TITLE
feat: add ProcessInstance.cancelProcessInstance state transition (ACTIVE → CANCELED) — #305 Phase 5d-4

### DIFF
--- a/configs/camunda-oca/fixtures/bpmn/cancellable-blocked.bpmn
+++ b/configs/camunda-oca/fixtures/bpmn/cancellable-blocked.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_cancellable_blocked" targetNamespace="http://bpmn.io/schema/bpmn" exporter="api-test-generator" exporterVersion="1.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_cancellable_blocked" name="Cancellable Blocked Process" isExecutable="true">
+    <bpmn:extensionElements />
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_to_serviceTask</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_to_serviceTask" sourceRef="StartEvent_1" targetRef="ServiceTask_1" />
+    <bpmn:serviceTask id="ServiceTask_1" name="Blocked Until Cancelled">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="cancelProcessInstanceTestBlock" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_to_serviceTask</bpmn:incoming>
+      <bpmn:outgoing>Flow_to_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_to_end" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1" name="End">
+      <bpmn:incoming>Flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_cancellable_blocked">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_to_serviceTask_di" bpmnElement="Flow_to_serviceTask">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_to_end_di" bpmnElement="Flow_to_end">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/configs/camunda-oca/fixtures/deployment-artifacts.json
+++ b/configs/camunda-oca/fixtures/deployment-artifacts.json
@@ -39,6 +39,16 @@
       }
     },
     {
+      "kind": "bpmnProcess",
+      "path": "bpmn/cancellable-blocked.bpmn",
+      "description": "BPMN process with a single service task wired to a unique job type `cancelProcessInstanceTestBlock` that is never activated anywhere else in the generated suite. The instance therefore stays ACTIVE indefinitely (no auto-completion, no race with parallel `activateJobs` runs that target other job types) until the test cancels it explicitly. Selected for chains whose consumer ops require `ModelHasCancellationBlocker` (e.g. cancelProcessInstance — see #305 Phase 5d-4 / #189). The unique job type is the whole point: do NOT consolidate with bpmn/service-task.bpmn (sampleJobType), or a parallel run that activates sampleJobType jobs could complete this PI before the cancel step fires.",
+      "providesStates": ["ModelHasCancellationBlocker"],
+      "providesValues": {
+        "ElementId": ["StartEvent_1", "ServiceTask_1", "EndEvent_1"],
+        "JobType": ["cancelProcessInstanceTestBlock"]
+      }
+    },
+    {
       "kind": "form",
       "path": "forms/simple.form",
       "description": "Minimal Camunda form JSON"

--- a/configs/camunda-oca/ontology/artifact-kinds.json
+++ b/configs/camunda-oca/ontology/artifact-kinds.json
@@ -8,7 +8,7 @@
       "name": "bpmnProcess",
       "identifierType": "ProcessDefinitionId",
       "producesStates": ["ProcessDefinitionDeployed"],
-      "producibleStates": ["ModelHasServiceTaskType", "ModelHasUserTask", "ModelEmitsIncident", "ProcessInstanceCompleted"],
+      "producibleStates": ["ModelHasServiceTaskType", "ModelHasUserTask", "ModelEmitsIncident", "ModelHasCancellationBlocker", "ProcessInstanceCompleted"],
       "producesSemantics": ["ProcessDefinitionKey"],
       "deploymentSlices": ["processDefinition"],
       "modelKind": "bpmn",

--- a/configs/camunda-oca/ontology/entity-kinds.json
+++ b/configs/camunda-oca/ontology/entity-kinds.json
@@ -170,6 +170,24 @@
         }
       ],
       "description": "#305 Phase 5d / #189 — a runtime-emitted incident, identified by its server-minted incidentKey. Incidents are not created via a client-facing endpoint; they are emitted as a side-effect of a process instance whose BPMN deterministically fails at runtime (e.g. incident-script-task.bpmn). Discovered at planning time via the IncidentKey runtimeEmission entry (discoveredVia searchIncidents, #305 Phase 5a). The only client-facing state transition on the OCA API is resolveIncident (ACTIVE → RESOLVED); read back via getIncident. Consumed by the StateTransitionVisibleAfterAction scenario template (#305 Phase 5d / #189). No mutators[] today — Incidents do not expose per-field mutators on the public API."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "ProcessInstance",
+      "shape": "runtime-entity",
+      "identifiers": [
+        "ProcessInstanceKey"
+      ],
+      "fetcher": "getProcessInstance",
+      "stateField": "state",
+      "transitions": [
+        {
+          "op": "cancelProcessInstance",
+          "from": "ACTIVE",
+          "to": "CANCELED"
+        }
+      ],
+      "description": "#305 Phase 5d-4 / #189 — a process instance, identified by its server-minted processInstanceKey. NOTE on shape: ProcessInstance is the direct response of createProcessInstance, not strictly a side-effect 'runtime-emitted' entity in the strict #305 sense; we classify it as a runtime-entity here purely so it can participate in the StateTransitionVisibleAfterAction template (which requires fetcher+stateField+transitions). The cancelProcessInstance transition (ACTIVE → CANCELED) is verified by read-back through getProcessInstance. Selection of the deployment fixture is driven by `requires: [ModelHasCancellationBlocker]` on the cancelProcessInstance op, which forces the planner to choose bpmn/cancellable-blocked.bpmn (a service task wired to a unique job type that no other test activates) so the instance stays ACTIVE until the test cancels it explicitly. No mutators[]. See #281 for the orthogonal EntityLifecycle two-revoker design that may later relocate ProcessInstance into a richer shape; this row scopes ProcessInstance to the state-transition concern only."
     }
   ]
 }

--- a/configs/camunda-oca/ontology/entity-kinds.json
+++ b/configs/camunda-oca/ontology/entity-kinds.json
@@ -151,7 +151,7 @@
           "to": "COMPLETED"
         }
       ],
-      "description": "#305 Phase 4 + Phase 5d-2 — a runtime-emitted user task, identified by its server-minted userTaskKey. UserTasks are not created via a client-facing endpoint; they are emitted as a side-effect of process-instance progression (when a user-task service-task activates). Discovered at planning time via the UserTaskKey runtimeEmission entry (discoveredVia searchUserTasks, post-#308). Mutated in place by updateUserTask (and, in future phases, assignUserTask/unassignUserTask) and read back via getUserTask. State transition: completeUserTask flips state CREATED → COMPLETED (Phase 5d-2 / #189). Consumed by both UpdatedFieldVisibleOnReadBack (mutators) and StateTransitionVisibleAfterAction (transitions)."
+      "description": "#305 Phase 4 + Phase 5d-2 — a runtime-emitted user task, identified by its server-minted userTaskKey. UserTasks are not created via a client-facing endpoint; they are emitted as a side-effect of process-instance progression (when a BPMN user-task element is activated). Discovered at planning time via the UserTaskKey runtimeEmission entry (discoveredVia searchUserTasks, post-#308). Mutated in place by updateUserTask (and, in future phases, assignUserTask/unassignUserTask) and read back via getUserTask. State transition: completeUserTask flips state CREATED → COMPLETED (Phase 5d-2 / #189). Consumed by both UpdatedFieldVisibleOnReadBack (mutators) and StateTransitionVisibleAfterAction (transitions)."
     },
     {
       "@type": "EntityKind",

--- a/configs/camunda-oca/ontology/entity-kinds.json
+++ b/configs/camunda-oca/ontology/entity-kinds.json
@@ -143,7 +143,15 @@
         "updateUserTask"
       ],
       "fetcher": "getUserTask",
-      "description": "#305 Phase 4 — a runtime-emitted user task, identified by its server-minted userTaskKey. UserTasks are not created via a client-facing endpoint; they are emitted as a side-effect of process-instance progression (when a user-task service-task activates). Discovered at planning time via the UserTaskKey runtimeEmission entry (discoveredVia searchUserTasks, post-#308). Mutated in place by updateUserTask (and, in future phases, assignUserTask/unassignUserTask/completeUserTask) and read back via getUserTask. Consumed by the UpdatedFieldVisibleOnReadBack scenario template (#305 Phase 4)."
+      "stateField": "state",
+      "transitions": [
+        {
+          "op": "completeUserTask",
+          "from": "CREATED",
+          "to": "COMPLETED"
+        }
+      ],
+      "description": "#305 Phase 4 + Phase 5d-2 — a runtime-emitted user task, identified by its server-minted userTaskKey. UserTasks are not created via a client-facing endpoint; they are emitted as a side-effect of process-instance progression (when a user-task service-task activates). Discovered at planning time via the UserTaskKey runtimeEmission entry (discoveredVia searchUserTasks, post-#308). Mutated in place by updateUserTask (and, in future phases, assignUserTask/unassignUserTask) and read back via getUserTask. State transition: completeUserTask flips state CREATED → COMPLETED (Phase 5d-2 / #189). Consumed by both UpdatedFieldVisibleOnReadBack (mutators) and StateTransitionVisibleAfterAction (transitions)."
     },
     {
       "@type": "EntityKind",

--- a/configs/camunda-oca/ontology/runtime-states.json
+++ b/configs/camunda-oca/ontology/runtime-states.json
@@ -98,6 +98,9 @@
     },
     {
       "operationId": "cancelProcessInstance",
+      "requires": [
+        "ModelHasCancellationBlocker"
+      ],
       "produces": [
         "ProcessInstanceCompleted"
       ]

--- a/configs/camunda-oca/ontology/semantics.json
+++ b/configs/camunda-oca/ontology/semantics.json
@@ -149,6 +149,16 @@
       "dependsOn": [
         "ProcessDefinitionDeployed"
       ]
+    },
+    {
+      "name": "ModelHasCancellationBlocker",
+      "parameter": "cancellationBlockerJobType",
+      "producedBy": [
+        "createDeployment"
+      ],
+      "dependsOn": [
+        "ProcessDefinitionDeployed"
+      ]
     }
   ],
   "identifiers": [

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -4804,7 +4804,13 @@ describeForThisConfig('bundled-spec invariants: entity-kinds ABox cross-referenc
     // (e.g. server-minted resources whose existence is only implied by
     // path-param conventions). These are deliberate ABox-only entries
     // and must not trip the spec-vs-abox drift check.
-    const ABOX_AUTHORITATIVE_KINDS = new Set(['Authorization', 'Document', 'UserTask', 'Incident']);
+    const ABOX_AUTHORITATIVE_KINDS = new Set([
+      'Authorization',
+      'Document',
+      'UserTask',
+      'Incident',
+      'ProcessInstance',
+    ]);
     const unaccounted = aboxOnly.filter((n) => !ABOX_AUTHORITATIVE_KINDS.has(n));
     expect(
       unaccounted,
@@ -8211,6 +8217,27 @@ describeForThisConfig(
         '/completion',
         ".state).toEqual('COMPLETED')",
         'user-task.bpmn',
+      ];
+      const missing = required.filter((needle) => !src.includes(needle));
+      expect(missing).toEqual([]);
+    });
+
+    it('ProcessInstance.cancelProcessInstance slice (#305 Phase 5d-4): emitted Playwright spec asserts state === CANCELED via getProcessInstance read-back, using cancellable-blocked.bpmn fixture', () => {
+      const specPath = join(
+        GENERATED_TESTS_DIR,
+        'state-transitions',
+        'ProcessInstance.cancelProcessInstance.lifecycle.spec.ts',
+      );
+      if (!existsSync(specPath)) {
+        return;
+      }
+      const src = readFileSync(specPath, 'utf8');
+      const required = [
+        "operationId: 'getProcessInstance'",
+        'invoke (transition): cancelProcessInstance',
+        '/cancellation',
+        ".state).toEqual('CANCELED')",
+        'cancellable-blocked.bpmn',
       ];
       const missing = required.filter((needle) => !src.includes(needle));
       expect(missing).toEqual([]);

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -8194,5 +8194,26 @@ describeForThisConfig(
       const missing = required.filter((needle) => !src.includes(needle));
       expect(missing).toEqual([]);
     });
+
+    it('UserTask.completeUserTask slice (#305 Phase 5d-2): emitted Playwright spec asserts state === COMPLETED via getUserTask read-back', () => {
+      const specPath = join(
+        GENERATED_TESTS_DIR,
+        'state-transitions',
+        'UserTask.completeUserTask.lifecycle.spec.ts',
+      );
+      if (!existsSync(specPath)) {
+        return;
+      }
+      const src = readFileSync(specPath, 'utf8');
+      const required = [
+        "operationId: 'getUserTask'",
+        "operationId: 'searchUserTasks'",
+        '/completion',
+        ".state).toEqual('COMPLETED')",
+        'user-task.bpmn',
+      ];
+      const missing = required.filter((needle) => !src.includes(needle));
+      expect(missing).toEqual([]);
+    });
   },
 );


### PR DESCRIPTION
## Summary

Third `StateTransitionVisibleAfterAction` slice (after Incident.resolveIncident #314 and UserTask.completeUserTask #316). Adds **ProcessInstance** as a runtime-entity and wires the **cancelProcessInstance** transition (ACTIVE → CANCELED), verified by read-back through `getProcessInstance`.

Closes part of #189 / #305 Phase 5d-4.

## What changed

ABox-only changes plus one new BPMN fixture:

- **New fixture** `configs/camunda-oca/fixtures/bpmn/cancellable-blocked.bpmn` — single service task wired to job type `cancelProcessInstanceTestBlock`. The job type is **unique by design**: it is never referenced anywhere else in the suite, so a parallel run that activates other job types (e.g. `sampleJobType`) cannot grab and complete this process instance before the cancel step fires. The process therefore stays ACTIVE until the test cancels it.
- **`semantics.json`** — new capability `ModelHasCancellationBlocker` (parameter: `cancellationBlockerJobType`, producedBy: `createDeployment`).
- **`artifact-kinds.json`** — `bpmnProcess.producibleStates` gains `ModelHasCancellationBlocker`.
- **`deployment-artifacts.json`** — registry entry for the new bpmn declares `providesStates: [ModelHasCancellationBlocker]` plus `providesValues` for the unique job type.
- **`runtime-states.json`** — `cancelProcessInstance` op-requirements gains `requires: [ModelHasCancellationBlocker]`. This cascades through the planner BFS and switches the existing `cancelProcessInstance.feature.spec.ts` from `service-task.bpmn` (sampleJobType, shared with activateJobs) to `cancellable-blocked.bpmn` (isolated). **This behaviour change is intentional** — no cancel test should rely on a shared-job-type fixture.
- **`entity-kinds.json`** — new ProcessInstance runtime-entity row (identifiers `ProcessInstanceKey`, fetcher `getProcessInstance`, stateField `state`, transitions: `[{cancelProcessInstance, ACTIVE, CANCELED}]`, no mutators).
- **`regression-invariants.test.ts`** — `ABOX_AUTHORITATIVE_KINDS` allowlist gains `'ProcessInstance'`; new L3 invariant pins the emitted `ProcessInstance.cancelProcessInstance.lifecycle.spec.ts` substrings.

## Notes on shape

ProcessInstance is the direct response of `createProcessInstance` (not strictly a side-effect 'runtime-emitted' entity in the strict #305 sense). We classify it as a `runtime-entity` here purely so it can participate in the `StateTransitionVisibleAfterAction` template (which requires fetcher + stateField + transitions). The new row's `description` documents this stretch and notes that **#281 (EntityLifecycle two-revoker design) is orthogonal** and may later relocate ProcessInstance into a richer shape. This row scopes ProcessInstance to the state-transition concern only.

## Emitted spec (chain)

```
createDeployment(cancellable-blocked.bpmn)
  → createProcessInstance(processDefinitionKey)
  → cancelProcessInstance (POST /process-instances/{key}/cancellation, expect 204)
  → getProcessInstance (await-eventually, expect state === 'CANCELED')
```

## Gate

- ✅ Lint clean
- ✅ 6 typechecks green (semantic-graph-extractor, path-analyser, emitter-sdk, materializer, request-validation, tests)
- ✅ `npm test` — 596 tests pass (was 595)

## Stacked on #316

This branch is stacked on `feat/state-transition-complete-user-task-305-phase-5d-2` (PR #316) because both touch `entity-kinds.json` and `regression-invariants.test.ts`. Once #316 merges, GitHub will retarget this PR's base diff to main automatically (or I'll rebase).

## Next (after this merges)

- Phase 5d-5: `modifyProcessInstance.terminate` (the more complex variant).