### PR TITLE
fix: pass polarity-aware predicate to awaitEventually for observe-membership steps

### DIFF
--- a/materializer/src/playwright/stepRenderer.ts
+++ b/materializer/src/playwright/stepRenderer.ts
@@ -109,6 +109,23 @@ export interface InlineStepRenderInput {
   method: string;
   /** Whether this step should be wrapped with `awaitEventually(...)`. */
   shouldAwaitEventually?: boolean;
+  /**
+   * Optional JS expression for the `predicate:` option of the
+   * `awaitEventually(...)` call. Must evaluate to a `(body: unknown)
+   * => boolean | Promise<boolean>` function. Only spliced in when
+   * {@link shouldAwaitEventually} is also true; ignored otherwise.
+   *
+   * Used by the EdgeLifecycle observe-membership step to drive
+   * polling toward the polarity of the membership assertion (present
+   * vs absent) instead of relying on the runtime's default
+   * `items.length > 0` heuristic, which is wrong for the absent case
+   * (an empty page is the success terminator, not a transient retry).
+   *
+   * The expression is interpolated verbatim into the emitted source —
+   * callers are responsible for producing a self-contained expression
+   * with balanced braces and any required type narrowing.
+   */
+  awaitEventuallyPredicate?: string;
 }
 
 /**
@@ -129,6 +146,7 @@ export function renderInlineStepLines({
   urlExpr,
   method,
   shouldAwaitEventually,
+  awaitEventuallyPredicate,
 }: InlineStepRenderInput): string[] {
   const lines: string[] = [];
   const bodyVar = `body${idx + 1}`;
@@ -171,9 +189,17 @@ export function renderInlineStepLines({
   if (shouldAwaitEventually) {
     lines.push(`    const ${varName} = await awaitEventually(`);
     lines.push(`      async () => request.${method}(url, { ${opts.join(', ')} }),`);
-    lines.push(
-      `      { method: '${step.method.toUpperCase()}', operationId: '${step.operationId}' },`,
-    );
+    if (awaitEventuallyPredicate) {
+      lines.push(`      {`);
+      lines.push(`        method: '${step.method.toUpperCase()}',`);
+      lines.push(`        operationId: '${step.operationId}',`);
+      lines.push(`        predicate: ${awaitEventuallyPredicate},`);
+      lines.push(`      },`);
+    } else {
+      lines.push(
+        `      { method: '${step.method.toUpperCase()}', operationId: '${step.operationId}' },`,
+      );
+    }
     lines.push(`    );`);
   } else {
     lines.push(`    const ${varName} = await request.${method}(url, { ${opts.join(', ')} });`);

--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -490,6 +490,31 @@ function appendObserveMembershipStep(
   const respVar = `resp${idx + 1}`;
   const urlExpr = buildUrlExpression(step.requestPlan.pathTemplate);
   const method = step.requestPlan.method.toLowerCase();
+  // Resolve binding name + access chains early so we can build the
+  // awaitEventually predicate (passed into `renderInlineStepLines`)
+  // and the post-call membership assertion from the same data. Both
+  // must agree on polarity and target binding \u2014 see #342 follow-up:
+  // without the predicate, the default `items.length > 0` heuristic
+  // drives polling and the absent case times out on a legitimately
+  // empty page (e.g. searchUsersForTenant after the only membership
+  // was unassigned).
+  const bindingName = resolveBindingNameForSemantic(
+    step.assertion.membershipSemanticType,
+    scenarioBindings,
+  );
+  const elementSegments = step.assertion.elementField.split('.').filter((s) => s.length > 0);
+  if (elementSegments.length === 0) {
+    throw new Error(`Empty elementField on observe assertion for operationId=${step.operationId}.`);
+  }
+  const shouldWrap = stepNeedsAwaitForOp(step.requestPlan, ecOps);
+  const predicateExpr = shouldWrap
+    ? buildMembershipPredicateExpr({
+        arrayPath: step.assertion.arrayPath,
+        elementSegments,
+        bindingName,
+        expect: step.assertion.expect,
+      })
+    : undefined;
   lines.push(`    await test.step('${escapeQuotes(label)}', async () => {`);
   const inline = renderInlineStepLines({
     step: step.requestPlan,
@@ -497,7 +522,8 @@ function appendObserveMembershipStep(
     varName: respVar,
     urlExpr,
     method,
-    shouldAwaitEventually: stepNeedsAwaitForOp(step.requestPlan, ecOps),
+    shouldAwaitEventually: shouldWrap,
+    awaitEventuallyPredicate: predicateExpr,
   });
   for (const line of reindent(inline, EXTRA_INDENT)) lines.push(line);
   // Membership assertion (template-unique). Walks the planner-declared
@@ -508,7 +534,7 @@ function appendObserveMembershipStep(
   const accessChain = buildOptionalAccessChain('__body', step.assertion.arrayPath);
   lines.push(`      const __raw = ${accessChain};`);
   // Fail loudly when the planner-declared arrayPath does not resolve to
-  // an array — the previous silent `Array.isArray(__raw) ? __raw : []`
+  // an array \u2014 the previous silent `Array.isArray(__raw) ? __raw : []`
   // fallback would let an absent-observe assertion pass against a
   // malformed response (e.g. server returned 200 with an unexpected
   // shape), masking real defects. (#274 review.)
@@ -518,16 +544,8 @@ function appendObserveMembershipStep(
   );
   lines.push('      }');
   lines.push('      const __arr: unknown[] = __raw;');
-  const elementSegments = step.assertion.elementField.split('.').filter((s) => s.length > 0);
-  if (elementSegments.length === 0) {
-    throw new Error(`Empty elementField on observe assertion for operationId=${step.operationId}.`);
-  }
   const elementAccess = buildOptionalAccessChain('r', elementSegments);
   lines.push(`      const __values = __arr.map((r) => ${elementAccess});`);
-  const bindingName = resolveBindingNameForSemantic(
-    step.assertion.membershipSemanticType,
-    scenarioBindings,
-  );
   const verb = step.assertion.expect === 'present' ? 'toContain' : 'not.toContain';
   lines.push(`      expect(__values).${verb}(ctx['${bindingName}']);`);
   // Note: the shared `renderInlineStepLines` does not emit extracts —
@@ -607,6 +625,60 @@ function buildOptionalAccessChain(rootExpr: string, segments: readonly string[])
     acc = `(${acc} as Record<string, unknown> | null | undefined)?.['${seg}']`;
   }
   return acc;
+}
+
+/**
+ * Build a self-contained JS expression for the `predicate:` option of
+ * the `awaitEventually(...)` call wrapping an observe-membership step
+ * (#342 follow-up). The predicate mirrors the post-call membership
+ * assertion so eventual-consistency polling converges to the SAME
+ * observable state the assertion checks for \u2014 not the runtime default
+ * (`items.length > 0`), which is wrong for both polarities:
+ *
+ *   - `expect: 'present'` \u2014 default returns `true` as soon as any item
+ *     surfaces, even if the specific binding value the test cares
+ *     about hasn't propagated yet.
+ *   - `expect: 'absent'`  \u2014 default keeps polling on an empty page,
+ *     so a tenant whose only membership was just revoked times out
+ *     even though the absent assertion would pass immediately.
+ *
+ * The returned expression is an arrow function literal `(body) => { ... }`
+ * that closes over the surrounding scope's `ctx` record (always in
+ * scope inside the emitted `test.step` callback). It narrows
+ * `body: unknown` defensively and returns `false` for any malformed
+ * shape (non-object body, missing array path, non-array value), which
+ * mirrors the assertion's own \u201cthrow on shape mismatch\u201d behaviour
+ * \u2014 the predicate will keep polling until either the shape becomes
+ * correct (and polarity matches) or the budget runs out.
+ */
+function buildMembershipPredicateExpr(opts: {
+  arrayPath: readonly string[];
+  elementSegments: readonly string[];
+  bindingName: string;
+  expect: 'present' | 'absent';
+}): string {
+  const { arrayPath, elementSegments, bindingName, expect } = opts;
+  // Identifier-safety: `bindingName` comes from `resolveBindingNameForSemantic`,
+  // which already enforces an identifier-shape, but we double-check
+  // here because the value is interpolated into a single-quoted JS
+  // string literal in the emitted source.
+  if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(bindingName)) {
+    throw new Error(
+      `buildMembershipPredicateExpr: bindingName '${bindingName}' is not a valid JS identifier.`,
+    );
+  }
+  const arrayAccess = buildOptionalAccessChain('body', arrayPath);
+  const elementAccess = buildOptionalAccessChain('r', elementSegments);
+  const negation = expect === 'absent' ? '!' : '';
+  return [
+    '(body) => {',
+    "        if (body === null || typeof body !== 'object') return false;",
+    `        const __raw = ${arrayAccess};`,
+    '        if (!Array.isArray(__raw)) return false;',
+    `        const __values = __raw.map((r) => ${elementAccess});`,
+    `        return ${negation}__values.includes(ctx['${bindingName}']);`,
+    '      }',
+  ].join('\n');
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/codegen/observe-membership-predicate.test.ts
+++ b/tests/codegen/observe-membership-predicate.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Unit tests for the EdgeLifecycle observe-membership step's
+ * `awaitEventually` predicate.
+ *
+ * # Defect class pinned here
+ *
+ * For an EC observe-membership step, the emitter wraps the search call
+ * in `awaitEventually(...)` but does NOT pass a custom `predicate:`.
+ * The runtime then falls back to the default predicate for POST /search
+ * (`isNonEmptyItemsPage` — `items.length > 0`). That default is wrong
+ * for BOTH directions of the membership assertion:
+ *
+ *   - `expect: 'present'` — the default treats any non-empty page as
+ *     "consistent", regardless of whether the target binding value is
+ *     actually in the page. The membership assertion that runs after
+ *     can fail intermittently when the indexer has surfaced *some*
+ *     items but not yet the one the test cares about.
+ *
+ *   - `expect: 'absent'` — the default keeps polling until the page is
+ *     non-empty. After a `revoke` (e.g. unassignUserFromTenant) the
+ *     tenant may have zero remaining users, so `items` stays `[]` and
+ *     `awaitEventually` exhausts the budget and throws
+ *     `EventualConsistencyTimeoutError` — even though the deletion
+ *     succeeded and the absent assertion would have passed on the very
+ *     first attempt. This is the failure mode observed in PR #343's
+ *     follow-up on TenantUserMembership.lifecycle.spec.ts.
+ *
+ * The fix is for `appendObserveMembershipStep` to emit a polarity-aware
+ * predicate over the parsed body, walking the planner-declared
+ * `arrayPath` → `elementField` chain and asserting (in)membership of
+ * `ctx[<bindingName>]` to match the step's `expect` direction. The
+ * outer membership assertion remains the source of truth; the
+ * predicate's only job is to drive eventual-consistency polling
+ * toward the same observable state.
+ *
+ * # Class scope
+ *
+ * Both tests below run `emitTemplateSuites` against a tiny synthesised
+ * scenario file so they exercise the production emitter end-to-end —
+ * not a unit slice of a render helper. The first asserts the
+ * present-observe predicate; the second asserts the absent-observe
+ * predicate. Both must reference `ctx['usernameVar']` and must encode
+ * the correct polarity. A regression on either branch (predicate
+ * missing, polarity flipped, ctx binding name wrong) fails the
+ * corresponding test.
+ */
+
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { emitTemplateSuites } from '../../materializer/src/playwright/templateEmitter.ts';
+
+const SCENARIO: unknown = {
+  templateName: 'EdgeLifecycle',
+  subjectName: 'TenantUserMembership',
+  subjectKind: 'Edge',
+  scenario: {
+    templateName: 'EdgeLifecycle',
+    subjectName: 'TenantUserMembership',
+    subjectKind: 'Edge',
+    steps: [
+      {
+        kind: 'prereqChain',
+        targetOperationId: 'assignUserToTenant',
+        operations: [],
+        bindings: { tenantIdVar: 'tenant_x', usernameVar: 'user_x' },
+        seedBindings: [],
+        requestPlan: [],
+      },
+      {
+        kind: 'invoke',
+        operationId: 'assignUserToTenant',
+        inputs: { TenantId: 'tenantIdVar', Username: 'usernameVar' },
+        produces: {},
+        requestPlan: {
+          operationId: 'assignUserToTenant',
+          method: 'PUT',
+          pathTemplate: '/tenants/{tenantId}/users/{username}',
+          expect: { status: 204 },
+        },
+      },
+      {
+        kind: 'observe',
+        operationId: 'searchUsersForTenant',
+        inputs: { TenantId: 'tenantIdVar' },
+        requestPlan: {
+          operationId: 'searchUsersForTenant',
+          method: 'POST',
+          pathTemplate: '/tenants/{tenantId}/users/search',
+          expect: { status: 200 },
+          bodyTemplate: {},
+          bodyKind: 'json',
+        },
+        assertion: {
+          kind: 'membership',
+          expect: 'present',
+          arrayPath: ['items'],
+          elementField: 'username',
+          membershipSemanticType: 'Username',
+        },
+      },
+      {
+        kind: 'invoke',
+        operationId: 'unassignUserFromTenant',
+        inputs: { TenantId: 'tenantIdVar', Username: 'usernameVar' },
+        produces: {},
+        requestPlan: {
+          operationId: 'unassignUserFromTenant',
+          method: 'DELETE',
+          pathTemplate: '/tenants/{tenantId}/users/{username}',
+          expect: { status: 204 },
+        },
+      },
+      {
+        kind: 'observe',
+        operationId: 'searchUsersForTenant',
+        inputs: { TenantId: 'tenantIdVar' },
+        requestPlan: {
+          operationId: 'searchUsersForTenant',
+          method: 'POST',
+          pathTemplate: '/tenants/{tenantId}/users/search',
+          expect: { status: 200 },
+          bodyTemplate: {},
+          bodyKind: 'json',
+        },
+        assertion: {
+          kind: 'membership',
+          expect: 'absent',
+          arrayPath: ['items'],
+          elementField: 'username',
+          membershipSemanticType: 'Username',
+        },
+      },
+    ],
+    bindings: { TenantId: 'tenantIdVar', Username: 'usernameVar' },
+    eventuallyConsistentOps: ['searchUsersForTenant'],
+  },
+};
+
+let tempDir: string;
+let suiteSource: string;
+
+beforeAll(async () => {
+  tempDir = await fs.mkdtemp(path.join(tmpdir(), 'observe-membership-pred-'));
+  const scenariosDir = path.join(tempDir, 'scenarios');
+  const outDir = path.join(tempDir, 'out');
+  await fs.mkdir(scenariosDir, { recursive: true });
+  await fs.writeFile(
+    path.join(scenariosDir, 'TenantUserMembership.json'),
+    JSON.stringify(SCENARIO),
+    'utf8',
+  );
+  await emitTemplateSuites({
+    scenariosDir,
+    outDir,
+    globalContextSeeds: [],
+  });
+  suiteSource = await fs.readFile(
+    path.join(outDir, 'TenantUserMembership.lifecycle.spec.ts'),
+    'utf8',
+  );
+});
+
+afterAll(async () => {
+  if (tempDir) await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+/**
+ * Slice the emitted spec into the two observe-step bodies so each
+ * assertion only inspects the section it cares about. The label-based
+ * split is robust to formatting changes elsewhere in the file.
+ */
+function sliceStep(label: string): string {
+  const start = suiteSource.indexOf(`await test.step('${label}'`);
+  expect(
+    start,
+    `expected to find a test.step labelled '${label}' in emitted suite`,
+  ).toBeGreaterThanOrEqual(0);
+  const after = suiteSource.indexOf("await test.step('", start + 1);
+  return suiteSource.slice(start, after === -1 ? undefined : after);
+}
+
+describe('observe-membership predicate (#342 follow-up)', () => {
+  it('emits a present-polarity predicate that requires the binding value to be in the items page', () => {
+    const block = sliceStep('observe (present)');
+    // Predicate must be present (otherwise the default `items.length > 0`
+    // fires, which can race the indexer surfacing the specific entity
+    // the test cares about).
+    expect(block).toMatch(/predicate:\s*\(body\)\s*=>/);
+    // Predicate must reference the membership binding via ctx.
+    expect(block).toContain("ctx['usernameVar']");
+    // Polarity: present → predicate returns true when value IS in items.
+    expect(block).toMatch(/\.includes\(\s*ctx\['usernameVar'\]\s*\)/);
+    // Negation absent for the present case.
+    expect(block).not.toMatch(/!\s*[A-Za-z_]\w*\.includes\(\s*ctx\['usernameVar'\]\s*\)/);
+  });
+
+  it('emits an absent-polarity predicate that requires the binding value to be missing from the items page', () => {
+    const block = sliceStep('observe (absent)');
+    expect(block).toMatch(/predicate:\s*\(body\)\s*=>/);
+    expect(block).toContain("ctx['usernameVar']");
+    // Polarity: absent → predicate returns true when value is NOT in items.
+    expect(block).toMatch(/!\s*[A-Za-z_]\w*\.includes\(\s*ctx\['usernameVar'\]\s*\)/);
+  });
+});


### PR DESCRIPTION
## Summary

EdgeLifecycle observe-membership steps (e.g. `searchUsersForTenant` in `TenantUserMembership.lifecycle`) wrapped their search call in `awaitEventually(...)` without a custom `predicate:`, falling back to the runtime default (`isNonEmptyItemsPage`: `items.length > 0`). That default is wrong for both polarities:

- **`expect: 'absent'`** — default keeps polling on an empty page, so a tenant whose only membership was just revoked times out with `EventualConsistencyTimeoutError` even though the absent assertion would pass immediately. This was the live failure surfaced after #343 merged.
- **`expect: 'present'`** — default returns `true` as soon as *any* item surfaces, even if the specific binding the test cares about hasn't propagated yet (race with the secondary-storage indexer).

## Fix

Make the materializer emit a polarity-aware predicate that mirrors the post-call membership assertion: walks the planner-declared `arrayPath`, projects each element via `elementField`, and returns `[!]values.includes(ctx['<binding>'])` so polling converges to the same observable state the assertion checks for.

- Extend `InlineStepRenderInput` with `awaitEventuallyPredicate?: string` (`stepRenderer.ts`) — opt-in; existing callers stay byte-identical.
- Add `buildMembershipPredicateExpr` helper (`templateEmitter.ts`) that reuses `buildOptionalAccessChain` for `arrayPath` + `elementField` walks, guards binding identifier-safety, and emits a closed-over `ctx` predicate.
- Wire `appendObserveMembershipStep` to compute the predicate before `renderInlineStepLines` and thread it through.

## Red/green/class-scoped guard

`tests/codegen/observe-membership-predicate.test.ts` was written first (RED), asserting that both polarities:

- emit a `predicate: (body) =>` field,
- reference the correct `ctx['<binding>']` slot,
- negate correctly for `'absent'`.

The guard is class-scoped (covers both polarities, not just the `absent` instance).

## Live verification

```
$ npx playwright test templates/EdgeLifecycle/TenantUserMembership.lifecycle.spec.ts
  ✓  1 templates/EdgeLifecycle/TenantUserMembership.lifecycle.spec.ts:9:3 › TenantUserMembership lifecycle › … (182ms)
  1 passed (420ms)
```

Previously timed out after 10010 ms in `observe (absent)`.

## Validation

- `npm run lint` — clean
- All per-workspace `tsc --noEmit` — clean
- `npm test` — **649 passed | 4 skipped**

Follows #342 / #343.
