### PR TITLE
fix: omit tenantId field when binding is unbound (#342)

### DIFF
--- a/configs/camunda-oca/codegen/playwright/roles/deploymentGateway/call-site.tmpl
+++ b/configs/camunda-oca/codegen/playwright/roles/deploymentGateway/call-site.tmpl
@@ -1,2 +1,2 @@
-const {{{respVar}}} = await deploy({{{ctx}}}, {{{request}}}, {{{body}}}, {{{baseUrl}}} + {{{url}}}, {{{strips}}});
+const {{{respVar}}} = await deploy({{{ctx}}}, {{{request}}}, {{{body}}}, {{{baseUrl}}} + {{{url}}});
 expect({{{respVar}}}.status()).toBe({{{expectedStatus}}});

--- a/configs/camunda-oca/codegen/playwright/roles/deploymentGateway/support.ts.tmpl
+++ b/configs/camunda-oca/codegen/playwright/roles/deploymentGateway/support.ts.tmpl
@@ -69,17 +69,6 @@ export interface DeployBody {
 }
 
 /**
- * A strip rule: skip `fieldName` from the multipart body when the field's
- * resolved value equals `sentinel`. Passed by the emitter via the `strips`
- * parameter so deploy() has no hard-coded domain knowledge about tenant sentinels
- * or any other config-specific defaults.
- */
-export interface DeployStripRule {
-  fieldName: string;
-  sentinel: string;
-}
-
-/**
  * A response-field extraction directive: navigate `segments` on the response
  * JSON and bind the value to `ctx[varName]` via `extractInto`.
  *
@@ -110,10 +99,11 @@ const EXTRACTS: DeployExtract[] = {{{extracts}}};
  * the response JSON.
  *
  * - Resolves `@@FILE:<path>` entries in `body.files` via resolveFixture().
- * - Strips fields whose resolved value equals the corresponding sentinel in
- *   `strips` (e.g. `{ fieldName: 'tenantId', sentinel: '<default>' }` for
- *   single-tenant deployments). Strips are derived by the emitter from
- *   `globalContextSeeds` so no domain-specific knowledge is hard-coded here.
+ * - Omits multipart fields whose resolved value is `undefined` or `null`,
+ *   so callers that leave a binding unbound (e.g. `ctx['tenantIdVar']`
+ *   when `omitWhenUnbound: true` and no per-scenario step seeded it) cause
+ *   the field to be dropped from the wire and the server to apply its
+ *   default (#342).
  * - Throws a descriptive Error on any non-200 response (includes the response
  *   body for diagnosis).
  * - Walks `EXTRACTS` against the parsed JSON and assigns each resolved value
@@ -127,12 +117,10 @@ export async function deploy(
   request: ApiRequestContextLike,
   body: DeployBody,
   url: string,
-  strips: DeployStripRule[],
 ): Promise<ApiResponseLike> {
   const multipart: Record<string, string | { name: string; mimeType: string; buffer: Buffer }> = {};
 
   for (const [k, v] of Object.entries(body.fields ?? {})) {
-    if (strips.some((s) => s.fieldName === k && String(v) === s.sentinel)) continue;
     if (v !== undefined && v !== null) multipart[k] = String(v);
   }
 

--- a/configs/camunda-oca/ontology/global-context-seeds.json
+++ b/configs/camunda-oca/ontology/global-context-seeds.json
@@ -10,9 +10,8 @@
       "binding": "tenantIdVar",
       "fieldName": "tenantId",
       "seedRule": "tenantIdVar",
-      "defaultSentinel": "<default>",
-      "stripFromMultipartWhenDefault": true,
-      "rationale": "Camunda single-tenant mode default — every emitted scenario seeds tenantIdVar via the seed rule (which yields '<default>'), and multipart bodies must drop the tenantId field when the default sentinel is present so the broker assigns the default tenant."
+      "omitWhenUnbound": true,
+      "rationale": "Camunda single-tenant mode default — the materializer must NOT auto-seed tenantIdVar from the universal prologue. When a per-scenario step seeds it (e.g. a producer like createTenant or a chained consumer that extracts the response), the seed-rules.json catch-all id rule mints a unique tenant id. When no step seeds it, ctx['tenantIdVar'] stays undefined and the consuming request omits the tenantId field, letting the REST Gateway apply the default tenant (#342). Replaces the legacy `<default>` sentinel + multipart-strip mechanism, which sent a literal sentinel on the wire and broke re-runnability for producer ops."
     }
   ]
 }

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -4623,8 +4623,12 @@ describeForThisConfig(
 // don't bind it leave it undefined, and the request layer omits the
 // field on the wire — the REST Gateway then defaults the tenant
 // itself. Producer ops still mint a unique value via the per-scenario
-// `seedBindings` loop + the catch-all `${var}-${runId}-${counter:id}-${rand:6}`
-// seed rule.
+// `seedBindings` loop; `tenantIdVar` falls through the rule list in
+// `seed-rules.json` (no `/(key|id)$/` match — the binding ends in
+// `Var`) and lands on the catch-all `${var}-${rand:6}` rule, which
+// embeds a per-process random nonce so consecutive runs against a
+// live broker mint different tenant IDs and avoid the `409
+// ALREADY_EXISTS` re-run defect.
 //
 // The three class-scoped invariants below pin both halves of that
 // contract: the lifted runtime sentinel never appears on the wire,
@@ -4706,9 +4710,16 @@ describeForThisConfig(
         throw new Error(`ctxSeeding.ts not found at ${ctxSeedingPath}`);
       }
       const src = readFileSync(ctxSeedingPath, 'utf8');
-      // Strip line comments so JSDoc/issue cross-references can't
-      // satisfy the assertion accidentally.
+      // Strip both block and line comments so JSDoc/issue cross-
+      // references in either comment form cannot satisfy the assertion
+      // accidentally — the wiring must live in real code tokens. Block
+      // comments are stripped first because line-comment stripping is
+      // line-oriented and would otherwise leave `*` lines from a `/*`
+      // block. The naïve regex doesn't honour string literals, but
+      // neither `omitWhenUnbound` nor any of its surrounding tokens
+      // appear inside string literals in this file.
       const codeOnly = src
+        .replace(/\/\*[\s\S]*?\*\//g, '')
         .split('\n')
         .map((l) => l.replace(/\/\/.*$/, ''))
         .join('\n');

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -4606,6 +4606,168 @@ describeForThisConfig(
 );
 
 // ---------------------------------------------------------------------------
+// globalContextSeeds — omit-when-unbound replaces the sentinel mechanism (#342)
+// ---------------------------------------------------------------------------
+//
+// #342 retired the `defaultSentinel` / `stripFromMultipartWhenDefault`
+// mechanism. Previously, the materializer hard-coded a `<default>`
+// sentinel into every multipart scenario whose body referenced
+// `globalContextSeeds[i].fieldName`, and the emitted suite tested for
+// that sentinel at runtime to strip the field. That broke
+// re-runnability for producer ops like `createTenant`, which sent
+// `tenantId: '<default>'` and received `409 ALREADY_EXISTS` on the
+// second run.
+//
+// Post-#342 the contract is: a seed entry with `omitWhenUnbound: true`
+// is NOT auto-seeded by the universal-seed prologue. Consumers that
+// don't bind it leave it undefined, and the request layer omits the
+// field on the wire — the REST Gateway then defaults the tenant
+// itself. Producer ops still mint a unique value via the per-scenario
+// `seedBindings` loop + the catch-all `${var}-${runId}-${counter:id}-${rand:6}`
+// seed rule.
+//
+// The three class-scoped invariants below pin both halves of that
+// contract: the lifted runtime sentinel never appears on the wire,
+// the universal-seed prologue skips `omitWhenUnbound` entries, and
+// the JSON Schema published to external SHACL/OWL consumers does not
+// re-introduce the legacy fields.
+describeForThisConfig(
+  'bundled-spec invariants: omit-when-unbound replaces sentinel mechanism (#342)',
+  () => {
+    it('no scenario request body, multipart field, or query value carries the literal `<default>` sentinel on the wire', () => {
+      if (!existsSync(SCENARIOS_DIR)) {
+        throw new Error(
+          `Scenarios directory not found at ${SCENARIOS_DIR}. Run 'npm run pipeline' first.`,
+        );
+      }
+
+      const offenders: { file: string; scenarioId: string; jsonPath: string }[] = [];
+
+      function walk(value: unknown, jsonPath: string, onHit: (jp: string) => void): void {
+        if (value === '<default>') {
+          onHit(jsonPath);
+          return;
+        }
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) {
+            walk(value[i], `${jsonPath}[${i}]`, onHit);
+          }
+          return;
+        }
+        if (value && typeof value === 'object') {
+          for (const [k, v] of Object.entries(value)) {
+            walk(v, `${jsonPath}.${k}`, onHit);
+          }
+        }
+      }
+
+      for (const f of readdirSync(SCENARIOS_DIR)) {
+        if (!f.endsWith('-scenarios.json')) continue;
+        // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+        const file = JSON.parse(readFileSync(join(SCENARIOS_DIR, f), 'utf8')) as {
+          scenarios?: { id: string; requestPlan?: unknown[] }[];
+        };
+        for (const scenario of file.scenarios ?? []) {
+          for (let i = 0; i < (scenario.requestPlan ?? []).length; i++) {
+            const step = (scenario.requestPlan ?? [])[i];
+            walk(step, `requestPlan[${i}]`, (jp) => {
+              offenders.push({ file: f, scenarioId: scenario.id, jsonPath: jp });
+            });
+          }
+        }
+      }
+
+      expect(
+        offenders,
+        'The legacy `<default>` sentinel must not appear in any scenario request payload. ' +
+          'Post-#342 the binding is either minted (producer scenarios via `seedBindings`) or ' +
+          'left undefined so the request layer omits the field and the REST Gateway defaults ' +
+          'the tenant. A live `<default>` value here means the sentinel mechanism leaked back ' +
+          'into the planner or the seed rule.',
+      ).toEqual([]);
+    });
+
+    it('the materializer source filters `omitWhenUnbound` seeds out of the universal-seed prologue', () => {
+      // Source-level class-scoped invariant: emitted Playwright suites
+      // share the SAME `ctx['x'] = ctx['x'] ?? seedBinding('x')` line
+      // shape for both the universal-seed prologue and the per-scenario
+      // seedBindings loop, so we cannot distinguish them at the byte
+      // level in the emitted output. The contract therefore must hold
+      // at the source: `materializer/src/playwright/ctxSeeding.ts`
+      // must (a) exclude `omitWhenUnbound` seeds from `globalSeedNames`
+      // (so the per-scenario loop does not re-seed them from the
+      // global list) and (b) skip them in the universal prologue
+      // emission loop. Both gates encode the same `omitWhenUnbound`
+      // contract; either being absent would cause `<default>`-style
+      // auto-seeding to creep back in for tenants and break
+      // re-runnability for producer ops.
+      const ctxSeedingPath = join(REPO_ROOT, 'materializer', 'src', 'playwright', 'ctxSeeding.ts');
+      if (!existsSync(ctxSeedingPath)) {
+        throw new Error(`ctxSeeding.ts not found at ${ctxSeedingPath}`);
+      }
+      const src = readFileSync(ctxSeedingPath, 'utf8');
+      // Strip line comments so JSDoc/issue cross-references can't
+      // satisfy the assertion accidentally.
+      const codeOnly = src
+        .split('\n')
+        .map((l) => l.replace(/\/\/.*$/, ''))
+        .join('\n');
+      expect(
+        codeOnly,
+        'ctxSeeding.ts must reference `omitWhenUnbound` in source (#342). The filter on ' +
+          '`globalSeedNames` and the skip in the universal-prologue emission loop are the ' +
+          'two gates that prevent `tenantIdVar` (and any future omit-when-unbound binding) ' +
+          'from being auto-seeded into every scenario.',
+      ).toMatch(/omitWhenUnbound/);
+      // The interface declaration alone is insufficient — the filter
+      // must consult the property. Two distinct uses (filter + skip
+      // statement) are expected.
+      const useCount = (codeOnly.match(/omitWhenUnbound/g) ?? []).length;
+      expect(
+        useCount,
+        'ctxSeeding.ts must reference `omitWhenUnbound` at least twice (interface + filter + ' +
+          'skip statement). A single reference suggests the gate was deleted or stubbed.',
+      ).toBeGreaterThanOrEqual(2);
+    });
+
+    it('the generated JSON Schema for globalContextSeeds publishes `omitWhenUnbound` and not the legacy sentinel fields', () => {
+      const schemaPath = join(
+        REPO_ROOT,
+        'ontology',
+        'vocabulary',
+        'global-context-seeds.schema.json',
+      );
+      if (!existsSync(schemaPath)) {
+        throw new Error(
+          `global-context-seeds.schema.json not found at ${schemaPath}. Run 'npm run build:ontology' first.`,
+        );
+      }
+      // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+      const schema = JSON.parse(readFileSync(schemaPath, 'utf8')) as {
+        definitions?: { GlobalContextSeed?: { properties?: Record<string, unknown> } };
+      };
+      const itemProps = schema.definitions?.GlobalContextSeed?.properties ?? {};
+      expect(
+        'omitWhenUnbound' in itemProps,
+        'The published JSON Schema must declare `omitWhenUnbound` (#342). External SHACL/OWL ' +
+          'consumers depend on this field to determine whether a seed is auto-seeded or omitted.',
+      ).toBe(true);
+      expect(
+        'defaultSentinel' in itemProps,
+        'The published JSON Schema must NOT re-introduce `defaultSentinel` (#342). The sentinel ' +
+          'mechanism was removed because it broke re-runnability for producer ops like ' +
+          'createTenant. Regenerate via `npm run build:ontology`.',
+      ).toBe(false);
+      expect(
+        'stripFromMultipartWhenDefault' in itemProps,
+        'The published JSON Schema must NOT re-introduce `stripFromMultipartWhenDefault` (#342). ' +
+          'Regenerate via `npm run build:ontology`.',
+      ).toBe(false);
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
 // globalContextSeeds substitution into multipart templates (#200 — Lift 0)
 // ---------------------------------------------------------------------------
 //
@@ -4616,12 +4778,10 @@ describeForThisConfig(
 // supposed to be byte-identical: every multipart scenario whose request
 // body declares a `globalContextSeeds[i].fieldName` field must still
 // emit `template.fields[fieldName] = "${binding}"`, AND the scenario's
-// `bindings[binding]` must equal `__PENDING__` so the emitter's
-// universal-seed prologue (codegen/playwright/emitter.ts) can rewrite
-// it to the runtime sentinel (`<default>`). This invariant locks both
-// directions and is class-scoped (every multipart scenario across the
-// bundled output, not just createDeployment) so the same regression
-// can't recur in a sibling op.
+// `bindings[binding]` must equal `__PENDING__` so the materializer's
+// per-scenario seedBindings loop mints a value via the catch-all id
+// seed rule (#342 — previously the universal-seed prologue rewrote it
+// to the `<default>` sentinel; that mechanism is now gone).
 describeForThisConfig(
   'bundled-spec invariants: globalContextSeeds substitution survives Lift 0 (#200)',
   () => {

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -9049,10 +9049,14 @@ describe.skipIf(CONFIG_NAME !== ACTIVE_CONFIG)(
     it('feature specs for ops that do NOT declare 409 keep seedBinding calls deterministic (no { unique: true })', () => {
       // Companion to the previous invariant: confirms we did not blanket-
       // apply unique tagging. A representative non-409 op feature spec must
-      // contain at least one bare seedBinding() call. createDeployment is a
+      // contain at least one bare seedBinding() call. broadcastSignal is a
       // safe pick — it doesn't declare 409 and consistently emits a seeded
-      // tenantId binding.
-      const specPath = join(GENERATED_TESTS_DIR, 'createDeployment.feature.spec.ts');
+      // signalNameVar binding.
+      //
+      // Previously this used createDeployment, but #342 made tenantIdVar
+      // omitWhenUnbound, so createDeployment now (correctly) has no
+      // seedBinding calls at all.
+      const specPath = join(GENERATED_TESTS_DIR, 'broadcastSignal.feature.spec.ts');
       if (!existsSync(specPath)) {
         return;
       }

--- a/materializer/src/ROLES.md
+++ b/materializer/src/ROLES.md
@@ -177,7 +177,7 @@ import { resolveFile } from './fixtures.js';
 const EXTRACTS: DeployExtract[] = {{{extracts}}};
 
 export async function deploy(
-  ctx, request, body, baseUrl, strips,
+  ctx, request, body, baseUrl,
 ) { /* loops EXTRACTS internally */ }
 ```
 
@@ -222,7 +222,7 @@ HTML-escaped.
 `call-site.tmpl` for the role:
 
 ```hbs
