### PR TITLE
chore: document PR review workflow (Copilot review request + comment handling)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,12 +382,19 @@ fix: address review comments — …
   add it via `gh` when opening the PR.
 - **Address Copilot review comments before requesting human review.** Fix
   the ones that are real, reply on each thread to record the resolution
-  (don't silently resolve), and after pushing fixes, re-request a Copilot
-  review via the "Re-request review" button in the PR UI so it can
-  confirm. The `copilot-pull-request-reviewer` integration is a GitHub
-  App and cannot be re-requested via the REST/GraphQL review-request
-  APIs — use the UI button (or push a new commit, which usually retriggers
-  it on its own).
+  (don't silently resolve), then re-trigger Copilot on the updated HEAD.
+  Two ways work:
+  - Click the ↻ "Re-request review" button next to Copilot in the PR's
+    Reviewers sidebar. This forces a fresh review on the current HEAD
+    even if no new commit has been pushed.
+  - Push a new commit. This usually (but not always) retriggers Copilot
+    automatically via webhook.
+
+  What does **not** work: the REST `POST /pulls/{n}/requested_reviewers`
+  endpoint and the GraphQL `requestReviews` mutation. The
+  `copilot-pull-request-reviewer` integration is a GitHub App, not a
+  collaborator/user, so both APIs reject it. Use the UI button or a new
+  commit.
 - Disagreeing with a Copilot suggestion is fine — reply with the reason
   (e.g. "intentional: contract boundary, see L42") and resolve. Don't
   resolve threads silently; the reply is the audit trail.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,6 +373,25 @@ fix: address review comments — …
   matters.
 - Reference the closing issue in the PR description (`Closes #NN`).
 
+## PR review
+
+- **Request a Copilot review on every PR.** It is a cheap first pass that
+  catches obvious issues (typos, missing null checks, mis-named symbols,
+  shadowed variables, unhandled error branches) before human reviewers
+  spend time on them. Click "Request review" → "Copilot" in the PR UI, or
+  add it via `gh` when opening the PR.
+- **Address Copilot review comments before requesting human review.** Fix
+  the ones that are real, reply on each thread to record the resolution
+  (don't silently resolve), and after pushing fixes, re-request a Copilot
+  review via the "Re-request review" button in the PR UI so it can
+  confirm. The `copilot-pull-request-reviewer` integration is a GitHub
+  App and cannot be re-requested via the REST/GraphQL review-request
+  APIs — use the UI button (or push a new commit, which usually retriggers
+  it on its own).
+- Disagreeing with a Copilot suggestion is fine — reply with the reason
+  (e.g. "intentional: contract boundary, see L42") and resolve. Don't
+  resolve threads silently; the reply is the audit trail.
+
 ## Continuous integration
 
 Single workflow: [.github/workflows/ci.yml](.github/workflows/ci.yml). Runs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,8 +378,9 @@ fix: address review comments — …
 - **Request a Copilot review on every PR.** It is a cheap first pass that
   catches obvious issues (typos, missing null checks, misnamed symbols,
   shadowed variables, unhandled error branches) before human reviewers
-  spend time on them. Click "Request review" → "Copilot" in the PR UI, or
-  add it via `gh` when opening the PR.
+  spend time on them. Click "Request review" → "Copilot" in the PR UI
+  (the REST/GraphQL APIs — and `gh`, which wraps them — cannot request
+  the Copilot reviewer; see the note below).
 - **Address Copilot review comments before requesting human review.** Fix
   the ones that are real, reply on each thread to record the resolution
   (don't silently resolve), then re-trigger Copilot on the updated HEAD.
@@ -390,11 +391,13 @@ fix: address review comments — …
   - Push a new commit. This usually (but not always) retriggers Copilot
     automatically via webhook.
 
-  What does **not** work: the REST `POST /pulls/{n}/requested_reviewers`
-  endpoint and the GraphQL `requestReviews` mutation. The
-  `copilot-pull-request-reviewer` integration is a GitHub App, not a
-  collaborator/user, so both APIs reject it. Use the UI button or a new
-  commit.
+  What does **not** work: the REST
+  `POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers`
+  endpoint and the GraphQL `requestReviews` mutation (and therefore
+  `gh pr edit --add-reviewer` / `gh pr create --reviewer`, which wrap the
+  REST endpoint). The `copilot-pull-request-reviewer` integration is a
+  GitHub App, not a collaborator/user, so all of these reject it. Use
+  the UI button or a new commit.
 - Disagreeing with a Copilot suggestion is fine — reply with the reason
   (e.g. "intentional: contract boundary, see L42") and resolve. Don't
   resolve threads silently; the reply is the audit trail.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,7 +376,7 @@ fix: address review comments — …
 ## PR review
 
 - **Request a Copilot review on every PR.** It is a cheap first pass that
-  catches obvious issues (typos, missing null checks, mis-named symbols,
+  catches obvious issues (typos, missing null checks, misnamed symbols,
   shadowed variables, unhandled error branches) before human reviewers
   spend time on them. Click "Request review" → "Copilot" in the PR UI, or
   add it via `gh` when opening the PR.


### PR DESCRIPTION
## Summary

Adds a new `## PR review` section to AGENTS.md codifying two patterns that have proven useful but were not previously written down:

1. **Request a Copilot review on every PR** — it's a cheap first pass that catches obvious issues (typos, missing null checks, shadowed variables, unhandled error branches) before human reviewers spend time on them.
2. **Address Copilot review comments before requesting human review** — fix the real ones, reply on each thread (don't silently resolve), and re-request via the PR UI button after pushing.

Also documents a non-obvious gotcha discovered during PR #351: the `copilot-pull-request-reviewer` integration is a GitHub App and **cannot** be re-requested via the REST or GraphQL review-request APIs — only via the UI button or by pushing a new commit. Future agents and maintainers won't have to rediscover this the hard way.

## Why now

This pattern came up while iterating on PR #351. The rules were sitting in a personal agent-rules file; promoting the team-relevant ones to AGENTS.md so every contributor (human or agent) gets the same guidance.

## Scope

Documentation only — no code, no behaviour, no test changes.