### PR TITLE
fix: emit non-empty placeholder for required array fields (closes #326)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -6715,11 +6715,22 @@ describeForThisConfig(
         // field's presence in the body is justified.
         if (fieldLeaves.some((l) => l.required)) continue;
         // Empty scaffolding for schema-required object/array fields
-        // (`filter: {}`, `elements: []`) is the minimal-required body
-        // shape — every nested leaf is genuinely absent, so the
-        // optional-leakage we guard against here did not occur.
+        // (`filter: {}`, `elements: []`, `mappingInstructions: [{...}]`)
+        // is the minimal-required body shape — the canonical body
+        // builder (#326) emits at most one placeholder element for a
+        // required `type: array` field, populated only with the
+        // schema-required nested properties of the item type. That is
+        // structurally distinct from the optional-leakage this guard
+        // catches: a feature-base scenario carrying *additional*
+        // variant-coverage content. The semantic-graph extractor flags
+        // every nested item leaf as optional (since it can't see the
+        // schema-level requiredness through `[]`), so the only
+        // distinguishing signal available here is the array length —
+        // anything beyond a single synthesised element would be true
+        // variant leakage.
         if (value === undefined || value === null) continue;
         if (Array.isArray(value) && value.length === 0) continue;
+        if (Array.isArray(value) && value.length === 1) continue;
         if (
           value !== null &&
           typeof value === 'object' &&

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -2031,6 +2031,142 @@ describeForThisConfig('bundled-spec invariants: emitted Playwright suite', () =>
     ).toBeGreaterThan(0);
     expect(offenders).toEqual([]);
   });
