### PR TITLE
fix(request-validation): drop additional-prop on multipart-only ops (#364)

### DIFF
--- a/request-validation/src/util/multipartSkip.ts
+++ b/request-validation/src/util/multipartSkip.ts
@@ -24,9 +24,11 @@ import type { OperationModel, SchemaFragment, ValidationScenario } from '../mode
  *      endpoints have no `additionalProperties: false` enforcement on
  *      form data the way a JSON body does, so an unknown extra form part
  *      is silently ignored and the upload returns 201, not the expected
- *      400. (Verified live: `POST /v2/documents -F file=x
- *      -F __unexpectedField=x` → 201.) Unconditional for multipart-only
- *      ops — any extra part is ignored regardless of the target.
+ *      400. Unconditional for multipart-only ops — any extra part is
+ *      ignored regardless of the target. Verified live:
+ *
+ *          POST /v2/documents -F file=x -F __unexpectedField=x   -> 201
+ *
  *
  * `shouldSkipForMultipart` returns `true` for scenarios that fall into
  * any of those classes on a multipart-only operation. Other scenarios

--- a/request-validation/src/util/multipartSkip.ts
+++ b/request-validation/src/util/multipartSkip.ts
@@ -1,9 +1,10 @@
 import type { OperationModel, SchemaFragment, ValidationScenario } from '../model/types.js';
 
 /**
- * Multipart-only operations need three classes of JSON-derived
+ * Multipart-only operations need four classes of JSON-derived
  * validation scenarios dropped before the multipart-adaptation pass
- * tries to wrap them as form-data submissions (#135):
+ * tries to wrap them as form-data submissions (rules 1-3 from #135;
+ * rule 4 from #364):
  *
  *   1. `body-top-type-mismatch` — there is no JSON top-level type to
  *      invert. Wrapping `[]` / scalar bodies as form data produces a

--- a/request-validation/src/util/multipartSkip.ts
+++ b/request-validation/src/util/multipartSkip.ts
@@ -20,10 +20,18 @@ import type { OperationModel, SchemaFragment, ValidationScenario } from '../mode
  *      mutations don't translate to a multipart `files=...` repetition
  *      pattern; the broker accepts the upload and returns 201.
  *
+ *   4. `additional-prop` / `additional-prop-general` (#364) — multipart
+ *      endpoints have no `additionalProperties: false` enforcement on
+ *      form data the way a JSON body does, so an unknown extra form part
+ *      is silently ignored and the upload returns 201, not the expected
+ *      400. (Verified live: `POST /v2/documents -F file=x
+ *      -F __unexpectedField=x` → 201.) Unconditional for multipart-only
+ *      ops — any extra part is ignored regardless of the target.
+ *
  * `shouldSkipForMultipart` returns `true` for scenarios that fall into
  * any of those classes on a multipart-only operation. Other scenarios
- * (additional-prop, missing-required, etc.) flow through the existing
- * adaptation pass unchanged.
+ * (missing-required, etc.) flow through the existing adaptation pass
+ * unchanged.
  *
  * A targeted multipart-aware mutation strategy (omit a required part,
  * send wrong Content-Type per part, exceed declared size) is a separate
@@ -64,6 +72,12 @@ function isArrayPart(schema: SchemaFragment | undefined): boolean {
 export function shouldSkipForMultipart(scenario: ValidationScenario, op: OperationModel): boolean {
   if (!isMultipartOnly(op)) return false;
   if (scenario.type === 'body-top-type-mismatch') return true;
+  // #364 — an unknown extra form part is ignored by multipart endpoints
+  // (no additionalProperties:false on form data), so the upload returns 201
+  // rather than 400. Drop regardless of target.
+  if (scenario.type === 'additional-prop' || scenario.type === 'additional-prop-general') {
+    return true;
+  }
   if (scenario.type === 'type-mismatch') {
     const part = topLevelMultipartPart(op, scenario.target);
     if (isBinaryPart(part)) return true;

--- a/tests/request-validation/multipart-skip.test.ts
+++ b/tests/request-validation/multipart-skip.test.ts
@@ -169,7 +169,7 @@ describe('shouldSkipForMultipart (#135)', () => {
     expect(shouldSkipForMultipart(s, op)).toBe(false);
   });
 
-  it('passes through scenario kinds that the adapter can wrap meaningfully (additional-prop, missing-required, …)', () => {
+  it('skips additional-prop / additional-prop-general on multipart-only ops (#364 — unknown form parts ignored → 201)', () => {
     const op = multipartOnlyOp({
       multipartSchema: {
         type: 'object',
@@ -178,11 +178,32 @@ describe('shouldSkipForMultipart (#135)', () => {
     });
     const cases: ValidationScenario[] = [
       scenario({ type: 'additional-prop', requestBody: { file: 'x', __extra__: 1 } }),
+      scenario({ type: 'additional-prop-general', requestBody: { file: 'x', __extra__: 1 } }),
+    ];
+    for (const s of cases) {
+      expect(shouldSkipForMultipart(s, op)).toBe(true);
+    }
+  });
+
+  it('still passes through scenario kinds the adapter can wrap meaningfully (missing-required, missing-body)', () => {
+    const op = multipartOnlyOp({
+      multipartSchema: {
+        type: 'object',
+        properties: { file: { type: 'string', format: 'binary' } },
+      },
+    });
+    const cases: ValidationScenario[] = [
       scenario({ type: 'missing-required', target: 'file', requestBody: {} }),
       scenario({ type: 'missing-body' }),
     ];
     for (const s of cases) {
       expect(shouldSkipForMultipart(s, op)).toBe(false);
     }
+  });
+
+  it('does NOT skip additional-prop on JSON-body ops (additionalProperties:false is enforced → 400)', () => {
+    const op = jsonOp();
+    const s = scenario({ type: 'additional-prop', requestBody: { name: 'x', __extra__: 1 } });
+    expect(shouldSkipForMultipart(s, op)).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Fixes #364 — `additional-prop` request-validation scenarios on **multipart-only** operations are false positives: the server silently ignores unknown form parts and returns **201**, not the asserted **400**.

## Change

`request-validation/src/util/multipartSkip.ts` — `shouldSkipForMultipart` now also drops `additional-prop` and `additional-prop-general` for multipart-only ops (4th rule, alongside the existing `body-top-type-mismatch` / binary-part `type-mismatch` / array-part `constraint-violation` rules). Multipart form data has no `additionalProperties: false` enforcement, so an extra part is ignored regardless of target.

JSON-body ops are unaffected — their `additionalProperties: false` returns 400, so they keep emitting `additional-prop`.

## Effect (regenerated OCA suite)

- `createDocument`, `createDocuments`, `createDeployment` (multipart-only) → **zero** `additional-prop` scenarios.
- `createDocumentLink` (JSON) and all other JSON ops → unchanged.

## Verification

- Updated the `multipart-skip` Layer-2 fixture: asserts `additional-prop`/`additional-prop-general` are skipped on multipart-only ops, still passed through on JSON ops, and `missing-required`/`missing-body` still wrap.
- Full request-validation unit suite green (47); regenerated suite + `lint:generated` clean.
- Root cause confirmed live (unsecured 8.8/8.10): `POST /v2/documents -F file=x -F __unexpectedField=x` → 201.

Closes #364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
