### PR TITLE
Draft: camunda-hub positive-suite ABox (#360)

### DIFF
--- a/configs/camunda-hub/ontology/entity-kinds.json
+++ b/configs/camunda-hub/ontology/entity-kinds.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://camunda.github.io/api-test-generator/ns/v1/entity-kinds.schema.json",
+  "@context": "https://camunda.github.io/api-test-generator/ns/v1/context.jsonld",
+  "version": 1,
+  "kinds": [
+    {
+      "@type": "EntityKind",
+      "name": "Folder",
+      "shape": "entity",
+      "identifiers": [
+        "FolderKey"
+      ],
+      "establishedBy": "createFolder",
+      "observableVia": "getFolder",
+      "revokedBy": "deleteFolder",
+      "description": "A Camunda Hub folder, identified by its server-minted folderKey (present in FolderResult, absent from FolderCreateRequest). Established by createFolder (POST /folders, requires projectKey from the global-context seed), observed via getFolder (GET /folders/{folderKey} -> 200), revoked via deleteFolder (DELETE -> 204). Carries the EntityLifecycle CRUD triple only. updateFolder (PATCH) is a mutator, but read-after-write is not modelled: mutators are forbidden on shape:'entity' and the UpdatedFieldVisibleOnReadBack template appliesTo shape:'runtime-entity' only (see #360 gap: in-API-mutable entities have no read-back template). parentFolderKey (folder->folder containment) and the folder->file containment are deferred (EdgeLifecycle needs dedicated assign/observe ops; Hub establishes containment via a create-body field and observes it via getFolder.content)."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "File",
+      "shape": "entity",
+      "identifiers": [
+        "FileKey"
+      ],
+      "establishedBy": "createFile",
+      "observableVia": "getFile",
+      "revokedBy": "deleteFile",
+      "description": "A Camunda Hub file, identified by its server-minted fileKey (present in FileResult, absent from FileCreateRequest). Established by createFile (POST /files, requires projectKey from the global-context seed; folderKey optional), observed via getFile (GET /files/{fileKey} -> 200), revoked via deleteFile (DELETE -> 204). Carries the EntityLifecycle CRUD triple only. updateFile (PATCH) is NOT modelled as a mutator here: (a) mutators are forbidden on shape:'entity'; (b) updateFile additionally requires the current `revision` (optimistic-concurrency token from FileResult.revision) and can return 409 on a stale value — a dependency pattern with no current ontology/emitter support (see #360 gap)."
+    }
+  ]
+}

--- a/configs/camunda-hub/ontology/global-context-seeds.json
+++ b/configs/camunda-hub/ontology/global-context-seeds.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://camunda.github.io/api-test-generator/ns/v1/global-context-seeds.schema.json",
+  "@context": {
+    "@vocab": "https://camunda.github.io/api-test-generator/ontology/global-context-seeds#"
+  },
+  "version": 1,
+  "seeds": [
+    {
+      "@type": "GlobalContextSeed",
+      "binding": "projectKeyVar",
+      "fieldName": "projectKey",
+      "seedRule": "projectKeyVar",
+      "rationale": "projectKey is required on every createFile/createFolder request but has NO producer operation in the Hub API — it references a project provisioned outside this API (analogous to OCA's tenantId, but NOT server-defaultable: the Hub rejects an unknown projectKey rather than substituting a default). omitWhenUnbound is therefore intentionally absent (false): the universal-seed prologue must always populate ctx['projectKeyVar'] so the field is sent on every create. PREREQUISITE (not satisfiable by this ABox alone): seed-rules.json must map the `projectKeyVar` rule to a real, pre-provisioned project key (a configured constant), not a freshly-minted random id — a random value would fail Hub project validation. See #360 (external-provisioning gap)."
+    }
+  ]
+}

