### PR TITLE
fix: stop lifting deep schema leaves into top-level request bodies

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -8310,7 +8310,15 @@ describeForThisConfig(
             if (op?.operationId !== opId) continue;
             const body = resolveSpecNode(op.requestBody, spec, new Set());
             const schema = body?.content?.['application/json']?.schema;
+            if (!schema) return undefined;
             const { properties } = mergeSchemaShape(schema, spec, new Set());
+            if (
+              !properties ||
+              typeof properties !== 'object' ||
+              Object.keys(properties).length === 0
+            ) {
+              return undefined;
+            }
             return new Set(Object.keys(properties));
           }
         }

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -8287,6 +8287,70 @@ describeForThisConfig(
       ).toEqual([]);
     });
 
+    it('every observe step bodyTemplate has only top-level keys declared by the operation request schema (defect-class guard: deep-leaf bleed-up #344-followup)', async () => {
+      // Class-scoped guard for a planner defect where
+      // `buildRequestBodyFromCanonical` lifts deeply-nested optional
+      // fields (e.g. `filter.name`) into the top-level body when a
+      // matching binding (e.g. `nameVar`) is in scope. The server
+      // rejects the request with 400 "Request property [X] cannot be
+      // parsed" because schemas like `MappingRuleSearchQueryRequest`
+      // declare `additionalProperties: false` with only
+      // {sort, filter, page} at the top level.
+      //
+      // The bug surfaces on /search observe steps for membership edges
+      // where a prereq chain establishes a binding whose leaf name
+      // collides with a deep optional schema property — but the defect
+      // is structural in the body builder, not specific to one edge.
+      // This invariant fails for every such case so the same class of
+      // bleed-up cannot recur silently in a sibling edge.
+      const spec = loadBundledSpec();
+      function topLevelKeysForOp(opId: string): Set<string> | undefined {
+        for (const pathOps of Object.values(spec.paths ?? {})) {
+          for (const op of Object.values(pathOps)) {
+            if (op?.operationId !== opId) continue;
+            const body = resolveSpecNode(op.requestBody, spec, new Set());
+            const schema = body?.content?.['application/json']?.schema;
+            const { properties } = mergeSchemaShape(schema, spec, new Set());
+            return new Set(Object.keys(properties));
+          }
+        }
+        return undefined;
+      }
+      const { loadEdgesAbox } = await import('../../path-analyser/src/ontology/loader.js');
+      const edges = loadEdgesAbox(REPO_ROOT);
+      if (!edges) throw new Error('edges ABox missing');
+      const offenders: string[] = [];
+      for (const edge of edges.edges) {
+        const file = loadTemplateFile(edge.name);
+        for (const [i, step] of file.scenario.steps.entries()) {
+          if (step.kind !== 'observe') continue;
+          // biome-ignore lint/plugin: runtime contract boundary — requestPlan typed as unknown in scenario file.
+          const rp = step.requestPlan as {
+            operationId?: string;
+            bodyTemplate?: Record<string, unknown>;
+          };
+          const opId = rp.operationId;
+          const body = rp.bodyTemplate;
+          if (!opId || !body || typeof body !== 'object') continue;
+          const allowed = topLevelKeysForOp(opId);
+          if (!allowed) continue; // no JSON body schema → nothing to check
+          for (const k of Object.keys(body)) {
+            if (!allowed.has(k)) {
+              offenders.push(
+                `${edge.name}: step[${i}] observe.${opId} bodyTemplate has top-level key '${k}' which is not a top-level property of the request schema (allowed: {${[...allowed].join(', ')}}).`,
+              );
+            }
+          }
+        }
+      }
+      expect(
+        offenders,
+        'Every observe-step body must only carry top-level keys the request schema declares. ' +
+          'Deep schema leaves (e.g. filter.name) must not be lifted to the top level — ' +
+          'servers with additionalProperties:false reject those with 400.',
+      ).toEqual([]);
+    });
+
     it('RoleUserMembership observe pins arrayPath=[items] and elementField=username (ambiguity-stability guard for findMembershipArrayPath)', () => {
       // Stability guard for the array-locator heuristic: when more than
       // one identifiedBy semantic appears array-nested in the same

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1402,8 +1402,19 @@ function buildRequestBodyFromCanonical(
         }
       }
     }
