### PR TITLE
test: add ElementId regression guard for modifyProcessInstancesBatchOperation (#165)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -3848,7 +3848,7 @@ describeForThisConfig('bundled-spec invariants: modelDerived value source (#162 
   // a seed line alone. Here we assert the binding is wired into the
   // `moveInstructions` body itself — the property that was broken — for
   // both the source and target ElementId variants.
-it('modifyProcessInstancesBatchOperation :: moveInstructions wires ctx.elementIdVar into the body (#165)', () => {
+  it('modifyProcessInstancesBatchOperation :: moveInstructions wires ctx.elementIdVar into the body (#165)', () => {
     const spec = join(GENERATED_TESTS_DIR, 'modifyProcessInstancesBatchOperation.variant.spec.ts');
     if (!existsSync(spec)) {
       throw new Error(

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -3848,7 +3848,7 @@ describeForThisConfig('bundled-spec invariants: modelDerived value source (#162 
   // a seed line alone. Here we assert the binding is wired into the
   // `moveInstructions` body itself — the property that was broken — for
   // both the source and target ElementId variants.
-  it('modifyProcessInstancesBatchOperation :: moveInstructions wire ctx.elementIdVar into the body (#165)', () => {
+it('modifyProcessInstancesBatchOperation :: moveInstructions wires ctx.elementIdVar into the body (#165)', () => {
     const spec = join(GENERATED_TESTS_DIR, 'modifyProcessInstancesBatchOperation.variant.spec.ts');
     if (!existsSync(spec)) {
       throw new Error(

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -3701,17 +3701,21 @@ describeForThisConfig('bundled-spec invariants: modelDerived value source (#162 
   // — not from the synthetic `fc:pos:<endpoint>:<semantic>` placeholder
   // the pre-PR-1 planner used.
   //
-  // The 4 single-deploy ElementId consumer sites covered here:
+  // The 5 single-deploy ElementId consumer sites covered here:
   //   - createProcessInstance        :: startInstructions[].elementId
   //   - activateAdHocSubProcessActivities :: elements[].elementId
   //   - completeJob                  :: result.activateElements[].elementId
   //   - modifyProcessInstance        :: activateInstructions[].elementId
+  //   - modifyProcessInstancesBatchOperation :: moveInstructions[].{source,target}ElementId
   //
-  // Other ElementId consumer sites that remain uncovered by PR 1:
-  //   - modifyProcessInstancesBatchOperation :: moveInstructions[].sourceElementId
-  //     (single-endpoint chain — the planner doesn't insert a
-  //      createDeployment prerequisite for batch operations even though
-  //      sourceElementId needs a model. Separate chain-construction issue.)
+  // The batch operation was originally carved out (#165): the early
+  // single-step-chain planner emitted no `createDeployment` prerequisite,
+  // so the ElementId leaf fell back to a synthetic placeholder. The
+  // planner now chains the deploy prerequisite and the optionalSubShape
+  // variant generator resolves `elementIdVar` via runtime emission
+  // (activateJobs → `json.jobs[0].elementId`), so the guard below applies.
+  //
+  // Other ElementId consumer sites that remain uncovered here:
   //   - migrateProcessInstance / migrateProcessInstancesBatchOperation
   //     (multi-deploy: source-model + target-model — needs per-deploy-step
   //      fixture selection. PR 1's helper takes the FIRST deploy step.)
@@ -3791,6 +3795,11 @@ describeForThisConfig('bundled-spec invariants: modelDerived value source (#162 
       variantFile: 'post--process-instances--{processInstanceKey}--modification-scenarios.json',
       varName: 'elementIdVar',
     },
+    {
+      endpoint: 'modifyProcessInstancesBatchOperation',
+      variantFile: 'post--process-instances--modification-scenarios.json',
+      varName: 'elementIdVar',
+    },
   ];
 
   for (const t of TARGETS) {
@@ -3829,6 +3838,33 @@ describeForThisConfig('bundled-spec invariants: modelDerived value source (#162 
       ).toBe(true);
     });
   }
+
+  // #165 — class-faithful guard for the batch operation. The generic
+  // file-wide `ctx.elementIdVar` check above is too weak to catch this
+  // issue's original symptom: a single-step chain (no `createDeployment`
+  // prerequisite) emitted a "lying" scenario where `elementIdVar` was
+  // seeded but the request body never consumed it (`sourceElementId`
+  // held a synthetic literal). A file-wide reference can be satisfied by
+  // a seed line alone. Here we assert the binding is wired into the
+  // `moveInstructions` body itself — the property that was broken — for
+  // both the source and target ElementId variants.
+  it('modifyProcessInstancesBatchOperation :: moveInstructions wire ctx.elementIdVar into the body (#165)', () => {
+    const spec = join(GENERATED_TESTS_DIR, 'modifyProcessInstancesBatchOperation.variant.spec.ts');
+    if (!existsSync(spec)) {
+      throw new Error(
+        'expected emitted spec not found: modifyProcessInstancesBatchOperation.variant.spec.ts',
+      );
+    }
+    const src = readFileSync(spec, 'utf8');
+    expect(
+      src.includes('sourceElementId: ctx.elementIdVar'),
+      'sourceElementId variant must wire ctx.elementIdVar into moveInstructions (not a synthetic placeholder)',
+    ).toBe(true);
+    expect(
+      src.includes('targetElementId: ctx.elementIdVar'),
+      'targetElementId variant must wire ctx.elementIdVar into moveInstructions (not a synthetic placeholder)',
+    ).toBe(true);
+  });
 });
 
 describeForThisConfig(


### PR DESCRIPTION
## What

Adds the regression guard that was the remaining open item of #165 (DoD item 3), and removes a stale carve-out comment.

## Background

#165's behavioural defect is already fixed in the generator: the planner now chains a `createDeployment` prerequisite for `modifyProcessInstancesBatchOperation`, and the optionalSubShape variant generator resolves `elementIdVar` via **runtime emission** (`activateJobs` → `json.jobs[0].elementId`) and wires it into the `moveInstructions` body. This replaced the original "lying scenario" where `elementIdVar` was seeded but never consumed (single-step chain → synthetic placeholder).

What was never landed was the L3 guard locking this in — the endpoint stayed carved out of the PR-4 ElementId coverage, and the carve-out comment still claimed (falsely) that the planner inserts no deploy prerequisite for batch operations.

## Changes

- Add `modifyProcessInstancesBatchOperation` to the PR-4 ElementId variant `TARGETS` (existence + binding + file-wide reference checks).
- Add a dedicated, class-faithful guard asserting the body wires `sourceElementId: ctx.elementIdVar` **and** `targetElementId: ctx.elementIdVar` into `moveInstructions`. The generic file-wide `ctx.elementIdVar` check is too weak here — a seed line alone could satisfy it; this asserts the exact property that was broken.
- Delete the stale carve-out comment block.

## Verification (red/green)

- **Green** on current regenerated output: full L3 suite 188 passed / 4 skipped; full `npm test` 700 passed / 4 skipped; `npm run lint` clean (193 files); `tests/tsconfig.json` typecheck clean.
- **Red** proof: temporarily reverting the emitted body to `sourceElementId: 'placeholder'` (simulating the lying-scenario relapse) fails the new guard with *"sourceElementId variant must wire ctx.elementIdVar into moveInstructions (not a synthetic placeholder)"*; restoring makes it green.

No production code changed — this is a test-only guard over behaviour that already ships.

Closes #165