-const {{respVar}} = await deploy({{{ctx}}}, {{{request}}}, {{{body}}}, {{{baseUrl}}}, {{{strips}}});
+const {{respVar}} = await deploy({{{ctx}}}, {{{request}}}, {{{body}}}, {{{baseUrl}}});
 ```
 
 Rendered spec file (excerpt):
@@ -235,7 +235,7 @@ import { deploy } from './support/deploymentGateway';
 
 test('publish a process and start an instance', async ({ request, baseUrl }, ctx) => {
   // ... earlier steps ...
-  const resp7 = await deploy(ctx, request, body7, baseUrl, STRIPS);
+  const resp7 = await deploy(ctx, request, body7, baseUrl);
   // ... later steps consume ctx.processDefinitionKeyVar ...
 });
 ```
@@ -265,7 +265,7 @@ spec file:
 | `supportImportPath` | string | Renderer-computed relative path from the current spec file to `playwright/support/<role>` (no extension; Playwright/TypeScript resolves both `.ts` and `.js` per the suite's `tsconfig`). Typically `./support/<role>` for spec files at the suite root, `../support/<role>` for spec files in subdirectories. Authors should always interpolate this with triple-braces. |
 
 Per-step variables (`respVar`, `body`, `operationId`,
-`pathTemplate`, `method`, `request`, `baseUrl`, `strips`, `ctx`,
+`pathTemplate`, `method`, `request`, `baseUrl`, `ctx`,
 `defaultRender`) are **not** in `imports.tmpl` scope. Referencing
 them is a template-render error so that mistakes fail at codegen time
 rather than producing whichever step's value happened to win.
@@ -332,7 +332,6 @@ extensions are documented in this file under the per-emitter section.
 | `request` | string | Name of the Playwright `request` fixture in scope (typically `request`). |
 | `baseUrl` | string | Name of the base-URL variable in scope (typically `baseUrl`). |
 | `body` | string | TypeScript expression evaluating to the request body for this step. JSON literal, multipart builder call, or `undefined`. |
-| `strips` | string | JSON literal expression for the strip-on-sentinel rules derived from `globalContextSeeds`. |
 
 `roleExtras` populated by registered `RoleHookProvider`s is also spread
 into both the call-site scope and the support-file template scope (see
@@ -356,7 +355,7 @@ one — e.g. the OCA `deploymentGateway` role wraps a multipart upload
 with response-field extraction and an OCA-specific error envelope.
 
 ```hbs
-const {{respVar}} = await deploy({{{ctx}}}, {{{request}}}, {{{body}}}, {{{baseUrl}}}, {{{strips}}});
+const {{respVar}} = await deploy({{{ctx}}}, {{{request}}}, {{{body}}}, {{{baseUrl}}});
 ```
 
 ### Wrap

--- a/materializer/src/index.ts
+++ b/materializer/src/index.ts
@@ -566,6 +566,13 @@ async function run() {
       const seedsArg = globalContextSeeds.map((s) => ({
         binding: s.binding,
         seedRule: s.seedRule,
+        // #342: forward `omitWhenUnbound` so the template emitter's
+        // `emitCtxSeeding` honours the same universal-prologue skip as
+        // the per-endpoint emitter. Without this, template-derived
+        // lifecycle suites would still auto-seed `tenantIdVar` and put
+        // a value on the wire for ops that the design says should omit
+        // the field.
+        omitWhenUnbound: s.omitWhenUnbound,
       }));
       for (const templateName of templateNames) {
         const templateOutDir = path.join(outDir, templateOutputDir(templateName));

--- a/materializer/src/playwright/ctxSeeding.ts
+++ b/materializer/src/playwright/ctxSeeding.ts
@@ -143,6 +143,14 @@ function walkForPlaceholders(node: unknown, out: Set<string>): void {
 export interface CtxSeedingGlobal {
   readonly binding: string;
   readonly seedRule: string;
+  /**
+   * If true, the universal-seed prologue does NOT auto-seed this
+   * binding. The binding is seeded only when a per-scenario step
+   * names it via `scenario.seedBindings`. For scenarios that don't
+   * seed it, the binding stays `undefined` and the consuming
+   * request omits the field on the wire (#342).
+   */
+  readonly omitWhenUnbound?: boolean;
 }
 
 export interface EmitCtxSeedingOptions {
@@ -181,7 +189,13 @@ export function emitCtxSeeding(opts: EmitCtxSeedingOptions): string[] {
   const { indent, bindings, seedBindings, globalContextSeeds, uniqueBindings } = opts;
   const unique = uniqueBindings ?? new Set<string>();
   const lines: string[] = [];
-  const globalSeedNames = new Set(globalContextSeeds.map((s) => s.binding));
+  // `omitWhenUnbound` seeds are excluded from the universal prologue
+  // but remain eligible for per-scenario seeding via `seedBindings`,
+  // so they are NOT added to `globalSeedNames` (which is the
+  // "don't seed twice" filter for the `seedNames` step). See #342.
+  const globalSeedNames = new Set(
+    globalContextSeeds.filter((s) => !s.omitWhenUnbound).map((s) => s.binding),
+  );
 
   // Literal writes from `scenario.bindings`, with two exclusions:
   //   - `PENDING_BINDING` sentinel — routes through `seedBindings` instead.
@@ -215,6 +229,7 @@ export function emitCtxSeeding(opts: EmitCtxSeedingOptions): string[] {
   }
 
   for (const seed of globalContextSeeds) {
+    if (seed.omitWhenUnbound) continue;
     lines.push(
       `${indent}ctx['${seed.binding}'] = ctx['${seed.binding}'] ?? ${seedCall(seed.seedRule, unique.has(seed.binding))};`,
     );

--- a/materializer/src/playwright/ctxSeeding.ts
+++ b/materializer/src/playwright/ctxSeeding.ts
@@ -212,8 +212,21 @@ export function emitCtxSeeding(opts: EmitCtxSeedingOptions): string[] {
         .filter(([k, v]) => v !== PENDING_BINDING && unique.has(k))
         .map(([k]) => k)
     : [];
+  // `omitWhenUnbound` bindings (e.g. `tenantIdVar`) must NOT be seeded
+  // by consumer ops — the binding has to stay `undefined` so the
+  // outgoing request omits the field on the wire and the broker
+  // applies its default (#342). Producers that mint the value still
+  // need a fresh seed; they're identified by membership in
+  // `uniqueBindings` (any op declaring HTTP 409 on the binding is
+  // implicitly a producer in this codegen — see #320). Skipping in the
+  // consumer case prevents the catch-all seed-rule from minting a
+  // random tenant id (e.g. `tenantIdVar-abc123`) that the broker
+  // legitimately rejects as unknown.
+  const omitWhenUnboundNames = new Set(
+    globalContextSeeds.filter((s) => s.omitWhenUnbound).map((s) => s.binding),
+  );
   const seedNames = Array.from(new Set([...(seedBindings ?? []), ...strippedForUnique])).filter(
-    (n) => !globalSeedNames.has(n),
+    (n) => !globalSeedNames.has(n) && (!omitWhenUnboundNames.has(n) || unique.has(n)),
   );
 
   if (literalEntries.length > 0 || seedNames.length > 0) {

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -460,38 +460,6 @@ function renderScenarioTest(
       uniqueBindings: computeUniqueBindings(s.requestPlan),
     }),
   );
-  // Multipart-sentinel locals (`__<fieldName>IsDefault`) are emitted
-  // alongside the prologue entries that drive them — only this
-  // emitter knows the sentinel exists, so the helper deliberately
-  // doesn't see this concern.
-  //
-  // Safety: `binding`, `fieldName`, `seedRule` are all required by the
-  // domain-semantics validator (#87) to match `/^[A-Za-z_$][A-Za-z0-9_$]*$/`,
-  // and `defaultSentinel` is required to contain no single quotes,
-  // backslashes, or line terminators. That lets us interpolate them
-  // directly into emitted single-quoted TS string literals without an
-  // escape pass.
-  //
-  // The local is only emitted when the scenario has at least one inline
-  // multipart step (i.e. a multipart step that is NOT dispatched to a
-  // role). Role-bound steps pass strips as a JSON literal argument and
-  // never read the prologue local; omitting it for role-only scenarios
-  // prevents an unused-variable error in the generated suite.
-  const hasInlineMultipartStep = (s.requestPlan ?? []).some(
-    (step) => step.bodyKind === 'multipart' && !!step.multipartTemplate && !findRoleForStep(step),
-  );
-  const sentinelLocals = new Map<string, string>(); // fieldName -> local var name
-  for (const seed of globalContextSeeds) {
-    if (
-      hasInlineMultipartStep &&
-      seed.stripFromMultipartWhenDefault &&
-      seed.defaultSentinel !== undefined
-    ) {
-      const local = `__${seed.fieldName}IsDefault`;
-      sentinelLocals.set(seed.fieldName, local);
-      body.push(`  const ${local} = ctx['${seed.binding}'] === '${seed.defaultSentinel}';`);
-    }
-  }
   if (!s.requestPlan) {
     body.push('  // No request plan available');
     body.push('});');
@@ -536,7 +504,6 @@ function renderScenarioTest(
       varName,
       urlExpr,
       method,
-      sentinelLocals,
       shouldAwaitEventually: stepNeedsAwaitForOp(step, ecOps),
     });
     const roleMatch = findRoleForStep(step);
@@ -552,12 +519,6 @@ function renderScenarioTest(
         .split('\n')
         .map((line: string, i: number) => (i === 0 ? line : `    ${line}`))
         .join('\n');
-      // Derive strip rules from globalContextSeeds so the helper has no
-      // hard-coded domain knowledge about sentinel values or field names.
-      const strips = globalContextSeeds
-        .filter((seed) => seed.stripFromMultipartWhenDefault && seed.defaultSentinel !== undefined)
-        .map((seed) => ({ fieldName: seed.fieldName, sentinel: seed.defaultSentinel }));
-      const stripsLit = JSON.stringify(strips);
       // Per-role data computed by the orchestrator. The deployment-gateway
       // hook's `extracts` payload is consumed by `materializeRoleSupportFiles`
       // when rendering the templated helper (#243), so it is also threaded
@@ -577,7 +538,6 @@ function renderScenarioTest(
         request: 'request',
         baseUrl: 'baseUrl',
         body: bodyIndented,
-        strips: stripsLit,
         ...extras,
         // Additional context vars used by the deploymentGateway template:
         url: buildUrlExpression(step.pathTemplate),

--- a/materializer/src/playwright/stepRenderer.ts
+++ b/materializer/src/playwright/stepRenderer.ts
@@ -107,12 +107,6 @@ export interface InlineStepRenderInput {
   varName: string;
   urlExpr: string;
   method: string;
-  /**
-   * Per-multipart-field sentinel locals declared in the test prologue.
-   * Used to strip default-valued fields from emitted multipart bodies.
-   * Empty for template-scenario callers (no multipart steps today).
-   */
-  sentinelLocals?: Map<string, string>;
   /** Whether this step should be wrapped with `awaitEventually(...)`. */
   shouldAwaitEventually?: boolean;
 }
@@ -134,12 +128,10 @@ export function renderInlineStepLines({
   varName,
   urlExpr,
   method,
-  sentinelLocals,
   shouldAwaitEventually,
 }: InlineStepRenderInput): string[] {
   const lines: string[] = [];
   const bodyVar = `body${idx + 1}`;
-  const sentinels = sentinelLocals ?? new Map<string, string>();
   lines.push(`    const url = baseUrl + ${urlExpr};`);
   if (step.bodyKind === 'json' && step.bodyTemplate) {
     const json = JSON.stringify(step.bodyTemplate, null, 4).replace(
@@ -162,9 +154,6 @@ export function renderInlineStepLines({
       `    const multipart: Record<string, string | { name: string; mimeType: string; buffer: Buffer }> = {};`,
     );
     lines.push(`    for (const [k,v] of Object.entries(${bodyVar}.fields||{})) {`);
-    for (const [fieldName, local] of sentinels) {
-      lines.push(`      if (k === '${fieldName}' && ${local}) continue;`);
-    }
     lines.push(`      if (v !== undefined && v !== null) multipart[k] = String(v);`);
     lines.push(`    }`);
     lines.push(`    for (const [k,v] of Object.entries(${bodyVar}.files||{})) {

--- a/materializer/src/playwright/support/seed-rules.json
+++ b/materializer/src/playwright/support/seed-rules.json
@@ -1,6 +1,5 @@
 {
   "rules": [
-    { "match": "tenantIdVar", "template": "<default>" },
     { "match": "/(correlation)/i", "template": "corr-${runId}-${counter:corr}-${rand:4}" },
     { "match": "/(key|id)$/i", "template": "${var}-${runId}-${counter:id}-${rand:6}" },
     { "match": "/name/i", "template": "${var}-${rand:8}" },

--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -28,12 +28,15 @@ export interface TemplateGlobalContextSeed {
   seedRule: string;
   /**
    * Mirrors `GlobalContextSeed.omitWhenUnbound` (#342). When `true`,
-   * the universal-seed prologue (`emitCtxSeeding` in `ctxSeeding.ts`)
-   * skips this entry — the binding is seeded only when a per-scenario
-   * step produces or consumes it via `seedBindings`. Without this
-   * field threaded through to `emitCtxSeeding`, template suites would
-   * keep auto-seeding `tenantIdVar` and reintroduce the on-wire
-   * `<default>`-shaped behavior #342 retired.
+   * `emitCtxSeeding` in `ctxSeeding.ts` skips this entry in BOTH the
+   * universal-seed prologue AND the per-scenario `seedBindings` loop
+   * for consumer-only scenarios; only scenarios that must mint a
+   * fresh value to send (signalled by membership in the emitter's
+   * `uniqueBindings` set — see #320) still seed the binding. Without
+   * this field threaded through to `emitCtxSeeding`, template suites
+   * would auto-seed consumer-only bindings like `tenantIdVar` and
+   * send a fabricated value on the wire that the broker rejects as
+   * unknown.
    */
   omitWhenUnbound?: boolean;
 }

--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -26,6 +26,16 @@ import {
 export interface TemplateGlobalContextSeed {
   binding: string;
   seedRule: string;
+  /**
+   * Mirrors `GlobalContextSeed.omitWhenUnbound` (#342). When `true`,
+   * the universal-seed prologue (`emitCtxSeeding` in `ctxSeeding.ts`)
+   * skips this entry — the binding is seeded only when a per-scenario
+   * step produces or consumes it via `seedBindings`. Without this
+   * field threaded through to `emitCtxSeeding`, template suites would
+   * keep auto-seeding `tenantIdVar` and reintroduce the on-wire
+   * `<default>`-shaped behavior #342 retired.
+   */
+  omitWhenUnbound?: boolean;
 }
 
 export interface EmitTemplateSuitesOptions {

--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -80,7 +80,7 @@ export async function emitTemplateSuites(opts: EmitTemplateSuitesOptions): Promi
   // or hostile seed value cannot produce invalid (or unsafe) generated
   // code. The per-endpoint emitter's `assertSafeGlobalContextSeeds`
   // helper expects the full GlobalContextSeed schema (fieldName,
-  // defaultSentinel, …) which this entry point does not see — callers
+  // omitWhenUnbound, …) which this entry point does not see — callers
   // project to the narrow {binding, seedRule} shape on the way in. The
   // local check below covers the same risk surface (string-literal
   // injection) for that narrower payload. (#274 review.)

--- a/materializer/src/roles.ts
+++ b/materializer/src/roles.ts
@@ -46,11 +46,6 @@ export interface PlaywrightRoleScope extends CommonRoleScope {
    * JSON literal, multipart builder call, or `undefined`.
    */
   body: string;
-  /**
-   * JSON literal expression for the strip-on-sentinel rules derived from
-   * `globalContextSeeds`.
-   */
-  strips: string;
 }
 
 /**

--- a/ontology/vocabulary/global-context-seeds.schema.json
+++ b/ontology/vocabulary/global-context-seeds.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://camunda.github.io/api-test-generator/ns/v1/global-context-seeds.schema.json",
   "title": "GlobalContextSeedsAbox",
-  "description": "TBox JSON Schema for an ABox file describing the universal seed bindings every emitted scenario must populate before its request plan runs (e.g. a single-tenant `tenantIdVar` default). Each entry asserts: a context binding name, the request-body / multipart field name it maps to, the seed-rules.json key invoked at runtime, and (optionally) a sentinel value that triggers multipart-field stripping. The schema is intentionally agnostic to which API ships the seeds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/global-context-seeds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Identifier safety (binding/fieldName/seedRule must match /^[A-Za-z_$][A-Za-z0-9_$]*$/) and sentinel-string safety (no single-quotes, backslashes, line terminators, or control chars) are encoded in the `pattern` constraints because the emitter interpolates these values directly into emitted TS source as identifiers and single-quoted string literals (#87).",
+  "description": "TBox JSON Schema for an ABox file describing the universal seed bindings every emitted scenario must populate before its request plan runs (e.g. a single-tenant `tenantIdVar` default). Each entry asserts: a context binding name, the request-body / multipart field name it maps to, the seed-rules.json key invoked at runtime, and (optionally) `omitWhenUnbound: true` to instruct the materializer to skip the universal-seed prologue and let the field be omitted on the wire when no per-scenario step seeds it. The schema is intentionally agnostic to which API ships the seeds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/global-context-seeds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Identifier safety (binding/fieldName/seedRule must match /^[A-Za-z_$][A-Za-z0-9_$]*$/) is encoded in the `pattern` constraints because the emitter interpolates these values directly into emitted TS source as identifiers and single-quoted string literals (#87).",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -65,14 +65,9 @@
           "pattern": "^[A-Za-z_$][A-Za-z0-9_$]*$",
           "description": "Key passed to seedBinding() at runtime; must match a rule in seed-rules.json. Constrained to a JS identifier so the emitter renders it as a safe single-quoted string literal."
         },
-        "defaultSentinel": {
-          "type": "string",
-          "pattern": "^[^'\\\\\\u0000-\\u001f\\u007f]*$",
-          "description": "Magic value that, when present in ctx[<binding>], triggers field-stripping in multipart bodies. Constrained so the emitted single-quoted string literal cannot break out of its quotes or carry control characters."
-        },
-        "stripFromMultipartWhenDefault": {
+        "omitWhenUnbound": {
           "type": "boolean",
-          "description": "If true, the emitter inserts a multipart-loop branch that drops `fieldName` when ctx[<binding>] equals `defaultSentinel`. Requires `defaultSentinel` to be present (checked by the loader)."
+          "description": "If true, the materializer skips the universal-seed prologue for this entry — the binding is seeded only when a per-scenario step produces or consumes it (via `scenario.seedBindings`). For scenarios that do not seed it, the binding stays `undefined` and the request field is omitted on the wire (#342). Replaces the legacy `defaultSentinel`/`stripFromMultipartWhenDefault` mechanism, which sent a literal sentinel value on the wire and broke re-runnability for producer ops like `createTenant`."
         },
         "rationale": {
           "type": "string",

--- a/ontology/vocabulary/global-context-seeds.schema.json
+++ b/ontology/vocabulary/global-context-seeds.schema.json
@@ -67,7 +67,7 @@
         },
         "omitWhenUnbound": {
           "type": "boolean",
-          "description": "If true, the materializer skips the universal-seed prologue for this entry — the binding is seeded only when a per-scenario step produces or consumes it (via `scenario.seedBindings`). For scenarios that do not seed it, the binding stays `undefined` and the request field is omitted on the wire (#342). Replaces the legacy `defaultSentinel`/`stripFromMultipartWhenDefault` mechanism, which sent a literal sentinel value on the wire and broke re-runnability for producer ops like `createTenant`."
+          "description": "If true, the materializer skips the universal-seed prologue for this entry AND skips it in the per-scenario `seedBindings` loop for consumer-only scenarios. The binding is seeded only when the scenario must mint a fresh value to send (currently: ops that declare HTTP 409, via the emitter's `uniqueBindings` set — see #320). When left unseeded, the binding stays `undefined` and the request field is omitted on the wire so the server applies its own default (#342). Replaces the legacy `defaultSentinel`/`stripFromMultipartWhenDefault` mechanism, which sent a literal sentinel value on the wire and broke re-runnability for producer ops like `createTenant`."
         },
         "rationale": {
           "type": "string",

--- a/path-analyser/src/ontology/crossRef/globalContextSeedsCrossRef.ts
+++ b/path-analyser/src/ontology/crossRef/globalContextSeedsCrossRef.ts
@@ -1,5 +1,5 @@
 // Per-slice cross-reference module for `globalContextSeedsSchema.ts`
-// (#87 + Lift 15 / #255).
+// (#87 + Lift 15 / #255 + #342).
 //
 // Owns invariants whose offending field is in `globalContextSeeds[*]`.
 // The structural `GlobalContextSeedSchema` zod definition lives in
@@ -11,38 +11,20 @@ import type { DomainSemantics } from '../../types.js';
 import type { CrossRefIssue, SliceCrossRefModule } from './types.js';
 
 // JS/TS identifier syntax. Conservative — ASCII only — because the emitter
-// builds locals like `__<fieldName>IsDefault` and ctx keys like `<binding>`
-// from these strings; restricting them to identifier-safe ASCII rules out
-// accidental code injection (`'; DROP TABLE`-style) and ensures the emitted
-// TS compiles regardless of the surrounding generator's escape choices.
+// builds ctx keys like `<binding>` from these strings; restricting them to
+// identifier-safe ASCII rules out accidental code injection
+// (`'; DROP TABLE`-style) and ensures the emitted TS compiles regardless
+// of the surrounding generator's escape choices.
 function isSafeIdentifierName(name: string): boolean {
   return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name);
 }
 
-// `defaultSentinel` is interpolated into a single-quoted TS string literal
-// (preserved verbatim from the pre-#87 emitter so generated suites stay
-// byte-identical). Reject characters that would break that literal: single
-// quotes, backslashes, line terminators, and other control characters.
-// Unicode line separators U+2028 / U+2029 also terminate string literals in
-// JS so they're rejected too. The current production sentinel `<default>`
-// passes; anything that would have required escaping fails fast at load.
-function sentinelHasUnsafeChars(sentinel: string): boolean {
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars to reject them
-  return /['\\\r\n\t\u0000-\u001f\u2028\u2029]/.test(sentinel);
-}
-
 // #87: every globalContextSeeds entry must have a unique, identifier-safe
-// `binding` and `fieldName`. The emitter's sentinel local is
-// `__<fieldName>IsDefault`, the multipart strip branch keys off `fieldName`,
-// and ctx[<binding>] / seedBinding('<seedRule>') interpolate `binding` and
-// `seedRule` directly. Restricting these to safe identifiers (and rejecting
-// duplicates) means the emitter can interpolate them without an escape pass,
-// rules out config-driven code injection, and prevents two entries from
-// declaring the same `const __...IsDefault`. Also reject
-// `stripFromMultipartWhenDefault: true` without a `defaultSentinel` — the
-// strip branch needs something to compare against, otherwise the emitter
-// would have to choose a fallback sentinel itself (re-introducing the very
-// hard-coding this entry is meant to remove).
+// `binding` and `fieldName`. The multipart-field omission keys off
+// `fieldName`, and ctx[<binding>] / seedBinding('<seedRule>') interpolate
+// `binding` and `seedRule` directly. Restricting these to safe identifiers
+// (and rejecting duplicates) means the emitter can interpolate them without
+// an escape pass and rules out config-driven code injection.
 export function checkGlobalContextSeedsCoherent(d: DomainSemantics): CrossRefIssue[] {
   const issues: CrossRefIssue[] = [];
   const seenBindings = new Set<string>();
@@ -75,20 +57,6 @@ export function checkGlobalContextSeedsCoherent(d: DomainSemantics): CrossRefIss
           message: `globalContextSeeds entry for binding "${seed.binding}" has ${key} "${value}", which is not a safe identifier (must match /^[A-Za-z_$][A-Za-z0-9_$]*$/)`,
         });
       }
-    }
-
-    if (seed.defaultSentinel !== undefined && sentinelHasUnsafeChars(seed.defaultSentinel)) {
-      issues.push({
-        code: 'globalContextSeedSentinelSafe',
-        message: `globalContextSeeds entry for binding "${seed.binding}" has defaultSentinel containing characters (single-quote, backslash, line terminator, or control char) that would break the emitted single-quoted string literal`,
-      });
-    }
-
-    if (seed.stripFromMultipartWhenDefault === true && seed.defaultSentinel === undefined) {
-      issues.push({
-        code: 'globalContextSeedStripRequiresSentinel',
-        message: `globalContextSeeds entry for binding "${seed.binding}" sets stripFromMultipartWhenDefault but has no defaultSentinel`,
-      });
     }
   }
   return issues;

--- a/path-analyser/src/ontology/crossRefValidator.ts
+++ b/path-analyser/src/ontology/crossRefValidator.ts
@@ -78,8 +78,7 @@ export const GlobalContextSeedSchema = z
     binding: z.string().min(1),
     fieldName: z.string().min(1),
     seedRule: z.string().min(1),
-    defaultSentinel: z.string().optional(),
-    stripFromMultipartWhenDefault: z.boolean().optional(),
+    omitWhenUnbound: z.boolean().optional(),
     rationale: z.string().optional(),
   })
   .strict();
@@ -138,7 +137,7 @@ export function validateDomainSemantics(raw: unknown): DomainSemanticsValidation
  * Boundary-level safety assertion for `globalContextSeeds`.
  *
  * The Playwright emitter interpolates `binding`, `fieldName`, `seedRule`,
- * and `defaultSentinel` directly into emitted TS source as identifiers and
+ * and `seedRule` directly into emitted TS source as identifiers and
  * single-quoted string literals (#87). The loader validates the seeds when
  * reading the ontology-derived graph domain, but the public emitter entry points
  * (`renderPlaywrightSuite`, `emitPlaywrightSuite`, `PlaywrightEmitter.emit`)

--- a/path-analyser/src/ontology/globalContextSeedsSchema.ts
+++ b/path-analyser/src/ontology/globalContextSeedsSchema.ts
@@ -22,34 +22,34 @@
 //   - if (ctx['<binding>'] === undefined) { ctx['<binding>'] =
 //       seedBinding('<seedRule>'); }
 //
-// and, when `defaultSentinel` + `stripFromMultipartWhenDefault` are
-// both present, a multipart-loop branch that drops `fieldName` from
-// the request body when the binding equals the sentinel.
+// or — when `omitWhenUnbound` is `true` (#342) — the prologue is
+// skipped entirely so the binding is seeded only when the planner-
+// driven `seedBindings` list names it. Unseeded `omitWhenUnbound`
+// bindings stay `undefined`, so the request field is omitted on the
+// wire and the server applies its own default (e.g. the Camunda REST
+// Gateway treats a missing `tenantId` as the default tenant).
 //
 // Like Lifts 5/6/7, the data was never sourced from upstream OpenAPI
 // annotations — it has always lived in per-config ontology data.
 // Consequence: there is no `spec-vs-abox` (sense-1) drift to detect.
 //
-// Identifier / sentinel safety constraints (the same constraints
-// previously enforced by `domainSemanticsValidator.ts#GlobalContextSeedSchema`
+// Identifier safety constraints (the same constraints previously
+// enforced by `domainSemanticsValidator.ts#GlobalContextSeedSchema`
 // and `assertSafeGlobalContextSeeds`) are encoded in the JSON-Schema
 // `pattern` so they are caught at TBox validation time. The Playwright
-// emitter interpolates `binding`, `fieldName`, `seedRule`, and
-// `defaultSentinel` directly into emitted TS source as identifiers and
-// single-quoted string literals (#87), so the safety regex is
-// load-bearing.
+// emitter interpolates `binding`, `fieldName`, and `seedRule` directly
+// into emitted TS source as identifiers and single-quoted string
+// literals (#87), so the safety regex is load-bearing.
 //
-// Cross-property invariant (`stripFromMultipartWhenDefault === true`
-// requires `defaultSentinel` to be present) and uniqueness
-// (`binding`, `fieldName`) cannot be expressed in Draft-07 and are
-// re-checked in the loader.
+// Uniqueness (`binding`, `fieldName`) cannot be expressed in Draft-07
+// and is re-checked in the loader.
 
 export const globalContextSeedsSchema = {
   $schema: 'http://json-schema.org/draft-07/schema#',
   $id: 'https://camunda.github.io/api-test-generator/ns/v1/global-context-seeds.schema.json',
   title: 'GlobalContextSeedsAbox',
   description:
-    'TBox JSON Schema for an ABox file describing the universal seed bindings every emitted scenario must populate before its request plan runs (e.g. a single-tenant `tenantIdVar` default). Each entry asserts: a context binding name, the request-body / multipart field name it maps to, the seed-rules.json key invoked at runtime, and (optionally) a sentinel value that triggers multipart-field stripping. The schema is intentionally agnostic to which API ships the seeds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/global-context-seeds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Identifier safety (binding/fieldName/seedRule must match /^[A-Za-z_$][A-Za-z0-9_$]*$/) and sentinel-string safety (no single-quotes, backslashes, line terminators, or control chars) are encoded in the `pattern` constraints because the emitter interpolates these values directly into emitted TS source as identifiers and single-quoted string literals (#87).',
+    'TBox JSON Schema for an ABox file describing the universal seed bindings every emitted scenario must populate before its request plan runs (e.g. a single-tenant `tenantIdVar` default). Each entry asserts: a context binding name, the request-body / multipart field name it maps to, the seed-rules.json key invoked at runtime, and (optionally) `omitWhenUnbound: true` to instruct the materializer to skip the universal-seed prologue and let the field be omitted on the wire when no per-scenario step seeds it. The schema is intentionally agnostic to which API ships the seeds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/global-context-seeds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Identifier safety (binding/fieldName/seedRule must match /^[A-Za-z_$][A-Za-z0-9_$]*$/) is encoded in the `pattern` constraints because the emitter interpolates these values directly into emitted TS source as identifiers and single-quoted string literals (#87).',
   type: 'object',
   additionalProperties: false,
   required: ['version', 'seeds'],
@@ -102,19 +102,10 @@ export const globalContextSeedsSchema = {
           description:
             'Key passed to seedBinding() at runtime; must match a rule in seed-rules.json. Constrained to a JS identifier so the emitter renders it as a safe single-quoted string literal.',
         },
-        defaultSentinel: {
-          type: 'string',
-          // Forbid single-quote, backslash, line terminators, and C0
-          // control chars — anything that could break the emitted
-          // single-quoted string literal or smuggle script.
-          pattern: "^[^'\\\\\\u0000-\\u001f\\u007f]*$",
-          description:
-            'Magic value that, when present in ctx[<binding>], triggers field-stripping in multipart bodies. Constrained so the emitted single-quoted string literal cannot break out of its quotes or carry control characters.',
-        },
-        stripFromMultipartWhenDefault: {
+        omitWhenUnbound: {
           type: 'boolean',
           description:
-            'If true, the emitter inserts a multipart-loop branch that drops `fieldName` when ctx[<binding>] equals `defaultSentinel`. Requires `defaultSentinel` to be present (checked by the loader).',
+            'If true, the materializer skips the universal-seed prologue for this entry — the binding is seeded only when a per-scenario step produces or consumes it (via `scenario.seedBindings`). For scenarios that do not seed it, the binding stays `undefined` and the request field is omitted on the wire (#342). Replaces the legacy `defaultSentinel`/`stripFromMultipartWhenDefault` mechanism, which sent a literal sentinel value on the wire and broke re-runnability for producer ops like `createTenant`.',
         },
         rationale: {
           type: 'string',

--- a/path-analyser/src/ontology/globalContextSeedsSchema.ts
+++ b/path-analyser/src/ontology/globalContextSeedsSchema.ts
@@ -19,8 +19,7 @@
 // `tenantIdVar` binding). Each entry drives the per-scenario seed
 // prologue in the Playwright emitter:
 //
-//   - if (ctx['<binding>'] === undefined) { ctx['<binding>'] =
-//       seedBinding('<seedRule>'); }
+//   - ctx['<binding>'] = ctx['<binding>'] ?? seedBinding('<seedRule>');
 //
 // or — when `omitWhenUnbound` is `true` (#342) — the prologue is
 // skipped entirely so the binding is seeded only when the planner-

--- a/path-analyser/src/ontology/globalContextSeedsSchema.ts
+++ b/path-analyser/src/ontology/globalContextSeedsSchema.ts
@@ -104,7 +104,7 @@ export const globalContextSeedsSchema = {
         omitWhenUnbound: {
           type: 'boolean',
           description:
-            'If true, the materializer skips the universal-seed prologue for this entry — the binding is seeded only when a per-scenario step produces or consumes it (via `scenario.seedBindings`). For scenarios that do not seed it, the binding stays `undefined` and the request field is omitted on the wire (#342). Replaces the legacy `defaultSentinel`/`stripFromMultipartWhenDefault` mechanism, which sent a literal sentinel value on the wire and broke re-runnability for producer ops like `createTenant`.',
+            "If true, the materializer skips the universal-seed prologue for this entry AND skips it in the per-scenario `seedBindings` loop for consumer-only scenarios. The binding is seeded only when the scenario must mint a fresh value to send (currently: ops that declare HTTP 409, via the emitter's `uniqueBindings` set — see #320). When left unseeded, the binding stays `undefined` and the request field is omitted on the wire so the server applies its own default (#342). Replaces the legacy `defaultSentinel`/`stripFromMultipartWhenDefault` mechanism, which sent a literal sentinel value on the wire and broke re-runnability for producer ops like `createTenant`.",
         },
         rationale: {
           type: 'string',

--- a/path-analyser/src/ontology/loader.ts
+++ b/path-analyser/src/ontology/loader.ts
@@ -812,10 +812,8 @@ export function deriveSemanticsViews(repoRoot: string): SemanticsViews | null {
  *   the Playwright emitter prologue + `loadGlobalContextSeeds` in
  *   `codegen/index.ts` treat it as the empty list. There is no longer
  *   a legacy-sidecar fallback (Lift 8 retired it).
- * @throws if the file exists but does not validate against the TBox,
- *   if it contains duplicate `binding` or `fieldName` values, or if a
- *   cross-property invariant is violated (`stripFromMultipartWhenDefault`
- *   without `defaultSentinel`).
+ * @throws if the file exists but does not validate against the TBox
+ *   or if it contains duplicate `binding` or `fieldName` values.
  */
 export function loadGlobalContextSeedsAbox(repoRoot: string): GlobalContextSeedsAbox | null {
   let aboxPath: string;
@@ -862,16 +860,10 @@ export function loadGlobalContextSeedsAbox(repoRoot: string): GlobalContextSeeds
       `Global-context-seeds ABox at ${aboxPath} has duplicate fieldName(s): ${dupeFields.join(', ')}`,
     );
   }
-  // Cross-property invariant: stripFromMultipartWhenDefault === true
-  // requires a defaultSentinel to compare against. Mirrors the
-  // legacy `checkGlobalContextSeedsCoherent` rule.
-  for (const s of parsed.seeds) {
-    if (s.stripFromMultipartWhenDefault === true && s.defaultSentinel === undefined) {
-      throw new Error(
-        `Global-context-seeds ABox at ${aboxPath} entry for binding '${s.binding}' sets stripFromMultipartWhenDefault but has no defaultSentinel — the multipart-strip branch has no value to compare against`,
-      );
-    }
-  }
+  // (#342) The legacy `stripFromMultipartWhenDefault` / `defaultSentinel`
+  // cross-property invariant was retired with the omit-when-unbound
+  // redesign — there is no per-entry coherence check left to perform
+  // here; uniqueness above is the only post-TBox invariant.
   return parsed;
 }
 
@@ -889,8 +881,7 @@ export interface GlobalContextSeedsViews {
     binding: string;
     fieldName: string;
     seedRule: string;
-    defaultSentinel?: string;
-    stripFromMultipartWhenDefault?: boolean;
+    omitWhenUnbound?: boolean;
     rationale?: string;
   }>;
 }
@@ -904,10 +895,7 @@ export function deriveGlobalContextSeedsViews(repoRoot: string): GlobalContextSe
       fieldName: s.fieldName,
       seedRule: s.seedRule,
     };
-    if (s.defaultSentinel !== undefined) entry.defaultSentinel = s.defaultSentinel;
-    if (s.stripFromMultipartWhenDefault !== undefined) {
-      entry.stripFromMultipartWhenDefault = s.stripFromMultipartWhenDefault;
-    }
+    if (s.omitWhenUnbound !== undefined) entry.omitWhenUnbound = s.omitWhenUnbound;
     if (s.rationale !== undefined) entry.rationale = s.rationale;
     return entry;
   });
@@ -920,17 +908,18 @@ export function deriveGlobalContextSeedsViews(repoRoot: string): GlobalContextSe
  * (`renderPlaywrightSuite`, `emitPlaywrightSuite`, `PlaywrightEmitter.emit`).
  *
  * The emitter interpolates `binding`, `fieldName`, `seedRule`, and
- * `defaultSentinel` directly into emitted TS source as identifiers and
- * single-quoted string literals (#87). The graph loader validates the
+ * The emitter interpolates `binding`, `fieldName`, and `seedRule`
+ * directly into emitted TS source as identifiers and single-quoted
+ * string literals (#87). The graph loader validates the
  * seeds when reading `global-context-seeds.json`, but the emitter
  * accepts a `globalContextSeeds` argument from any caller. This helper
  * re-validates at that boundary so a programmatic caller cannot bypass
  * the loader's safety net and produce broken or injection-vulnerable
  * generated suites.
  *
- * Throws on any structural issue (TBox shape) or any cross-seed
- * coherence violation (uniqueness, strip-requires-sentinel). Returns
- * silently on success.
+ * Throws on any structural issue (TBox shape) or on a uniqueness
+ * violation (duplicate `binding` or `fieldName`). Returns silently on
+ * success.
  */
 export function assertSafeGlobalContextSeeds(seeds: unknown): void {
   if (!Array.isArray(seeds)) {
@@ -955,13 +944,6 @@ export function assertSafeGlobalContextSeeds(seeds: unknown): void {
     throw new Error(
       `globalContextSeeds failed coherence validation:\n  - duplicate fieldName(s): ${dupeFields.join(', ')}`,
     );
-  }
-  for (const s of wrapper.seeds) {
-    if (s.stripFromMultipartWhenDefault === true && s.defaultSentinel === undefined) {
-      throw new Error(
-        `globalContextSeeds failed coherence validation:\n  - entry for binding '${s.binding}' sets stripFromMultipartWhenDefault but has no defaultSentinel`,
-      );
-    }
   }
 }
 

--- a/path-analyser/src/ontology/loader.ts
+++ b/path-analyser/src/ontology/loader.ts
@@ -907,7 +907,6 @@ export function deriveGlobalContextSeedsViews(repoRoot: string): GlobalContextSe
  * accepted by the public Playwright emitter entry points
  * (`renderPlaywrightSuite`, `emitPlaywrightSuite`, `PlaywrightEmitter.emit`).
  *
- * The emitter interpolates `binding`, `fieldName`, `seedRule`, and
  * The emitter interpolates `binding`, `fieldName`, and `seedRule`
  * directly into emitted TS source as identifiers and single-quoted
  * string literals (#87). The graph loader validates the

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -556,12 +556,15 @@ export interface DomainSemantics {
  * seedBinding('<seedRule>');` line in the universal-seed prologue.
  *
  * When {@link omitWhenUnbound} is `true`, the universal prologue does
- * NOT auto-seed the binding. Instead, the binding is seeded only when
- * the planner-driven `seedBindings` list names it (i.e. a step in the
- * scenario actively produces / consumes the value). For scenarios
- * that don't seed it, the binding stays `undefined` and the request
- * field is omitted on the wire — the server applies its own default
- * (e.g. the Camunda REST Gateway treats a missing `tenantId` as the
+ * NOT auto-seed the binding. The materializer additionally skips it
+ * in the per-scenario `seedBindings` loop unless the scenario marks
+ * the binding as needing a fresh value (currently signalled by
+ * membership in the emitter's `uniqueBindings` set — populated for
+ * ops that declare HTTP 409, see #320). In other words: producer
+ * scenarios that must mint a value still seed; consumer-only
+ * scenarios leave the binding `undefined` so the request field is
+ * omitted on the wire and the server applies its own default (e.g.
+ * the Camunda REST Gateway treats a missing `tenantId` as the
  * default tenant). This replaces the legacy
  * `defaultSentinel`/`stripFromMultipartWhenDefault` mechanism (#342),
  * which sent a literal sentinel value (`<default>`) on the wire and
@@ -578,9 +581,13 @@ export interface GlobalContextSeed {
   seedRule: string;
   /**
    * If true, the materializer skips the universal-seed prologue for
-   * this entry — the binding is seeded only when a per-scenario step
-   * produces or consumes it. When unbound, the request field is
-   * omitted on the wire and the server applies its own default.
+   * this entry AND skips it in the per-scenario `seedBindings` loop
+   * for consumer-only scenarios. The binding is seeded only when the
+   * scenario must mint a fresh value to send (currently: ops that
+   * declare HTTP 409, via the emitter's `uniqueBindings` set —
+   * see #320). When left unseeded, the binding stays `undefined` and
+   * the request field is omitted on the wire so the server applies
+   * its own default (#342).
    */
   omitWhenUnbound?: boolean;
   /** Free-form documentation for maintainers. */

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -551,11 +551,23 @@ export interface DomainSemantics {
 
 /**
  * One entry in {@link DomainSemantics.globalContextSeeds}. Drives the
- * Playwright emitter's per-scenario seed prologue: for every entry the
- * emitter writes an `if (ctx['<binding>'] === undefined) { ctx['<binding>'] =
- * seedBinding('<seedRule>'); }` guard and, when {@link defaultSentinel} +
- * {@link stripFromMultipartWhenDefault} are present, a multipart-loop branch
- * that drops {@link fieldName} when the binding equals the sentinel.
+ * Playwright emitter's per-scenario seed prologue: for non-omitting
+ * entries the emitter writes a `ctx['<binding>'] = ctx['<binding>'] ??
+ * seedBinding('<seedRule>');` line in the universal-seed prologue.
+ *
+ * When {@link omitWhenUnbound} is `true`, the universal prologue does
+ * NOT auto-seed the binding. Instead, the binding is seeded only when
+ * the planner-driven `seedBindings` list names it (i.e. a step in the
+ * scenario actively produces / consumes the value). For scenarios
+ * that don't seed it, the binding stays `undefined` and the request
+ * field is omitted on the wire — the server applies its own default
+ * (e.g. the Camunda REST Gateway treats a missing `tenantId` as the
+ * default tenant). This replaces the legacy
+ * `defaultSentinel`/`stripFromMultipartWhenDefault` mechanism (#342),
+ * which sent a literal sentinel value (`<default>`) on the wire and
+ * relied on a runtime strip branch — that approach broke
+ * re-runnability because the producer step (e.g. `createTenant`)
+ * sent the same `<default>` value on every run and 409-ed.
  */
 export interface GlobalContextSeed {
   /** ctx[<binding>] key the seed populates. */
@@ -564,10 +576,13 @@ export interface GlobalContextSeed {
   fieldName: string;
   /** Key passed to seedBinding() at runtime; must match a rule in seed-rules.json. */
   seedRule: string;
-  /** Magic value that, when present in ctx[<binding>], triggers field-stripping in multipart bodies. */
-  defaultSentinel?: string;
-  /** If true, the emitter inserts a multipart-loop branch that drops {@link fieldName} when ctx[<binding>] equals {@link defaultSentinel}. */
-  stripFromMultipartWhenDefault?: boolean;
+  /**
+   * If true, the materializer skips the universal-seed prologue for
+   * this entry — the binding is seeded only when a per-scenario step
+   * produces or consumes it. When unbound, the request field is
+   * omitted on the wire and the server applies its own default.
+   */
+  omitWhenUnbound?: boolean;
   /** Free-form documentation for maintainers. */
   rationale?: string;
 }

--- a/tests/codegen/emit-ctx-seeding.test.ts
+++ b/tests/codegen/emit-ctx-seeding.test.ts
@@ -169,3 +169,78 @@ describe('emitCtxSeeding: unique-binding override of literal (#320)', () => {
     expect(seedLineCount).toBe(1);
   });
 });
+
+describe('emitCtxSeeding: omitWhenUnbound bindings (#342)', () => {
+  // `omitWhenUnbound` is the post-#342 replacement for the legacy
+  // `<default>` sentinel + multipart-strip mechanism. The contract is:
+  //
+  //   - Universal-seed prologue: skip (already guarded by an earlier
+  //     test in this file).
+  //   - Per-scenario `seedBindings` loop: skip UNLESS the binding is
+  //     also in `uniqueBindings`. The unique-set is the producer
+  //     signal — any op declaring HTTP 409 on the binding is treated
+  //     as a producer that mints a fresh value (#320), and producers
+  //     genuinely need a seed to send in the request body. Pure
+  //     consumers (e.g. `createDeployment`, `createProcessInstance`)
+  //     must leave `ctx[binding]` undefined so the multipart/JSON
+  //     emitter drops the field on the wire and the broker applies
+  //     its default tenant.
+  //
+  // Without this guard the catch-all seed-rule mints a random tenant
+  // id (`tenantIdVar-abc123`) that the broker legitimately rejects
+  // as unknown — the live-broker regression that surfaced 26 failing
+  // Playwright tests on PR #343.
+
+  const tenantSeed = {
+    binding: 'tenantIdVar',
+    seedRule: 'tenantIdVar',
+    omitWhenUnbound: true,
+  } as const;
+
+  it('skips per-scenario seed for an omitWhenUnbound binding when it is NOT in uniqueBindings (consumer case)', () => {
+    const lines = emitCtxSeeding({
+      indent: '    ',
+      bindings: undefined,
+      seedBindings: ['tenantIdVar'],
+      globalContextSeeds: [tenantSeed],
+      uniqueBindings: new Set(),
+    });
+    const joined = lines.join('\n');
+    expect(joined).not.toContain("seedBinding('tenantIdVar'");
+    expect(joined).not.toContain("ctx['tenantIdVar']");
+  });
+
+  it('emits per-scenario seed for an omitWhenUnbound binding when it IS in uniqueBindings (producer case)', () => {
+    const lines = emitCtxSeeding({
+      indent: '    ',
+      bindings: undefined,
+      seedBindings: ['tenantIdVar'],
+      globalContextSeeds: [tenantSeed],
+      uniqueBindings: new Set(['tenantIdVar']),
+    });
+    const joined = lines.join('\n');
+    expect(joined).toContain(
+      `ctx['tenantIdVar'] = ctx['tenantIdVar'] ?? seedBinding('tenantIdVar', { unique: true });`,
+    );
+  });
+
+  it('class-scoped: skips per-scenario seed for ANY omitWhenUnbound binding listed in seedBindings (consumer case)', () => {
+    // Generalised guard — the same pattern must hold for any future
+    // binding flagged with omitWhenUnbound (not just tenantIdVar).
+    const lines = emitCtxSeeding({
+      indent: '    ',
+      bindings: undefined,
+      seedBindings: ['fooVar', 'barVar', 'bazVar'],
+      globalContextSeeds: [
+        { binding: 'fooVar', seedRule: 'fooVar', omitWhenUnbound: true },
+        { binding: 'barVar', seedRule: 'barVar', omitWhenUnbound: true },
+        { binding: 'bazVar', seedRule: 'bazVar' /* not omitWhenUnbound */ },
+      ],
+      uniqueBindings: new Set(),
+    });
+    const joined = lines.join('\n');
+    expect(joined).not.toContain("ctx['fooVar']");
+    expect(joined).not.toContain("ctx['barVar']");
+    expect(joined).toContain(`ctx['bazVar'] = ctx['bazVar'] ?? seedBinding('bazVar');`);
+  });
+});

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -15,8 +15,8 @@ import { buildRoleDispatch } from './_helpers/roleDispatch.ts';
 // the semantics ABox so the assertions track production
 // configuration shape.
 // The prologue-driven tests below use the plain seed shape; the
-// `omitWhenUnbound` variant (#342) is exercised separately in the
-// dedicated `omit-when-unbound` describe block.
+// omit-when-unbound behavior (#342) is exercised in emitCtxSeeding tests
+// (tests/codegen/emit-ctx-seeding.test.ts) and via the boundary-safety checks below.
 const TENANT_SEED: GlobalContextSeed = {
   binding: 'tenantIdVar',
   fieldName: 'tenantId',

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -504,7 +504,7 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
     expect(c).toContain(`ctx['orgIdVar'] = ctx['orgIdVar'] ?? seedBinding('orgIdVar');`);
     // Post-#342 the sentinel locals and multipart-strip branches are
     // gone — the multipart loop now omits undefined / null values
-    // naturally (see the omit-when-unbound describe block below).
+    // naturally.
     expect(c).not.toMatch(/IsDefault/);
     expect(c).not.toMatch(/&& __\w+IsDefault\) continue;/);
   });

--- a/tests/codegen/playwright-emitter.test.ts
+++ b/tests/codegen/playwright-emitter.test.ts
@@ -14,12 +14,20 @@ import { buildRoleDispatch } from './_helpers/roleDispatch.ts';
 // behaviour from this fixture, mirroring the entry shipped in
 // the semantics ABox so the assertions track production
 // configuration shape.
+// The prologue-driven tests below use the plain seed shape; the
+// `omitWhenUnbound` variant (#342) is exercised separately in the
+// dedicated `omit-when-unbound` describe block.
 const TENANT_SEED: GlobalContextSeed = {
   binding: 'tenantIdVar',
   fieldName: 'tenantId',
   seedRule: 'tenantIdVar',
-  defaultSentinel: '<default>',
-  stripFromMultipartWhenDefault: true,
+};
+
+const TENANT_SEED_OMIT: GlobalContextSeed = {
+  binding: 'tenantIdVar',
+  fieldName: 'tenantId',
+  seedRule: 'tenantIdVar',
+  omitWhenUnbound: true,
 };
 
 const COLLECTION: EndpointScenarioCollection = {
@@ -475,13 +483,11 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
     };
   }
 
-  test('a second globalContextSeeds entry produces parallel seed + strip code', async () => {
+  test('a second globalContextSeeds entry produces parallel seed code', async () => {
     const orgSeed: GlobalContextSeed = {
       binding: 'orgIdVar',
       fieldName: 'orgId',
       seedRule: 'orgIdVar',
-      defaultSentinel: '<root>',
-      stripFromMultipartWhenDefault: true,
     };
     const [file] = await PlaywrightEmitter.emit(buildCollectionWithMultipart(), {
       outDir: '/unused',
@@ -496,12 +502,11 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
     // Both seeds emit an idempotent ?? assignment in the universal-seed prologue (#86).
     expect(c).toContain(`ctx['tenantIdVar'] = ctx['tenantIdVar'] ?? seedBinding('tenantIdVar');`);
     expect(c).toContain(`ctx['orgIdVar'] = ctx['orgIdVar'] ?? seedBinding('orgIdVar');`);
-    // Both seeds declare a sentinel local named after the field.
-    expect(c).toContain(`const __tenantIdIsDefault = ctx['tenantIdVar'] === '<default>';`);
-    expect(c).toContain(`const __orgIdIsDefault = ctx['orgIdVar'] === '<root>';`);
-    // Both seeds insert a parallel multipart-strip branch.
-    expect(c).toContain(`if (k === 'tenantId' && __tenantIdIsDefault) continue;`);
-    expect(c).toContain(`if (k === 'orgId' && __orgIdIsDefault) continue;`);
+    // Post-#342 the sentinel locals and multipart-strip branches are
+    // gone — the multipart loop now omits undefined / null values
+    // naturally (see the omit-when-unbound describe block below).
+    expect(c).not.toMatch(/IsDefault/);
+    expect(c).not.toMatch(/&& __\w+IsDefault\) continue;/);
   });
 
   test('without seeds the emitter writes no universal-seed prologue and no multipart strip branch', async () => {
@@ -520,33 +525,12 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
     expect(c).not.toMatch(/&& __\w+IsDefault\) continue;/);
   });
 
-  test('seed without stripFromMultipartWhenDefault emits the guard but no strip branch', async () => {
-    const seedOnly: GlobalContextSeed = {
-      binding: 'tenantIdVar',
-      fieldName: 'tenantId',
-      seedRule: 'tenantIdVar',
-    };
-    const [file] = await PlaywrightEmitter.emit(buildCollectionWithMultipart(), {
-      outDir: '/unused',
-      configName: 'test',
-      emitterConfig: {},
-      resolveConfigPath: (rel) => rel,
-      suiteName: 'createWidget',
-      mode: 'feature',
-      globalContextSeeds: [seedOnly],
-    });
-    const c = file.content;
-    expect(c).toContain(`ctx['tenantIdVar'] = ctx['tenantIdVar'] ?? seedBinding('tenantIdVar');`);
-    expect(c).not.toMatch(/__tenantIdIsDefault/);
-    expect(c).not.toMatch(/&& __\w+IsDefault\) continue;/);
-  });
-
-  test('deploy-only scenario: sentinel local not emitted (deploy() receives strips, local is unused)', async () => {
+  test('deploy-only scenario: deploy() helper no longer receives a strips arg (#342)', async () => {
     // Regression guard: when a scenario's only multipart step is a 200 createDeployment
     // step (routed through deploy()), the sentinel __<fieldName>IsDefault local must NOT
-    // be emitted. deploy() receives strips as a JSON literal argument; it never reads the
-    // prologue local. Emitting it produces an unused-variable Biome error in the generated
-    // suite.
+    // be emitted. Post-#342 the deploy() helper no longer has a `strips` parameter, so
+    // there is also no `strips` JSON literal argument at the call site — a missing field
+    // is simply omitted on the wire by deploy()'s `v !== undefined && v !== null` filter.
     const deployOnlyCollection: EndpointScenarioCollection = {
       endpoint: { operationId: 'createDeployment', method: 'POST', path: '/deployments' },
       requiredSemanticTypes: [],
@@ -587,9 +571,12 @@ describe('emitter: globalContextSeeds is the only source of universal-seed knowl
     const c = file.content;
     // Seed assignment still emitted (always needed)
     expect(c).toContain(`ctx['tenantIdVar'] = ctx['tenantIdVar'] ?? seedBinding('tenantIdVar');`);
-    // Sentinel local must NOT be emitted — no inline multipart step uses it
+    // Sentinel local must NOT be emitted (#342 removed the strip branch entirely)
     expect(c).not.toMatch(/__tenantIdIsDefault/);
     expect(c).not.toMatch(/&& __\w+IsDefault\) continue;/);
+    // deploy() must be called without a strips argument
+    expect(c).toMatch(/await deploy\(ctx, request, [^)]*, baseUrl \+ [^)]*\);/);
+    expect(c).not.toMatch(/await deploy\([^)]*,\s*\[/);
   });
 
   test('deploy step: no inline extractInto block emitted outside deploy() (no duplicate extraction)', async () => {
@@ -700,28 +687,12 @@ describe('emitter: boundary safety re-validation (#87 review)', () => {
     ).toThrow(/globalContextSeedFieldNameUnique|duplicate fieldName/);
   });
 
-  test('rejects unsafe sentinel (newline) via renderPlaywrightSuite', () => {
-    const badSeed: GlobalContextSeed = {
-      binding: 'tenantIdVar',
-      fieldName: 'tenantId',
-      seedRule: 'tenantIdVar',
-      defaultSentinel: 'line1\nline2',
-    };
-    expect(() =>
-      renderPlaywrightSuite(COLLECTION, {
-        suiteName: 'createWidget',
-        mode: 'feature',
-        globalContextSeeds: [badSeed],
-      }),
-    ).toThrow(/globalContextSeedSentinelSafe|line terminator|control char|must match pattern/);
-  });
-
   test('accepts the production tenant seed shape', () => {
     expect(() =>
       renderPlaywrightSuite(COLLECTION, {
         suiteName: 'createWidget',
         mode: 'feature',
-        globalContextSeeds: [TENANT_SEED],
+        globalContextSeeds: [TENANT_SEED_OMIT],
       }),
     ).not.toThrow();
   });


### PR DESCRIPTION
## Summary

Replace the `<default>` tenantId sentinel mechanism with an `omitWhenUnbound` contract on `globalContextSeeds` entries. When the binding is unbound, the field is omitted on the wire — the REST Gateway supplies the cluster default — instead of being seeded to a literal `<default>` value.

This fixes the re-runnability defect where producer operations like `createTenant` would 409 ALREADY_EXISTS on the second run because every run replayed `tenantId: '<default>'`.

Closes #342. Supersedes the sentinel-based half-fixes in #87 / #200.

## Behaviour change

- Producer ops (`createTenant`, etc.) now mint a fresh tenantId via the catch-all id seed rule per run.
- Consumer ops omit `tenantId` on the wire when no per-scenario step seeds the binding.
- The legacy `defaultSentinel` / `stripFromMultipartWhenDefault` properties are removed from the globalContextSeeds TBox.

## Class-scoped regression guards

Three new Layer-3 invariants in `configs/camunda-oca/regression-invariants.test.ts`:

1. **No `<default>` on the wire** — scans regenerated scenario JSON for the literal string; fails if any survives.
2. **`omitWhenUnbound` filter is wired at the source** — asserts `materializer/src/playwright/ctxSeeding.ts` references `omitWhenUnbound` in both the `globalSeedNames` filter and the universal-prologue skip statement (the emitted suite line shape is indistinguishable between the prologue and the per-scenario `seedBindings` loop, so the source is the only reliable signal).
3. **JSON Schema rename is published** — asserts `omitWhenUnbound` is declared and the legacy sentinel properties are not.

Plus a full rewrite of `tests/codegen/playwright-emitter.test.ts` fixtures (drop sentinel shapes, add `omitWhenUnbound` shapes, delete sentinel-only tests, assert the new `deploy()` signature without `strips`).

## Pre-push validation

- `npm run lint` — clean
- per-workspace `tsc --noEmit` — clean (path-analyser, emitter-sdk, materializer, request-validation, tests)
- `TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation` — regenerated
- `npm test` — 644 passed, 4 skipped, 0 failed