-    // Fill a few optional fields if present and we have bindings
-    for (const f of nodes.filter((n) => !n.required && !n.path.includes('[]'))) {
+    // Fill a few optional fields if present and we have bindings.
+    //
+    // Restricted to top-level fields (no '.' in path): otherwise the
+    // leaf-projection (`path.split('.').pop()`) silently lifts deeply
+    // nested optional properties (e.g. `filter.name` in a SearchQueryRequest
+    // whose top is `{additionalProperties: false, properties: {sort, filter,
+    // page}}`) into the top-level body when a binding happens to share
+    // the leaf name (e.g. `nameVar`). The server then rejects the request
+    // with 400 "Request property [name] cannot be parsed". This is the
+    // same defect class as #174 sub-class 1.
+    for (const f of nodes.filter(
+      (n) => !n.required && !n.path.includes('[]') && !n.path.includes('.'),
+    )) {
       const leaf = f.path.split('.').pop() ?? '';
       if (allowedFields && !allowedFields.has(leaf)) continue;
       const varBase = `${camelCase(bindingMap[f.path] || leaf || 'value')}Var`;
@@ -1415,11 +1426,18 @@ function buildRequestBodyFromCanonical(
         }
       }
     }
-    // Fallback: ensure all domain request.* bindings are present even if canonical nodes are missing (e.g., oneOf variants).
+    // Fallback: ensure all domain request.* bindings are present even if
+    // canonical nodes are missing (e.g., oneOf variants). Restricted to
+    // top-level fields for the same reason as the loop above — deep-leaf
+    // bleed-up corrupts the body shape for any schema with
+    // additionalProperties:false.
     const leafSet = new Set(
-      nodes.filter((n) => !n.path.includes('[]')).map((n) => n.path.split('.').pop() ?? ''),
+      nodes
+        .filter((n) => !n.path.includes('[]') && !n.path.includes('.'))
+        .map((n) => n.path.split('.').pop() ?? ''),
     );
     for (const [fieldPath, param] of Object.entries(bindingMap)) {
+      if (fieldPath.includes('.')) continue;
       const leaf = fieldPath.split('.').pop() ?? '';
       if (!leafSet.has(leaf)) continue; // don't inject fields not in schema
       if (allowedFields && !allowedFields.has(leaf)) continue;


### PR DESCRIPTION
## Problem

8 observe-membership steps across 4 EdgeLifecycle suites
(`GroupMappingRuleMembership`, `RoleMappingRuleMembership`,
`TenantMappingRuleMembership`, `TenantRoleMembership`) failed against a
live cluster with HTTP 400 `Request property [name] cannot be parsed`.

The emitted body was `{ "name": "${nameVar}" }` for ops whose request
schema is `additionalProperties: false` with only `{sort, filter,
page}` at the top level (e.g. `MappingRuleSearchQueryRequest`).

## Root cause

`buildRequestBodyFromCanonical` in `path-analyser/src/index.ts` had two
passes — "fill a few optional fields" and the `bindingMap` fallback —
that iterated all non-array canonical nodes and projected each path to
its leaf segment (`path.split('.').pop()`). When a scenario binding's
name collided with a deeply-nested optional field's leaf (e.g.
`nameVar` and `filter.name`), the leaf was injected at the **top
level** of the body, skipping the `filter` wrapper.

Same defect class as #174 sub-class 1 (deep-leaf bleed-up).

## Fix

Restrict both passes to top-level fields (`!path.includes('.')`) so
nested optional properties stay nested.

## Red/green

Class-scoped Layer-3 invariant added to
`configs/camunda-oca/regression-invariants.test.ts`: for every
EdgeLifecycle observe step, the emitted `bodyTemplate` may only carry
top-level keys declared by the operation's request schema.

- Pre-fix: 8 offenders across 4 edges (red).
- Post-fix: 0 offenders (green).

## Validation

- `npm run lint`, all per-workspace `tsc --noEmit`, `tests/tsconfig.json` — clean
- `TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation` — regenerated cleanly
- `npm test` — **650 passed**, 4 skipped (was 649 — the new invariant)
- Live: `npx playwright test templates/EdgeLifecycle/` — **all 12 suites pass**, including the previously-failing 4

## Branching

Branched off `main` rather than stacking on #344 — the two fixes are
independent (emitter vs. planner) and reviewable in isolation.