### PR TITLE
fix: emit enum literal for required enum-typed request-body fields

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -95,6 +95,9 @@ interface SpecNode {
   required?: string[];
   properties?: Record<string, SpecNode>;
   allOf?: SpecNode[];
+  oneOf?: SpecNode[];
+  items?: SpecNode;
+  enum?: unknown[];
   content?: Record<string, { schema?: SpecNode }>;
   schema?: SpecNode;
   requestBody?: SpecNode;
@@ -173,6 +176,30 @@ function mergeSchemaShape(
     }
   }
   return { required, properties };
+}
+
+/**
+ * Walk a (possibly `$ref`- or `allOf`-wrapped) schema node and return its
+ * `enum` array if one is declared anywhere along the chain. Used by the
+ * `#338` invariant to recover enum constraints from spec nodes that are
+ * frequently wrapped as `allOf: [{ $ref: '#/components/schemas/SomeEnum' }]`
+ * (e.g. `resourceType`, `permissionTypes.items`).
+ *
+ * Returns the raw enum array — callers compare emitted values against it.
+ */
+function effectiveEnumFromSpec(
+  node: SpecNode | undefined,
+  spec: BundledSpec,
+  seen: Set<string>,
+): unknown[] | undefined {
+  const r = resolveSpecNode(node, spec, seen);
+  if (!r) return undefined;
+  if (Array.isArray(r.enum)) return r.enum;
+  for (const part of r.allOf ?? []) {
+    const e = effectiveEnumFromSpec(part, spec, new Set(seen));
+    if (e) return e;
+  }
+  return undefined;
 }
 
 function collectRequiredArrayKeysFromSchema(
@@ -8886,7 +8913,7 @@ describe.skipIf(CONFIG_NAME !== ACTIVE_CONFIG)(
 describeForThisConfig(
   'bundled-spec invariants: enum-typed request-body field seeding (#338)',
   () => {
-    it('no feature or variant scenario seeds a ${...} placeholder or a "placeholder" array item for a required enum-typed request-body field', () => {
+    it('every required enum-typed request-body field is seeded with a valid enum literal (no ${...} placeholder, no "placeholder" array element, no non-member literal)', () => {
       if (!existsSync(FEATURE_SCENARIOS_DIR)) {
         throw new Error(
           `Feature output directory not found at ${FEATURE_SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
@@ -8898,89 +8925,47 @@ describeForThisConfig(
         );
       }
 
-      interface SchemaObject {
-        type?: string;
-        $ref?: string;
-        required?: string[];
-        properties?: Record<string, SchemaObject>;
-        items?: SchemaObject;
-        oneOf?: SchemaObject[];
-        allOf?: SchemaObject[];
-        enum?: unknown[];
-      }
-
-      interface OpenApiSpec {
-        paths: Record<
-          string,
-          Record<
-            string,
-            {
-              operationId?: string;
-              requestBody?: { content?: { 'application/json'?: { schema?: SchemaObject } } };
-            }
-          >
-        >;
-        components?: { schemas?: Record<string, SchemaObject> };
-      }
-
-      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
-      const spec = JSON.parse(readFileSync(BUNDLED_SPEC_PATH, 'utf8')) as OpenApiSpec;
-
-      function resolveRef(ref: string): SchemaObject | undefined {
-        const name = ref.split('/').pop() ?? '';
-        return spec.components?.schemas?.[name];
-      }
-
-      function resolveSchemaObj(s: SchemaObject, depth = 0): SchemaObject {
-        if (depth > 20) return s;
-        if (s.$ref) {
-          const target = resolveRef(s.$ref);
-          if (target) return resolveSchemaObj(target, depth + 1);
-        }
-        return s;
-      }
-
-      /** Walk $ref + allOf chain to find an enum array. */
-      function effectiveEnum(s: SchemaObject, depth = 0): unknown[] | undefined {
-        if (depth > 20) return undefined;
-        const r = resolveSchemaObj(s, depth);
-        if (Array.isArray(r.enum)) return r.enum;
-        if (Array.isArray(r.allOf)) {
-          for (const part of r.allOf) {
-            const e = effectiveEnum(part, depth + 1);
-            if (e) return e;
-          }
-        }
-        return undefined;
-      }
+      const spec = loadBundledSpec();
 
       /**
-       * Walk a request-body schema (root + any oneOf variants) and collect,
-       * for every top-level required field, the enum values declared on the
-       * field's scalar schema (`fieldEnums`) and on its items' scalar schema
-       * when the field is an array (`itemEnums`).
+       * Walk a request-body schema and collect, for every required
+       * top-level field across the root branch and any `oneOf` variants,
+       * the enum values declared on the field's scalar schema
+       * (`fieldEnums`) and on its items' scalar schema when the field is
+       * an array (`itemEnums`).
+       *
+       * Uses the shared `mergeSchemaShape` / `resolveSpecNode` helpers
+       * so `allOf`-composed bodies (or oneOf variants composed via
+       * `allOf`) contribute their required+properties — otherwise the
+       * invariant would silently skip enum-typed required fields hidden
+       * behind `allOf` wrappers (review comment on #339).
        */
-      function collectEnumFields(rootSchema: SchemaObject): {
+      function collectEnumFields(rootSchema: SpecNode | undefined): {
         fieldEnums: Map<string, unknown[]>;
         itemEnums: Map<string, unknown[]>;
       } {
         const fieldEnums = new Map<string, unknown[]>();
         const itemEnums = new Map<string, unknown[]>();
-        const branches: SchemaObject[] = [];
-        const root = resolveSchemaObj(rootSchema);
-        if (root.properties) branches.push(root);
-        for (const v of root.oneOf ?? []) branches.push(resolveSchemaObj(v));
+        const branches: SpecNode[] = [];
+        const rootResolved = resolveSpecNode(rootSchema, spec, new Set());
+        if (rootResolved) branches.push(rootResolved);
+        for (const variant of rootResolved?.oneOf ?? []) {
+          const v = resolveSpecNode(variant, spec, new Set());
+          if (v) branches.push(v);
+        }
+
         for (const branch of branches) {
-          const required = new Set(branch.required ?? []);
-          for (const [field, sub] of Object.entries(branch.properties ?? {})) {
-            if (!required.has(field)) continue;
-            const fieldEnum = effectiveEnum(sub);
+          const { required, properties } = mergeSchemaShape(branch, spec, new Set());
+          for (const field of required) {
+            const sub = properties[field];
+            if (!sub) continue;
+            const fieldEnum = effectiveEnumFromSpec(sub, spec, new Set());
             if (fieldEnum && fieldEnum.length > 0 && !fieldEnums.has(field)) {
               fieldEnums.set(field, fieldEnum);
             }
-            const resolved = resolveSchemaObj(sub);
-            if (resolved.type === 'array' && resolved.items) {
-              const itemEnum = effectiveEnum(resolved.items);
+            const resolvedSub = resolveSpecNode(sub, spec, new Set());
+            if (resolvedSub?.type === 'array' && resolvedSub.items) {
+              const itemEnum = effectiveEnumFromSpec(resolvedSub.items, spec, new Set());
               if (itemEnum && itemEnum.length > 0 && !itemEnums.has(field)) {
                 itemEnums.set(field, itemEnum);
               }
@@ -8998,7 +8983,8 @@ describeForThisConfig(
       for (const pathItem of Object.values(spec.paths ?? {})) {
         for (const op of Object.values(pathItem)) {
           if (!op.operationId) continue;
-          const jsonBody = op.requestBody?.content?.['application/json']?.schema;
+          const body = resolveSpecNode(op.requestBody, spec, new Set());
+          const jsonBody = body?.content?.['application/json']?.schema;
           if (!jsonBody) continue;
           const collected = collectEnumFields(jsonBody);
           if (collected.fieldEnums.size > 0 || collected.itemEnums.size > 0) {
@@ -9014,15 +9000,30 @@ describeForThisConfig(
         }[];
       }
 
+      type OffenderReason = 'placeholder-var' | 'placeholder-literal' | 'non-enum-member';
       const offenders: {
         file: string;
         scenario: string;
         operationId: string;
         field: string;
-        value: string;
+        value: unknown;
         expectedEnum: unknown[];
+        reason: OffenderReason;
       }[] = [];
       const placeholderPattern = /^\$\{[^}]+\}$/;
+
+      function classifyScalar(value: unknown, expectedEnum: unknown[]): OffenderReason | null {
+        if (typeof value === 'string' && placeholderPattern.test(value)) return 'placeholder-var';
+        if (!expectedEnum.includes(value)) return 'non-enum-member';
+        return null;
+      }
+
+      function classifyArrayElement(elem: unknown, expectedEnum: unknown[]): OffenderReason | null {
+        if (typeof elem === 'string' && placeholderPattern.test(elem)) return 'placeholder-var';
+        if (elem === 'placeholder') return 'placeholder-literal';
+        if (!expectedEnum.includes(elem)) return 'non-enum-member';
+        return null;
+      }
 
       for (const dir of [FEATURE_SCENARIOS_DIR, VARIANT_SCENARIOS_DIR]) {
         if (!existsSync(dir)) continue;
@@ -9035,35 +9036,35 @@ describeForThisConfig(
               const enums = enumFieldsByOp.get(step.operationId);
               if (!enums) continue;
               for (const [field, value] of Object.entries(step.bodyTemplate ?? {})) {
-                // Scalar enum field: a string that looks like ${var} is a placeholder seed.
                 const fieldEnum = enums.fieldEnums.get(field);
-                if (fieldEnum && typeof value === 'string' && placeholderPattern.test(value)) {
-                  offenders.push({
-                    file: f,
-                    scenario: scenario.id,
-                    operationId: step.operationId,
-                    field,
-                    value,
-                    expectedEnum: fieldEnum,
-                  });
-                  continue;
+                if (fieldEnum) {
+                  const reason = classifyScalar(value, fieldEnum);
+                  if (reason) {
+                    offenders.push({
+                      file: f,
+                      scenario: scenario.id,
+                      operationId: step.operationId,
+                      field,
+                      value,
+                      expectedEnum: fieldEnum,
+                      reason,
+                    });
+                    continue;
+                  }
                 }
-                // Array enum field: any element that's a ${var} placeholder OR
-                // the generic synthesised "placeholder" literal is wrong.
                 const itemEnum = enums.itemEnums.get(field);
                 if (itemEnum && Array.isArray(value)) {
                   for (const elem of value) {
-                    const isPlaceholderVar =
-                      typeof elem === 'string' && placeholderPattern.test(elem);
-                    const isGenericPlaceholder = elem === 'placeholder';
-                    if (isPlaceholderVar || isGenericPlaceholder) {
+                    const reason = classifyArrayElement(elem, itemEnum);
+                    if (reason) {
                       offenders.push({
                         file: f,
                         scenario: scenario.id,
                         operationId: step.operationId,
                         field,
-                        value: JSON.stringify(elem),
+                        value: elem,
                         expectedEnum: itemEnum,
+                        reason,
                       });
                     }
                   }
@@ -9076,9 +9077,10 @@ describeForThisConfig(
 
       expect(
         offenders,
-        'A scenario bodyTemplate seeds a placeholder for a required enum-typed request-body field. ' +
-          'The planner must emit the first enum value as an inline literal instead of ${var} or "placeholder". ' +
-          'Server validation rejects unknown enum values with HTTP 400 (#338).',
+        'A scenario bodyTemplate seeds an invalid value for a required enum-typed request-body field. ' +
+          'The planner must emit a literal that is a member of the declared enum (#338). ' +
+          'Servers reject ${var} placeholders, "placeholder" array elements, and non-member literals ' +
+          'with HTTP 400.',
       ).toEqual([]);
     });
   },

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -8865,3 +8865,221 @@ describe.skipIf(CONFIG_NAME !== ACTIVE_CONFIG)(
     });
   },
 );
+
+// ---------------------------------------------------------------------------
+// Enum-typed request-body field seeding (#338)
+// ---------------------------------------------------------------------------
+//
+// The planner previously discarded enum constraints on required request-body
+// fields: even though the extractor captured them, `buildRequestBodyFromCanonical`
+// fell through to the seedBinding fallback and emitted `${fieldVar}` placeholders
+// the universal seed prologue rewrote to random short strings. Servers reject
+// those with HTTP 400 "Value <random> is not a valid <Enum>." Same for arrays
+// whose items are enums (e.g. `permissionTypes: array of PermissionTypeEnum`):
+// the synthesised element was a literal `"placeholder"` string the server
+// rejected.
+//
+// This invariant is class-scoped (all required enum-typed request-body fields
+// across the bundled spec — not just `ownerType` / `permissionTypes` from
+// `createAuthorization` that triggered the bug report) so the same category
+// of bug cannot recur in a sibling op.
+describeForThisConfig(
+  'bundled-spec invariants: enum-typed request-body field seeding (#338)',
+  () => {
+    it('no feature or variant scenario seeds a ${...} placeholder or a "placeholder" array item for a required enum-typed request-body field', () => {
+      if (!existsSync(FEATURE_SCENARIOS_DIR)) {
+        throw new Error(
+          `Feature output directory not found at ${FEATURE_SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+        );
+      }
+      if (!existsSync(BUNDLED_SPEC_PATH)) {
+        throw new Error(
+          `Bundled spec not found at ${BUNDLED_SPEC_PATH}. Run 'npm run fetch-spec' first.`,
+        );
+      }
+
+      interface SchemaObject {
+        type?: string;
+        $ref?: string;
+        required?: string[];
+        properties?: Record<string, SchemaObject>;
+        items?: SchemaObject;
+        oneOf?: SchemaObject[];
+        allOf?: SchemaObject[];
+        enum?: unknown[];
+      }
+
+      interface OpenApiSpec {
+        paths: Record<
+          string,
+          Record<
+            string,
+            {
+              operationId?: string;
+              requestBody?: { content?: { 'application/json'?: { schema?: SchemaObject } } };
+            }
+          >
+        >;
+        components?: { schemas?: Record<string, SchemaObject> };
+      }
+
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const spec = JSON.parse(readFileSync(BUNDLED_SPEC_PATH, 'utf8')) as OpenApiSpec;
+
+      function resolveRef(ref: string): SchemaObject | undefined {
+        const name = ref.split('/').pop() ?? '';
+        return spec.components?.schemas?.[name];
+      }
+
+      function resolveSchemaObj(s: SchemaObject, depth = 0): SchemaObject {
+        if (depth > 20) return s;
+        if (s.$ref) {
+          const target = resolveRef(s.$ref);
+          if (target) return resolveSchemaObj(target, depth + 1);
+        }
+        return s;
+      }
+
+      /** Walk $ref + allOf chain to find an enum array. */
+      function effectiveEnum(s: SchemaObject, depth = 0): unknown[] | undefined {
+        if (depth > 20) return undefined;
+        const r = resolveSchemaObj(s, depth);
+        if (Array.isArray(r.enum)) return r.enum;
+        if (Array.isArray(r.allOf)) {
+          for (const part of r.allOf) {
+            const e = effectiveEnum(part, depth + 1);
+            if (e) return e;
+          }
+        }
+        return undefined;
+      }
+
+      /**
+       * Walk a request-body schema (root + any oneOf variants) and collect,
+       * for every top-level required field, the enum values declared on the
+       * field's scalar schema (`fieldEnums`) and on its items' scalar schema
+       * when the field is an array (`itemEnums`).
+       */
+      function collectEnumFields(rootSchema: SchemaObject): {
+        fieldEnums: Map<string, unknown[]>;
+        itemEnums: Map<string, unknown[]>;
+      } {
+        const fieldEnums = new Map<string, unknown[]>();
+        const itemEnums = new Map<string, unknown[]>();
+        const branches: SchemaObject[] = [];
+        const root = resolveSchemaObj(rootSchema);
+        if (root.properties) branches.push(root);
+        for (const v of root.oneOf ?? []) branches.push(resolveSchemaObj(v));
+        for (const branch of branches) {
+          const required = new Set(branch.required ?? []);
+          for (const [field, sub] of Object.entries(branch.properties ?? {})) {
+            if (!required.has(field)) continue;
+            const fieldEnum = effectiveEnum(sub);
+            if (fieldEnum && fieldEnum.length > 0 && !fieldEnums.has(field)) {
+              fieldEnums.set(field, fieldEnum);
+            }
+            const resolved = resolveSchemaObj(sub);
+            if (resolved.type === 'array' && resolved.items) {
+              const itemEnum = effectiveEnum(resolved.items);
+              if (itemEnum && itemEnum.length > 0 && !itemEnums.has(field)) {
+                itemEnums.set(field, itemEnum);
+              }
+            }
+          }
+        }
+        return { fieldEnums, itemEnums };
+      }
+
+      // Build per-op map: opId -> { fieldEnums, itemEnums }
+      const enumFieldsByOp = new Map<
+        string,
+        { fieldEnums: Map<string, unknown[]>; itemEnums: Map<string, unknown[]> }
+      >();
+      for (const pathItem of Object.values(spec.paths ?? {})) {
+        for (const op of Object.values(pathItem)) {
+          if (!op.operationId) continue;
+          const jsonBody = op.requestBody?.content?.['application/json']?.schema;
+          if (!jsonBody) continue;
+          const collected = collectEnumFields(jsonBody);
+          if (collected.fieldEnums.size > 0 || collected.itemEnums.size > 0) {
+            enumFieldsByOp.set(op.operationId, collected);
+          }
+        }
+      }
+
+      interface FeatureScenarioFile {
+        scenarios: {
+          id: string;
+          requestPlan?: { operationId: string; bodyTemplate?: Record<string, unknown> }[];
+        }[];
+      }
+
+      const offenders: {
+        file: string;
+        scenario: string;
+        operationId: string;
+        field: string;
+        value: string;
+        expectedEnum: unknown[];
+      }[] = [];
+      const placeholderPattern = /^\$\{[^}]+\}$/;
+
+      for (const dir of [FEATURE_SCENARIOS_DIR, VARIANT_SCENARIOS_DIR]) {
+        if (!existsSync(dir)) continue;
+        for (const f of readdirSync(dir)) {
+          if (!f.endsWith('-scenarios.json')) continue;
+          // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+          const file = JSON.parse(readFileSync(join(dir, f), 'utf8')) as FeatureScenarioFile;
+          for (const scenario of file.scenarios ?? []) {
+            for (const step of scenario.requestPlan ?? []) {
+              const enums = enumFieldsByOp.get(step.operationId);
+              if (!enums) continue;
+              for (const [field, value] of Object.entries(step.bodyTemplate ?? {})) {
+                // Scalar enum field: a string that looks like ${var} is a placeholder seed.
+                const fieldEnum = enums.fieldEnums.get(field);
+                if (fieldEnum && typeof value === 'string' && placeholderPattern.test(value)) {
+                  offenders.push({
+                    file: f,
+                    scenario: scenario.id,
+                    operationId: step.operationId,
+                    field,
+                    value,
+                    expectedEnum: fieldEnum,
+                  });
+                  continue;
+                }
+                // Array enum field: any element that's a ${var} placeholder OR
+                // the generic synthesised "placeholder" literal is wrong.
+                const itemEnum = enums.itemEnums.get(field);
+                if (itemEnum && Array.isArray(value)) {
+                  for (const elem of value) {
+                    const isPlaceholderVar =
+                      typeof elem === 'string' && placeholderPattern.test(elem);
+                    const isGenericPlaceholder = elem === 'placeholder';
+                    if (isPlaceholderVar || isGenericPlaceholder) {
+                      offenders.push({
+                        file: f,
+                        scenario: scenario.id,
+                        operationId: step.operationId,
+                        field,
+                        value: JSON.stringify(elem),
+                        expectedEnum: itemEnum,
+                      });
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      expect(
+        offenders,
+        'A scenario bodyTemplate seeds a placeholder for a required enum-typed request-body field. ' +
+          'The planner must emit the first enum value as an inline literal instead of ${var} or "placeholder". ' +
+          'Server validation rejects unknown enum values with HTTP 400 (#338).',
+      ).toEqual([]);
+    });
+  },
+);

--- a/path-analyser/src/canonicalSchemas.ts
+++ b/path-analyser/src/canonicalSchemas.ts
@@ -9,6 +9,22 @@ export interface CanonicalNodeMeta {
   type: string;
   required: boolean;
   semanticProvider?: string; // semantic type if x-semantic-provider: true
+  /**
+   * Enum values declared on this field's schema (after $ref + allOf
+   * resolution). Present for scalar leaf nodes whose schema constrains
+   * the value to a fixed set. Used by `buildRequestBodyFromCanonical`
+   * to emit an enum literal instead of seeding a `${var}` placeholder
+   * (#338).
+   */
+  enum?: unknown[];
+  /**
+   * Enum values declared on this array node's item schema. Present for
+   * top-level array fields whose items are scalar enums (e.g.
+   * `permissionTypes: { type: 'array', items: { enum: […] } }`). Used
+   * by the array synthesiser to emit `[enum[0]]` instead of the generic
+   * `['placeholder']` element (#338).
+   */
+  itemEnum?: unknown[];
 }
 
 export interface OperationCanonicalShapes {
@@ -29,6 +45,7 @@ interface SchemaObject {
   anyOf?: SchemaObject[];
   oneOf?: SchemaObject[];
   'x-semantic-provider'?: boolean;
+  enum?: unknown[];
   // Permissive escape hatch so the allOf merger can copy over arbitrary
   // OpenAPI keywords (description, example, format, …) without per-key
   // typing or unsafe casts.
@@ -178,6 +195,13 @@ function walkSchema(
   if (type === 'array' && schema.items) {
     const childPath = `${pathSoFar}[]`;
     const childPointer = `${pointer}/items`;
+    // Capture an item-level enum (e.g. `permissionTypes: { type: 'array',
+    // items: { enum: […] } }`) so the array synthesiser can emit
+    // `[enum[0]]` instead of the generic `['placeholder']` element
+    // (#338). `schema.items` may itself be a $ref / allOf, so resolve
+    // it before reading `.enum`.
+    const resolvedItems = resolveSchema(schema.items, components);
+    const itemEnum = Array.isArray(resolvedItems.enum) ? resolvedItems.enum : undefined;
     acc.push({
       path: `${pathSoFar}[]`,
       pointer: childPointer,
@@ -186,6 +210,7 @@ function walkSchema(
       semanticProvider: schema['x-semantic-provider']
         ? inferSemanticTypeFromPath(pathSoFar)
         : undefined,
+      itemEnum,
     });
     walkSchema(schema.items, childPointer, childPath, acc, seen, components, false, depth + 1);
     return;
@@ -194,7 +219,19 @@ function walkSchema(
     const semantic = schema['x-semantic-provider']
       ? inferSemanticTypeFromPath(pathSoFar)
       : undefined;
-    acc.push({ path: pathSoFar, pointer, type, required, semanticProvider: semantic });
+    // Capture leaf enum (e.g. `ownerType: { enum: ['USER', …] }`) so
+    // `buildRequestBodyFromCanonical` can emit an enum literal instead
+    // of seeding a `${var}` placeholder (#338). `schema` at this point
+    // is already $ref/allOf-resolved by the recursive descent above.
+    const enumValues = Array.isArray(schema.enum) ? schema.enum : undefined;
+    acc.push({
+      path: pathSoFar,
+      pointer,
+      type,
+      required,
+      semanticProvider: semantic,
+      enum: enumValues,
+    });
   }
 }
 

--- a/path-analyser/src/extractSchemas.ts
+++ b/path-analyser/src/extractSchemas.ts
@@ -385,9 +385,11 @@ function effectiveType(schema: JsonSchema, components: Components): string {
 
 /**
  * Walk a (possibly $ref- or allOf-wrapped) schema and return its `enum`
- * array if one is declared. Used by `findOneOfGroups` and `walkSchema` to
- * surface enum constraints to the planner so it can emit a real enum
- * literal instead of seeding a `${var}` placeholder (#338).
+ * array if one is declared. Used by `findOneOfGroups` (in this module)
+ * to populate per-variant `fieldEnums` / `fieldItemEnums` so the planner
+ * can emit a real enum literal instead of seeding a `${var}` placeholder
+ * (#338). The canonical-schema walker in `canonicalSchemas.ts` performs
+ * the same role for the non-oneOf path via its own resolver.
  *
  * Returns `undefined` when no enum is declared anywhere along the chain.
  * The result is the raw `enum` array — callers pick the first value.

--- a/path-analyser/src/extractSchemas.ts
+++ b/path-analyser/src/extractSchemas.ts
@@ -31,6 +31,7 @@ interface JsonSchema {
   nullable?: boolean;
   discriminator?: { propertyName?: string; mapping?: Record<string, string> };
   'x-polymorphic-schema'?: boolean;
+  enum?: unknown[];
   [key: string]: unknown;
 }
 
@@ -269,9 +270,20 @@ function findOneOfGroups(
       const required = vs.required || [];
       const optional = Object.keys(props).filter((k) => !required.includes(k));
       const fieldTypes: Record<string, string> = {};
+      const fieldEnums: Record<string, unknown[]> = {};
+      const fieldItemEnums: Record<string, unknown[]> = {};
       for (const [fname, fsch] of Object.entries(props)) {
         const ft = effectiveType(fsch, components);
         if (ft && ft !== 'unknown') fieldTypes[fname] = ft;
+        const enumValues = effectiveEnum(fsch, components);
+        if (enumValues && enumValues.length > 0) fieldEnums[fname] = enumValues;
+        if (ft === 'array') {
+          const itemSchema = resolveSchema(fsch, components).items;
+          if (itemSchema) {
+            const itemEnum = effectiveEnum(itemSchema, components);
+            if (itemEnum && itemEnum.length > 0) fieldItemEnums[fname] = itemEnum;
+          }
+        }
       }
       let discriminator: { field: string; value: string } | undefined;
       if (resolved.discriminator?.propertyName) {
@@ -289,6 +301,8 @@ function findOneOfGroups(
         required,
         optional,
         fieldTypes,
+        fieldEnums: Object.keys(fieldEnums).length > 0 ? fieldEnums : undefined,
+        fieldItemEnums: Object.keys(fieldItemEnums).length > 0 ? fieldItemEnums : undefined,
         discriminator,
       };
     });
@@ -367,6 +381,36 @@ function effectiveType(schema: JsonSchema, components: Components): string {
   // If it references a known key format, default to string
   if (typeof s.format === 'string' && /Key$/.test(s.format)) return 'string';
   return 'unknown';
+}
+
+/**
+ * Walk a (possibly $ref- or allOf-wrapped) schema and return its `enum`
+ * array if one is declared. Used by `findOneOfGroups` and `walkSchema` to
+ * surface enum constraints to the planner so it can emit a real enum
+ * literal instead of seeding a `${var}` placeholder (#338).
+ *
+ * Returns `undefined` when no enum is declared anywhere along the chain.
+ * The result is the raw `enum` array — callers pick the first value.
+ */
+function effectiveEnum(
+  schema: JsonSchema | undefined,
+  components: Components,
+  depth = 0,
+): unknown[] | undefined {
+  if (!schema || depth > 10) return undefined;
+  if (Array.isArray(schema.enum)) return schema.enum;
+  if (schema.$ref) {
+    const target = components[refName(schema.$ref)];
+    const e = effectiveEnum(target, components, depth + 1);
+    if (e) return e;
+  }
+  if (Array.isArray(schema.allOf)) {
+    for (const part of schema.allOf) {
+      const e = effectiveEnum(part, components, depth + 1);
+      if (e) return e;
+    }
+  }
+  return undefined;
 }
 
 function refName(ref: string): string {

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1047,7 +1047,10 @@ function camelCase(name: string) {
 }
 
 type CanonicalShape = {
-  requestByMediaType?: Record<string, { path: string; type: string; required: boolean }[]>;
+  requestByMediaType?: Record<
+    string,
+    { path: string; type: string; required: boolean; enum?: unknown[]; itemEnum?: unknown[] }[]
+  >;
 };
 
 type RequestBodyPlan =
@@ -1091,13 +1094,20 @@ type RequestBodyPlan =
  *     that themselves declare required content);
  *   - otherwise it seeds a string `'placeholder'`.
  *
- * Item-schema enums could in principle be sourced from the bundled
- * spec for stricter validity, but the canonical nodes don't carry
- * enum metadata today; the L3 invariant for #326 only requires that
- * the emitted value is not literally `[]`, and the broader live-cluster
- * acceptance is tracked separately.
+ * Item-schema enums are sourced from the bundled spec (#338): top-level
+ * array nodes carry an `itemEnum` field captured during canonical-shape
+ * walking, and `buildRequestBodyFromCanonical` short-circuits to
+ * `[itemEnum[0]]` before delegating to this helper. The helper itself
+ * remains enum-unaware for deeper nested arrays — those still seed a
+ * `'placeholder'` element, tracked separately.
  */
-type CanonicalNode = { path: string; type: string; required: boolean };
+type CanonicalNode = {
+  path: string;
+  type: string;
+  required: boolean;
+  enum?: unknown[];
+  itemEnum?: unknown[];
+};
 
 function synthesizeObjectFromPrefix(
   prefix: string,
@@ -1283,6 +1293,12 @@ function buildRequestBodyFromCanonical(
             template[name] = `${'${'}${varName}}`;
           } else if (defaults && Object.hasOwn(defaults, name)) {
             template[name] = defaults[name];
+          } else if (chosenVariant?.fieldEnums?.[name]?.length) {
+            // #338 — schema declares an enum for this required field.
+            // Emit the first enum literal instead of seeding a
+            // `${var}` placeholder that the server rejects with 400.
+            const values = chosenVariant.fieldEnums[name];
+            template[name] = values[0];
           } else if ((declaredTypeByLeaf[name] ?? chosenVariant?.fieldTypes?.[name]) === 'object') {
             // Object-typed required field with no binding: emit {} rather than seeding
             // a string placeholder. An empty object is always a valid JSON value and
@@ -1292,7 +1308,16 @@ function buildRequestBodyFromCanonical(
             // #326 — emit a synthesised one-element array honouring the
             // item schema's own required set rather than `[]`, which
             // servers reject ("No elements provided" etc.).
-            template[name] = [synthesizeArrayElement(name, nodes)];
+            // #338 — when the array's item schema declares an enum
+            // (e.g. `permissionTypes: array of PermissionTypeEnum`),
+            // emit `[enum[0]]` instead of the generic placeholder
+            // element so the request validates server-side.
+            const itemEnum = chosenVariant?.fieldItemEnums?.[name];
+            if (itemEnum?.length) {
+              template[name] = [itemEnum[0]];
+            } else {
+              template[name] = [synthesizeArrayElement(name, nodes)];
+            }
           } else {
             scenario.bindings ||= {};
             if (!scenario.bindings[varName]) scenario.bindings[varName] = PENDING_BINDING;
@@ -1330,6 +1355,11 @@ function buildRequestBodyFromCanonical(
           template[leaf] = `${'${'}${varName}}`;
         } else if (defaults && Object.hasOwn(defaults, leaf)) {
           template[leaf] = defaults[leaf];
+        } else if (f.enum?.length) {
+          // #338 — schema declares an enum for this required scalar
+          // field. Emit the first enum literal instead of seeding a
+          // `${var}` placeholder that the server rejects with 400.
+          template[leaf] = f.enum[0];
         } else if (f.type === 'object') {
           // Object-typed required field with no binding: emit {} rather than seeding
           // a string placeholder. An empty object is always a valid JSON value and
@@ -1340,8 +1370,16 @@ function buildRequestBodyFromCanonical(
           // recorded as `<field>[]` for top-level arrays; strip the
           // suffix so the helper's prefix match (`<base>[].<key>`)
           // lines up with the canonical sub-nodes.
-          const basePath = f.path.replace(/\[\]$/, '');
-          template[leaf] = [synthesizeArrayElement(basePath, nodes)];
+          // #338 — when the array's item schema declares an enum
+          // (captured on the canonical node as `itemEnum`), emit
+          // `[itemEnum[0]]` instead of synthesising a placeholder
+          // element. Servers reject `["placeholder"]` with 400.
+          if (f.itemEnum?.length) {
+            template[leaf] = [f.itemEnum[0]];
+          } else {
+            const basePath = f.path.replace(/\[\]$/, '');
+            template[leaf] = [synthesizeArrayElement(basePath, nodes)];
+          }
         } else {
           scenario.bindings ||= {};
           if (!scenario.bindings[varName]) scenario.bindings[varName] = PENDING_BINDING;

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -421,6 +421,20 @@ export interface RequestOneOfVariant {
   optional: string[];
   /** Effective JSON Schema type for each field in this variant ('object', 'array', 'string', …). */
   fieldTypes: Record<string, string>;
+  /**
+   * Enum values for scalar fields in this variant, captured from the
+   * field's resolved schema (`enum`, traversing $ref + allOf). Used by
+   * `buildRequestBodyFromCanonical` to emit an enum literal instead of a
+   * `${var}` placeholder for required enum-typed fields (#338).
+   */
+  fieldEnums?: Record<string, unknown[]>;
+  /**
+   * For `array` fields, enum values declared on the item schema (e.g.
+   * `permissionTypes: { type: 'array', items: { enum: […] } }`). Used to
+   * synthesise a one-element array containing an enum literal instead of
+   * the generic `['placeholder']` element (#338).
+   */
+  fieldItemEnums?: Record<string, unknown[]>;
   discriminator?: { field: string; value: string };
 }
 


### PR DESCRIPTION
Closes #338

## Problem

The planner discarded enum constraints on required request-body fields. Even though the extractor captured them, `buildRequestBodyFromCanonical` fell through to the `seedBinding` fallback and emitted `${fieldVar}` placeholders that the universal seed prologue rewrote to random short strings. Servers rejected those with HTTP 400 `Value <random> is not a valid <Enum>`. Arrays whose items are enums (e.g. `permissionTypes: array of PermissionTypeEnum`) had the same problem — the synthesised element was a literal `"placeholder"` string the server rejected.

Concretely, `post /authorizations` `feature-1` previously emitted:

```json
{
  "ownerId": "${ownerIdVar}",
  "ownerType": "${ownerTypeVar}",
  "resourceId": "${resourceIdVar}",
  "resourceType": "${resourceTypeVar}",
  "permissionTypes": ["placeholder"]
}
```

and now emits:

```json
{
  "ownerId": "${ownerIdVar}",
  "ownerType": "USER",
  "resourceId": "${resourceIdVar}",
  "resourceType": "AUDIT_LOG",
  "permissionTypes": ["ACCESS"]
}
```

## Change

Thread enum metadata through extractor + canonical-schema walker + planner, and emit `enum[0]` as an inline literal for required scalar enums and `[itemEnum[0]]` for arrays of scalar enums. Both oneOf and non-oneOf code paths covered.

`effectiveEnum` walks `$ref` + `allOf` directly (without going through `resolveSchema`, which strips the `allOf` wrap without propagating `enum`). This is required because OpenAPI enums commonly live behind `allOf: [{ $ref: '#/components/schemas/SomeEnum' }]` wrappers (e.g. `resourceType`, `permissionTypes.items`).

## Red / green / class-scoped

- **Red** — added L3 invariant `bundled-spec invariants: enum-typed request-body field seeding (#338)` to `configs/camunda-oca/regression-invariants.test.ts`. Verified it fails against pre-fix output (reports `ownerType: "${ownerTypeVar}"`, `permissionTypes: ["placeholder"]` offenders across `createAuthorization`, `updateAuthorization`, and several other ops).
- **Green** — passes after the planner change.
- **Class-scoped** — walks every operation's request-body schema (root + oneOf variants), builds a per-op map of required enum-typed fields, then scans every feature + variant scenario for `${...}` placeholders on those fields (scalar) or `${...}` / `"placeholder"` array elements (arrays). The same category of bug cannot recur in a sibling op without the invariant catching it.

## Validation

- `npm run lint` — clean
- All workspace `tsc --noEmit` typechecks — clean
- `npm test` — 640 passed, 4 skipped, 61 files
