### PR TITLE
feat: cross-run identifier uniqueness via per-process runNonce (#304)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -8244,3 +8244,98 @@ describeForThisConfig(
     });
   },
 );
+
+// -----------------------------------------------------------------------------
+// #304 — Cross-run identifier uniqueness for client-minted bindings consumed
+// by operations that declare an HTTP 409 (Conflict) response.
+//
+// Class-scoped invariant: for every operation in the bundled graph whose
+// `responseLeafPaths` contains a '409' entry, if a feature spec file was
+// emitted for that operation AND that spec contains a seedBinding(...) call,
+// then every seedBinding(...) call inside that spec must pass `{ unique: true }`.
+//
+// Why "every call in the spec" rather than "only the path-param identifier":
+// the planner stamps `declares409` per-step, so the emitter unique-tags ALL
+// client-minted bindings consumed by that step's request — including
+// non-identifier fields like `passwordVar` on createUser. That is intentional:
+// non-identifier fields tagged unique are harmless (they just become non-
+// snapshot-stable), and identifier-shape detection at the emitter would be
+// strictly more complex without an observable benefit.
+//
+// A spec with zero seedBinding(...) calls (e.g. one whose payload bindings
+// all come from earlier-step `extractInto` calls — no client-minted seeds)
+// trivially passes.
+// -----------------------------------------------------------------------------
+
+describe.skipIf(CONFIG_NAME !== ACTIVE_CONFIG)(
+  '#304: feature specs for ops declaring HTTP 409 use seedBinding({ unique: true }) for client-minted bindings',
+  () => {
+    it('every emitted feature spec for an op with `409` in responseLeafPaths flags ALL its seedBinding calls as { unique: true }', () => {
+      if (!existsSync(GRAPH_PATH)) {
+        throw new Error(
+          `Operation dependency graph not found at ${GRAPH_PATH}. Run 'npm run testsuite:generate' first.`,
+        );
+      }
+      if (!existsSync(GENERATED_TESTS_DIR)) {
+        throw new Error(
+          `Generated tests directory not found at ${GENERATED_TESTS_DIR}. Run 'npm run testsuite:generate' first.`,
+        );
+      }
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const graph = JSON.parse(readFileSync(GRAPH_PATH, 'utf8')) as {
+        operations?: Record<string, { responseLeafPaths?: Record<string, unknown> }>;
+      };
+      const opsRecord = graph.operations ?? {};
+      const opsWith409: string[] = [];
+      for (const [opId, op] of Object.entries(opsRecord)) {
+        if (op?.responseLeafPaths && '409' in op.responseLeafPaths) {
+          opsWith409.push(opId);
+        }
+      }
+      // Sanity: the upstream spec must actually declare 409 on at least the
+      // canonical create-style ops. If this fires, either the spec pin
+      // regressed or the loader stopped propagating responseLeafPaths.
+      expect(opsWith409.length).toBeGreaterThan(0);
+
+      // seedBinding(' …  ') with an exact match of zero or one `, { unique: true }`
+      // arg. We accept either single or double quotes around the name to be
+      // resilient to Biome formatter choices in generated output.
+      const seedCallRe =
+        /\bseedBinding\(\s*(['"])([A-Za-z_$][\w$]*)\1\s*(,\s*\{\s*unique:\s*true\s*\})?\s*\)/g;
+
+      const violations: string[] = [];
+      for (const opId of opsWith409) {
+        const specPath = join(GENERATED_TESTS_DIR, `${opId}.feature.spec.ts`);
+        if (!existsSync(specPath)) continue;
+        const src = readFileSync(specPath, 'utf8');
+        const matches = [...src.matchAll(seedCallRe)];
+        for (const m of matches) {
+          const bindingName = m[2];
+          const hasUnique = m[3] !== undefined;
+          if (!hasUnique) {
+            violations.push(
+              `${opId}.feature.spec.ts: seedBinding('${bindingName}') missing { unique: true }`,
+            );
+          }
+        }
+      }
+      expect(violations).toEqual([]);
+    });
+
+    it('feature specs for ops that do NOT declare 409 keep seedBinding calls deterministic (no { unique: true })', () => {
+      // Companion to the previous invariant: confirms we did not blanket-
+      // apply unique tagging. A representative non-409 op feature spec must
+      // contain at least one bare seedBinding() call. createDeployment is a
+      // safe pick — it doesn't declare 409 and consistently emits a seeded
+      // tenantId binding.
+      const specPath = join(GENERATED_TESTS_DIR, 'createDeployment.feature.spec.ts');
+      if (!existsSync(specPath)) {
+        return;
+      }
+      const src = readFileSync(specPath, 'utf8');
+      // At least one bare seedBinding('xxx') call (no `{ unique: true }`).
+      const bareCallRe = /\bseedBinding\(\s*['"][A-Za-z_$][\w$]*['"]\s*\)/;
+      expect(bareCallRe.test(src)).toBe(true);
+    });
+  },
+);

--- a/materializer/src/playwright/ctxSeeding.ts
+++ b/materializer/src/playwright/ctxSeeding.ts
@@ -44,6 +44,7 @@
 
 import type { RequestStep } from 'path-analyser/types';
 import { PENDING_BINDING } from 'path-analyser/types';
+import { camelCase } from './stepRenderer.js';
 
 /**
  * Compute the set of binding names that must be seeded with
@@ -100,7 +101,16 @@ const PLACEHOLDER_RE = /\\?\$\{([^}]+)\}/g;
 
 function collectPathTemplateRefs(pathTemplate: string | undefined, out: Set<string>): void {
   if (!pathTemplate) return;
-  for (const m of pathTemplate.matchAll(PATH_PLACEHOLDER_RE)) out.add(m[1]);
+  // Mirror stepRenderer.buildUrlExpression: every `{param}` placeholder in
+  // the URL is substituted at runtime as `ctx.${camelCase(param)}Var`, so
+  // the corresponding ctx binding name is `${camelCase(param)}Var` — NOT
+  // the raw placeholder name. Without this transform, path-only client-
+  // minted identifiers (e.g. usernameVar consumed by a 409-declaring
+  // DELETE /users/{username}) would never match the seeded ctx binding
+  // set and would silently miss `{ unique: true }` tagging. (#318 review.)
+  for (const m of pathTemplate.matchAll(PATH_PLACEHOLDER_RE)) {
+    out.add(`${camelCase(m[1])}Var`);
+  }
 }
 
 function walkForPlaceholders(node: unknown, out: Set<string>): void {

--- a/materializer/src/playwright/ctxSeeding.ts
+++ b/materializer/src/playwright/ctxSeeding.ts
@@ -96,7 +96,7 @@ function collectBindingRefs(step: RequestStep): Set<string> {
 }
 
 const PATH_PLACEHOLDER_RE = /\{([A-Za-z_$][\w$]*)\}/g;
-const PLACEHOLDER_RE = /\$\{([A-Za-z_$][\w$]*)\}/g;
+const PLACEHOLDER_RE = /\\?\$\{([^}]+)\}/g;
 
 function collectPathTemplateRefs(pathTemplate: string | undefined, out: Set<string>): void {
   if (!pathTemplate) return;

--- a/materializer/src/playwright/ctxSeeding.ts
+++ b/materializer/src/playwright/ctxSeeding.ts
@@ -42,7 +42,75 @@
  * together) rather than at the call sites.
  */
 
+import type { RequestStep } from 'path-analyser/types';
 import { PENDING_BINDING } from 'path-analyser/types';
+
+/**
+ * Compute the set of binding names that must be seeded with
+ * `{ unique: true }` for a given scenario's `requestPlan`.
+ *
+ * A binding qualifies as **unique** iff:
+ *
+ *   1. It is **client-minted** — referenced as a `${binding}` placeholder
+ *      in some step's `bodyTemplate` or as a `pathParams[].var`, AND
+ *   2. It is NOT extracted from any earlier step's response (i.e. not
+ *      bound via `extract[].bind` before its first consuming step), AND
+ *   3. The consuming step's operation declares an HTTP 409 (Conflict)
+ *      response in the OpenAPI spec (`step.declares409 === true`,
+ *      stamped by the planner from `Operation.responseLeafPaths['409']`).
+ *
+ * Without (3) the binding is safe to re-seed deterministically: the server
+ * will not 409 on a re-run, so cross-run uniqueness is unnecessary and
+ * keeping the seed deterministic preserves snapshot comparability.
+ *
+ * Without (2) the binding is server-minted (the client never sends it as
+ * input to the create endpoint); marking it unique would have no effect.
+ *
+ * See #304 for the underlying re-runnability problem and the design
+ * rationale (criterion = 409 declared ∧ client-minted).
+ */
+export function computeUniqueBindings(
+  requestPlan: readonly RequestStep[] | undefined,
+): Set<string> {
+  const unique = new Set<string>();
+  if (!requestPlan || requestPlan.length === 0) return unique;
+  const extracted = new Set<string>();
+  for (const step of requestPlan) {
+    if (step.declares409) {
+      for (const ref of collectBindingRefs(step)) {
+        if (!extracted.has(ref)) unique.add(ref);
+      }
+    }
+    for (const e of step.extract ?? []) extracted.add(e.bind);
+  }
+  return unique;
+}
+
+function collectBindingRefs(step: RequestStep): Set<string> {
+  const refs = new Set<string>();
+  for (const p of step.pathParams ?? []) refs.add(p.var);
+  walkForPlaceholders(step.bodyTemplate, refs);
+  walkForPlaceholders(step.multipartTemplate, refs);
+  return refs;
+}
+
+const PLACEHOLDER_RE = /\$\{([A-Za-z_$][\w$]*)\}/g;
+
+function walkForPlaceholders(node: unknown, out: Set<string>): void {
+  if (node === null || node === undefined) return;
+  if (typeof node === 'string') {
+    for (const m of node.matchAll(PLACEHOLDER_RE)) out.add(m[1]);
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const v of node) walkForPlaceholders(v, out);
+    return;
+  }
+  if (typeof node === 'object') {
+    // biome-ignore lint/plugin: narrowed to non-null object above; Record cast is contract-safe.
+    for (const v of Object.values(node as Record<string, unknown>)) walkForPlaceholders(v, out);
+  }
+}
 
 /**
  * Subset of {@link GlobalContextSeed} consumed by this helper. The
@@ -64,10 +132,25 @@ export interface EmitCtxSeedingOptions {
   seedBindings: readonly string[] | undefined;
   /** Universal-seed prologue entries (the ABox-driven list). */
   globalContextSeeds: readonly CtxSeedingGlobal[];
+  /**
+   * Binding names that must be seeded with `{ unique: true }` so they
+   * diverge across separate run invocations. Populated by the emitter
+   * for client-minted identifiers consumed by operations that declare an
+   * HTTP 409 (Conflict) response — re-runs would otherwise collide on
+   * the previous run's identifiers (#304). Names match against both
+   * `seedBindings[i]` and `globalContextSeeds[i].binding` (the seed
+   * rule's second arg is the same name in both code paths).
+   */
+  uniqueBindings?: ReadonlySet<string>;
+}
+
+function seedCall(name: string, unique: boolean): string {
+  return unique ? `seedBinding('${name}', { unique: true })` : `seedBinding('${name}')`;
 }
 
 export function emitCtxSeeding(opts: EmitCtxSeedingOptions): string[] {
-  const { indent, bindings, seedBindings, globalContextSeeds } = opts;
+  const { indent, bindings, seedBindings, globalContextSeeds, uniqueBindings } = opts;
+  const unique = uniqueBindings ?? new Set<string>();
   const lines: string[] = [];
   const globalSeedNames = new Set(globalContextSeeds.map((s) => s.binding));
 
@@ -82,13 +165,15 @@ export function emitCtxSeeding(opts: EmitCtxSeedingOptions): string[] {
       lines.push(`${indent}ctx['${k}'] = ${JSON.stringify(v)};`);
     }
     for (const name of seedNames) {
-      lines.push(`${indent}ctx['${name}'] = ctx['${name}'] ?? seedBinding('${name}');`);
+      lines.push(
+        `${indent}ctx['${name}'] = ctx['${name}'] ?? ${seedCall(name, unique.has(name))};`,
+      );
     }
   }
 
   for (const seed of globalContextSeeds) {
     lines.push(
-      `${indent}ctx['${seed.binding}'] = ctx['${seed.binding}'] ?? seedBinding('${seed.seedRule}');`,
+      `${indent}ctx['${seed.binding}'] = ctx['${seed.binding}'] ?? ${seedCall(seed.seedRule, unique.has(seed.binding))};`,
     );
   }
 

--- a/materializer/src/playwright/ctxSeeding.ts
+++ b/materializer/src/playwright/ctxSeeding.ts
@@ -89,12 +89,19 @@ export function computeUniqueBindings(
 function collectBindingRefs(step: RequestStep): Set<string> {
   const refs = new Set<string>();
   for (const p of step.pathParams ?? []) refs.add(p.var);
+  collectPathTemplateRefs(step.pathTemplate, refs);
   walkForPlaceholders(step.bodyTemplate, refs);
   walkForPlaceholders(step.multipartTemplate, refs);
   return refs;
 }
 
+const PATH_PLACEHOLDER_RE = /\{([A-Za-z_$][\w$]*)\}/g;
 const PLACEHOLDER_RE = /\$\{([A-Za-z_$][\w$]*)\}/g;
+
+function collectPathTemplateRefs(pathTemplate: string | undefined, out: Set<string>): void {
+  if (!pathTemplate) return;
+  for (const m of pathTemplate.matchAll(PATH_PLACEHOLDER_RE)) out.add(m[1]);
+}
 
 function walkForPlaceholders(node: unknown, out: Set<string>): void {
   if (node === null || node === undefined) return;

--- a/materializer/src/playwright/ctxSeeding.ts
+++ b/materializer/src/playwright/ctxSeeding.ts
@@ -137,9 +137,16 @@ export interface EmitCtxSeedingOptions {
    * diverge across separate run invocations. Populated by the emitter
    * for client-minted identifiers consumed by operations that declare an
    * HTTP 409 (Conflict) response — re-runs would otherwise collide on
-   * the previous run's identifiers (#304). Names match against both
-   * `seedBindings[i]` and `globalContextSeeds[i].binding` (the seed
-   * rule's second arg is the same name in both code paths).
+   * the previous run's identifiers (#304).
+   *
+   * **Keyed by binding name** (the ctx key being seeded), NOT by seed
+   * rule. For the `seedNames` loop the two coincide; for the
+   * `globalContextSeeds` loop the emitted `seedBinding(seedRule, ...)`
+   * call uses `seedRule` as the name argument while uniqueness is
+   * decided by membership of the ctx `binding` in this set. The
+   * resulting `seedBinding('seedRule', { unique: true })` is still
+   * correct: `seedBinding`'s name arg drives the per-binding counter
+   * seed, while the `unique` flag toggles which PRNG env is used.
    */
   uniqueBindings?: ReadonlySet<string>;
 }

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -14,7 +14,7 @@ import type {
   RequestStep,
 } from 'path-analyser/types';
 import type { ImportsTemplateScope, PlaywrightRoleScope } from '../roles.js';
-import { emitCtxSeeding } from './ctxSeeding.js';
+import { computeUniqueBindings, emitCtxSeeding } from './ctxSeeding.js';
 import {
   loadProjectScaffoldingFiles,
   materializeFixtures,
@@ -457,6 +457,7 @@ function renderScenarioTest(
       bindings: s.bindings,
       seedBindings: s.seedBindings,
       globalContextSeeds,
+      uniqueBindings: computeUniqueBindings(s.requestPlan),
     }),
   );
   // Multipart-sentinel locals (`__<fieldName>IsDefault`) are emitted

--- a/materializer/src/playwright/support/seeding.ts
+++ b/materializer/src/playwright/support/seeding.ts
@@ -1,13 +1,32 @@
 // Centralized seeding utilities for generated Playwright tests.
 // Provides pattern-based value generation with optional deterministic mode.
 // Deterministic mode: set TEST_SEED to a stable string (e.g. commit hash) to make outputs reproducible.
+import { randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
 
 type LocalRequire = ((id: string) => unknown) | undefined;
 const localRequire: LocalRequire =
   typeof createRequire === 'function' ? createRequire(import.meta.url) : undefined;
 
-export type SeedOptions = Record<string, never>;
+/**
+ * Per-call options for {@link seedBinding}.
+ *
+ * - `unique: true` mixes a per-process `runNonce` into the seed for this
+ *   binding so the value differs across pipeline/run invocations. Use for
+ *   client-minted identifiers consumed by operations that declare an HTTP
+ *   409 (Conflict) response — re-running the suite against the same cluster
+ *   would otherwise collide on the previous run's identifiers (#304).
+ *
+ * - The nonce is sourced from env `TEST_RUN_NONCE` if set (lets CI replay
+ *   a specific failed run), otherwise from `crypto.randomUUID()` at first
+ *   use. Within a single process the nonce is stable, so retries and
+ *   parallel workers within the same Playwright run see the same value.
+ *
+ * - When `unique` is omitted/false the helper remains fully deterministic
+ *   (TEST_SEED + per-spec salt only), so request bodies stay snapshot-
+ *   comparable apart from the identifier slots.
+ */
+export type SeedOptions = { unique?: boolean };
 
 interface SeedRule {
   match: RegExp | ((name: string) => boolean);
@@ -76,6 +95,39 @@ function resolveSeed(): { seed: string; random: boolean } {
 // seedBinding() call in every worker returns the same value (#175).
 let _specSalt = '';
 let _globalEnv: SeedEnv | undefined;
+let _uniqueEnv: SeedEnv | undefined;
+let _runNonce: string | undefined;
+
+/**
+ * Resolve the per-process run nonce used by `seedBinding(name, { unique: true })`.
+ *
+ * Sourced from env `TEST_RUN_NONCE` if set (lets CI pin a specific replay),
+ * otherwise from `crypto.randomUUID()` at first use. Stable for the process
+ * lifetime so retries and parallel workers within the same Playwright run
+ * see the same identifier — only across separate invocations does it change.
+ *
+ * Exported only for the helper unit test; production code should not call
+ * it directly.
+ */
+export function _resolveRunNonce(): string {
+  if (_runNonce !== undefined) return _runNonce;
+  const env = process.env.TEST_RUN_NONCE;
+  _runNonce = env && env.length > 0 ? env : randomUUID();
+  return _runNonce;
+}
+
+/**
+ * Reset cached per-process state. Test-only helper — generated suites
+ * never call this. Used by the seeding unit test to simulate a fresh
+ * process invocation between two `seedBinding(..., { unique: true })`
+ * calls.
+ */
+export function _resetSeedingForTest(): void {
+  _specSalt = '';
+  _globalEnv = undefined;
+  _uniqueEnv = undefined;
+  _runNonce = undefined;
+}
 
 /**
  * Set the per-suite salt before the first seedBinding() call.
@@ -92,9 +144,10 @@ let _globalEnv: SeedEnv | undefined;
 export function initSpecSalt(salt: string): void {
   _specSalt = salt;
   _globalEnv = undefined; // reset so next seedBinding() picks up the new salt
+  _uniqueEnv = undefined;
 }
 
-function buildGlobalEnv(): SeedEnv {
+function buildEnv(opts: { mixRunNonce: boolean }): SeedEnv {
   const { seed: seedStr, random } = resolveSeed();
   let seedNum = 0;
   if (random) {
@@ -106,10 +159,23 @@ function buildGlobalEnv(): SeedEnv {
     // Mix in the per-spec-file salt so parallel workers draw different sequences.
     for (let i = 0; i < _specSalt.length; i++)
       seedNum = (Math.imul(31, seedNum) + _specSalt.charCodeAt(i)) | 0;
+    if (opts.mixRunNonce) {
+      // Mix in the per-process run nonce so identifier-shaped bindings
+      // diverge across separate pipeline/run invocations (#304). The PRNG
+      // sequence for unique bindings is therefore distinct from the
+      // deterministic sequence used for snapshot-stable bindings.
+      const nonce = _resolveRunNonce();
+      for (let i = 0; i < nonce.length; i++)
+        seedNum = (Math.imul(31, seedNum) + nonce.charCodeAt(i)) | 0;
+    }
   }
   const rand = random ? Math.random : mulberry32(seedNum >>> 0);
   const counters = new Map<string, number>();
-  const runId = random ? `rt-${Date.now().toString(36)}` : `det-${seedStr}`;
+  const runId = random
+    ? `rt-${Date.now().toString(36)}`
+    : opts.mixRunNonce
+      ? `det-${seedStr}-${_resolveRunNonce()}`
+      : `det-${seedStr}`;
   return {
     random: () => rand().toString(36).slice(2),
     counter: (bucket = 'default') => {
@@ -123,8 +189,13 @@ function buildGlobalEnv(): SeedEnv {
 }
 
 function getGlobalEnv(): SeedEnv {
-  if (!_globalEnv) _globalEnv = buildGlobalEnv();
+  if (!_globalEnv) _globalEnv = buildEnv({ mixRunNonce: false });
   return _globalEnv;
+}
+
+function getUniqueEnv(): SeedEnv {
+  if (!_uniqueEnv) _uniqueEnv = buildEnv({ mixRunNonce: true });
+  return _uniqueEnv;
 }
 
 /**
@@ -236,9 +307,9 @@ function expandTemplate(tpl: string, varName: string, env: SeedEnv): string {
   });
 }
 
-export function seedBinding(varName: string, _opts?: SeedOptions): string {
+export function seedBinding(varName: string, opts?: SeedOptions): string {
   loadRules();
-  const env = getGlobalEnv();
+  const env = opts?.unique ? getUniqueEnv() : getGlobalEnv();
   for (const r of rules) {
     const m = r.match instanceof RegExp ? r.match.test(varName) : r.match(varName);
     if (m) return r.gen(varName, env);

--- a/materializer/src/playwright/support/seeding.ts
+++ b/materializer/src/playwright/support/seeding.ts
@@ -138,8 +138,11 @@ export function _resetSeedingForTest(): void {
  * (operationId), which is stable across regenerations.
  *
  * Calling this function resets the PRNG state so the new salt takes effect
- * from the next seedBinding() call onward. It must not be called after
- * seedBinding() has already been called in the same process.
+ * from the next seedBinding() call onward. Re-calling it after
+ * seedBinding() has already been called in the same process is
+ * supported: any cached PRNG envs are discarded and rebuilt with the
+ * new salt on the next seed call. Test helpers rely on this to reset
+ * deterministic state between cases.
  */
 export function initSpecSalt(salt: string): void {
   _specSalt = salt;

--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -6,7 +6,7 @@ import type {
   RequestStep,
   TemplateScenarioFile,
 } from 'path-analyser/types';
-import { emitCtxSeeding } from './ctxSeeding.js';
+import { computeUniqueBindings, emitCtxSeeding } from './ctxSeeding.js';
 import {
   buildUrlExpression,
   escapeQuotes,
@@ -294,6 +294,7 @@ function renderLifecycleSuite(
       bindings: prereq.bindings,
       seedBindings: prereq.seedBindings,
       globalContextSeeds,
+      uniqueBindings: computeUniqueBindings(prereq.requestPlan),
     }),
   );
 
@@ -675,6 +676,7 @@ function renderReadBackSuite(
       bindings: prereq.bindings,
       seedBindings: prereq.seedBindings,
       globalContextSeeds,
+      uniqueBindings: computeUniqueBindings(prereq.requestPlan),
     }),
   );
 
@@ -862,6 +864,7 @@ function renderStateTransitionSuite(
       bindings: prereq.bindings,
       seedBindings: prereq.seedBindings,
       globalContextSeeds,
+      uniqueBindings: computeUniqueBindings(prereq.requestPlan),
     }),
   );
 

--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -294,7 +294,7 @@ function renderLifecycleSuite(
       bindings: prereq.bindings,
       seedBindings: prereq.seedBindings,
       globalContextSeeds,
-      uniqueBindings: computeUniqueBindings(prereq.requestPlan),
+      uniqueBindings: computeUniqueBindings(allRequestSteps),
     }),
   );
 
@@ -676,7 +676,7 @@ function renderReadBackSuite(
       bindings: prereq.bindings,
       seedBindings: prereq.seedBindings,
       globalContextSeeds,
-      uniqueBindings: computeUniqueBindings(prereq.requestPlan),
+      uniqueBindings: computeUniqueBindings(allRequestSteps),
     }),
   );
 
