### PR TITLE
fix: render multi-line DOT labels as real newlines, not literal \n

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -7447,6 +7447,30 @@ describeForThisConfig('bundled-spec invariants: ontology visualisation emitter',
     expect(mmd.trim().length, 'ABox Mermaid must not be empty').toBeGreaterThan(0);
     expect(mmd, 'ABox Mermaid must start with graph').toContain('graph LR');
   });
+
+  // Regression for the "literal \n in SVG" bug: DOT labels must contain the
+  // 2-char newline escape (backslash + n) — not the 3-char over-escaped
+  // sequence (backslash + backslash + n), which Graphviz unescapes to a
+  // literal '\n' string in the rendered SVG. Class-scoped: applies to every
+  // label in every DOT emitter that doesn't require pipeline output.
+  it('DOT emitters must not over-escape newlines in labels', async () => {
+    const { emitTboxDot, emitAboxDot } = await import('../../scripts/visualise-ontology.ts');
+    const { buildBundle } = await import('../../scripts/export-ontology.ts');
+    const bundle = buildBundle();
+    const outputs: Record<string, string> = {
+      tbox: emitTboxDot('camunda-oca'),
+      abox: emitAboxDot(bundle),
+    };
+    for (const [name, dot] of Object.entries(outputs)) {
+      const labelMatches = dot.match(/label="[^"]*"/g) ?? [];
+      for (const match of labelMatches) {
+        expect(
+          match.includes('\\\\n'),
+          `${name} DOT label over-escapes newline (renders as literal \\n in SVG): ${match}`,
+        ).toBe(false);
+      }
+    }
+  });
 });
 
 // ===========================================================================

--- a/scripts/visualise-ontology.ts
+++ b/scripts/visualise-ontology.ts
@@ -234,8 +234,11 @@ export function emitAboxDot(bundle: ReturnType<typeof buildBundle>): string {
   for (const e of edges) {
     const fromId = dotId(e.endpoints.from);
     const toId = dotId(e.endpoints.to);
+    // Join with a real newline; dotLabel() converts \n → the DOT \n escape.
+    // Joining with the literal '\n' two-char sequence would be double-escaped
+    // by dotLabel() into '\\n' and rendered verbatim in the SVG.
     const lbl = [e.name, `+${e.establishedBy}`, `−${e.revokedBy}`, `obs: ${e.observableVia}`].join(
-      '\\n',
+      '\n',
     );
     lines.push(`  ${fromId} -> ${toId} [label="${dotLabel(lbl)}"];`);
   }


### PR DESCRIPTION
## Problem

The ontology ABox SVG diagram (https://camunda.github.io/api-test-generator/ns/v1/viz/camunda-oca/abox.svg) showed `\n` rendered as literal text between edge label fields instead of as a newline.

## Root cause

`emitAboxDot` builds edge labels with `.join('\\n')` — the 2-char string backslash + n.
`dotLabel()` then runs `replace(/\\\\/g, '\\\\\\\\')` first, which doubles every backslash. The label entering the DOT file is the 3-char sequence backslash + backslash + n.
Graphviz unescapes `\\\\` to a literal backslash and emits the trailing `n` as plain text — so the SVG shows `\n` verbatim.

## Fix

Feed `dotLabel()` a real newline. Its third replace (`replace(/\\n/g, '\\\\n')`) already converts a real newline to the DOT `\\n` newline escape correctly.

## Regression guard

Adds a class-scoped L3 invariant in `configs/camunda-oca/regression-invariants.test.ts` that scans every `label="..."` in the TBox and ABox DOT emitter outputs and fails if any contains the 3-char over-escaped sequence. Verified red→green: stashing the production fix and running just the new invariant reproduces the bug, restoring the fix turns it green.

Scoping the test to all DOT labels rather than the single regressed site is deliberate — the same over-escape pattern could resurface in any sibling emitter (e.g. `emitOperationsDot` if its labels grow multi-line in future).