### PR TITLE
feat: add camunda-hub config (phase 1 — request-validation only) (#128)

### DIFF
--- a/configs.json
+++ b/configs.json
@@ -13,6 +13,18 @@
         "maxChainAlternatives": 20,
         "maxVariantsPerEndpoint": 20
       }
+    },
+    "camunda-hub": {
+      "description": "Camunda Hub Public API V2 (spike — request-validation only)",
+      "spec": {
+        "source": "github:camunda/camunda-hub",
+        "$comment": "Hub spec lives at restapi/public-api/src/main/resources/openapi/v2/ in the (private) camunda/camunda-hub repo. Pinned ref + expected hash live in configs/camunda-hub/spec-pin.json. This config currently exercises only the request-validation (negative) suite; positive-test ABox authoring is deferred — see the camunda-hub config README/issue."
+      },
+      "planner": {
+        "$comment": "Same caps as camunda-oca; not load-bearing for request-validation, but kept consistent so a future positive-suite extension does not need a config edit.",
+        "maxChainAlternatives": 20,
+        "maxVariantsPerEndpoint": 20
+      }
     }
   }
 }

--- a/configs/camunda-hub/request-validation.json
+++ b/configs/camunda-hub/request-validation.json
@@ -1,0 +1,4 @@
+{
+  "$comment": "Per-config request-validation settings for camunda-hub. Hub does not (yet) declare a position on enum case-insensitivity; default `false` emits case-only mutations as 400-expecting tests, which is the conservative choice. Revisit if hub's parser turns out to accept enum values case-insensitively.",
+  "enumCaseInsensitive": false
+}

--- a/configs/camunda-hub/spec-pin.json
+++ b/configs/camunda-hub/spec-pin.json
@@ -1,0 +1,5 @@
+{
+  "$comment": "Spec pin for the camunda-hub config (spike). Mirrors the camunda-oca contract: specRef MUST be a 40-char commit SHA on camunda/camunda-hub, expectedSpecHash is the specHash printed in spec/camunda-hub/bundled/spec-metadata.json after bundling. The hub spec lives at restapi/public-api/src/main/resources/openapi/v2/ inside camunda/camunda-hub (private repo). Initial pin: latest main as of 2026-06-02.",
+  "specRef": "f6e7a8a124f58064610f0fa8e48e9915624414ee",
+  "expectedSpecHash": "sha256:9e0c24c2d0a549f6bf009e3328f612b16779f811f503a5ae39d3475f9ca13ab1"
+}


### PR DESCRIPTION
## Summary