--- a/configs/camunda-hub/ontology/scenario-templates.json
+++ b/configs/camunda-hub/ontology/scenario-templates.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://camunda.github.io/api-test-generator/ns/v1/scenario-template.schema.json",
+  "@context": {
+    "@vocab": "https://camunda.github.io/api-test-generator/ns/v1/",
+    "templates": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/templates",
+      "@container": "@set"
+    },
+    "appliesTo": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/appliesTo"
+    },
+    "steps": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/steps",
+      "@container": "@list"
+    },
+    "kind": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/kind"
+    },
+    "op": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/op"
+    },
+    "for": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/for"
+    },
+    "expect": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/expect"
+    }
+  },
+  "version": 1,
+  "templates": [
+    {
+      "@type": "ScenarioTemplate",
+      "name": "EntityLifecycle",
+      "appliesTo": { "kind": "Entity" },
+      "description": "Establish an entity instance (create), verify it is visible by GET-by-id (status 200), revoke it (delete), verify it is no longer visible by GET-by-id (status 404). Applies to every shape:'entity' kind in the entity-kinds ABox (Hub: File, Folder); consumes establishedBy, observableVia, revokedBy. present -> expect(resp.status()).toBe(200); absent -> expect(resp.status()).toBe(404). Verbatim reuse of the config-agnostic OCA template; the only Hub-specific input is the projectKey global-context seed threaded into the establishedBy create body.",
+      "steps": [
+        { "kind": "PrereqChain", "for": "establishedBy" },
+        { "kind": "Invoke", "op": "establishedBy" },
+        { "kind": "Observe", "op": "observableVia", "expect": "present" },
+        { "kind": "Invoke", "op": "revokedBy" },
+        { "kind": "Observe", "op": "observableVia", "expect": "absent" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Draft of the minimal **positive-suite ABox** for the `camunda-hub` config (#360):

- `configs/camunda-hub/ontology/entity-kinds.json` — `File` + `Folder` as `shape: entity` (EntityLifecycle CRUD triple `createX`/`getX`/`deleteX`).
- `configs/camunda-hub/ontology/global-context-seeds.json` — `projectKeyVar → projectKey` (the required-but-producerless key; `tenantId`-style seed).
- `configs/camunda-hub/ontology/scenario-templates.json` — `EntityLifecycle`.

All three validate against the TBox JSON Schemas (AJV).

## Why draft — not mergeable yet

These files are **non-functional in isolation**; they depend on work that isn't here yet (full triage in #360):

1. **Spec annotations.** The Hub spec carries no `x-semantic-*` on its keys. The planner needs `x-semantic-type` (`FileKey`/`FolderKey`) + `x-semantic-provider` on the create responses. There is **no local-overlay mechanism**, so these must land **upstream in `camunda/camunda-hub`** (Option A, the OCA pattern) or via a **new generator overlay feature** (Option B). Decision pending on #360.
2. **Generator gaps:**
   - **Composite `getFolder` response** trips canonical-path validation (`content.folders[].folderKey` not in canonical shape) → **Folder blocked**.
   - No read-back template for in-API-mutable entities (`updateFile`/`updateFolder`).
   - Optimistic concurrency (`revision`/`409`) unmodeled.
   - Field-established containment edges (`folderKey`/`parentFolderKey`) unsupported by `EdgeLifecycle`.
3. **Test project.** `projectKey` has no create-project API → positive runs need a real pre-provisioned Hub project (Hub-team/infra ask).

## Validation done

Ran the planner against a **throwaway annotated** copy of the Hub spec:
- **File — proven:** `createFile → getFile/deleteFile` chain built, `productionMap: { FileKey: createFile }`, `projectKeyVar` seed bound.
- **Folder — blocked** on gap 2 above.

## Merge criteria

Mergeable once: (a) A-vs-B annotation path chosen and File annotations landed, and (b) gap 2 (composite response) resolved so Folder validates. Until then this stays a draft so the ABox isn't dead config on `main`.

Refs #360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
