### PR TITLE
feat: emit request-validation as parallel secured/unsecured profiles

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -2843,7 +2843,13 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
     // valid enum member only by ASCII case. Catches any future analyser
     // (e.g. a sibling oneOf/anyOf walker) that re-introduces a case-only
     // mutation.
-    const REQUEST_VALIDATION_DIR = join(REPO_ROOT, 'generated', CONFIG_NAME, 'request-validation');
+    const REQUEST_VALIDATION_DIR = join(
+      REPO_ROOT,
+      'generated',
+      CONFIG_NAME,
+      'request-validation',
+      'unsecured',
+    );
     if (!existsSync(REQUEST_VALIDATION_DIR)) {
       throw new Error(
         `Generated request-validation directory not found at ${REQUEST_VALIDATION_DIR}. ` +
@@ -2961,7 +2967,13 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
     // Catches the original `searchVariables - Param query.truncateValues
     // wrong type` case (path `/variables/search` carrying `truncateValues`
     // in slot 2) and any sibling emitter regression.
-    const REQUEST_VALIDATION_DIR = join(REPO_ROOT, 'generated', CONFIG_NAME, 'request-validation');
+    const REQUEST_VALIDATION_DIR = join(
+      REPO_ROOT,
+      'generated',
+      CONFIG_NAME,
+      'request-validation',
+      'unsecured',
+    );
     if (!existsSync(REQUEST_VALIDATION_DIR)) {
       throw new Error(
         `Generated request-validation directory not found at ${REQUEST_VALIDATION_DIR}. ` +
@@ -3044,7 +3056,13 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
     // Catches not just the original `minLength: 1` empty-string emission
     // (paramConstraintViolations.ts) but any sibling code path that
     // synthesises a path-routing-significant violator in future.
-    const REQUEST_VALIDATION_DIR = join(REPO_ROOT, 'generated', CONFIG_NAME, 'request-validation');
+    const REQUEST_VALIDATION_DIR = join(
+      REPO_ROOT,
+      'generated',
+      CONFIG_NAME,
+      'request-validation',
+      'unsecured',
+    );
     if (!existsSync(REQUEST_VALIDATION_DIR)) {
       throw new Error(
         `Generated request-validation directory not found at ${REQUEST_VALIDATION_DIR}. ` +
@@ -3179,6 +3197,91 @@ describeForThisConfig('bundled-spec invariants: emitted request-validation suite
     expect(offenders).toEqual([]);
   });
 });
+
+describeForThisConfig(
+  'bundled-spec invariants: request-validation secured/unsecured profile split (#346)',
+  () => {
+    // The request-validation suite is emitted as two parallel self-contained
+    // profiles. The unsecured profile is the deployment-mode-agnostic 400
+    // baseline; the secured profile adds auth-absent (HTTP 401) tests for
+    // conditionally-secured operations (camunda/camunda#53708). These
+    // invariants pin the contract regardless of whether the *currently pinned*
+    // spec carries `x-enforcement` annotations (with none, the auth-absent set
+    // is empty and the two profiles coincide — the assertions hold either way).
+    const RV_DIR = join(REPO_ROOT, 'generated', CONFIG_NAME, 'request-validation');
+    const UNSECURED_DIR = join(RV_DIR, 'unsecured');
+    const SECURED_DIR = join(RV_DIR, 'secured');
+
+    function requireDir(dir: string): void {
+      if (!existsSync(dir)) {
+        throw new Error(
+          `Generated request-validation profile directory not found at ${dir}. ` +
+            `Run 'npm run generate:request-validation' (or 'npm run pipeline') first.`,
+        );
+      }
+    }
+
+    function specFiles(dir: string): string[] {
+      return readdirSync(dir)
+        .filter((f) => f.endsWith('.spec.ts'))
+        .sort();
+    }
+
+    it('emits both profiles as self-contained suites with spec files', () => {
+      requireDir(UNSECURED_DIR);
+      requireDir(SECURED_DIR);
+      expect(specFiles(UNSECURED_DIR).length).toBeGreaterThan(0);
+      expect(specFiles(SECURED_DIR).length).toBeGreaterThan(0);
+      // Each profile carries its own standalone scaffolding so it runs in place.
+      for (const dir of [UNSECURED_DIR, SECURED_DIR]) {
+        expect(existsSync(join(dir, 'playwright.config.ts'))).toBe(true);
+        expect(existsSync(join(dir, 'tsconfig.json'))).toBe(true);
+        expect(existsSync(join(dir, 'support', 'http.ts'))).toBe(true);
+      }
+    });
+
+    it('never expects a 401 in the unsecured profile (class-scoped)', () => {
+      requireDir(UNSECURED_DIR);
+      const offenders: string[] = [];
+      for (const f of specFiles(UNSECURED_DIR)) {
+        const src = readFileSync(join(UNSECURED_DIR, f), 'utf8');
+        if (/scenarioKind:\s*['"]auth-absent['"]/.test(src)) offenders.push(`${f}: auth-absent`);
+        if (/assertResponseStatus\([^)]*,\s*401\s*,/.test(src)) offenders.push(`${f}: 401`);
+      }
+      expect(offenders).toEqual([]);
+    });
+
+    it('every auth-absent test in the secured profile is an unauthenticated 401 (class-scoped)', () => {
+      requireDir(SECURED_DIR);
+      // Match each emitted auth-absent test block and assert its shape.
+      const TEST_BLOCK = /test\([^]*?scenarioKind:\s*'auth-absent'[^]*?}\);/g;
+      const offenders: string[] = [];
+      for (const f of specFiles(SECURED_DIR)) {
+        const src = readFileSync(join(SECURED_DIR, f), 'utf8');
+        let block: RegExpExecArray | null;
+        TEST_BLOCK.lastIndex = 0;
+        while ((block = TEST_BLOCK.exec(src)) !== null) {
+          const text = block[0];
+          if (!/assertResponseStatus\([^)]*,\s*401\s*,/.test(text)) {
+            offenders.push(`${f}: auth-absent block does not assert 401`);
+          }
+          if (!/headers:\s*\{\}/.test(text)) {
+            offenders.push(`${f}: auth-absent block sends auth headers`);
+          }
+        }
+      }
+      expect(offenders).toEqual([]);
+    });
+
+    it('secured profile is a superset of the unsecured profile spec files', () => {
+      requireDir(UNSECURED_DIR);
+      requireDir(SECURED_DIR);
+      const securedSet = new Set(specFiles(SECURED_DIR));
+      const missing = specFiles(UNSECURED_DIR).filter((f) => !securedSet.has(f));
+      expect(missing).toEqual([]);
+    });
+  },
+);
 
 describeForThisConfig('bundled-spec invariants: scenario seed-binding completeness (#136)', () => {
   // Class-scoped invariant pinning the planner-side fix for #136.
@@ -3980,6 +4083,7 @@ describeForThisConfig(
         'generated',
         CONFIG_NAME,
         'request-validation',
+        'unsecured',
       );
       if (!existsSync(REQUEST_VALIDATION_DIR)) {
         throw new Error(

--- a/request-validation/README.md
+++ b/request-validation/README.md
@@ -43,8 +43,33 @@ If you are not deep into the codebase, here is the 30‑second view:
 | `format-invalid`                   | Violates `format` (e.g. date-time, uuid)           |
 | `allof-missing-required`           | Missing fields mandated by merged `allOf`          |
 | `allof-conflict`                   | Conflicting values across `allOf` parts            |
+| `auth-absent`                      | Request without credentials against a conditionally-secured op — expects 401 (secured profile only) |
 
-All generated scenarios currently expect 400; "stateful" follow-on semantic checks are out of scope here.
+Most generated scenarios expect HTTP 400. The exception is `auth-absent`,
+which expects 401 and is emitted only into the secured profile (see below);
+"stateful" follow-on semantic checks are out of scope here.
+
+### Secured / unsecured profiles
+
+The suite is emitted as **two parallel, self-contained profiles** under
+`generated/<config>/request-validation/`:
+
+| Profile      | Contents                                  | Run against            |
+|--------------|-------------------------------------------|------------------------|
+| `unsecured/` | The 400-validation tests (baseline)       | a server with auth off |
+| `secured/`   | The same 400 tests **plus** `auth-absent` (401) tests | a server started with auth on |
+
+The `auth-absent` tests are derived purely from data: an operation is flagged
+when it declares (or inherits) a `security` block referencing a security scheme
+whose `x-enforcement` is `conditional` (camunda/camunda#53708). An explicit
+`security: []` (publicly unauthenticated at runtime) is never flagged. When the
+bundled spec carries no `x-enforcement` annotations the `auth-absent` set is
+empty and the two profiles are byte-identical.
+
+Each profile is a standalone Playwright suite (own scaffolding + `support/`).
+The local runner (`npm run test:pw:request-validation`) runs the `unsecured`
+profile by default; set `RV_PROFILE=secured` to run the secured one (supply
+credentials via `CAMUNDA_BASIC_AUTH_USER` / `CAMUNDA_BASIC_AUTH_PASSWORD`).
 
 ### Quickstart: generate against `stable/8.9` and run against a local cluster
 
@@ -58,8 +83,8 @@ npm run generate:request-validation
 # 2. Start a local Camunda 8.9 cluster (defaults to http://localhost:8080).
 c8ctl cluster start 8.9
 
-# 3. Install + run the generated suite in place.
-cd generated/<config>/request-validation
+# 3. Install + run the generated suite in place (unsecured profile).
+cd generated/<config>/request-validation/unsecured
 npm install
 CORE_APPLICATION_URL=http://localhost:8080 npm test
 ```
@@ -82,17 +107,20 @@ npm run regenerate
 
 Artifacts are written to `generated/`. By default the suite is **standalone** —
 it vendors its runtime helpers and project scaffolding so it can run in place
-with no external dependency other than a running Camunda server:
+with no external dependency other than a running Camunda server. Pick a profile
+(`unsecured/` or `secured/` — see above):
 
 ```
-cd generated/<config>/request-validation
+cd generated/<config>/request-validation/unsecured
 npm install
 CORE_APPLICATION_URL=http://localhost:8080 npm test
 ```
 
-For a cluster that requires Basic auth:
+For a cluster that requires Basic auth (and to run the `secured/` profile,
+which adds the 401 auth-absent tests):
 
 ```
+cd generated/<config>/request-validation/secured
 CAMUNDA_BASIC_AUTH_USER=demo CAMUNDA_BASIC_AUTH_PASSWORD=demo npm test
 ```
 

--- a/request-validation/scripts/generate.ts
+++ b/request-validation/scripts/generate.ts
@@ -11,6 +11,7 @@ import {
   generateUniqueItemsViolations,
 } from '../src/analysis/advancedSchema.js';
 import { generateAllOfConflicts, generateAllOfMissingRequired } from '../src/analysis/allOf.js';
+import { generateAuthAbsent } from '../src/analysis/authAbsent.js';
 import { generateBodyTopTypeMismatch, generateMissingBody } from '../src/analysis/bodyTopLevel.js';
 import { generateBodyTypeMismatch } from '../src/analysis/bodyTypeMismatch.js';
 import { generateConstraintViolations } from '../src/analysis/constraintViolations.js';
@@ -213,6 +214,16 @@ async function main() {
   if (wantKind('union')) {
     scenarios.push(
       ...generateUnionViolations(model.operations, {
+        onlyOperations: opts.onlyOperations,
+      }),
+    );
+  }
+  // auth-absent (HTTP 401) scenarios are not "deep": they depend only on the
+  // operation's conditional-auth status, not on body/parameter shape. They are
+  // emitted exclusively into the `secured` profile (see profile split below).
+  if (wantKind('auth-absent')) {
+    scenarios.push(
+      ...generateAuthAbsent(model.operations, {
         onlyOperations: opts.onlyOperations,
       }),
     );
@@ -607,15 +618,41 @@ async function main() {
     deduped.push(...filtered);
   }
 
-  await emitQaTests(deduped, {
-    outDir: opts.outDir,
-    qaImportDepth: opts.qaImportDepth,
-    standalone: opts.standalone,
-    specCommit,
-    generationTimestamp,
-  });
+  // ---- Profile split: parallel secured / unsecured suites ----
+  // The negative-validation tests (400s) are deployment-mode-agnostic and run
+  // in both profiles. The auth-absent (401) tests only make sense against a
+  // server started in secured mode, so they go into the `secured` suite only.
+  //
+  //   generated/<config>/request-validation/unsecured/   — 400 tests only
+  //   generated/<config>/request-validation/secured/     — 400 tests + 401 tests
+  //
+  // Each subdir is a self-contained standalone suite (own scaffolding +
+  // support). When the bundled spec carries no `x-enforcement: conditional`
+  // annotations (no conditionally-secured ops), the auth-absent set is empty
+  // and the two suites are byte-identical.
+  const PROFILES = [
+    { name: 'unsecured', scenarios: deduped.filter((s) => s.type !== 'auth-absent') },
+    { name: 'secured', scenarios: deduped },
+  ] as const;
+  for (const profile of PROFILES) {
+    const profileDir = path.join(opts.outDir, profile.name);
+    // Clean the profile dir before emitting so stale spec files from a prior
+    // run (e.g. an operation removed from the spec, or a different pinned spec
+    // that flagged different ops) cannot survive into the new suite. The
+    // emitter recreates all scaffolding + support files from scratch.
+    fs.rmSync(profileDir, { recursive: true, force: true });
+    await emitQaTests(profile.scenarios, {
+      outDir: profileDir,
+      qaImportDepth: opts.qaImportDepth,
+      standalone: opts.standalone,
+      specCommit,
+      generationTimestamp,
+    });
+  }
   console.log('[generate] Summary:', {
     totalScenarios: deduped.length,
+    authAbsent: deduped.filter((s) => s.type === 'auth-absent').length,
+    profiles: PROFILES.map((p) => `${p.name}:${p.scenarios.length}`),
     kinds: Array.from(new Set(deduped.map((s) => s.type))).sort(),
     deepMode: opts.deep,
     maxMissing: opts.maxMissing ?? null,

--- a/request-validation/scripts/generate.ts
+++ b/request-validation/scripts/generate.ts
@@ -634,15 +634,18 @@ async function main() {
     { name: 'unsecured', scenarios: deduped.filter((s) => s.type !== 'auth-absent') },
     { name: 'secured', scenarios: deduped },
   ] as const;
+  // Clean the whole suite output dir before emitting so that (a) stale spec
+  // files from a prior run cannot survive into either profile, and (b) legacy
+  // top-level artifacts from before the profile split — when spec files and
+  // scaffolding lived directly under `opts.outDir` rather than in
+  // `unsecured/`/`secured/` subdirs — are removed and can't be accidentally
+  // executed or mistaken for current output. The emitter recreates each
+  // profile dir (and the parent) recursively; MANIFEST/COVERAGE are rewritten
+  // into the recreated parent below.
+  fs.rmSync(opts.outDir, { recursive: true, force: true });
   for (const profile of PROFILES) {
-    const profileDir = path.join(opts.outDir, profile.name);
-    // Clean the profile dir before emitting so stale spec files from a prior
-    // run (e.g. an operation removed from the spec, or a different pinned spec
-    // that flagged different ops) cannot survive into the new suite. The
-    // emitter recreates all scaffolding + support files from scratch.
-    fs.rmSync(profileDir, { recursive: true, force: true });
     await emitQaTests(profile.scenarios, {
-      outDir: profileDir,
+      outDir: path.join(opts.outDir, profile.name),
       qaImportDepth: opts.qaImportDepth,
       standalone: opts.standalone,
       specCommit,

--- a/request-validation/src/analysis/authAbsent.ts
+++ b/request-validation/src/analysis/authAbsent.ts
@@ -1,0 +1,51 @@
+import type { OperationModel, ValidationScenario } from '../model/types.js';
+import { makeId } from './common.js';
+
+interface Opts {
+  onlyOperations?: Set<string>;
+}
+
+/**
+ * Generate auth-absent (HTTP 401) scenarios for the secured-server profile.
+ *
+ * For every operation that is conditionally secured on the `auth` axis
+ * (`OperationModel.conditionalAuth`, derived from `x-enforcement: conditional`
+ * security schemes + the operation's `security` block — camunda/camunda#53708),
+ * emit a single scenario that issues the request WITHOUT any credentials
+ * (`headersAuth: false`) and expects the server — when started in secured mode —
+ * to reject it with 401 before any body/parameter validation runs.
+ *
+ * Operations that are unconditionally public (`security: []`) or not secured at
+ * all yield no scenario, so against an unsecured server this generator's output
+ * is empty and the two emitted profiles coincide.
+ */
+export function generateAuthAbsent(ops: OperationModel[], opts: Opts): ValidationScenario[] {
+  const out: ValidationScenario[] = [];
+  for (const op of ops) {
+    if (opts.onlyOperations && !opts.onlyOperations.has(op.operationId)) continue;
+    if (!op.conditionalAuth) continue;
+    out.push({
+      id: makeId([op.operationId, 'auth-absent']),
+      operationId: op.operationId,
+      method: op.method,
+      path: op.path,
+      type: 'auth-absent',
+      params: buildDummyParams(op.path),
+      expectedStatus: 401,
+      description: 'Request without authentication is rejected with 401 (secured mode)',
+      headersAuth: false,
+    });
+  }
+  return out;
+}
+
+function buildDummyParams(path: string): Record<string, string> | undefined {
+  const m = path.match(/\{([^}]+)}/g);
+  if (!m) return undefined;
+  const params: Record<string, string> = {};
+  for (const token of m) {
+    const name = token.slice(1, -1);
+    params[name] = 'x';
+  }
+  return params;
+}

--- a/request-validation/src/emit/qaEmitter.ts
+++ b/request-validation/src/emit/qaEmitter.ts
@@ -337,6 +337,8 @@ function buildBaseTitle(s: ValidationScenario): string {
       return `${s.operationId} - allOf missing required`;
     case 'allof-conflict':
       return `${s.operationId} - allOf conflict`;
+    case 'auth-absent':
+      return `${s.operationId} - Missing authentication`;
     default:
       return s.id; // Fallback is globally unique id
   }

--- a/request-validation/src/model/types.ts
+++ b/request-validation/src/model/types.ts
@@ -43,6 +43,16 @@ export interface OperationModel {
   multipartRequiredProps?: string[];
   /** All request body media types advertised by the operation */
   mediaTypes?: string[];
+  /**
+   * True when the operation is secured *conditionally* on the `auth`
+   * deployment-mode axis: it declares (or inherits) a `security` requirement
+   * that references a security scheme whose `x-enforcement` is `conditional`
+   * (camunda/camunda#53708). Such an operation returns 401 when called
+   * without credentials against a server started in secured mode, and is
+   * unauthenticated otherwise. An explicit `security: []` override (publicly
+   * unauthenticated at runtime) yields `false`.
+   */
+  conditionalAuth?: boolean;
 }
 
 export interface ParameterModel {
@@ -82,7 +92,8 @@ export type ScenarioKind =
   | 'oneof-cross-bleed'
   | 'discriminator-structure-mismatch'
   | 'allof-missing-required'
-  | 'allof-conflict';
+  | 'allof-conflict'
+  | 'auth-absent';
 
 export interface ValidationScenario {
   id: string;

--- a/request-validation/src/spec/loader.ts
+++ b/request-validation/src/spec/loader.ts
@@ -120,6 +120,9 @@ export async function loadSpec(file: string): Promise<SpecModel> {
     if (!isRecord(methods)) continue;
     // Path-level parameters are inherited by every operation under the path.
     const pathLevelParams = Array.isArray(methods.parameters) ? methods.parameters : [];
+    // Path-item-level `security` sits between operation-level and global in the
+    // OpenAPI precedence chain (op.security ?? pathItem.security ?? global).
+    const pathLevelSecurity = methods.security;
     for (const [m, op] of Object.entries(methods)) {
       const method = m.toUpperCase();
       if (!isRecord(op)) continue;
@@ -183,6 +186,7 @@ export async function loadSpec(file: string): Promise<SpecModel> {
         mediaTypes,
         conditionalAuth:
           securityRequiresConditional(op.security, conditionalSchemes) ??
+          securityRequiresConditional(pathLevelSecurity, conditionalSchemes) ??
           securityRequiresConditional(globalSecurity, conditionalSchemes) ??
           false,
       });

--- a/request-validation/src/spec/loader.ts
+++ b/request-validation/src/spec/loader.ts
@@ -49,6 +49,51 @@ function asDiscriminator(
   return { propertyName, mapping };
 }
 
+/**
+ * Collect the names of security schemes that declare `x-enforcement:
+ * conditional` (camunda/camunda#53708). These are enforced only under
+ * certain deployment-mode profiles (e.g. the `auth: [secured]` axis) and
+ * bypassed otherwise, so an operation referencing one is the auth-absent
+ * (401) test surface for the secured profile.
+ */
+function collectConditionalSchemes(api: unknown): Set<string> {
+  const names = new Set<string>();
+  if (isRecord(api) && isRecord(api.components) && isRecord(api.components.securitySchemes)) {
+    for (const [name, scheme] of Object.entries(api.components.securitySchemes)) {
+      if (isRecord(scheme) && scheme['x-enforcement'] === 'conditional') {
+        names.add(name);
+      }
+    }
+  }
+  return names;
+}
+
+/**
+ * Evaluate an OpenAPI `security` requirement list against the set of
+ * conditionally-enforced scheme names.
+ *
+ * - `true`      — at least one requirement references a conditional scheme.
+ * - `false`     — the list is present but references no conditional scheme
+ *                 (including the explicit `security: []` public override).
+ * - `undefined` — no `security` declared at this level; the caller should
+ *                 fall back to the global `security`.
+ */
+function securityRequiresConditional(
+  security: unknown,
+  conditional: Set<string>,
+): boolean | undefined {
+  if (!Array.isArray(security)) return undefined;
+  if (security.length === 0) return false;
+  for (const requirement of security) {
+    if (isRecord(requirement)) {
+      for (const schemeName of Object.keys(requirement)) {
+        if (conditional.has(schemeName)) return true;
+      }
+    }
+  }
+  return false;
+}
+
 function buildParameter(raw: unknown): ParameterModel | undefined {
   if (!isRecord(raw)) return undefined;
   const name = asString(raw.name);
@@ -69,6 +114,8 @@ export async function loadSpec(file: string): Promise<SpecModel> {
   const api: unknown = await SwaggerParser.dereference(file);
   const operations: OperationModel[] = [];
   const paths = isRecord(api) && isRecord(api.paths) ? api.paths : {};
+  const conditionalSchemes = collectConditionalSchemes(api);
+  const globalSecurity = isRecord(api) ? api.security : undefined;
   for (const [p, methods] of Object.entries(paths)) {
     if (!isRecord(methods)) continue;
     // Path-level parameters are inherited by every operation under the path.
@@ -134,6 +181,10 @@ export async function loadSpec(file: string): Promise<SpecModel> {
         multipartSchema,
         multipartRequiredProps,
         mediaTypes,
+        conditionalAuth:
+          securityRequiresConditional(op.security, conditionalSchemes) ??
+          securityRequiresConditional(globalSecurity, conditionalSchemes) ??
+          false,
       });
     }
   }

--- a/scripts/run-pw-request-validation.ts
+++ b/scripts/run-pw-request-validation.ts
@@ -15,7 +15,12 @@ import { getRequestValidationSuiteDir } from '../path-analyser/src/configResolve
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = resolve(dirname(__filename), '..');
 
-const config = join(getRequestValidationSuiteDir(REPO_ROOT), 'playwright.config.ts');
+// The request-validation suite is emitted as two parallel profiles
+// (unsecured/ and secured/). Default to the unsecured profile — it runs
+// against a plain local dev server. Set RV_PROFILE=secured to run the suite
+// that adds the auth-absent (401) tests against a secured server.
+const profile = process.env.RV_PROFILE === 'secured' ? 'secured' : 'unsecured';
+const config = join(getRequestValidationSuiteDir(REPO_ROOT), profile, 'playwright.config.ts');
 
 const child = spawn('npx', ['playwright', 'test', '-c', config, ...process.argv.slice(2)], {
   stdio: 'inherit',

--- a/tests/regression/generated-suites-typecheck.test.ts
+++ b/tests/regression/generated-suites-typecheck.test.ts
@@ -42,8 +42,15 @@ const SUITES: readonly Suite[] = [
     tsconfig: path.join(getPlaywrightSuiteDir(REPO_ROOT), 'tsconfig.json'),
   },
   {
-    label: 'request-validation',
-    tsconfig: path.join(getRequestValidationSuiteDir(REPO_ROOT), 'tsconfig.json'),
+    // The request-validation suite is emitted as two parallel self-contained
+    // profiles (unsecured/ + secured/), each with its own tsconfig.json. Both
+    // must typecheck under strict mode.
+    label: 'request-validation (unsecured)',
+    tsconfig: path.join(getRequestValidationSuiteDir(REPO_ROOT), 'unsecured', 'tsconfig.json'),
+  },
+  {
+    label: 'request-validation (secured)',
+    tsconfig: path.join(getRequestValidationSuiteDir(REPO_ROOT), 'secured', 'tsconfig.json'),
   },
 ];
 

--- a/tests/request-validation/auth-absent.test.ts
+++ b/tests/request-validation/auth-absent.test.ts
@@ -1,0 +1,216 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { generateAuthAbsent } from '../../request-validation/src/analysis/authAbsent.js';
+import { renderScenarioForTest } from '../../request-validation/src/emit/qaEmitter.js';
+import type {
+  OperationModel,
+  ValidationScenario,
+} from '../../request-validation/src/model/types.js';
+import { loadSpec } from '../../request-validation/src/spec/loader.js';
+
+/**
+ * Guards the auth-absent (HTTP 401) negative-test feature that underpins the
+ * secured-profile request-validation suite (issue #346 / camunda/camunda#53708).
+ *
+ * Layer 1 — loader derives `conditionalAuth` from `x-enforcement: conditional`
+ *           security schemes + the operation's `security` block.
+ * Layer 2 — generator emits exactly one well-formed 401 scenario per
+ *           conditionally-secured op and nothing for unsecured/public ops.
+ * Emitter — an auth-absent scenario renders with no auth header and a 401
+ *           assertion.
+ */
+
+describe('request-validation: auth-absent loader derivation (#346)', () => {
+  let tmp: string;
+  let specPath: string;
+
+  beforeAll(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'rv-auth-absent-'));
+    specPath = join(tmp, 'spec.json');
+    const spec = {
+      openapi: '3.0.3',
+      info: { title: 'fixture', version: '1.0.0' },
+      components: {
+        securitySchemes: {
+          BearerAuth: {
+            type: 'http',
+            scheme: 'bearer',
+            'x-enforcement': 'conditional',
+            'x-enforcement-modes': { auth: ['secured'] },
+          },
+          basicAuth: {
+            type: 'http',
+            scheme: 'basic',
+            'x-enforcement': 'conditional',
+            'x-enforcement-modes': { auth: ['secured'] },
+          },
+          // A scheme with no conditional enforcement — must NOT flag an op.
+          apiKey: { type: 'apiKey', in: 'header', name: 'X-Api-Key' },
+        },
+      },
+      paths: {
+        '/secured': {
+          post: {
+            operationId: 'securedOp',
+            security: [{ BearerAuth: [] }, { basicAuth: [] }],
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+        '/public': {
+          get: {
+            operationId: 'publicOp',
+            // Explicit public override at runtime.
+            security: [],
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+        '/unconditional': {
+          get: {
+            operationId: 'unconditionalOp',
+            // References only a non-conditional scheme.
+            security: [{ apiKey: [] }],
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+        '/no-security': {
+          get: {
+            operationId: 'noSecurityOp',
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+    };
+    writeFileSync(specPath, JSON.stringify(spec));
+  });
+
+  afterAll(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('flags only operations whose security references a conditional scheme', async () => {
+    const model = await loadSpec(specPath);
+    const byId = new Map(model.operations.map((o) => [o.operationId, o]));
+    expect(byId.get('securedOp')?.conditionalAuth).toBe(true);
+    expect(byId.get('publicOp')?.conditionalAuth).toBe(false);
+    expect(byId.get('unconditionalOp')?.conditionalAuth).toBe(false);
+    expect(byId.get('noSecurityOp')?.conditionalAuth).toBe(false);
+  });
+
+  it('falls back to the global security requirement when an op declares none', async () => {
+    const globalSecuredPath = join(tmp, 'spec-global.json');
+    writeFileSync(
+      globalSecuredPath,
+      JSON.stringify({
+        openapi: '3.0.3',
+        info: { title: 'fixture', version: '1.0.0' },
+        security: [{ BearerAuth: [] }],
+        components: {
+          securitySchemes: {
+            BearerAuth: { type: 'http', scheme: 'bearer', 'x-enforcement': 'conditional' },
+          },
+        },
+        paths: {
+          '/inherits': {
+            get: { operationId: 'inheritsOp', responses: { '200': { description: 'ok' } } },
+          },
+          '/overrides': {
+            get: {
+              operationId: 'overridesOp',
+              security: [],
+              responses: { '200': { description: 'ok' } },
+            },
+          },
+        },
+      }),
+    );
+    const model = await loadSpec(globalSecuredPath);
+    const byId = new Map(model.operations.map((o) => [o.operationId, o]));
+    expect(byId.get('inheritsOp')?.conditionalAuth).toBe(true);
+    expect(byId.get('overridesOp')?.conditionalAuth).toBe(false);
+  });
+});
+
+describe('request-validation: generateAuthAbsent contract (#346)', () => {
+  const ops: OperationModel[] = [
+    {
+      operationId: 'securedOp',
+      method: 'POST',
+      path: '/secured',
+      tags: [],
+      parameters: [],
+      conditionalAuth: true,
+    },
+    {
+      operationId: 'withPath',
+      method: 'GET',
+      path: '/items/{itemKey}',
+      tags: [],
+      parameters: [],
+      conditionalAuth: true,
+    },
+    {
+      operationId: 'publicOp',
+      method: 'GET',
+      path: '/public',
+      tags: [],
+      parameters: [],
+      conditionalAuth: false,
+    },
+    { operationId: 'undefinedOp', method: 'GET', path: '/legacy', tags: [], parameters: [] },
+  ];
+
+  it('emits exactly one 401 scenario per conditionally-secured op and none otherwise', () => {
+    const scenarios = generateAuthAbsent(ops, {});
+    expect(scenarios.map((s) => s.operationId).sort()).toEqual(['securedOp', 'withPath']);
+  });
+
+  it('every emitted scenario is a well-formed unauthenticated 401 request (class-scoped)', () => {
+    const scenarios = generateAuthAbsent(ops, {});
+    for (const s of scenarios) {
+      expect(s.type).toBe('auth-absent');
+      expect(s.expectedStatus).toBe(401);
+      expect(s.headersAuth).toBe(false);
+      // No body is sent — auth is rejected before any body/parameter validation.
+      expect(s.requestBody).toBeUndefined();
+      expect(s.multipartForm).toBeUndefined();
+    }
+  });
+
+  it('fills path-template tokens with dummy params so routing reaches the auth filter', () => {
+    const [withPath] = generateAuthAbsent(
+      ops.filter((o) => o.operationId === 'withPath'),
+      {},
+    );
+    expect(withPath.params).toEqual({ itemKey: 'x' });
+  });
+
+  it('honours the onlyOperations filter', () => {
+    const scenarios = generateAuthAbsent(ops, { onlyOperations: new Set(['securedOp']) });
+    expect(scenarios.map((s) => s.operationId)).toEqual(['securedOp']);
+  });
+});
+
+describe('request-validation: auth-absent emitter shape (#346)', () => {
+  const scenario: ValidationScenario = {
+    id: 'securedOp__auth_absent',
+    operationId: 'securedOp',
+    method: 'POST',
+    path: '/secured',
+    type: 'auth-absent',
+    expectedStatus: 401,
+    description: 'unauthenticated',
+    headersAuth: false,
+  };
+
+  it('sends no auth header and asserts 401', () => {
+    const rendered = renderScenarioForTest(scenario, 'securedOp - Missing authentication');
+    // headersAuth:false => empty headers object, never jsonHeaders().
+    expect(rendered).toContain('headers: {}');
+    expect(rendered).not.toContain('jsonHeaders()');
+    expect(rendered).toContain('assertResponseStatus(testInfo, res, 401');
+    // No request body is emitted.
+    expect(rendered).not.toContain('const requestBody');
+  });
+});

--- a/tests/request-validation/auth-absent.test.ts
+++ b/tests/request-validation/auth-absent.test.ts
@@ -130,6 +130,45 @@ describe('request-validation: auth-absent loader derivation (#346)', () => {
     expect(byId.get('inheritsOp')?.conditionalAuth).toBe(true);
     expect(byId.get('overridesOp')?.conditionalAuth).toBe(false);
   });
+
+  it('honours path-item-level security between operation-level and global (op ?? pathItem ?? global)', async () => {
+    const pathItemPath = join(tmp, 'spec-path-item.json');
+    writeFileSync(
+      pathItemPath,
+      JSON.stringify({
+        openapi: '3.0.3',
+        info: { title: 'fixture', version: '1.0.0' },
+        // No global security — proves the path-item level is what flags the op.
+        components: {
+          securitySchemes: {
+            BearerAuth: { type: 'http', scheme: 'bearer', 'x-enforcement': 'conditional' },
+          },
+        },
+        paths: {
+          // Path-item declares conditional security; the op declares none, so
+          // it must inherit the path-item requirement.
+          '/path-secured': {
+            security: [{ BearerAuth: [] }],
+            get: { operationId: 'inheritsPathOp', responses: { '200': { description: 'ok' } } },
+          },
+          // Path-item is conditional, but the op overrides with explicit public
+          // — op-level precedence wins, so it must NOT be flagged.
+          '/path-overridden': {
+            security: [{ BearerAuth: [] }],
+            get: {
+              operationId: 'overridesPathOp',
+              security: [],
+              responses: { '200': { description: 'ok' } },
+            },
+          },
+        },
+      }),
+    );
+    const model = await loadSpec(pathItemPath);
+    const byId = new Map(model.operations.map((o) => [o.operationId, o]));
+    expect(byId.get('inheritsPathOp')?.conditionalAuth).toBe(true);
+    expect(byId.get('overridesPathOp')?.conditionalAuth).toBe(false);
+  });
 });
 
 describe('request-validation: generateAuthAbsent contract (#346)', () => {


### PR DESCRIPTION
## What

Splits the request-validation negative suite into **two parallel, self-contained profiles** under `generated/<config>/request-validation/`:

| Profile | Contents | Run against |
|---|---|---|
| `unsecured/` | The HTTP 400 validation tests (deployment-mode-agnostic baseline) | a server with auth **off** |
| `secured/` | The same 400 tests **plus** new HTTP 401 `auth-absent` tests for conditionally-secured ops | a server started with auth **on** |

## Why

Issue #346 / #301 want the negative suite to be runnable against both a secured and an unsecured server. A request sent without credentials to a conditionally-secured operation should get a 401; against an unsecured server it should not. Encoding this as two profiles lets each run be unambiguous.

## How

- **Data-driven flagging.** An operation is flagged `conditionalAuth` when it declares (or inherits) a `security` block referencing a security scheme whose `x-enforcement` is `conditional` (upstream camunda/camunda#53708). An explicit `security: []` (publicly unauthenticated) is never flagged.
- **New `auth-absent` scenario kind** -> one unauthenticated request (`headersAuth: false` -> `headers: {}`) asserting **401** per flagged op.
- **Profile split** in `generate.ts`: `unsecured` = all scenarios except `auth-absent`; `secured` = all. Each subdir is a fully standalone suite (own scaffolding + `support/`). Each profile dir is cleaned before emit so stale specs can't survive a regen.
- **Runner**: `scripts/run-pw-request-validation.ts` defaults to `unsecured`; `RV_PROFILE=secured` switches (supply `CAMUNDA_BASIC_AUTH_USER`/`PASSWORD`).

## Dormant until the spec pin is bumped

The **currently pinned spec carries no `x-enforcement` annotations**, so `conditionalAuth` is false for every op -> `auth-absent` set is empty -> `secured/` and `unsecured/` are **byte-identical** (verified with `diff -rq`, 35 specs each, 0 auth-absent tests). The feature only activates when the spec pin is bumped to a SHA carrying the annotations. This preserves the existing baseline.

## Tests

- New `tests/request-validation/auth-absent.test.ts` — loader derivation (temp-spec fixtures incl. `security: []` and global-fallback cases), generator contract, emitter shape. (7 tests)
- New Layer-3 `#346` profile-split invariants in `configs/camunda-oca/regression-invariants.test.ts` — both profiles exist + scaffolded; `unsecured/` never expects 401; every `secured/` auth-absent test is an unauthenticated 401 with `headers: {}`; secured ⊇ unsecured. (dormancy-safe — they hold with zero auth-absent tests)
- Existing Layer-3 invariants and `generated-suites-typecheck.test.ts` repointed at the `unsecured/` subdir; the typecheck test now covers both profile subdirs.

### Verification
- `npm run lint` — clean (0 warnings/infos)
- `npx tsc --noEmit` — request-validation + tests/tsconfig both OK
- `npm test` — **662 passed / 4 skipped** (63 files); both `request-validation (unsecured)` and `(secured)` typecheck

Closes #346