Adds a second named generator configuration pointing at the **Camunda Hub Public API V2** spec ([camunda/camunda-hub](https://github.com/camunda/camunda-hub), path `restapi/public-api/src/main/resources/openapi/v2/`). #128 has called for OCA + Hub side-by-side selectability since early May; this PR lands the **minimum viable** hub config that exercises the negative (request-validation) suite end-to-end.

> ⚠️ **Phase 1 only.** Positive-suite (path-analyser) emission for hub requires authoring `configs/camunda-hub/ontology/*.json` and is intentionally deferred. See the follow-ups list below.

## Changes (3 files, +21 lines, additive)

| File | Purpose |
|---|---|
| `configs.json` | New `camunda-hub` block alongside `camunda-oca`. |
| `configs/camunda-hub/spec-pin.json` | Pinned camunda-hub commit SHA + matching `specHash` from the bundled spec. |
| `configs/camunda-hub/request-validation.json` | Conservative `enumCaseInsensitive=false` (revisit once hub's parser behaviour is known). |

**No shared code is touched.** The existing #128 plumbing (per-config `configResolver`, partitioned `spec/<config>/` + `generated/<config>/` output paths, per-config `request-validation` config loader, the parallel secured/unsecured profile split from #347) all worked **unchanged on the first attempt** against a different API. That's the architecture working as designed.

## Verification

```bash
CONFIG=camunda-hub npm run generate:request-validation
```

Output:

- **70 deduped scenarios** across **8 mutation kinds** (`additional-prop`, `additional-prop-general`, `body-top-type-mismatch`, `constraint-violation`, `enum-violation`, `missing-body`, `missing-required`, `missing-required-combo`, `type-mismatch`)
- **4 spec files** under `generated/camunda-hub/request-validation/{secured,unsecured}/`
- **5 / 9 hub operations covered.** The 4 uncovered (`getFile`, `getFolder`, `deleteFile`, `deleteFolder`) are pure path-param GET/DELETE with no request body to mutate — correctly nothing to mutate.
- Lint clean (`npm run lint` → 0 fixes)
- OCA pipeline unaffected (`CONFIG=camunda-oca` resolves and runs unchanged)

Excerpt from the generated `COVERAGE.md`:

```
| OperationId  | Method | Path                  | Total | KindCov% |
| createFile   | POST   | /files                | 31    | 88%      |
| createFolder | POST   | /folders              | 13    | 75%      |
| searchFiles  | POST   | /files/search         | 7     | 50%      |
| updateFile   | PATCH  | /files/{fileKey}      | 11    | 63%      |
| updateFolder | PATCH  | /folders/{folderKey}  | 8     | 50%      |

Endpoint coverage: 5/9 (55.6%) have at least one scenario.
```

The bundler accepted the hub spec **out of the box** via `--spec-dir` mode (5 paths, 9 operations, 36 schemas, 6 unions, 0 eventually-consistent). No upstream `camunda-schema-bundler` change is needed.

## How I built the bundled spec for this spike

The repo's `scripts/fetch-spec.ts` currently always pulls from `camunda/camunda` (no `--repo-url` plumbing yet — that's the first follow-up below). For this spike I pulled the 8 hub spec files via `gh api` from the private repo and bundled them locally:

```bash
mkdir -p /tmp/hub-spec && cd /tmp/hub-spec
for f in rest-api.yaml common-responses.yaml cursors.yaml files.yaml \
         filters.yaml folders.yaml problem-detail.yaml search-models.yaml; do
  gh api "repos/camunda/camunda-hub/contents/restapi/public-api/src/main/resources/openapi/v2/$f" \
    --jq '.content' | base64 -d > "$f"
done

cd <repo-root>
mkdir -p spec/camunda-hub/bundled
npx camunda-schema-bundler \
  --spec-dir /tmp/hub-spec \
  --output-spec spec/camunda-hub/bundled/rest-api.bundle.json \
  --output-metadata spec/camunda-hub/bundled/spec-metadata.json
```

Reviewers with read access to camunda-hub can reproduce the same bundled spec deterministically (the `specHash` in `spec-pin.json` will match).

## Deferred follow-ups (separate PRs)

These are scope boundaries of this PR, not bugs:

1. **`scripts/fetch-spec.ts` per-config repo support.** Read `configs[<name>].spec.source` from `configs.json` (already authored: `"github:camunda/camunda-hub"`) and pass `--repo-url` + the deep `restapi/public-api/src/main/resources/openapi/v2/` subpath to the bundler so `CONFIG=camunda-hub npm run fetch-spec` works in CI. Hub being private also means CI needs a read-scoped token in the workflow env.
2. **Positive suite for hub.** Author `configs/camunda-hub/ontology/{entity-kinds,edges,semantics,artifact-kinds,runtime-states,scenario-templates,global-context-seeds}.json`. Hub's CRUD-only shape (no BPMN, no jobs, 0 eventually-consistent operations) means a small ABox: 2 entity kinds (File, Folder), possibly one `FolderContainsFile` edge, no artifact-kinds, minimal runtime-states.
3. **`configs/camunda-hub/regression-invariants.test.ts`** with `describe.skipIf`-guarded named L3 asserts (the same pattern OCA uses, so the CI matrix only runs the active config's invariants).

## Why this is safe to merge as-is

- **Strictly additive.** No file outside `configs/camunda-hub/` is modified except a single block append in `configs.json`.
- **OCA is unaffected.** `CONFIG` defaults to `camunda-oca`; CI still runs the OCA matrix; the OCA spec-pin gate, regression invariants, and pipeline outputs are all untouched.
- **No shared-code drift.** Zero changes to `path-analyser/`, `request-validation/`, `materializer/`, `semantic-graph-extractor/`, or any script under `scripts/`. If hub's config wiring is later determined to be wrong, the fix is contained to `configs/camunda-hub/`.

Closes-towards #128 (phase 1 of N).