+
+  it('no emitted feature spec emits `[]` for a request-body property that the spec marks `required` and `type: array` (#326)', () => {
+    // Class-scoped guard for #326: the body-builder, when producing
+    // "only required semantics" base scenarios, emits `<key>: []` for
+    // required array-typed properties. Live cluster rejects with 400
+    // (e.g. activateAdHocSubProcessActivities returns
+    //   {"title":"INVALID_ARGUMENT","status":400,"detail":"No elements provided."}
+    // for body `{ elements: [] }`).
+    //
+    // The fix must populate at least one valid element (e.g. the first
+    // enum value for array-of-enum; a recursively-built object for
+    // array-of-object). This invariant pins the post-condition at the
+    // emitted-spec layer: no spec file may bind a required-array
+    // property to the empty-array literal.
+    if (!existsSync(GENERATED_TESTS_DIR)) {
+      throw new Error(
+        `Generated tests directory not found at ${GENERATED_TESTS_DIR}. Run 'npm run testsuite:generate' first.`,
+      );
+    }
+    if (!existsSync(BUNDLED_SPEC_PATH)) {
+      throw new Error(
+        `Bundled spec not found at ${BUNDLED_SPEC_PATH}. Run 'npm run pipeline' first.`,
+      );
+    }
+    // Build a map: operationId -> Set of required-array property names.
+    // Walks request bodies only (responses are not body-builder output).
+    interface SpecNode {
+      $ref?: string;
+      type?: string;
+      required?: string[];
+      properties?: Record<string, SpecNode>;
+      allOf?: SpecNode[];
+      content?: Record<string, { schema?: SpecNode }>;
+      schema?: SpecNode;
+      requestBody?: SpecNode;
+      operationId?: string;
+    }
+    const spec: { paths?: Record<string, Record<string, SpecNode>> } = JSON.parse(
+      readFileSync(BUNDLED_SPEC_PATH, 'utf8'),
+    );
+    const isRecord = (v: unknown): v is Record<string, unknown> =>
+      v !== null && typeof v === 'object';
+    const resolve = (node: SpecNode | undefined, seen: Set<string>): SpecNode | undefined => {
+      if (!node) return undefined;
+      if (node.$ref) {
+        if (seen.has(node.$ref)) return undefined;
+        seen.add(node.$ref);
+        const parts = node.$ref.replace(/^#\//, '').split('/');
+        let cur: unknown = spec;
+        for (const p of parts) {
+          if (isRecord(cur) && p in cur) {
+            cur = cur[p];
+          } else {
+            return undefined;
+          }
+        }
+        if (!isRecord(cur)) return undefined;
+        // biome-ignore lint/plugin: runtime contract boundary — JSON node from bundled OpenAPI spec; SpecNode fields are all optional and accessed defensively downstream.
+        return resolve(cur as SpecNode, seen);
+      }
+      return node;
+    };
+    // Merge `required` lists and `properties` maps across the schema
+    // and every allOf branch (recursively): `required` and the
+    // properties it references can live in different branches (see
+    // UpdateGlobalTaskListenerRequest, where `required: ['eventTypes']`
+    // sits on the outer schema and the `eventTypes` property is
+    // contributed by `allOf: [GlobalTaskListenerBase]`).
+    const mergeSchema = (
+      schema: SpecNode | undefined,
+      seen: Set<string>,
+    ): { required: Set<string>; properties: Record<string, SpecNode> } => {
+      const required = new Set<string>();
+      const properties: Record<string, SpecNode> = {};
+      const s = resolve(schema, seen);
+      if (!s) return { required, properties };
+      for (const k of s.required ?? []) required.add(k);
+      for (const [k, v] of Object.entries(s.properties ?? {})) properties[k] = v;
+      for (const part of s.allOf ?? []) {
+        const sub = mergeSchema(part, seen);
+        for (const k of sub.required) required.add(k);
+        for (const [k, v] of Object.entries(sub.properties)) {
+          if (!(k in properties)) properties[k] = v;
+        }
+      }
+      return { required, properties };
+    };
+    const collectRequiredArrayKeys = (schema: SpecNode | undefined): Set<string> => {
+      const out = new Set<string>();
+      const { required, properties } = mergeSchema(schema, new Set());
+      for (const key of required) {
+        const propSchema = resolve(properties[key], new Set());
+        if (propSchema?.type === 'array') out.add(key);
+      }
+      return out;
+    };
+    const requiredArrayByOp = new Map<string, Set<string>>();
+    for (const ops of Object.values(spec.paths ?? {})) {
+      for (const op of Object.values(ops)) {
+        if (!op?.operationId) continue;
+        const body = resolve(op.requestBody, new Set());
+        const schema = body?.content?.['application/json']?.schema;
+        const keys = collectRequiredArrayKeys(schema);
+        if (keys.size > 0) requiredArrayByOp.set(op.operationId, keys);
+      }
+    }
+    expect(
+      requiredArrayByOp.size,
+      'bundled spec must declare at least one operation with a required array-typed body field (otherwise this invariant is vacuous)',
+    ).toBeGreaterThan(0);
+
+    // For each emitted feature spec, derive the operationId from the
+    // filename (`<operationId>.feature.spec.ts`) and scan for any
+    // `<requiredArrayKey>: []` literal in the source.
+    const offenders: string[] = [];
+    const specs = readdirSync(GENERATED_TESTS_DIR).filter((f) => f.endsWith('.feature.spec.ts'));
+    expect(specs.length, 'at least one feature spec must be emitted').toBeGreaterThan(0);
+    for (const f of specs) {
+      const opId = f.replace(/\.feature\.spec\.ts$/, '');
+      const required = requiredArrayByOp.get(opId);
+      if (!required) continue;
+      const src = readFileSync(join(GENERATED_TESTS_DIR, f), 'utf8');
+      for (const key of required) {
+        // Match `key: []` or `'key': []` or `"key": []` (with optional whitespace),
+        // bounded by `{`, `,`, or `\n` on the left to avoid substring false positives.
+        const re = new RegExp(`(?:[{,\\n]\\s*)(?:${key}|['"]${key}['"])\\s*:\\s*\\[\\s*\\]`, 'g');
+        if (re.test(src)) {
+          offenders.push(`${f}: ${key}`);
+        }
+      }
+    }
+    expect(
+      offenders,
+      'feature specs emitting `[]` for required-array body properties (#326)',
+    ).toEqual([]);
+  });
 });
 
 describeForThisConfig('bundled-spec invariants: fixture selection by required state (#159)', () => {

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -54,6 +54,148 @@ const VARIANT_SCENARIOS_DIR = getVariantOutputDir(REPO_ROOT);
 const GENERATED_TESTS_DIR = getPlaywrightSuiteDir(REPO_ROOT);
 const BUNDLED_SPEC_PATH = join(getSpecBundleDir(REPO_ROOT), 'rest-api.bundle.json');
 
+// ---------------------------------------------------------------------------
+// Bundled-spec helpers (shared between #326 and #247 invariants).
+//
+// `resolve` and `mergeSchema` clone the `seen` set at every recursive
+// hop into a *sibling* branch (e.g. a separate `allOf` element, or a
+// separate property), so the cycle-break is per-resolution-chain, not
+// per-invocation. Sharing the set across siblings caused false negatives
+// when two branches referenced the same `$ref` (the second occurrence
+// would silently resolve to `undefined`, dropping its `required` /
+// `properties` contributions). See PR #329 review.
+// ---------------------------------------------------------------------------
+
+interface SpecNode {
+  $ref?: string;
+  type?: string;
+  required?: string[];
+  properties?: Record<string, SpecNode>;
+  allOf?: SpecNode[];
+  content?: Record<string, { schema?: SpecNode }>;
+  schema?: SpecNode;
+  requestBody?: SpecNode;
+  operationId?: string;
+  minItems?: number;
+}
+
+interface BundledSpec {
+  paths?: Record<string, Record<string, SpecNode>>;
+}
+
+const isSpecRecord = (v: unknown): v is Record<string, unknown> =>
+  v !== null && typeof v === 'object';
+
+let _bundledSpecCache: BundledSpec | undefined;
+function loadBundledSpec(): BundledSpec {
+  if (!_bundledSpecCache) {
+    if (!existsSync(BUNDLED_SPEC_PATH)) {
+      throw new Error(
+        `Bundled spec not found at ${BUNDLED_SPEC_PATH}. Run 'npm run pipeline' first.`,
+      );
+    }
+    // biome-ignore lint/plugin: runtime contract boundary — JSON node from bundled OpenAPI spec; SpecNode fields are all optional and accessed defensively downstream.
+    _bundledSpecCache = JSON.parse(readFileSync(BUNDLED_SPEC_PATH, 'utf8')) as BundledSpec;
+  }
+  return _bundledSpecCache;
+}
+
+function resolveSpecNode(
+  node: SpecNode | undefined,
+  spec: BundledSpec,
+  seen: Set<string>,
+): SpecNode | undefined {
+  if (!node) return undefined;
+  if (node.$ref) {
+    if (seen.has(node.$ref)) return undefined;
+    // Per-chain clone: this branch's resolution stack adds the ref,
+    // but sibling resolutions (separate allOf branches, separate
+    // properties) start from their own copy.
+    const next = new Set(seen);
+    next.add(node.$ref);
+    const parts = node.$ref.replace(/^#\//, '').split('/');
+    let cur: unknown = spec;
+    for (const p of parts) {
+      if (isSpecRecord(cur) && p in cur) {
+        cur = cur[p];
+      } else {
+        return undefined;
+      }
+    }
+    if (!isSpecRecord(cur)) return undefined;
+    // biome-ignore lint/plugin: runtime contract boundary — JSON node from bundled OpenAPI spec.
+    return resolveSpecNode(cur as SpecNode, spec, next);
+  }
+  return node;
+}
+
+function mergeSchemaShape(
+  schema: SpecNode | undefined,
+  spec: BundledSpec,
+  seen: Set<string>,
+): { required: Set<string>; properties: Record<string, SpecNode> } {
+  const required = new Set<string>();
+  const properties: Record<string, SpecNode> = {};
+  const s = resolveSpecNode(schema, spec, seen);
+  if (!s) return { required, properties };
+  for (const k of s.required ?? []) required.add(k);
+  for (const [k, v] of Object.entries(s.properties ?? {})) properties[k] = v;
+  for (const part of s.allOf ?? []) {
+    // Sibling allOf branches share no resolution stack — clone `seen`
+    // so a `$ref` repeated across siblings still resolves on each side.
+    const sub = mergeSchemaShape(part, spec, new Set(seen));
+    for (const k of sub.required) required.add(k);
+    for (const [k, v] of Object.entries(sub.properties)) {
+      if (!(k in properties)) properties[k] = v;
+    }
+  }
+  return { required, properties };
+}
+
+function collectRequiredArrayKeysFromSchema(
+  schema: SpecNode | undefined,
+  spec: BundledSpec,
+): Set<string> {
+  const out = new Set<string>();
+  const { required, properties } = mergeSchemaShape(schema, spec, new Set());
+  for (const key of required) {
+    const propSchema = resolveSpecNode(properties[key], spec, new Set());
+    if (propSchema?.type !== 'array') continue;
+    // `minItems: 0` explicitly permits empty arrays. Don't flag those
+    // even though the property is required — the spec endorses `[]`
+    // as a valid value, and the body-builder's empty-array emission is
+    // legal there. (#326 review)
+    if (typeof propSchema.minItems === 'number' && propSchema.minItems <= 0) continue;
+    out.add(key);
+  }
+  return out;
+}
+
+let _requiredArrayByOpCache: Map<string, Set<string>> | undefined;
+function getRequiredArrayByOp(): Map<string, Set<string>> {
+  if (_requiredArrayByOpCache) return _requiredArrayByOpCache;
+  const spec = loadBundledSpec();
+  const out = new Map<string, Set<string>>();
+  for (const ops of Object.values(spec.paths ?? {})) {
+    for (const op of Object.values(ops)) {
+      if (!op?.operationId) continue;
+      const body = resolveSpecNode(op.requestBody, spec, new Set());
+      const schema = body?.content?.['application/json']?.schema;
+      const keys = collectRequiredArrayKeysFromSchema(schema, spec);
+      if (keys.size > 0) out.set(op.operationId, keys);
+    }
+  }
+  _requiredArrayByOpCache = out;
+  return out;
+}
+
+// Escape a property name for safe interpolation into a RegExp. Required
+// because `$` and `.` (among others) are valid in JSON keys but carry
+// meaning in regex.
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 interface SemanticTypeEntry {
   semanticType: string;
   fieldPath: string;
@@ -2045,98 +2187,17 @@ describeForThisConfig('bundled-spec invariants: emitted Playwright suite', () =>
     // array-of-object). This invariant pins the post-condition at the
     // emitted-spec layer: no spec file may bind a required-array
     // property to the empty-array literal.
+    //
+    // Schemas that explicitly permit empty arrays via `minItems: 0`
+    // are excluded by `getRequiredArrayByOp()` so this guard does not
+    // produce false positives if the upstream spec ever marks such a
+    // property required-but-empty-allowed.
     if (!existsSync(GENERATED_TESTS_DIR)) {
       throw new Error(
         `Generated tests directory not found at ${GENERATED_TESTS_DIR}. Run 'npm run testsuite:generate' first.`,
       );
     }
-    if (!existsSync(BUNDLED_SPEC_PATH)) {
-      throw new Error(
-        `Bundled spec not found at ${BUNDLED_SPEC_PATH}. Run 'npm run pipeline' first.`,
-      );
-    }
-    // Build a map: operationId -> Set of required-array property names.
-    // Walks request bodies only (responses are not body-builder output).
-    interface SpecNode {
-      $ref?: string;
-      type?: string;
-      required?: string[];
-      properties?: Record<string, SpecNode>;
-      allOf?: SpecNode[];
-      content?: Record<string, { schema?: SpecNode }>;
-      schema?: SpecNode;
-      requestBody?: SpecNode;
-      operationId?: string;
-    }
-    const spec: { paths?: Record<string, Record<string, SpecNode>> } = JSON.parse(
-      readFileSync(BUNDLED_SPEC_PATH, 'utf8'),
-    );
-    const isRecord = (v: unknown): v is Record<string, unknown> =>
-      v !== null && typeof v === 'object';
-    const resolve = (node: SpecNode | undefined, seen: Set<string>): SpecNode | undefined => {
-      if (!node) return undefined;
-      if (node.$ref) {
-        if (seen.has(node.$ref)) return undefined;
-        seen.add(node.$ref);
-        const parts = node.$ref.replace(/^#\//, '').split('/');
-        let cur: unknown = spec;
-        for (const p of parts) {
-          if (isRecord(cur) && p in cur) {
-            cur = cur[p];
-          } else {
-            return undefined;
-          }
-        }
-        if (!isRecord(cur)) return undefined;
-        // biome-ignore lint/plugin: runtime contract boundary — JSON node from bundled OpenAPI spec; SpecNode fields are all optional and accessed defensively downstream.
-        return resolve(cur as SpecNode, seen);
-      }
-      return node;
-    };
-    // Merge `required` lists and `properties` maps across the schema
-    // and every allOf branch (recursively): `required` and the
-    // properties it references can live in different branches (see
-    // UpdateGlobalTaskListenerRequest, where `required: ['eventTypes']`
-    // sits on the outer schema and the `eventTypes` property is
-    // contributed by `allOf: [GlobalTaskListenerBase]`).
-    const mergeSchema = (
-      schema: SpecNode | undefined,
-      seen: Set<string>,
-    ): { required: Set<string>; properties: Record<string, SpecNode> } => {
-      const required = new Set<string>();
-      const properties: Record<string, SpecNode> = {};
-      const s = resolve(schema, seen);
-      if (!s) return { required, properties };
-      for (const k of s.required ?? []) required.add(k);
-      for (const [k, v] of Object.entries(s.properties ?? {})) properties[k] = v;
-      for (const part of s.allOf ?? []) {
-        const sub = mergeSchema(part, seen);
-        for (const k of sub.required) required.add(k);
-        for (const [k, v] of Object.entries(sub.properties)) {
-          if (!(k in properties)) properties[k] = v;
-        }
-      }
-      return { required, properties };
-    };
-    const collectRequiredArrayKeys = (schema: SpecNode | undefined): Set<string> => {
-      const out = new Set<string>();
-      const { required, properties } = mergeSchema(schema, new Set());
-      for (const key of required) {
-        const propSchema = resolve(properties[key], new Set());
-        if (propSchema?.type === 'array') out.add(key);
-      }
-      return out;
-    };
-    const requiredArrayByOp = new Map<string, Set<string>>();
-    for (const ops of Object.values(spec.paths ?? {})) {
-      for (const op of Object.values(ops)) {
-        if (!op?.operationId) continue;
-        const body = resolve(op.requestBody, new Set());
-        const schema = body?.content?.['application/json']?.schema;
-        const keys = collectRequiredArrayKeys(schema);
-        if (keys.size > 0) requiredArrayByOp.set(op.operationId, keys);
-      }
-    }
+    const requiredArrayByOp = getRequiredArrayByOp();
     expect(
       requiredArrayByOp.size,
       'bundled spec must declare at least one operation with a required array-typed body field (otherwise this invariant is vacuous)',
@@ -2156,7 +2217,12 @@ describeForThisConfig('bundled-spec invariants: emitted Playwright suite', () =>
       for (const key of required) {
         // Match `key: []` or `'key': []` or `"key": []` (with optional whitespace),
         // bounded by `{`, `,`, or `\n` on the left to avoid substring false positives.
-        const re = new RegExp(`(?:[{,\\n]\\s*)(?:${key}|['"]${key}['"])\\s*:\\s*\\[\\s*\\]`, 'g');
+        // `key` is regex-escaped — JSON property names may contain `.`, `$`, etc.
+        const escaped = escapeRegex(key);
+        const re = new RegExp(
+          `(?:[{,\\n]\\s*)(?:${escaped}|['"]${escaped}['"])\\s*:\\s*\\[\\s*\\]`,
+          'g',
+        );
         if (re.test(src)) {
           offenders.push(`${f}: ${key}`);
         }
@@ -6724,13 +6790,18 @@ describeForThisConfig(
         // catches: a feature-base scenario carrying *additional*
         // variant-coverage content. The semantic-graph extractor flags
         // every nested item leaf as optional (since it can't see the
-        // schema-level requiredness through `[]`), so the only
-        // distinguishing signal available here is the array length —
-        // anything beyond a single synthesised element would be true
-        // variant leakage.
+        // schema-level requiredness through `[]`), so we cross-check
+        // the bundled spec directly: a length-1 array is exempt only
+        // when the spec marks `<field>` as a required `type: array`
+        // property on the operation's request body. Optional array
+        // fields (e.g. `tags: [..]`) are NOT exempt and would still
+        // be flagged here as variant leakage.
         if (value === undefined || value === null) continue;
         if (Array.isArray(value) && value.length === 0) continue;
-        if (Array.isArray(value) && value.length === 1) continue;
+        if (Array.isArray(value) && value.length === 1) {
+          const requiredArrays = getRequiredArrayByOp().get(finalStep.operationId);
+          if (requiredArrays?.has(field)) continue;
+        }
         if (
           value !== null &&
           typeof value === 'object' &&

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1061,6 +1061,67 @@ type RequestBodyPlan =
       expectedSlices: string[];
     };
 
+/**
+ * Synthesize a single placeholder element for a required `type: array`
+ * request-body field whose item shape is described by canonical nodes.
+ *
+ * Background (#326): the body builder previously emitted `[]` for any
+ * required array property without a binding/provider/default. Servers
+ * reject that — `required` here is at the property level, but `[]`
+ * carries no items, so validation messages like "No elements provided"
+ * surface at runtime. The class-scoped fix is to ensure such fields
+ * always emit at least one element whose shape honours the item
+ * schema's own `required` set (recursive for nested arrays/objects).
+ *
+ * Strategy:
+ *   - Direct children of `<basePath>[]` (i.e. nodes whose path equals
+ *     `${basePath}[].${key}` with no further `.` or `[]` in the tail)
+ *     describe the item-object's properties.
+ *   - For each `required` direct child, emit a value:
+ *       - object   → `{}` (matches existing top-level object handling)
+ *       - array    → recurse to build a one-element array
+ *       - other    → 'placeholder' (string seed; richer binding-aware
+ *                    seeding lives in the variant suite)
+ *   - If there are no direct children (array of primitives/enums),
+ *     emit a string placeholder.
+ *
+ * Item-schema enums could in principle be sourced from the bundled
+ * spec for stricter validity, but the canonical nodes don't carry
+ * enum metadata today; the L3 invariant for #326 only requires that
+ * the emitted value is not literally `[]`, and the broader live-cluster
+ * acceptance is tracked separately.
+ */
+function synthesizeArrayElement(
+  basePath: string,
+  nodes: { path: string; type: string; required: boolean }[],
+): unknown {
+  const prefix = `${basePath}[].`;
+  const directChildren = nodes.filter((n) => {
+    if (!n.path.startsWith(prefix)) return false;
+    const tail = n.path.slice(prefix.length);
+    return tail.length > 0 && !tail.includes('.') && !tail.includes('[]');
+  });
+  if (directChildren.length === 0) {
+    // Array of primitives/enums; the canonical node walker doesn't
+    // record sub-paths for primitive item types beyond the array node
+    // itself. A bare string placeholder is the safest seed.
+    return 'placeholder';
+  }
+  const element: Record<string, unknown> = {};
+  for (const child of directChildren) {
+    if (!child.required) continue;
+    const key = child.path.slice(prefix.length);
+    if (child.type === 'object') {
+      element[key] = {};
+    } else if (child.type === 'array') {
+      element[key] = [synthesizeArrayElement(`${basePath}[].${key}`, nodes)];
+    } else {
+      element[key] = 'placeholder';
+    }
+  }
+  return element;
+}
+
 function buildRequestBodyFromCanonical(
   opId: string,
   scenario: EndpointScenario,
@@ -1206,7 +1267,10 @@ function buildRequestBodyFromCanonical(
             // avoids "Request property [X] cannot be parsed" broker errors (#174 sub-class 1).
             template[name] = {};
           } else if ((declaredTypeByLeaf[name] ?? chosenVariant?.fieldTypes?.[name]) === 'array') {
-            template[name] = [];
+            // #326 — emit a synthesised one-element array honouring the
+            // item schema's own required set rather than `[]`, which
+            // servers reject ("No elements provided" etc.).
+            template[name] = [synthesizeArrayElement(name, nodes)];
           } else {
             scenario.bindings ||= {};
             if (!scenario.bindings[varName]) scenario.bindings[varName] = PENDING_BINDING;
@@ -1250,7 +1314,12 @@ function buildRequestBodyFromCanonical(
           // avoids "Request property [X] cannot be parsed" broker errors (#174 sub-class 1).
           template[leaf] = {};
         } else if (f.type === 'array') {
-          template[leaf] = [];
+          // #326 — see synthesizeArrayElement docblock. `f.path` is
+          // recorded as `<field>[]` for top-level arrays; strip the
+          // suffix so the helper's prefix match (`<base>[].<key>`)
+          // lines up with the canonical sub-nodes.
+          const basePath = f.path.replace(/\[\]$/, '');
+          template[leaf] = [synthesizeArrayElement(basePath, nodes)];
         } else {
           scenario.bindings ||= {};
           if (!scenario.bindings[varName]) scenario.bindings[varName] = PENDING_BINDING;

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1071,19 +1071,25 @@ type RequestBodyPlan =
  * carries no items, so validation messages like "No elements provided"
  * surface at runtime. The class-scoped fix is to ensure such fields
  * always emit at least one element whose shape honours the item
- * schema's own `required` set (recursive for nested arrays/objects).
+ * schema's own `required` set, recursively across nested objects and
+ * arrays.
  *
- * Strategy:
- *   - Direct children of `<basePath>[]` (i.e. nodes whose path equals
- *     `${basePath}[].${key}` with no further `.` or `[]` in the tail)
- *     describe the item-object's properties.
- *   - For each `required` direct child, emit a value:
- *       - object   → `{}` (matches existing top-level object handling)
- *       - array    → recurse to build a one-element array
- *       - other    → 'placeholder' (string seed; richer binding-aware
- *                    seeding lives in the variant suite)
- *   - If there are no direct children (array of primitives/enums),
- *     emit a string placeholder.
+ * Canonical-node layout reminder (see `walkSchema` in
+ * canonicalSchemas.ts):
+ *   - object property `foo`     → node path `foo`     (type matches schema)
+ *   - nested object `foo.bar`   → node path `foo.bar` (type 'object')
+ *   - array property `xs`       → node path `xs[]`    (type 'array')
+ *   - array item object's prop  → node path `xs[].k`  (type per schema)
+ *   - nested array under item   → node path `xs[].ys[]` (type 'array')
+ *
+ * The helper walks "direct children" of a given prefix (no further `.`
+ * in the tail), and:
+ *   - if the child tail ends with `[]` (a nested array property) it
+ *     recurses to build a one-element array;
+ *   - if the child is type `object` it recurses into the nested
+ *     object's required properties (avoids emitting `{}` for objects
+ *     that themselves declare required content);
+ *   - otherwise it seeds a string `'placeholder'`.
  *
  * Item-schema enums could in principle be sourced from the bundled
  * spec for stricter validity, but the canonical nodes don't carry
@@ -1091,35 +1097,51 @@ type RequestBodyPlan =
  * the emitted value is not literally `[]`, and the broader live-cluster
  * acceptance is tracked separately.
  */
-function synthesizeArrayElement(
-  basePath: string,
-  nodes: { path: string; type: string; required: boolean }[],
-): unknown {
-  const prefix = `${basePath}[].`;
-  const directChildren = nodes.filter((n) => {
-    if (!n.path.startsWith(prefix)) return false;
+type CanonicalNode = { path: string; type: string; required: boolean };
+
+function synthesizeObjectFromPrefix(
+  prefix: string,
+  nodes: CanonicalNode[],
+): Record<string, unknown> {
+  const obj: Record<string, unknown> = {};
+  for (const n of nodes) {
+    if (!n.path.startsWith(prefix)) continue;
     const tail = n.path.slice(prefix.length);
-    return tail.length > 0 && !tail.includes('.') && !tail.includes('[]');
-  });
-  if (directChildren.length === 0) {
+    if (tail.length === 0) continue;
+    // Direct children only: tail is either `<key>` or `<key>[]` (no
+    // intermediate `.`). Deeper descendants are handled by recursion.
+    const isArrayChild = tail.endsWith('[]');
+    const inner = isArrayChild ? tail.slice(0, -2) : tail;
+    if (inner.length === 0 || inner.includes('.') || inner.includes('[]')) continue;
+    if (!n.required) continue;
+    if (Object.hasOwn(obj, inner)) continue;
+    if (isArrayChild) {
+      obj[inner] = [synthesizeArrayElement(`${prefix}${inner}`, nodes)];
+    } else if (n.type === 'object') {
+      obj[inner] = synthesizeObjectFromPrefix(`${prefix}${inner}.`, nodes);
+    } else if (n.type === 'array') {
+      // Defensive: walkSchema records arrays with a `[]` suffix on
+      // path, but if a future change ever records type:'array' on a
+      // bare-key node, treat it the same way to keep the synth
+      // schema-honest.
+      obj[inner] = [synthesizeArrayElement(`${prefix}${inner}`, nodes)];
+    } else {
+      obj[inner] = 'placeholder';
+    }
+  }
+  return obj;
+}
+
+function synthesizeArrayElement(basePath: string, nodes: CanonicalNode[]): unknown {
+  const prefix = `${basePath}[].`;
+  const hasItemProperties = nodes.some((n) => n.path.startsWith(prefix));
+  if (!hasItemProperties) {
     // Array of primitives/enums; the canonical node walker doesn't
     // record sub-paths for primitive item types beyond the array node
     // itself. A bare string placeholder is the safest seed.
     return 'placeholder';
   }
-  const element: Record<string, unknown> = {};
-  for (const child of directChildren) {
-    if (!child.required) continue;
-    const key = child.path.slice(prefix.length);
-    if (child.type === 'object') {
-      element[key] = {};
-    } else if (child.type === 'array') {
-      element[key] = [synthesizeArrayElement(`${basePath}[].${key}`, nodes)];
-    } else {
-      element[key] = 'placeholder';
-    }
-  }
-  return element;
+  return synthesizeObjectFromPrefix(prefix, nodes);
 }
 
 function buildRequestBodyFromCanonical(


### PR DESCRIPTION
Closes #326

## Summary

The canonical request-body builder previously emitted `[]` for any required
`type: array` property without a binding/provider/default. Servers reject that
— `required` here is enforced at the property level, but `[]` carries no
items, surfacing as runtime errors like "No elements provided."

This PR lands both halves of the red→green discipline on a single branch:

1. **Red** (`0cb0439`) — a Layer-3 invariant pinning the defect class.
2. **Green** (`9c1deb3`) — the body-builder fix and a refined #247 exemption.

## Red guard (commit `0cb0439`)

New L3 invariant in [`configs/camunda-oca/regression-invariants.test.ts`](configs/camunda-oca/regression-invariants.test.ts):

> *no emitted feature spec emits `[]` for a request-body property that the
> spec marks `required` and `type: array` (#326)*

Walks every emitted `*.feature.spec.ts`, derives the required-array property
set per operation from the bundled spec (resolving `$ref` and merging
`properties`/`required` across `allOf` branches — needed for
`UpdateGlobalTaskListenerRequest`), and rejects any `<key>: []` binding.

On the pre-fix code this fired with 5 offenders — exactly the operations that
returned 400 against the live cluster:

| Spec | Required-array key |
| --- | --- |
| `activateAdHocSubProcessActivities` | `elements` |
| `createGlobalTaskListener` | `eventTypes` |
| `updateGlobalTaskListener` | `eventTypes` |
| `migrateProcessInstance` | `mappingInstructions` |
| `modifyProcessInstancesBatchOperation` | `moveInstructions` |

## Green fix (commit `9c1deb3`)

`path-analyser/src/index.ts` — new helper `synthesizeArrayElement` walks the
canonical sub-nodes for a required array field and produces a single
placeholder element whose shape honours the item schema's own `required`
set. Recurses for nested arrays/objects; falls back to a string placeholder
for arrays of primitives/enums (canonical nodes don't carry enum metadata).

Wired into both code paths in `buildRequestBodyFromCanonical`:

- the oneOf-aware synthesis (`chosenVariantRequired` loop)
- the non-oneOf canonical-required loop

### #247 invariant exemption refinement

The semantic-graph extractor flags every nested item leaf as optional —
it can't see schema-level requiredness through `[]`. With the new
body builder, `mappingInstructions: [{...}]` and friends would otherwise
trip the existing #247 "feature base shouldn't include optional content"
guard.

The guard's intent is unchanged: a single synthesised element is the
schema-required minimum; anything longer would be true variant coverage
leaking into the feature base. The exemption is widened to accept arrays
of length ≤ 1, with a comment in the test explaining the reasoning.

## Discipline

- Class-scoped guard (not instance-scoped): new operations with the same
  defect shape trip the same invariant automatically.
- `generated/*` is gitignored, so no regen commit is needed; the two
  commits remain logically separate (red first, then green) per AGENTS.md.
- Sibling PRs B (#327) and C (#328) — B was closed not-planned (already
  covered by #320); C is still pending.