@@ -864,7 +864,7 @@ function renderStateTransitionSuite(
       bindings: prereq.bindings,
       seedBindings: prereq.seedBindings,
       globalContextSeeds,
-      uniqueBindings: computeUniqueBindings(prereq.requestPlan),
+      uniqueBindings: computeUniqueBindings(allRequestSteps),
     }),
   );
 

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -648,6 +648,14 @@ function buildRequestPlan(
         ),
       },
     };
+    // #304: stamp 409-declaration so the emitter can flag client-minted
+    // identifier bindings consumed by this step as `{ unique: true }`,
+    // ensuring cross-run identifiers diverge and the second run against
+    // the same cluster doesn't 409 on the first run's IDs.
+    const declared = graph.operations[opRef.operationId]?.responseLeafPaths;
+    if (declared && '409' in declared) {
+      step.declares409 = true;
+    }
     // The legacy `response.*` valueBindings-driven extract block was
     // retired in #251 — the ABox no longer carries `response.*` entries
     // because the planner now auto-derives the equivalent extracts from

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -467,6 +467,15 @@ export interface RequestStep {
    * discovery shape without re-deriving it.
    */
   discoveryIntent?: DiscoveryIntent;
+  /**
+   * Per-step copy of `Operation.responseLeafPaths['409']` presence — true
+   * when this step's operation declares an HTTP 409 (Conflict) response
+   * in the OpenAPI spec. Stamped by `buildRequestPlan` so the emitter can
+   * decide (together with "binding is client-minted") which seedBinding
+   * calls to mark `{ unique: true }` for cross-run identifier uniqueness
+   * (#304). Absent / false ⇒ no 409 declared.
+   */
+  declares409?: boolean;
 }
 
 /**

--- a/tests/codegen/compute-unique-bindings.test.ts
+++ b/tests/codegen/compute-unique-bindings.test.ts
@@ -1,0 +1,107 @@
+// biome-ignore-all lint/suspicious/noTemplateCurlyInString: literal `${var}` placeholders appear in test fixture data that mimics planner bodyTemplate strings.
+import { describe, expect, it } from 'vitest';
+import { computeUniqueBindings } from '../../materializer/src/playwright/ctxSeeding.ts';
+import type { RequestStep } from '../../path-analyser/src/types.ts';
+
+/**
+ * Focused unit tests for the per-scenario `computeUniqueBindings` helper.
+ * The bulk of #304 behaviour is covered end-to-end by the L3 invariants in
+ * `configs/camunda-oca/regression-invariants.test.ts`, but the path-
+ * template ctx-name derivation (post-#318 review fix) is subtle enough
+ * to warrant a layer-1-style unit test so a regression points at the
+ * helper, not at the emitted suites.
+ */
+
+function step(overrides: Partial<RequestStep> = {}): RequestStep {
+  const base: RequestStep = {
+    operationId: 'op',
+    method: 'POST',
+    pathTemplate: '/x',
+    expect: { status: 200 },
+  };
+  return { ...base, ...overrides };
+}
+
+describe('computeUniqueBindings (#304 / #318 review)', () => {
+  it('returns an empty set for an empty or undefined requestPlan', () => {
+    expect(computeUniqueBindings(undefined)).toEqual(new Set());
+    expect(computeUniqueBindings([])).toEqual(new Set());
+  });
+
+  it('tags body-template placeholders consumed by 409-declaring steps', () => {
+    const plan: RequestStep[] = [
+      step({
+        operationId: 'createUser',
+        declares409: true,
+        bodyTemplate: { username: '${usernameVar}', password: '${passwordVar}' },
+      }),
+    ];
+    expect(computeUniqueBindings(plan)).toEqual(new Set(['usernameVar', 'passwordVar']));
+  });
+
+  it('does NOT tag bindings consumed by non-409 steps', () => {
+    const plan: RequestStep[] = [
+      step({
+        operationId: 'searchUsers',
+        declares409: false,
+        bodyTemplate: { filter: '${filterVar}' },
+      }),
+    ];
+    expect(computeUniqueBindings(plan)).toEqual(new Set());
+  });
+
+  it('does NOT tag server-extracted bindings even when consumed by 409 steps', () => {
+    // First step creates a Role, extracting `roleIdVar` from the response.
+    // Second step is a 409-declaring assign that consumes `roleIdVar` in
+    // its body — but it's server-minted, so we must not tag it unique.
+    const plan: RequestStep[] = [
+      step({
+        operationId: 'createRole',
+        declares409: true,
+        bodyTemplate: { name: '${nameVar}' },
+        extract: [{ fieldPath: 'roleId', bind: 'roleIdVar' }],
+      }),
+      step({
+        operationId: 'assignRoleToUser',
+        declares409: true,
+        bodyTemplate: { roleId: '${roleIdVar}' },
+      }),
+    ];
+    const unique = computeUniqueBindings(plan);
+    expect(unique.has('nameVar')).toBe(true);
+    expect(unique.has('roleIdVar')).toBe(false);
+  });
+
+  it('derives ctx binding names from `{param}` placeholders in pathTemplate via camelCase + "Var" suffix (#318 review)', () => {
+    // The emitter's URL substitution uses `ctx.${camelCase(p)}Var`, so the
+    // unique set must contain that derived name — NOT the raw placeholder.
+    // Without this transform, path-only client-minted identifiers on
+    // 409-declaring ops would silently miss { unique: true } tagging.
+    const plan: RequestStep[] = [
+      step({
+        operationId: 'updateUser',
+        method: 'PUT',
+        pathTemplate: '/v2/users/{username}/roles/{roleName}',
+        declares409: true,
+      }),
+    ];
+    const unique = computeUniqueBindings(plan);
+    expect(unique.has('usernameVar')).toBe(true);
+    expect(unique.has('roleNameVar')).toBe(true);
+    // Raw placeholder names must NOT appear — they don't match any ctx key.
+    expect(unique.has('username')).toBe(false);
+    expect(unique.has('roleName')).toBe(false);
+  });
+
+  it('walks multipartTemplate placeholders', () => {
+    const plan: RequestStep[] = [
+      step({
+        operationId: 'createResource',
+        declares409: true,
+        bodyKind: 'multipart',
+        multipartTemplate: [{ name: 'resourceName', value: '${resourceNameVar}' }],
+      }),
+    ];
+    expect(computeUniqueBindings(plan)).toEqual(new Set(['resourceNameVar']));
+  });
+});

