### PR TITLE
fix: enumerate polymorphic semantic-type siblings per variant (closes #324)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -4008,18 +4008,6 @@ describeForThisConfig('bundled-spec invariants: suite-partition cut (#162 PR 4)'
     }
 
     const graph = loadGraph();
-    // Narrow allowlist for #324 (exposed by the spec bump in #322).
-    // The new `evaluateExpression` endpoint declares an optional flat
-    // top-level `scopeKey` annotated with three semantic types
-    // (`ScopeKey`, `ProcessInstanceKey`, `ElementInstanceKey`). The
-    // variant planner enumerates one variant per field, not one per
-    // `(field, semanticType)` pair, so the two polymorphic siblings
-    // are missing. Tracked in #324 — when that lands, remove this
-    // allowlist and the offenders will be covered for real.
-    const knownOffenders = new Set<string>([
-      'evaluateExpression|scopeKey|ProcessInstanceKey',
-      'evaluateExpression|scopeKey|ElementInstanceKey',
-    ]);
     const offenders: { operationId: string; semantic: string; fieldPath: string }[] = [];
     for (const op of graph.operations) {
       for (const e of op.requestBodySemanticTypes ?? []) {
@@ -4035,8 +4023,6 @@ describeForThisConfig('bundled-spec invariants: suite-partition cut (#162 PR 4)'
         if (e.fieldPath.startsWith('$')) continue;
         const covered = variantBySemanticByOp.get(op.operationId);
         if (!covered?.has(e.semanticType)) {
-          const key = `${op.operationId}|${e.fieldPath}|${e.semanticType}`;
-          if (knownOffenders.has(key)) continue;
           offenders.push({
             operationId: op.operationId,
             semantic: e.semanticType,

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -2029,15 +2029,15 @@ export function generateOptionalSubShapeVariants(
       if (collectionScenarios.length >= maxVariants) break outer;
 
       // Skip duplicates BEFORE any planning work: `requestBodySemanticTypes`
-      // can repeat a (rootPath, fieldPath, semantic) triple for true
-      // siblings, and the producer-chain BFS below is the most expensive
-      // step in this function — never run it for a key we've already
-      // emitted. The dedup key includes `leaf.semantic` so polymorphic
-      // semantic-type annotations on the SAME field (e.g.
-      // `evaluateExpression.scopeKey` annotated as both `ScopeKey` and
-      // `ProcessInstanceKey` and `ElementInstanceKey`) each get their own
-      // variant — one per semantic binding — rather than collapsing into
-      // the first semantic seen (#324).
+      // can repeat the exact same (rootPath, fieldPath, semantic) triple
+      // for true duplicates, and the producer-chain BFS below is the most
+      // expensive step in this function — never run it for a key we've
+      // already emitted. The dedup key includes `leaf.semantic`, so
+      // polymorphic semantic-type annotations on the SAME field (e.g.
+      // `evaluateExpression.scopeKey` annotated as `ScopeKey`,
+      // `ProcessInstanceKey`, and `ElementInstanceKey`) are intentionally
+      // kept as separate variants — one per semantic binding — rather than
+      // collapsing into the first semantic seen (#324).
       const variantKey = `${subShape.rootPath}::${leaf.fieldPath}::${leaf.semantic}`;
       if (seenVariantKeys.has(variantKey)) continue;
 

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -2029,10 +2029,16 @@ export function generateOptionalSubShapeVariants(
       if (collectionScenarios.length >= maxVariants) break outer;
 
       // Skip duplicates BEFORE any planning work: `requestBodySemanticTypes`
-      // can repeat a (rootPath, fieldPath) pair for siblings, and the
-      // producer-chain BFS below is the most expensive step in this
-      // function — never run it for a key we've already emitted.
-      const variantKey = `${subShape.rootPath}::${leaf.fieldPath}`;
+      // can repeat a (rootPath, fieldPath, semantic) triple for true
+      // siblings, and the producer-chain BFS below is the most expensive
+      // step in this function — never run it for a key we've already
+      // emitted. The dedup key includes `leaf.semantic` so polymorphic
+      // semantic-type annotations on the SAME field (e.g.
+      // `evaluateExpression.scopeKey` annotated as both `ScopeKey` and
+      // `ProcessInstanceKey` and `ElementInstanceKey`) each get their own
+      // variant — one per semantic binding — rather than collapsing into
+      // the first semantic seen (#324).
+      const variantKey = `${subShape.rootPath}::${leaf.fieldPath}::${leaf.semantic}`;
       if (seenVariantKeys.has(variantKey)) continue;
 
       // Resolve producer candidates. When authoritative (provider:true)

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -1031,7 +1031,7 @@ describe('planner contracts: variant planner enumerates polymorphic semantic-typ
     // (ScopeKey) was emitted because the dedup key ignored semantic.
     const triples = variants.scenarios
       .map((s) => ({
-        variantKey: s.variantKey,
+        variantKey: s.variantKey ?? '',
         leafSemantics: s.populatesSubShape?.leafSemantics,
       }))
       .sort((a, b) => a.variantKey.localeCompare(b.variantKey));

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -1029,15 +1029,19 @@ describe('planner contracts: variant planner enumerates polymorphic semantic-typ
     // Class-scoped: three distinct semantic-type annotations on the
     // same field => three variant scenarios. Pre-#324 only the first
     // (ScopeKey) was emitted because the dedup key ignored semantic.
-    const triples = variants.scenarios.map((s) => ({
-      variantKey: s.variantKey,
-      leafSemantics: s.populatesSubShape?.leafSemantics,
-    }));
-    expect(triples).toEqual([
-      { variantKey: '::scopeKey::ScopeKey', leafSemantics: ['ScopeKey'] },
-      { variantKey: '::scopeKey::ProcessInstanceKey', leafSemantics: ['ProcessInstanceKey'] },
-      { variantKey: '::scopeKey::ElementInstanceKey', leafSemantics: ['ElementInstanceKey'] },
-    ]);
+    const triples = variants.scenarios
+      .map((s) => ({
+        variantKey: s.variantKey,
+        leafSemantics: s.populatesSubShape?.leafSemantics,
+      }))
+      .sort((a, b) => a.variantKey.localeCompare(b.variantKey));
+    expect(triples).toEqual(
+      [
+        { variantKey: '::scopeKey::ScopeKey', leafSemantics: ['ScopeKey'] },
+        { variantKey: '::scopeKey::ProcessInstanceKey', leafSemantics: ['ProcessInstanceKey'] },
+        { variantKey: '::scopeKey::ElementInstanceKey', leafSemantics: ['ElementInstanceKey'] },
+      ].sort((a, b) => a.variantKey.localeCompare(b.variantKey)),
+    );
   });
 
   it('still dedupes true duplicates: the same (fieldPath, semantic) pair appearing twice emits one variant', () => {

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -510,7 +510,7 @@ describe('planner contracts: variant planner respects success-status producer fi
     expect(variants.scenarios).toHaveLength(1);
     const [scenario] = variants.scenarios;
     expect(scenario.strategy).toBe('optionalSubShapeVariant');
-    expect(scenario.variantKey).toBe('addons[]::addons[].productId');
+    expect(scenario.variantKey).toBe('addons[]::addons[].productId::ProductId');
     expect(scenario.operations.map((o) => o.operationId)).toEqual(['placeOrder']);
   });
 });
@@ -972,5 +972,101 @@ describe('planner contracts: IncidentKey runtimeEmission discover-and-bind chain
       extractInto: 'incidentKeyVar',
       consistency: 'eventual',
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture P: variant planner enumerates polymorphic semantic-type siblings on
+// the same field (#324)
+// ---------------------------------------------------------------------------
+//
+// Mirrors the `evaluateExpression.scopeKey` shape exposed by the spec
+// bump in #322: a single optional flat top-level field that carries
+// MULTIPLE semantic-type annotations (e.g. `ScopeKey`,
+// `ProcessInstanceKey`, `ElementInstanceKey`). Pre-fix the planner's
+// variant dedup key was `${rootPath}::${fieldPath}` which collapsed all
+// polymorphic siblings into the first semantic — emitting one variant
+// instead of N.
+//
+// Class-scoped guarantee: for any optional field with N distinct
+// semantic-type annotations, the variant planner emits N variants —
+// one per `(rootPath, fieldPath, semantic)` triple — each carrying its
+// own `populatesSubShape.leafSemantics` value.
+const fixturePolymorphicSemanticSiblings: OperationGraph = makeGraph([
+  makeOp('mintScopeKey', {
+    produces: ['ScopeKey'],
+    providerMap: { ScopeKey: true },
+  }),
+  makeOp('mintProcessInstanceKey', {
+    produces: ['ProcessInstanceKey'],
+    providerMap: { ProcessInstanceKey: true },
+  }),
+  makeOp('mintElementInstanceKey', {
+    produces: ['ElementInstanceKey'],
+    providerMap: { ElementInstanceKey: true },
+  }),
+  makeOp('evaluateExpression', {
+    optionalSubShapes: [
+      {
+        rootPath: '',
+        leaves: [
+          { fieldPath: 'scopeKey', semantic: 'ScopeKey' },
+          { fieldPath: 'scopeKey', semantic: 'ProcessInstanceKey' },
+          { fieldPath: 'scopeKey', semantic: 'ElementInstanceKey' },
+        ],
+      },
+    ],
+  }),
+]);
+
+describe('planner contracts: variant planner enumerates polymorphic semantic-type siblings (#324)', () => {
+  it('emits one variant per (fieldPath, semantic) for a flat optional with three semantic-type annotations', () => {
+    const variants = generateOptionalSubShapeVariants(
+      fixturePolymorphicSemanticSiblings,
+      'evaluateExpression',
+      { maxVariantsPerEndpoint: 10 },
+    );
+    // Class-scoped: three distinct semantic-type annotations on the
+    // same field => three variant scenarios. Pre-#324 only the first
+    // (ScopeKey) was emitted because the dedup key ignored semantic.
+    const triples = variants.scenarios.map((s) => ({
+      variantKey: s.variantKey,
+      leafSemantics: s.populatesSubShape?.leafSemantics,
+    }));
+    expect(triples).toEqual([
+      { variantKey: '::scopeKey::ScopeKey', leafSemantics: ['ScopeKey'] },
+      { variantKey: '::scopeKey::ProcessInstanceKey', leafSemantics: ['ProcessInstanceKey'] },
+      { variantKey: '::scopeKey::ElementInstanceKey', leafSemantics: ['ElementInstanceKey'] },
+    ]);
+  });
+
+  it('still dedupes true duplicates: the same (fieldPath, semantic) pair appearing twice emits one variant', () => {
+    // Construct a fixture where the extractor emitted the same
+    // (fieldPath, semantic) pair twice in `requestBodySemanticTypes`
+    // (a legitimate occurrence — e.g. a field referenced from two
+    // oneOf branches that both annotate the same semantic). Pre- and
+    // post-#324 must both dedupe these.
+    const fixtureDuplicate: OperationGraph = makeGraph([
+      makeOp('mintScopeKey', {
+        produces: ['ScopeKey'],
+        providerMap: { ScopeKey: true },
+      }),
+      makeOp('evaluateExpression', {
+        optionalSubShapes: [
+          {
+            rootPath: '',
+            leaves: [
+              { fieldPath: 'scopeKey', semantic: 'ScopeKey' },
+              { fieldPath: 'scopeKey', semantic: 'ScopeKey' },
+            ],
+          },
+        ],
+      }),
+    ]);
+    const variants = generateOptionalSubShapeVariants(fixtureDuplicate, 'evaluateExpression', {
+      maxVariantsPerEndpoint: 10,
+    });
+    expect(variants.scenarios.length).toBe(1);
+    expect(variants.scenarios[0].variantKey).toBe('::scopeKey::ScopeKey');
   });
 });


### PR DESCRIPTION
Closes #324.

## What

Fix the variant planner's dedup key so polymorphic semantic-type siblings on the same optional field each emit their own variant scenario.

`generateOptionalSubShapeVariants` (`path-analyser/src/scenarioGenerator.ts`) keyed the `seenVariantKeys` set on `(rootPath, fieldPath)`. When `requestBodySemanticTypes` annotates the same field with multiple semantics (`evaluateExpression.scopeKey` carries `ScopeKey`, `ProcessInstanceKey`, and `ElementInstanceKey` after the spec bump in #322), only the first semantic survived dedup and the polymorphic siblings were silently dropped.

Including `leaf.semantic` in the dedup key — and in the persisted `variantKey` so downstream consumers can distinguish the variants — emits one scenario per `(rootPath, fieldPath, semantic)` triple. True duplicates (same semantic appearing twice on the same field) still dedupe.

## Tests

- New L2 fixture `fixturePolymorphicSemanticSiblings` in `tests/fixtures/planner/planner-contracts.test.ts` asserts the class-scoped property: any optional leaf with N distinct semantic annotations on the same `(rootPath, fieldPath)` produces N variants, each with its own `populatesSubShape.leafSemantics`.
- Paired fixture pins the still-dedupe behaviour for genuine duplicates (same `(fieldPath, semantic)` repeated).
- The narrow allowlist that #322 added to the L3 invariant "variant suite covers every flat top-level optional present in the feature suite pre-cut" is removed — with the planner fix in place the offenders are covered for real.

## Commit split

Per AGENTS.md generator-vs-output discipline:
1. `fix:` — planner change + new L2 fixture
2. `test:` — allowlist removal (deferred from #322)

`generated/` is gitignored, so no regenerated-output commit is needed; CI regenerates from the bundled spec on every run.

## Verification

- `npm run lint`: clean
- per-workspace `tsc --noEmit` (extractor, path-analyser, emitter-sdk, materializer, request-validation, tests): clean
- `npm run testsuite:generate && npm run generate:request-validation`: succeeded
- `npm test`: 625 passed, 4 skipped, 0 failed

## Backstory

- #320 → #323 fixed the materializer/emitter side of the spec-bump fallout.
- #322 bumped the pinned spec and added a narrow allowlist to keep the invariant green pending this planner fix.
- This PR is the planner fix that lets the allowlist retire.
