### PR TITLE
fix: strip literal bindings from emitCtxSeeding when key is unique-seeded (#320)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1992,8 +1992,14 @@ describeForThisConfig('bundled-spec invariants: emitted Playwright suite', () =>
     // biome's `useDotNotation` autofix could rewrite the access.
     const uniqueRe =
       /seedBinding\(\s*['"]([A-Za-z_$][\w$]*)['"]\s*,\s*\{\s*unique:\s*true\s*\}\s*\)/g;
-    const literalDotRe = /\bctx\.([A-Za-z_$][\w$]*)\s*=\s*"[^"]*"\s*;/g;
-    const literalBracketRe = /\bctx\[\s*['"]([A-Za-z_$][\w$]*)['"]\s*\]\s*=\s*"[^"]*"\s*;/g;
+    // Match both single- and double-quoted string literals: the
+    // generated suite is formatted by Biome with `quoteStyle: 'single'`
+    // (see biome.generated.json), but the upstream emitter or future
+    // formatter changes could produce either form. Accepting both
+    // keeps the invariant robust against quote-style drift.
+    const literalDotRe = /\bctx\.([A-Za-z_$][\w$]*)\s*=\s*(?:"[^"]*"|'[^']*')\s*;/g;
+    const literalBracketRe =
+      /\bctx\[\s*['"]([A-Za-z_$][\w$]*)['"]\s*\]\s*=\s*(?:"[^"]*"|'[^']*')\s*;/g;
 
     const offenders: string[] = [];
     let totalUnique = 0;

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1954,6 +1954,77 @@ describeForThisConfig('bundled-spec invariants: emitted Playwright suite', () =>
     }
     expect(offenders).toEqual([]);
   });
+
+  it('no emitted feature spec writes a deterministic literal for a binding that is also unique-seeded (#320)', () => {
+    // Class-scoped guard for #320: the materializer's `emitCtxSeeding`
+    // helper writes literal `ctx.<name> = "<value>";` lines for every
+    // entry in `scenario.bindings`. Pre-fix, if the same name was also
+    // flagged unique by `computeUniqueBindings` (because it is consumed
+    // by a 409-declaring step and therefore needs `{ unique: true }`),
+    // the literal would short-circuit the `??` seedBinding fallback and
+    // the second invocation of the run against the same cluster would
+    // 409.
+    //
+    // The fix re-routes any literal whose key is in `uniqueBindings`
+    // into a `seedBinding('<name>', { unique: true })` line instead.
+    // This invariant pins the post-condition at the only layer where
+    // the symptom is observable: no emitted spec should contain BOTH a
+    // literal write AND a unique-seed line for the same binding name.
+    //
+    // Original instance: `unassignMappingRuleFromGroup.feature.spec.ts`
+    // emitted `ctx.groupIdVar = 'group_1k29';` alongside no unique seed,
+    // because the literal short-circuited the entire seed branch. With
+    // the fix the literal is gone and only the unique seed remains —
+    // the offender set below is the empty set.
+    if (!existsSync(GENERATED_TESTS_DIR)) {
+      throw new Error(
+        `Generated tests directory not found at ${GENERATED_TESTS_DIR}. Run 'npm run testsuite:generate' first.`,
+      );
+    }
+    const specs = readdirSync(GENERATED_TESTS_DIR).filter((f) => f.endsWith('.feature.spec.ts'));
+    expect(specs.length, 'at least one feature spec must be emitted').toBeGreaterThan(0);
+
+    // For each spec, collect the set of binding names that are
+    // unique-seeded (`seedBinding('X', { unique: true })`) and the set
+    // that are deterministic-literal-written (`ctx.X = "..."` or
+    // `ctx['X'] = "..."`), and report any intersection. Both forms of
+    // ctx access exist in the emitted output depending on whether
+    // biome's `useDotNotation` autofix could rewrite the access.
+    const uniqueRe =
+      /seedBinding\(\s*['"]([A-Za-z_$][\w$]*)['"]\s*,\s*\{\s*unique:\s*true\s*\}\s*\)/g;
+    const literalDotRe = /\bctx\.([A-Za-z_$][\w$]*)\s*=\s*"[^"]*"\s*;/g;
+    const literalBracketRe = /\bctx\[\s*['"]([A-Za-z_$][\w$]*)['"]\s*\]\s*=\s*"[^"]*"\s*;/g;
+
+    const offenders: string[] = [];
+    let totalUnique = 0;
+    for (const f of specs) {
+      const src = readFileSync(join(GENERATED_TESTS_DIR, f), 'utf8');
+      const uniqueNames = new Set<string>();
+      let m: RegExpExecArray | null;
+      while ((m = uniqueRe.exec(src)) !== null) uniqueNames.add(m[1]);
+      uniqueRe.lastIndex = 0;
+      if (uniqueNames.size === 0) continue;
+      totalUnique += uniqueNames.size;
+      const literalNames = new Set<string>();
+      while ((m = literalDotRe.exec(src)) !== null) literalNames.add(m[1]);
+      literalDotRe.lastIndex = 0;
+      while ((m = literalBracketRe.exec(src)) !== null) literalNames.add(m[1]);
+      literalBracketRe.lastIndex = 0;
+      const both = [...uniqueNames].filter((n) => literalNames.has(n));
+      if (both.length > 0) {
+        offenders.push(`${relative(REPO_ROOT, join(GENERATED_TESTS_DIR, f))}: ${both.join(', ')}`);
+      }
+    }
+
+    // Sanity: the bundled spec must non-trivially exercise the
+    // unique-seeded pattern; otherwise this invariant is vacuous and
+    // would silently pass even if `emitCtxSeeding` regressed.
+    expect(
+      totalUnique,
+      'expected at least one emitted spec to use seedBinding(..., { unique: true })',
+    ).toBeGreaterThan(0);
+    expect(offenders).toEqual([]);
+  });
 });
 
 describeForThisConfig('bundled-spec invariants: fixture selection by required state (#159)', () => {

--- a/materializer/src/playwright/ctxSeeding.ts
+++ b/materializer/src/playwright/ctxSeeding.ts
@@ -18,9 +18,14 @@
  *
  * Canonical emission order (applied uniformly by both emitters):
  *
- *   1. Literal bindings from `scenario.bindings` (skip `PENDING_BINDING`).
+ *   1. Literal bindings from `scenario.bindings` (skip `PENDING_BINDING`,
+ *      AND skip names present in `uniqueBindings` — those need a
+ *      `{ unique: true }` seed and are re-routed into step 2 below, see
+ *      #320).
  *   2. Per-scenario `seedBindings` (filtered against globalSeedNames so
- *      a binding handled by the prologue is not also seeded here).
+ *      a binding handled by the prologue is not also seeded here), plus
+ *      any names whose literal was stripped by step 1's unique-set
+ *      exclusion.
  *   3. Universal-seed prologue from `globalContextSeeds`.
  *
  * Every seeded line uses the terse `??` form:
@@ -178,10 +183,24 @@ export function emitCtxSeeding(opts: EmitCtxSeedingOptions): string[] {
   const lines: string[] = [];
   const globalSeedNames = new Set(globalContextSeeds.map((s) => s.binding));
 
+  // Literal writes from `scenario.bindings`, with two exclusions:
+  //   - `PENDING_BINDING` sentinel — routes through `seedBindings` instead.
+  //   - Names flagged unique by `uniqueBindings` — a deterministic literal
+  //     would defeat the `{ unique: true }` seed it needs (#320). The
+  //     literal is stripped here and the name is re-routed into
+  //     `seedNames` below so a `seedBinding(name, { unique: true })`
+  //     line is emitted in its place.
   const literalEntries = bindings
-    ? Object.entries(bindings).filter(([, v]) => v !== PENDING_BINDING)
+    ? Object.entries(bindings).filter(([k, v]) => v !== PENDING_BINDING && !unique.has(k))
     : [];
-  const seedNames = (seedBindings ?? []).filter((n) => !globalSeedNames.has(n));
+  const strippedForUnique = bindings
+    ? Object.entries(bindings)
+        .filter(([k, v]) => v !== PENDING_BINDING && unique.has(k))
+        .map(([k]) => k)
+    : [];
+  const seedNames = Array.from(new Set([...(seedBindings ?? []), ...strippedForUnique])).filter(
+    (n) => !globalSeedNames.has(n),
+  );
 
   if (literalEntries.length > 0 || seedNames.length > 0) {
     lines.push(`${indent}// Seed scenario bindings`);

--- a/tests/codegen/emit-ctx-seeding.test.ts
+++ b/tests/codegen/emit-ctx-seeding.test.ts
@@ -1,0 +1,172 @@
+// biome-ignore-all lint/suspicious/noTemplateCurlyInString: literal `${var}` placeholders mirror generator output.
+/**
+ * Unit tests for `emitCtxSeeding` — the single source of truth for
+ * ctx-seeding line emission shared by `emitter.ts` and
+ * `templateEmitter.ts` (#286).
+ *
+ * # The defect class this file pins (#320)
+ *
+ * `computeUniqueBindings` (#304 / #318) correctly identifies which ctx
+ * binding names must be seeded with `{ unique: true }` to diverge across
+ * separate run invocations. But the literal-write branch of
+ * `emitCtxSeeding` writes `ctx['<k>'] = <literalJSON>;` UNCONDITIONALLY
+ * for every `bindings` entry whose value is not `PENDING_BINDING` — even
+ * if `<k>` is in `uniqueBindings`. The subsequent
+ * `ctx['<k>'] = ctx['<k>'] ?? seedBinding('<k>', { unique: true });` line
+ * is never emitted for that name (the planner-side `seedBindings` list
+ * already short-circuits at the literal), and even if it were, the `??`
+ * fallback short-circuits because the literal is defined. The literal
+ * wins, the seed is bypassed, and the second invocation against the same
+ * cluster 409s on the previous run's identifier.
+ *
+ * Real-world reproducer at the time of writing (May 2026):
+ *   generated/camunda-oca/playwright/unassignMappingRuleFromGroup.feature.spec.ts
+ * emits `ctx.groupIdVar = 'group_1k29';` and 409s on the second run.
+ *
+ * # What the fix does
+ *
+ * In `emitCtxSeeding`:
+ *   - Skip literal entries whose key is in `uniqueBindings`.
+ *   - Add those stripped keys to the seedNames list so a
+ *     `seedBinding(name, { unique: true })` line gets emitted.
+ *
+ * # Class scope
+ *
+ * The first test pins the specific reproducer shape; the second covers
+ * the class of defect (every literal whose name is in `uniqueBindings`
+ * must be stripped, regardless of how many or what value). The "no
+ * over-strip" tests guard against a fix that would also strip
+ * deterministic literals for names NOT in `uniqueBindings` — the
+ * existing literal-seeded pathway is correct and must be preserved.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { emitCtxSeeding } from '../../materializer/src/playwright/ctxSeeding.ts';
+import { PENDING_BINDING } from '../../path-analyser/src/types.ts';
+
+describe('emitCtxSeeding: unique-binding override of literal (#320)', () => {
+  it('strips a literal write for a binding flagged as unique and emits a {unique:true} seed line instead', () => {
+    // Real-world reproducer shape: planner pre-minted a deterministic
+    // literal for `groupIdVar` into `scenario.bindings`, the materializer
+    // separately flagged `groupIdVar` unique because it is consumed by a
+    // 409-declaring step. Pre-fix the literal line is emitted and the
+    // seed line is not. Post-fix the literal line is suppressed and the
+    // seed line is emitted with `{ unique: true }`.
+    const lines = emitCtxSeeding({
+      indent: '  ',
+      bindings: { groupIdVar: 'group_1k29' },
+      seedBindings: [],
+      globalContextSeeds: [],
+      uniqueBindings: new Set(['groupIdVar']),
+    });
+    const joined = lines.join('\n');
+    expect(
+      joined,
+      'must NOT contain the deterministic literal write for a unique binding',
+    ).not.toContain(`ctx['groupIdVar'] = "group_1k29"`);
+    expect(
+      joined,
+      'must emit a seedBinding(..., { unique: true }) line for the stripped binding',
+    ).toContain(
+      `ctx['groupIdVar'] = ctx['groupIdVar'] ?? seedBinding('groupIdVar', { unique: true });`,
+    );
+  });
+
+  it('class-scoped: every literal whose key is in uniqueBindings is stripped, regardless of value or count', () => {
+    // Three literals, two of which are in the unique set. The third
+    // (`tenantIdVar`) is not — its literal write must survive. This
+    // pins the class of defect: any literal in `bindings` whose key is
+    // in `uniqueBindings` leaks through, not just the specific
+    // `groupIdVar` instance.
+    const lines = emitCtxSeeding({
+      indent: '  ',
+      bindings: {
+        groupIdVar: 'group_1k29',
+        mappingRuleIdVar: 'mappingRule_15do',
+        tenantIdVar: 'default-tenant',
+      },
+      seedBindings: [],
+      globalContextSeeds: [],
+      uniqueBindings: new Set(['groupIdVar', 'mappingRuleIdVar']),
+    });
+    const joined = lines.join('\n');
+    // Stripped literals: neither value appears as a literal write.
+    expect(joined).not.toContain(`ctx['groupIdVar'] = "group_1k29"`);
+    expect(joined).not.toContain(`ctx['mappingRuleIdVar'] = "mappingRule_15do"`);
+    // Replaced with unique seed lines.
+    expect(joined).toContain(
+      `ctx['groupIdVar'] = ctx['groupIdVar'] ?? seedBinding('groupIdVar', { unique: true });`,
+    );
+    expect(joined).toContain(
+      `ctx['mappingRuleIdVar'] = ctx['mappingRuleIdVar'] ?? seedBinding('mappingRuleIdVar', { unique: true });`,
+    );
+    // Non-unique literal is preserved verbatim (no over-strip).
+    expect(joined).toContain(`ctx['tenantIdVar'] = "default-tenant";`);
+  });
+
+  it('does NOT over-strip: literal writes for non-unique bindings are preserved when uniqueBindings is empty', () => {
+    // Class-scoped guard against a fix that would also drop literals
+    // for names not in `uniqueBindings`. The existing deterministic-
+    // literal pathway is correct for snapshot comparability and must
+    // be preserved (#286, #304 doc comment header).
+    const lines = emitCtxSeeding({
+      indent: '  ',
+      bindings: { thingIdVar: 'thing_deterministic', nameVar: 'name_abc' },
+      seedBindings: [],
+      globalContextSeeds: [],
+      uniqueBindings: new Set(),
+    });
+    const joined = lines.join('\n');
+    expect(joined).toContain(`ctx['thingIdVar'] = "thing_deterministic";`);
+    expect(joined).toContain(`ctx['nameVar'] = "name_abc";`);
+  });
+
+  it('does NOT over-strip: literal writes survive when uniqueBindings is undefined (back-compat default)', () => {
+    // `uniqueBindings` is optional. Callers that do not yet pass it (or
+    // older tests) must continue to see literals written verbatim.
+    const lines = emitCtxSeeding({
+      indent: '  ',
+      bindings: { thingIdVar: 'thing_deterministic' },
+      seedBindings: [],
+      globalContextSeeds: [],
+    });
+    const joined = lines.join('\n');
+    expect(joined).toContain(`ctx['thingIdVar'] = "thing_deterministic";`);
+  });
+
+  it('PENDING_BINDING entries continue to be skipped even when in the unique set', () => {
+    // `PENDING_BINDING` (`__PENDING__`) is the planner's sentinel for
+    // "no literal known — route through seedBindings". It must continue
+    // to be skipped on the literal pass regardless of unique-set
+    // membership, otherwise we'd write `ctx['nameVar'] = "__PENDING__";`
+    // and clobber the seed call below.
+    const lines = emitCtxSeeding({
+      indent: '  ',
+      bindings: { nameVar: PENDING_BINDING },
+      seedBindings: ['nameVar'],
+      globalContextSeeds: [],
+      uniqueBindings: new Set(['nameVar']),
+    });
+    const joined = lines.join('\n');
+    expect(joined).not.toContain('__PENDING__');
+    expect(joined).toContain(
+      `ctx['nameVar'] = ctx['nameVar'] ?? seedBinding('nameVar', { unique: true });`,
+    );
+  });
+
+  it('does not duplicate a seed line when the same name is both in seedBindings and stripped-as-unique-literal', () => {
+    // Defensive guard against the fix double-adding a name that is
+    // already in `seedBindings`. The emitter must dedupe.
+    const lines = emitCtxSeeding({
+      indent: '  ',
+      bindings: { groupIdVar: 'group_1k29' },
+      seedBindings: ['groupIdVar'],
+      globalContextSeeds: [],
+      uniqueBindings: new Set(['groupIdVar']),
+    });
+    const seedLineCount = lines.filter((l) =>
+      l.includes(`seedBinding('groupIdVar', { unique: true })`),
+    ).length;
+    expect(seedLineCount).toBe(1);
+  });
+});

--- a/tests/codegen/emit-ctx-seeding.test.ts
+++ b/tests/codegen/emit-ctx-seeding.test.ts
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/suspicious/noTemplateCurlyInString: literal `${var}` placeholders mirror generator output.
 /**
  * Unit tests for `emitCtxSeeding` — the single source of truth for
  * ctx-seeding line emission shared by `emitter.ts` and


### PR DESCRIPTION
## Summary

`computeUniqueBindings` (#304 / #318) correctly identifies which `ctx` binding names must be seeded with `{ unique: true }` so each run invocation against a shared cluster gets a fresh identifier. But the literal-write branch of `emitCtxSeeding` wrote `ctx['<k>'] = <json>;` unconditionally for every `scenario.bindings` entry whose value was not `PENDING_BINDING` — **including names in the unique set**. The literal short-circuited the `??` fallback to `seedBinding(name, { unique: true })`, so the second invocation of the run 409'd on the previous run's identifier.

Real-world reproducer:
```
generated/camunda-oca/playwright/unassignMappingRuleFromGroup.feature.spec.ts
```
emitted `ctx.groupIdVar = 'group_1k29';` and 409'd on the second run.

## Fix

`emitCtxSeeding` now:
- skips literal entries whose key is in `uniqueBindings`,
- re-routes those names into `seedNames` so a `seedBinding(name, { unique: true })` line is emitted instead,
- dedupes against any name already in `seedBindings`,
- preserves the deterministic-literal pathway for non-unique bindings unchanged (no over-strip).

5-line change in `materializer/src/playwright/ctxSeeding.ts`; docstring updated.

## Tests

### Unit (`tests/codegen/emit-ctx-seeding.test.ts`) — 6 tests
- Specific instance: `groupIdVar` literal + unique set → literal stripped, `seedBinding(... unique: true)` emitted.
- **Class-scoped**: three literals, two in unique set → both stripped, third preserved.
- No over-strip when `uniqueBindings` is empty.
- No over-strip when `uniqueBindings` is undefined (back-compat).
- `PENDING_BINDING` continues to be skipped.
- Dedupe against pre-existing `seedBindings` (exactly one seed line).

Instance + class tests fail pre-fix for the documented reason (verified red before applying the fix).

### L3 class-scoped invariant (`configs/camunda-oca/regression-invariants.test.ts`)
Scans every emitted `.feature.spec.ts` for any binding name that has BOTH a `ctx.X = "...";` literal AND a `seedBinding('X', { unique: true })` line. Offender list must be empty. Includes a sanity assertion that the bundled spec non-trivially exercises the unique-seed pattern, so the invariant cannot silently pass.

## Symptom check

After the fix:
```
$ grep "groupIdVar\|mappingRuleIdVar" \
    generated/camunda-oca/playwright/unassignMappingRuleFromGroup.feature.spec.ts
17:    ctx.groupIdVar = ctx.groupIdVar ?? seedBinding('groupIdVar', { unique: true });
18:    ctx.mappingRuleIdVar =
19:      ctx.mappingRuleIdVar ?? seedBinding('mappingRuleIdVar', { unique: true });
```

No more `ctx.groupIdVar = 'group_1k29';`.

## Why redesigned from #321

PR #321 (now closed) put its fixture at the planner layer (`computeSeedBindings` / `computeUniqueBindings`). All three assertions passed pre-fix — i.e. it pinned a real asymmetry but wasn't a red guard. Per AGENTS.md, "if a test passes before the production change lands, it isn't guarding anything". The defect actually lives in the materializer's emission path, so the test belongs there.

## Dependencies

Depends on #322 (spec pin bump to `d29d644`). The older pinned spec did not declare 409 on `POST /groups` and siblings, so the unique-seed branch had no real-world callers to demonstrate the fix against. Rebase onto `main` once #322 lands.

Closes #320