--- a/tests/codegen/seeding.test.ts
+++ b/tests/codegen/seeding.test.ts
@@ -1,7 +1,15 @@
 // Tests for materializer/src/playwright/support/seeding.ts
-// Focus: per-spec-file salt (#175) — cross-worker id collision prevention.
-import { afterEach, describe, expect, test } from 'vitest';
-import { initSpecSalt, seedBinding } from '../../materializer/src/playwright/support/seeding.ts';
+// Focus:
+//   - per-spec-file salt (#175) — cross-worker id collision prevention.
+//   - per-process runNonce (#304) — cross-run identifier uniqueness when
+//     the caller passes `{ unique: true }`. Non-unique calls remain fully
+//     deterministic so snapshot-comparable bindings keep their values.
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import {
+  _resetSeedingForTest,
+  initSpecSalt,
+  seedBinding,
+} from '../../materializer/src/playwright/support/seeding.ts';
 
 describe('seeding: per-spec-file salt (#175)', () => {
   afterEach(() => {
@@ -41,5 +49,65 @@ describe('seeding: per-spec-file salt (#175)', () => {
     });
     const unique = new Set(values);
     expect(unique.size).toBe(specs.length);
+  });
+});
+
+describe('seeding: per-process runNonce for { unique: true } bindings (#304)', () => {
+  beforeEach(() => {
+    _resetSeedingForTest();
+    delete process.env.TEST_RUN_NONCE;
+  });
+
+  afterEach(() => {
+    _resetSeedingForTest();
+    delete process.env.TEST_RUN_NONCE;
+  });
+
+  test('two simulated process invocations of seedBinding({ unique: true }) produce different values', () => {
+    initSpecSalt('createRole');
+    const valRun1 = seedBinding('roleIdVar', { unique: true });
+    // Simulate a fresh process by clearing per-process state (incl. nonce).
+    _resetSeedingForTest();
+    initSpecSalt('createRole');
+    const valRun2 = seedBinding('roleIdVar', { unique: true });
+    expect(valRun1).not.toBe(valRun2);
+  });
+
+  test('without { unique: true } the value is identical across simulated process invocations (snapshot determinism preserved)', () => {
+    initSpecSalt('createRole');
+    const valRun1 = seedBinding('roleIdVar');
+    _resetSeedingForTest();
+    initSpecSalt('createRole');
+    const valRun2 = seedBinding('roleIdVar');
+    expect(valRun1).toBe(valRun2);
+  });
+
+  test('within a single process the unique value is stable across calls (parallel workers / retries see the same id)', () => {
+    initSpecSalt('createRole');
+    const valFirst = seedBinding('roleIdVar', { unique: true });
+    // No reset — same process. The nonce must be cached so subsequent
+    // calls in the same Playwright run (different test bodies, retried
+    // attempts) see the same identifier.
+    initSpecSalt('createRole');
+    const valSecond = seedBinding('roleIdVar', { unique: true });
+    expect(valFirst).toBe(valSecond);
+  });
+
+  test('TEST_RUN_NONCE env var pins the nonce so two simulated invocations replay identically', () => {
+    process.env.TEST_RUN_NONCE = 'pinned-replay-nonce-abc';
+    initSpecSalt('createRole');
+    const valRun1 = seedBinding('roleIdVar', { unique: true });
+    _resetSeedingForTest();
+    process.env.TEST_RUN_NONCE = 'pinned-replay-nonce-abc';
+    initSpecSalt('createRole');
+    const valRun2 = seedBinding('roleIdVar', { unique: true });
+    expect(valRun1).toBe(valRun2);
+  });
+
+  test('unique and non-unique values for the same binding differ within a single process (distinct PRNG sequences)', () => {
+    initSpecSalt('createRole');
+    const det = seedBinding('roleIdVar');
+    const uniq = seedBinding('roleIdVar', { unique: true });
+    expect(det).not.toBe(uniq);
   });
 });


