### PR TITLE
fix: walk oneOf/anyOf when resolving parameter semantic types

### DIFF
--- a/semantic-graph-extractor/graph-builder.ts
+++ b/semantic-graph-extractor/graph-builder.ts
@@ -64,7 +64,17 @@ export class GraphBuilder {
     // Find matches between produced and consumed types
     for (const produced of producedTypes) {
       for (const consumed of consumedTypes) {
-        if (produced.semanticType === consumed.semanticType) {
+        // #330: a consumer whose schema is a union of branded-key
+        // schemas (e.g. `ResourceKey = oneOf [ProcessDefinitionKey,
+        // FormKey, …]`) is satisfied by any producer of any single
+        // branch. The edge is labelled with the PRODUCER's semantic
+        // type so materialisation can chase the producer's actual
+        // response field path — the union itself has no field path of
+        // its own.
+        const matchesSingular = produced.semanticType === consumed.semanticType;
+        const matchesAlternative =
+          consumed.semanticTypeAlternatives?.includes(produced.semanticType) === true;
+        if (matchesSingular || matchesAlternative) {
           const dependency: DependencyEdge = {
             sourceOperationId: sourceOp.operationId,
             targetOperationId: targetOp.operationId,
@@ -111,6 +121,9 @@ export class GraphBuilder {
       if (param.semanticType) {
         consumed.push({
           semanticType: param.semanticType,
+          // #330: propagate union alternatives so findDependencies can
+          // match producers of any branch.
+          semanticTypeAlternatives: param.semanticTypeAlternatives,
           fieldPath: `${param.location}.${param.name}`,
           required: param.required,
           description: param.description,

--- a/semantic-graph-extractor/schema-analyzer.ts
+++ b/semantic-graph-extractor/schema-analyzer.ts
@@ -350,29 +350,40 @@ export class SchemaAnalyzer {
    */
   private extractParameter(param: ParameterObject, spec: OpenAPISpec): OperationParameter {
     let semanticType: string | undefined;
+    let semanticTypeAlternatives: string[] | undefined;
     let provider: boolean | undefined;
     if (param.schema) {
-      // If schema is a $ref, resolve and search for x-semantic-type
+      // #330: collect every branch semantic type reachable through
+      // `$ref` / `allOf` / `oneOf` / `anyOf`. Works for both inline and
+      // referenced schemas.
+      const alternatives = this.findSemanticTypeAlternativesInSchema(param.schema, spec);
+      if (alternatives.length > 0) {
+        semanticTypeAlternatives = alternatives;
+        semanticType = alternatives[0];
+      }
       if ('$ref' in param.schema && param.schema.$ref) {
         const ref = param.schema.$ref;
         const resolved = this.resolveReference<Schema>(ref, spec);
         if (resolved) {
-          semanticType = this.findSemanticTypeInSchema(resolved);
+          // Provider flag still keys off the (single) resolved schema's
+          // own annotation — unions don't carry `x-semantic-provider`.
           if (semanticType && resolved['x-semantic-provider'] === true) {
             provider = true;
           }
-          // Heuristic: if still not found, derive from last segment of ref if it looks like a semantic type (PascalCase + Key suffix)
+          // #330: ref-name heuristic only fires when union-walking also
+          // returned nothing. Its previous role of short-circuiting with
+          // a synthetic name (e.g. `ResourceKey`) actively suppressed the
+          // union resolution; kept here as a tertiary fallback for
+          // operations whose key-shaped ref still has no branch
+          // annotations, so behaviour doesn't regress.
           if (!semanticType) {
             const name = ref.split('/').pop();
             if (name && /[A-Z]/.test(name) && /Key$/.test(name)) {
-              // Only assign if that schema ultimately expands to a semantic type in its allOf/oneOf chain
               semanticType = name;
             }
           }
         }
       } else if (!('$ref' in param.schema)) {
-        // Direct inline schema: check x-semantic-type
-        semanticType = param.schema['x-semantic-type'];
         if (semanticType && param.schema['x-semantic-provider'] === true) {
           provider = true;
         }
@@ -386,6 +397,7 @@ export class SchemaAnalyzer {
       name: param.name,
       location: param.in,
       semanticType,
+      semanticTypeAlternatives,
       required: param.required || param.in === 'path', // path params are always required
       description: param.description,
       schema,
@@ -780,6 +792,53 @@ export class SchemaAnalyzer {
     }
 
     return undefined;
+  }
+
+  /**
+   * #330: collect ALL semantic-type annotations reachable from a schema by
+   * walking `$ref`, `allOf`, `oneOf` and `anyOf` transitively. Used for
+   * parameters whose declared schema is a union of branded-key schemas
+   * (e.g. `ResourceKey = oneOf [ProcessDefinitionKey, FormKey, …]`) so the
+   * graph builder can recognise a producer of any single branch as a valid
+   * satisfier for the union consumer.
+   *
+   * De-duplicated, declaration-order preserved (matters because callers pick
+   * the first entry as the singular `semanticType` for back-compat).
+   * `$ref` cycles are broken by a `seen` set keyed on the ref pointer.
+   */
+  private findSemanticTypeAlternativesInSchema(
+    schema: Schema | ReferenceObject,
+    spec: OpenAPISpec,
+    seen: Set<string> = new Set(),
+  ): string[] {
+    const out: string[] = [];
+    const push = (st: string | undefined) => {
+      if (st && !out.includes(st)) out.push(st);
+    };
+    if ('$ref' in schema) {
+      const ref = schema.$ref;
+      if (!ref) return out;
+      if (seen.has(ref)) return out;
+      seen.add(ref);
+      const resolved = this.resolveReference<Schema>(ref, spec);
+      if (resolved) {
+        for (const st of this.findSemanticTypeAlternativesInSchema(resolved, spec, seen)) {
+          push(st);
+        }
+      }
+      return out;
+    }
+    push(schema['x-semantic-type']);
+    for (const branch of schema.allOf ?? []) {
+      for (const st of this.findSemanticTypeAlternativesInSchema(branch, spec, seen)) push(st);
+    }
+    for (const branch of schema.oneOf ?? []) {
+      for (const st of this.findSemanticTypeAlternativesInSchema(branch, spec, seen)) push(st);
+    }
+    for (const branch of schema.anyOf ?? []) {
+      for (const st of this.findSemanticTypeAlternativesInSchema(branch, spec, seen)) push(st);
+    }
+    return out;
   }
 
   /**

--- a/semantic-graph-extractor/types.ts
+++ b/semantic-graph-extractor/types.ts
@@ -340,6 +340,19 @@ export interface OperationParameter {
   name: string;
   location: 'path' | 'query' | 'header' | 'cookie';
   semanticType?: string;
+  /**
+   * #330: when the parameter's schema resolves (transitively through `$ref`,
+   * `allOf`, `oneOf`, `anyOf`) to a UNION of branded-key schemas, every branch
+   * that carries an `x-semantic-type` lands here. `semanticType` itself is set
+   * to the first alternative for back-compat with code paths that key on a
+   * single string (graph-builder fallback, planner `requires`, scenario
+   * generator's path-param lookup). The graph builder additionally treats any
+   * producer of ANY alternative as a valid edge for this consumer.
+   *
+   * Always includes `semanticType` as its first element when both are present,
+   * so callers iterating alternatives don't need to also iterate the singular.
+   */
+  semanticTypeAlternatives?: string[];
   required: boolean;
   description?: string;
   // NEW: Schema validation details
@@ -363,6 +376,14 @@ export interface ParameterSchema {
 
 export interface SemanticTypeReference {
   semanticType: string;
+  /**
+   * #330: parallel to `OperationParameter.semanticTypeAlternatives`. When the
+   * source schema for this reference resolves to a union of branded-key
+   * schemas, every branch's `x-semantic-type` lands here. The graph builder
+   * matches a producer against any alternative when emitting an edge from
+   * `produced → consumed`. Always includes `semanticType` as its first element.
+   */
+  semanticTypeAlternatives?: string[];
   fieldPath: string;
   required: boolean;
   description?: string;

--- a/tests/fixtures/extractor/extractor-graph.test.ts
+++ b/tests/fixtures/extractor/extractor-graph.test.ts
@@ -270,3 +270,160 @@ describe('SemanticGraphExtractor.extractGraph(): JSON input parsing', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// #330 — parameter whose schema is a union of branded-key schemas.
+//
+// `getResourceContent` declares `path.resourceKey` as `$ref: ResourceKey`
+// where `ResourceKey = oneOf [ProcessDefinitionKey, FormKey]`. Each branch
+// carries its own `x-semantic-type` and has a producer in the graph.
+//
+// Pre-#330 behaviour (the bug):
+//   - `findSemanticTypeInSchema` only walked `allOf`, so the union returned
+//     `undefined`.
+//   - A ref-name heuristic synthesised the string "ResourceKey" \u2014 a name
+//     no schema, producer or consumer in the spec ever uses.
+//   - The graph-builder's strict `===` equality found zero producers of
+//     "ResourceKey", so the consumer had zero incoming edges and the planner
+//     fell back to a free-form placeholder that fails the server's `LongKey`
+//     regex (`^-?[0-9]+$`).
+//
+// Post-#330: the extractor walks `oneOf` (and `anyOf`, `$ref`), collects every
+// branch's `x-semantic-type` into `semanticTypeAlternatives`, and the
+// graph-builder treats a producer of any branch as a valid edge source.
+// ---------------------------------------------------------------------------
+const fixtureUnionOfBrandedKeysParam: OpenAPISpec = {
+  openapi: '3.0.3',
+  info: { title: 'fixture-union-of-branded-keys-param', version: '0.0.0' },
+  components: {
+    schemas: {
+      ProcessDefinitionKey: {
+        type: 'string',
+        'x-semantic-type': 'ProcessDefinitionKey',
+      },
+      FormKey: {
+        type: 'string',
+        'x-semantic-type': 'FormKey',
+      },
+      ResourceKey: {
+        oneOf: [
+          { $ref: '#/components/schemas/ProcessDefinitionKey' },
+          { $ref: '#/components/schemas/FormKey' },
+        ],
+      },
+    },
+  },
+  paths: {
+    '/process-definitions/deploy': {
+      post: {
+        operationId: 'deployProcessDefinition',
+        responses: {
+          '200': {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    processDefinitionKey: {
+                      type: 'string',
+                      'x-semantic-type': 'ProcessDefinitionKey',
+                      'x-semantic-provider': true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/forms/deploy': {
+      post: {
+        operationId: 'deployForm',
+        responses: {
+          '200': {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    formKey: {
+                      type: 'string',
+                      'x-semantic-type': 'FormKey',
+                      'x-semantic-provider': true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/resources/{resourceKey}/content': {
+      get: {
+        operationId: 'getResourceContent',
+        parameters: [
+          {
+            name: 'resourceKey',
+            in: 'path',
+            required: true,
+            schema: { $ref: '#/components/schemas/ResourceKey' },
+          },
+        ],
+        responses: { '200': { description: 'ok' } },
+      },
+    },
+  },
+};
+
+describe('#330: parameter with oneOf-of-branded-keys schema', () => {
+  it('records every branch x-semantic-type in semanticTypeAlternatives', () => {
+    const analyzer = new SchemaAnalyzer();
+    const operations = analyzer.extractOperations(fixtureUnionOfBrandedKeysParam);
+    const consumer = operations.find((o) => o.operationId === 'getResourceContent');
+    expect(consumer, 'getResourceContent operation must be extracted').toBeDefined();
+    const param = consumer?.parameters.find((p) => p.name === 'resourceKey');
+    expect(param).toBeDefined();
+    expect(param?.semanticTypeAlternatives).toEqual(
+      expect.arrayContaining(['ProcessDefinitionKey', 'FormKey']),
+    );
+    // Singular is set to the first branch for back-compat with code paths
+    // that key on a single string (planner `requires`, scenario generator
+    // path-param lookup).
+    expect(param?.semanticType).toBe('ProcessDefinitionKey');
+  });
+
+  it('does NOT fall back to the ref-name heuristic when union branches resolve', () => {
+    const analyzer = new SchemaAnalyzer();
+    const operations = analyzer.extractOperations(fixtureUnionOfBrandedKeysParam);
+    const consumer = operations.find((o) => o.operationId === 'getResourceContent');
+    const param = consumer?.parameters.find((p) => p.name === 'resourceKey');
+    // Pre-#330 the heuristic synthesised the literal string "ResourceKey",
+    // which appears nowhere in `components.schemas` as a semantic type.
+    expect(param?.semanticType).not.toBe('ResourceKey');
+    expect(param?.semanticTypeAlternatives).not.toContain('ResourceKey');
+  });
+
+  it('creates an edge from any branch producer to the union consumer', () => {
+    const graph = buildGraphFrom(fixtureUnionOfBrandedKeysParam);
+
+    const fromProcess = graph.edges.find(
+      (e) =>
+        e.sourceOperationId === 'deployProcessDefinition' &&
+        e.targetOperationId === 'getResourceContent',
+    );
+    const fromForm = graph.edges.find(
+      (e) => e.sourceOperationId === 'deployForm' && e.targetOperationId === 'getResourceContent',
+    );
+
+    expect(fromProcess, 'expected edge deployProcessDefinition → getResourceContent').toBeDefined();
+    expect(fromForm, 'expected edge deployForm → getResourceContent').toBeDefined();
+    // Edge label is the PRODUCER's branch type (not the union name) so
+    // materialisation can chase the producer's response field path.
+    expect(fromProcess?.semanticType).toBe('ProcessDefinitionKey');
+    expect(fromForm?.semanticType).toBe('FormKey');
+  });
+});


### PR DESCRIPTION
Closes #330

## Problem

`getResourceContent` (and every other operation whose path parameter resolves to a union of branded-key schemas) emitted a non-compliant free-form placeholder like `resourceKeyVar-6z7zvt`, failing the server's `LongKey` regex with HTTP 400.

Two bugs, one chain:

1. **Extractor didn't walk unions.** `SchemaAnalyzer.findSemanticTypeInSchema` only recursed into `allOf`. For `ResourceKey = oneOf [ProcessDefinitionKey, FormKey, ...]` it returned `undefined`, and a ref-name fallback synthesised the literal string `"ResourceKey"` — a name that exists nowhere as a real semantic type.
2. **Graph builder required exact string equality.** Even if the extractor had recorded one branch, the consumer would still miss producers of the other branches.

## Fix

- New `SchemaAnalyzer.findSemanticTypeAlternativesInSchema` walks `$ref`, `allOf`, `oneOf` and `anyOf` transitively (deduped, declaration-order preserved, cycle-guarded).
- `OperationParameter` and `SemanticTypeReference` carry a new optional `semanticTypeAlternatives: string[]`. The singular `semanticType` is set to the first alternative for back-compat with the planner's `requires`-keyed lookup and the scenario generator's path-param search.
- The ref-name heuristic only fires when union resolution returns nothing, so previously-handled keyish refs without branch annotations still extract.
- `GraphBuilder.findDependencies` treats a producer of any single branch as a valid edge source for a union consumer. The edge is labelled with the producer's semantic type so materialisation chases the producer's response field path.

## Regression guard (class-scoped, per issue prescription)

Added three fixtures in `tests/fixtures/extractor/extractor-graph.test.ts`:

- Every branch's `x-semantic-type` lands in `semanticTypeAlternatives`.
- The ref-name heuristic does NOT fire when branches resolve.
- The graph builder emits an edge from each branch producer to the union consumer.

Confirmed **red on `main`** (3/3 failed) and **green on this branch** (3/3 pass).

## Verified

`generated/camunda-oca/playwright/getResourceContent.feature.spec.ts` now chains `createDeployment → getResourceContent`, extracting `processDefinitionKey` into the `resourceKey` path placeholder. The free-form `resourceKeyVar-...` placeholder is gone.

## Out of scope

#326 (placeholder array items for `*Key` array fields in request bodies) shares the same root pattern but on the body side. Deferred to a follow-up.
