### PR TITLE
fix: make emitter roleHooks advisory rather than required at registration (#350)

### DIFF
--- a/materializer/src/index.ts
+++ b/materializer/src/index.ts
@@ -5,7 +5,6 @@ import {
   type EmitContext,
   type EmitterStrategy,
   getEmitter,
-  getRoleHookProvider,
   type LoadedRoleBundle,
   listEmitters,
   type RoleHookProvider,
@@ -43,6 +42,7 @@ import {
 } from './playwright/materialize-support.js';
 import { loadRoleBundlesForActiveConfig } from './playwright/roleRenderer.js';
 import { emitTemplateSuites } from './playwright/templateEmitter.js';
+import { resolveRoleExtras } from './roleHookResolver.js';
 
 // Built-in emitter registrations. RoleHookProviders are no longer
 // registered statically here: every provider lives next to its role
@@ -407,30 +407,18 @@ async function run() {
       : undefined;
     getRoleForOperationFn = (opId: string) => getEmitterRoleForOperation(domain, opId);
   }
-  for (const hook of emitter.roleHooks ?? []) {
-    const provider = getRoleHookProvider(hook);
-    if (!provider) {
-      console.error(
-        `Emitter ${JSON.stringify(emitter.id)} declares roleHook ${JSON.stringify(
-          hook,
-        )} but no provider is registered for that hook name.`,
-      );
-      process.exit(1);
-    }
-    const extras = await provider.compute({ repoRoot, configName });
-    if (extras === undefined) continue;
-    if (!roleExtras) roleExtras = new Map<string, Record<string, unknown>>();
-    if (roleExtras.has(provider.role)) {
-      console.error(
-        `Role-hook provider for hook ${JSON.stringify(
-          hook,
-        )} attempted to overwrite extras for role ${JSON.stringify(
-          provider.role,
-        )} already populated by an earlier hook. Hook providers must own disjoint roles.`,
-      );
-      process.exit(1);
-    }
-    roleExtras.set(provider.role, extras);
+  // #350: roleHook resolution. Declarations are advisory — a config that
+  // doesn't ship a provider for a declared hook simply doesn't populate
+  // the corresponding role's extras. Operations actually dispatched to
+  // the unbacked role surface a named error at materialization time
+  // (`findRoleForStep` in playwright/emitter.ts and the support-template
+  // assertions in materialize-support.ts). The resolver throws on
+  // duplicate-role conflicts (formerly `process.exit(1)` here).
+  try {
+    roleExtras = await resolveRoleExtras(emitter, { repoRoot, configName });
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
   }
 
   // #243: Vendor per-role helper files now that `roleExtras` is populated,

--- a/materializer/src/index.ts
+++ b/materializer/src/index.ts
@@ -42,7 +42,7 @@ import {
 } from './playwright/materialize-support.js';
 import { loadRoleBundlesForActiveConfig } from './playwright/roleRenderer.js';
 import { emitTemplateSuites } from './playwright/templateEmitter.js';
-import { resolveRoleExtras } from './roleHookResolver.js';
+import { RoleHookConflictError, resolveRoleExtras } from './roleHookResolver.js';
 
 // Built-in emitter registrations. RoleHookProviders are no longer
 // registered statically here: every provider lives next to its role
@@ -412,12 +412,16 @@ async function run() {
   // the corresponding role's extras. Operations actually dispatched to
   // the unbacked role surface a named error at materialization time
   // (`findRoleForStep` in playwright/emitter.ts and the support-template
-  // assertions in materialize-support.ts). The resolver throws on
-  // duplicate-role conflicts (formerly `process.exit(1)` here).
+  // assertions in materialize-support.ts). The resolver throws
+  // `RoleHookConflictError` on duplicate-role conflicts (formerly
+  // `process.exit(1)` here); any other error from a provider’s
+  // `compute()` propagates with its full stack so unexpected hook bugs
+  // remain debuggable.
   try {
     roleExtras = await resolveRoleExtras(emitter, { repoRoot, configName });
   } catch (err) {
-    console.error(err instanceof Error ? err.message : String(err));
+    if (!(err instanceof RoleHookConflictError)) throw err;
+    console.error(err.message);
     process.exit(1);
   }
 

--- a/materializer/src/roleHookResolver.ts
+++ b/materializer/src/roleHookResolver.ts
@@ -1,0 +1,78 @@
+/**
+ * Resolve per-role extras from an emitter's declared `roleHooks` (#350).
+ *
+ * Extracted from the orchestrator's `run()` so the dispatch contract is
+ * unit-testable independently of disk I/O. Consumers pass an emitter
+ * (whose `roleHooks` declaration drives the loop) and a small context
+ * object; the function looks up each declared hook in the SDK registry.
+ *
+ * Contract (#350):
+ *
+ * - **Advisory declaration.** A hook declared in `emitter.roleHooks`
+ *   that has no registered provider is *skipped*, not a hard error.
+ *   This lets a single emitter (e.g. `PlaywrightEmitter` declaring
+ *   `['deployment']`) target both configs that ship a deployment role
+ *   bundle (camunda-oca) and configs that don't (camunda-hub) without
+ *   forcing the latter to vendor a no-op provider just to satisfy
+ *   registration. The downstream dispatch sites
+ *   (`findRoleForStep` in the playwright emitter,
+ *   `materializeRoleSupportFiles` in materialize-support) already raise
+ *   meaningful errors when an operation *is* dispatched to a role
+ *   whose extras / bundle aren't populated, so the advisory check is
+ *   safe.
+ *
+ * - **Disjoint roles.** Two providers attempting to populate the same
+ *   role key throw — providers must own disjoint roles.
+ *
+ * - **Undefined extras = skip.** A provider whose `compute()` returns
+ *   `undefined` is treated as "nothing to contribute for this config";
+ *   the role is simply not added to the returned map.
+ */
+import { type EmitterStrategy, getRoleHookProvider } from '@camunda8/emitter-sdk';
+
+export interface RoleHookCtx {
+  /** Absolute path to the repo root. Forwarded to provider.compute(). */
+  repoRoot: string;
+  /** Active config name (e.g. 'camunda-oca'). Forwarded to provider.compute(). */
+  configName: string;
+}
+
+/**
+ * Resolve every declared `roleHook` for the given emitter and return
+ * the per-role extras map. Returns `undefined` when no hook contributed
+ * anything (so the caller can skip allocating an empty map).
+ *
+ * Throws `Error` if two providers populate the same role.
+ */
+export async function resolveRoleExtras(
+  emitter: Pick<EmitterStrategy, 'id' | 'roleHooks'>,
+  ctx: RoleHookCtx,
+): Promise<Map<string, Record<string, unknown>> | undefined> {
+  let roleExtras: Map<string, Record<string, unknown>> | undefined;
+  for (const hook of emitter.roleHooks ?? []) {
+    const provider = getRoleHookProvider(hook);
+    if (!provider) {
+      // Advisory: the emitter declares this hook but the active config
+      // didn't ship a provider for it. Operations that actually need the
+      // role's extras will surface a named error at dispatch time
+      // (`findRoleForStep` / `materializeRoleSupportFiles`); silent skip
+      // is correct for configs that have no operation dispatched to the
+      // role.
+      continue;
+    }
+    const extras = await provider.compute(ctx);
+    if (extras === undefined) continue;
+    if (!roleExtras) roleExtras = new Map<string, Record<string, unknown>>();
+    if (roleExtras.has(provider.role)) {
+      throw new Error(
+        `Role-hook provider for hook ${JSON.stringify(
+          hook,
+        )} attempted to overwrite extras for role ${JSON.stringify(
+          provider.role,
+        )} already populated by an earlier hook. Hook providers must own disjoint roles.`,
+      );
+    }
+    roleExtras.set(provider.role, extras);
+  }
+  return roleExtras;
+}

--- a/materializer/src/roleHookResolver.ts
+++ b/materializer/src/roleHookResolver.ts
@@ -30,6 +30,20 @@
  */
 import { type EmitterStrategy, getRoleHookProvider } from '@camunda8/emitter-sdk';
 
+/**
+ * Thrown when two role-hook providers attempt to populate the same role
+ * key. This is a deterministic, expected failure (not a bug in the
+ * provider's compute()), so the orchestrator catches it specifically and
+ * exits with the message — any other error from a provider should bubble
+ * up with its full stack trace.
+ */
+export class RoleHookConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RoleHookConflictError';
+  }
+}
+
 export interface RoleHookCtx {
   /** Absolute path to the repo root. Forwarded to provider.compute(). */
   repoRoot: string;
@@ -64,7 +78,7 @@ export async function resolveRoleExtras(
     if (extras === undefined) continue;
     if (!roleExtras) roleExtras = new Map<string, Record<string, unknown>>();
     if (roleExtras.has(provider.role)) {
-      throw new Error(
+      throw new RoleHookConflictError(
         `Role-hook provider for hook ${JSON.stringify(
           hook,
         )} attempted to overwrite extras for role ${JSON.stringify(

--- a/tests/codegen/role-hook-resolver.test.ts
+++ b/tests/codegen/role-hook-resolver.test.ts
@@ -5,8 +5,8 @@
 // remain usable from configs that don't ship a deploymentGateway role
 // bundle (e.g. camunda-hub, where 0/9 operations are multipart).
 //
-// Each `it` pins one named property of the contract documented in
-// `materializer/src/roleHookResolver.ts`.
+// Each `test(...)` block pins one named property of the contract
+// documented in `materializer/src/roleHookResolver.ts`.
 
 import {
   _resetRegistriesForTests,
@@ -15,7 +15,10 @@ import {
   registerRoleHookProvider,
 } from '@camunda8/emitter-sdk';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
-import { resolveRoleExtras } from '../../materializer/src/roleHookResolver.ts';
+import {
+  RoleHookConflictError,
+  resolveRoleExtras,
+} from '../../materializer/src/roleHookResolver.ts';
 
 const CTX = { repoRoot: '/tmp/never-read', configName: 'unit-test' };
 
@@ -77,9 +80,12 @@ describe('resolveRoleExtras (#350 — advisory roleHooks)', () => {
     expect(result?.has('deploymentGateway')).toBe(false);
   });
 
-  test('two providers populating the same role throw (no silent overwrite)', async () => {
+  test('two providers populating the same role throw RoleHookConflictError (no silent overwrite)', async () => {
     registerRoleHookProvider(provider('hookA', 'sharedRole', { a: 1 }));
     registerRoleHookProvider(provider('hookB', 'sharedRole', { b: 2 }));
+    await expect(resolveRoleExtras(emitter(['hookA', 'hookB']), CTX)).rejects.toThrowError(
+      RoleHookConflictError,
+    );
     await expect(resolveRoleExtras(emitter(['hookA', 'hookB']), CTX)).rejects.toThrowError(
       /attempted to overwrite extras for role "sharedRole"/,
     );

--- a/tests/codegen/role-hook-resolver.test.ts
+++ b/tests/codegen/role-hook-resolver.test.ts
@@ -1,0 +1,92 @@
+// Class-scoped regression guard for #350: the orchestrator's roleHook
+// dispatch must treat declared-but-unprovided hooks as advisory (skip),
+// not as a hard registration-time failure. This is what allows the
+// PlaywrightEmitter to declare `roleHooks: ['deployment']` once and
+// remain usable from configs that don't ship a deploymentGateway role
+// bundle (e.g. camunda-hub, where 0/9 operations are multipart).
+//
+// Each `it` pins one named property of the contract documented in
+// `materializer/src/roleHookResolver.ts`.
+
+import {
+  _resetRegistriesForTests,
+  type EmitterStrategy,
+  type RoleHookProvider,
+  registerRoleHookProvider,
+} from '@camunda8/emitter-sdk';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { resolveRoleExtras } from '../../materializer/src/roleHookResolver.ts';
+
+const CTX = { repoRoot: '/tmp/never-read', configName: 'unit-test' };
+
+function emitter(roleHooks: string[]): Pick<EmitterStrategy, 'id' | 'roleHooks'> {
+  return { id: 'stub', roleHooks };
+}
+
+function provider(
+  hook: string,
+  role: string,
+  extras: Record<string, unknown> | undefined,
+): RoleHookProvider {
+  return {
+    hook,
+    role,
+    async compute() {
+      return extras;
+    },
+  };
+}
+
+beforeEach(() => {
+  _resetRegistriesForTests();
+});
+
+afterEach(() => {
+  _resetRegistriesForTests();
+});
+
+describe('resolveRoleExtras (#350 — advisory roleHooks)', () => {
+  test('declared hook without a registered provider is skipped (no throw)', async () => {
+    // The pre-#350 orchestrator called process.exit(1) here. The contract
+    // now is: the emitter's declaration is advisory, and configs that
+    // don't dispatch any operation to the role need not vendor a provider.
+    const result = await resolveRoleExtras(emitter(['deployment']), CTX);
+    expect(result).toBeUndefined();
+  });
+
+  test('declared hook with a registered provider populates roleExtras under provider.role', async () => {
+    registerRoleHookProvider(provider('deployment', 'deploymentGateway', { extracts: ['x'] }));
+    const result = await resolveRoleExtras(emitter(['deployment']), CTX);
+    expect(result).toBeDefined();
+    expect(result?.get('deploymentGateway')).toEqual({ extracts: ['x'] });
+  });
+
+  test('provider returning undefined is treated as "nothing to contribute" — role omitted', async () => {
+    registerRoleHookProvider(provider('deployment', 'deploymentGateway', undefined));
+    const result = await resolveRoleExtras(emitter(['deployment']), CTX);
+    expect(result).toBeUndefined();
+  });
+
+  test('mixed: one missing provider + one populated provider — populated wins, missing skipped', async () => {
+    // Pins the class-scope guarantee: a single missing provider does not
+    // poison the loop. Other hooks in the same emitter still run.
+    registerRoleHookProvider(provider('cleanup', 'cleanupRole', { token: 'abc' }));
+    const result = await resolveRoleExtras(emitter(['deployment', 'cleanup']), CTX);
+    expect(result?.size).toBe(1);
+    expect(result?.get('cleanupRole')).toEqual({ token: 'abc' });
+    expect(result?.has('deploymentGateway')).toBe(false);
+  });
+
+  test('two providers populating the same role throw (no silent overwrite)', async () => {
+    registerRoleHookProvider(provider('hookA', 'sharedRole', { a: 1 }));
+    registerRoleHookProvider(provider('hookB', 'sharedRole', { b: 2 }));
+    await expect(resolveRoleExtras(emitter(['hookA', 'hookB']), CTX)).rejects.toThrowError(
+      /attempted to overwrite extras for role "sharedRole"/,
+    );
+  });
+
+  test('emitter without roleHooks returns undefined (no allocation, no work)', async () => {
+    const result = await resolveRoleExtras({ id: 'stub' }, CTX);
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #350. Makes emitter `roleHooks` declarations advisory rather than required at registration time.

## Why

The orchestrator's hook-resolution loop in `materializer/src/index.ts` previously called `process.exit(1)` when an emitter declared a `roleHook` with no registered provider. That coupling forced every config to vendor a provider for every hook declared by every enabled emitter — even when no operation in the config dispatches to the corresponding role.

Concrete instance discovered during the camunda-hub spike: `PlaywrightEmitter` declares `roleHooks: ['deployment']` unconditionally, but camunda-hub has 0/9 multipart operations and never needs the `deploymentGateway` role. Without this fix, camunda-hub would either have to vendor a no-op deployment hook or fork the Playwright emitter.

## What changed

1. **Extracted** the hook-resolution loop into `materializer/src/roleHookResolver.ts` (`resolveRoleExtras`) so the contract is unit-testable without booting the full pipeline.
2. **Behaviour change**: a declared hook with no registered provider is now skipped (advisory), not a hard exit.
3. **Behaviour preserved**: duplicate-role conflicts still fail (now thrown rather than `process.exit(1)`); the orchestrator catches and exits with the same message.
4. **Safety**: dispatch-time guards already exist for operations actually bound to an unbacked role (`findRoleForStep` in `playwright/emitter.ts` raises with operation/role names; `materialize-support.ts` assertions catch missing extras keys). Skipping in `resolveRoleExtras` is therefore safe.

## Red / green / class-scoped

- **Red**: 6 named assertions in `tests/codegen/role-hook-resolver.test.ts` would fail against the pre-fix shape (which exited on missing providers).
- **Green**: all 6 pass against the new resolver.
- **Class-scoped**: tests cover the full defect class — missing provider alone, missing mixed with populated (loop continues), undefined-extras-skip, duplicate-role conflict, no-roleHooks, populated.

## Pre-push checks

- `npm run lint` — clean
- Per-workspace typecheck — clean (the 2 pre-existing `jsonld`/`n3` module errors in `tests/codegen/ontology-roundtrip.test.ts` are unrelated to this PR; verified they reproduce on `main`)
- Pipeline regenerated with `TEST_SEED=snapshot-baseline npm run testsuite:generate && npm run generate:request-validation` — all OCA Layer-3 invariants pass
- `npm test` — 667 passed, 4 skipped; the 2 failures are the pre-existing `jsonld`/`n3` import issues, unrelated to this change

## Out of scope

This PR doesn't touch camunda-hub. With this orchestrator fix in place, a follow-up can wire camunda-hub through the Playwright emitter (currently it only emits the negative request-validation suite via #128 / #349).