### PR DESCRIPTION
Closes #304.

## Problem

Re-running the generated Playwright suite against the same cluster floods the second run with 409 Conflict responses on create-style operations. `seedBinding()` is fully deterministic (TEST_SEED + per-suite salt only), so client-minted identifiers collide with rows created by the prior run.

## Approach

1. **Seeding helper** (`materializer/src/playwright/support/seeding.ts`) gains a `{ unique: true }` opt-in that mixes a per-process `runNonce` (`TEST_RUN_NONCE` env for CI replay, else `crypto.randomUUID()` at first use) into a parallel PRNG env. Non-unique calls stay byte-deterministic — snapshots unchanged.
2. **Planner** (`path-analyser/src/index.ts`) stamps `RequestStep.declares409` from the extracted `responseLeafPaths['409']` signal so the emitter doesn't need the live graph.
3. **Emitters** (`materializer/src/playwright/{emitter,templateEmitter}.ts`) compute `computeUniqueBindings(requestPlan)` per scenario: a binding is flagged `unique:true` iff (a) it's referenced by a 409-declaring step's body/path, AND (b) it is NOT extracted from a prior step's response (client-minted, not server-issued).

The 409 declaration in the OpenAPI spec is the single source of truth. Ops that collide but lack a 409 declaration are an upstream OpenAPI gap to fix — not a generator workaround.

## Verification

- 8/8 helper unit tests (`tests/codegen/seeding.test.ts`) including 5 new #304 cases (unique-across-runs, deterministic-within-run, TEST_RUN_NONCE replay, etc.).
- 2 new class-scoped L3 invariants in `configs/camunda-oca/regression-invariants.test.ts`:
  - Every emitted feature spec for an op with `409` in `responseLeafPaths` tags ALL `seedBinding()` calls `{ unique: true }`.
  - `createDeployment` (no 409) keeps at least one bare `seedBinding('x')` call — guards against blanket-tagging.
- 603/603 tests pass; lint clean; all 6 typechecks pass; full `npm run pipeline` regen clean.

Example diff in `createUser.feature.spec.ts`:
```
ctx.usernameVar = ctx.usernameVar ?? seedBinding('usernameVar', { unique: true });
ctx.tenantIdVar = ctx.tenantIdVar ?? seedBinding('tenantIdVar');
```