### PR TITLE
fix(request-validation): attach auth header to multipart tests (#362)

### DIFF
--- a/request-validation/src/emit/qaEmitter.ts
+++ b/request-validation/src/emit/qaEmitter.ts
@@ -89,6 +89,14 @@ function buildFile(
   const resource = deriveResource(scenarios[0].path);
   const describeTitle = `${capitalize(resource)} Validation API Tests`;
   const httpImport = standalone ? './support/http' : `${'../'.repeat(depth)}utils/http`;
+  // #362 — multipart requests that need auth attach authHeaders() (Authorization
+  // only, no JSON content-type that would break the multipart boundary). Import
+  // it only when the file actually emits such a request, so JSON-only files
+  // don't carry an unused import (the generated suite lints with noUnusedImports).
+  const usesAuthHeaders = scenarios.some(
+    (s) => s.headersAuth && s.bodyEncoding === 'multipart' && !!s.multipartForm,
+  );
+  const authImport = usesAuthHeaders ? 'authHeaders, ' : '';
   const lines: string[] = [];
   lines.push(LICENSE_HEADER.trimEnd());
   const meta: string[] = [];
@@ -101,14 +109,16 @@ function buildFile(
   lines.push(meta.join('\n'));
   if (standalone) {
     lines.push("import {test} from '@playwright/test'");
-    lines.push(`import {jsonHeaders, buildUrl, assertResponseStatus} from '${httpImport}'`);
+    lines.push(
+      `import {${authImport}jsonHeaders, buildUrl, assertResponseStatus} from '${httpImport}'`,
+    );
   } else {
     // Legacy QA-tree mode: the external `utils/http` module does not export
     // `assertResponseStatus`, so fall back to a bare `expect(...).toBe(...)`
     // assertion. Diagnostics-rich failure messages and report attachments are
     // a standalone-only feature.
     lines.push("import {expect, test} from '@playwright/test'");
-    lines.push(`import {jsonHeaders, buildUrl} from '${httpImport}'`);
+    lines.push(`import {${authImport}jsonHeaders, buildUrl} from '${httpImport}'`);
   }
   lines.push('');
   lines.push(`test.describe('${describeTitle}', () => {`);
@@ -179,7 +189,7 @@ function renderScenario(s: ValidationScenario, title: string, standalone: boolea
   }
   const headersExpr = s.headersAuth
     ? s.bodyEncoding === 'multipart'
-      ? '{}'
+      ? 'authHeaders()'
       : 'jsonHeaders()'
     : '{}';
   const dataPart =

--- a/request-validation/src/emit/qaEmitter.ts
+++ b/request-validation/src/emit/qaEmitter.ts
@@ -93,8 +93,12 @@ function buildFile(
   // only, no JSON content-type that would break the multipart boundary). Import
   // it only when the file actually emits such a request, so JSON-only files
   // don't carry an unused import (the generated suite lints with noUnusedImports).
+  // This condition must mirror the `headersExpr` selection below exactly —
+  // `headersExpr` emits authHeaders() for any multipart+auth scenario (it does
+  // not depend on multipartForm), so gating the import on multipartForm here
+  // would risk referencing authHeaders() without importing it.
   const usesAuthHeaders = scenarios.some(
-    (s) => s.headersAuth && s.bodyEncoding === 'multipart' && !!s.multipartForm,
+    (s) => s.headersAuth && s.bodyEncoding === 'multipart',
   );
   const authImport = usesAuthHeaders ? 'authHeaders, ' : '';
   const lines: string[] = [];

--- a/request-validation/src/emit/qaEmitter.ts
+++ b/request-validation/src/emit/qaEmitter.ts
@@ -97,9 +97,7 @@ function buildFile(
   // `headersExpr` emits authHeaders() for any multipart+auth scenario (it does
   // not depend on multipartForm), so gating the import on multipartForm here
   // would risk referencing authHeaders() without importing it.
-  const usesAuthHeaders = scenarios.some(
-    (s) => s.headersAuth && s.bodyEncoding === 'multipart',
-  );
+  const usesAuthHeaders = scenarios.some((s) => s.headersAuth && s.bodyEncoding === 'multipart');
   const authImport = usesAuthHeaders ? 'authHeaders, ' : '';
   const lines: string[] = [];
   lines.push(LICENSE_HEADER.trimEnd());

--- a/tests/request-validation/multipart-auth-header.test.ts
+++ b/tests/request-validation/multipart-auth-header.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { renderScenarioForTest } from '../../request-validation/src/emit/qaEmitter.js';
+import type { ValidationScenario } from '../../request-validation/src/model/types.js';
+
+/**
+ * Guards #362 — multipart request-validation tests must attach the auth header.
+ *
+ * Before the fix, a multipart scenario rendered `headers: {}` even when it
+ * needed auth (`headersAuth: true`), so against a secured server the request was
+ * rejected with 401 before validation instead of returning the intended 400.
+ * The fix emits `authHeaders()` (Authorization only — never `jsonHeaders()`,
+ * whose `Content-Type: application/json` would break the multipart boundary).
+ * Auth-absent multipart scenarios (`headersAuth: false`) must still send no
+ * header at all.
+ */
+
+const base: Omit<ValidationScenario, 'headersAuth'> = {
+  id: 'createDocument__additional_prop',
+  operationId: 'createDocument',
+  method: 'POST',
+  path: '/documents',
+  type: 'additional-prop',
+  expectedStatus: 400,
+  description: 'unknown form part',
+  bodyEncoding: 'multipart',
+  multipartForm: { file: 'x', __unexpectedField: 'x' },
+};
+
+describe('request-validation: multipart auth header (#362)', () => {
+  it('attaches authHeaders() on a multipart request that needs auth', () => {
+    const rendered = renderScenarioForTest({ ...base, headersAuth: true }, 'createDocument - x');
+    expect(rendered).toContain('headers: authHeaders()');
+    // never the JSON helper (its content-type breaks the multipart boundary)…
+    expect(rendered).not.toContain('jsonHeaders()');
+    // …and not the old empty-headers bug.
+    expect(rendered).not.toContain('headers: {}');
+    // still a multipart submission.
+    expect(rendered).toContain('multipart: formData');
+  });
+
+  it('sends no auth header for an auth-absent multipart scenario', () => {
+    const rendered = renderScenarioForTest({ ...base, headersAuth: false }, 'createDocument - x');
+    expect(rendered).toContain('headers: {}');
+    expect(rendered).not.toContain('authHeaders()');
+  });
+});


### PR DESCRIPTION
## What

Fixes #362 — multipart request-validation tests omitted the auth header, so on a **secured** server they were rejected with **401 before validation** instead of returning the intended **400**.

## Change

`request-validation/src/emit/qaEmitter.ts`:
- The multipart-with-auth branch now emits **`authHeaders()`** instead of `headers: {}`. `authHeaders()` sends only the `Authorization` header — never `jsonHeaders()`, whose `Content-Type: application/json` would break the multipart boundary.
- `authHeaders` is added to the file import **only when the file actually emits such a request**, so JSON-only files don't carry an unused import (the generated suite lints with `noUnusedImports`).
- Auth-absent multipart scenarios (`headersAuth: false`) still send no header — unchanged.

## Why it was wrong

The emitter's header ternary returned `'{}'` for the multipart branch even when `headersAuth: true`. Affected the Deployments and Documents 400-tests in the secured profile — **15 cases** in the SNAPSHOT full-suite run came back 401 instead of 400.

## Verification

- New regression test `tests/request-validation/multipart-auth-header.test.ts` (multipart+auth → `authHeaders()`, never `jsonHeaders()`/`headers: {}`; auth-absent multipart → `headers: {}`).
- Full request-validation unit suite green (47 tests); regenerated OCA suite + `lint:generated` clean (no unused import; JSON-only files unaffected).
- Confirmed with `curl` on a secured 8.10 server: identical malformed multipart request → **401** without auth, **400** (`Required part 'resources'/'file' is not present.`) with valid creds.

Closes #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
