### PR TITLE
feat: emit fake-ID 404 negative tests for read-by-key endpoints (#381)

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -2836,6 +2836,102 @@ describeForThisConfig('bundled-spec invariants: x-semantic-establishes (#104)', 
   });
 });
 
+describeForThisConfig('bundled-spec invariants: 404 fake-ID emitter (#381 / #279)', () => {
+  const UNSECURED_DIR = join(
+    REPO_ROOT,
+    'generated',
+    CONFIG_NAME,
+    'request-validation',
+    'unsecured',
+  );
+
+  function requireSuiteDir(): void {
+    if (!existsSync(UNSECURED_DIR)) {
+      throw new Error(
+        `Generated request-validation directory not found at ${UNSECURED_DIR}. ` +
+          `Run 'npm run generate:request-validation' (or 'npm run pipeline') first.`,
+      );
+    }
+  }
+
+  // Match each individual `test( ... });` block and capture its own
+  // scenarioKind. Anchoring on per-block `scenarioKind` (rather than embedding
+  // the literal kind inside a lazy cross-test span) prevents a match from
+  // greedily spanning earlier tests in the same file and mislabelling the
+  // operationId. The generated suite is biome-formatted (single quotes,
+  // 2-space indent) after emission, so the closing `\n  });` is stable.
+  const TEST_BLOCK = /test\('[^]*?scenarioKind:\s*'([^']+)',[^]*?\n {2}\}\);/g;
+
+  function collectBlocks(): { file: string; operationId: string; block: string }[] {
+    const out: { file: string; operationId: string; block: string }[] = [];
+    for (const f of readdirSync(UNSECURED_DIR)) {
+      if (!f.endsWith('.spec.ts')) continue;
+      const src = readFileSync(join(UNSECURED_DIR, f), 'utf8');
+      let m: RegExpExecArray | null;
+      TEST_BLOCK.lastIndex = 0;
+      while ((m = TEST_BLOCK.exec(src)) !== null) {
+        if (m[1] !== 'not-found-fake-id') continue;
+        const block = m[0];
+        const opMatch = /operationId:\s*'([^']+)'/.exec(block);
+        out.push({
+          file: relative(REPO_ROOT, join(UNSECURED_DIR, f)),
+          operationId: opMatch ? opMatch[1] : '<unknown>',
+          block,
+        });
+      }
+    }
+    return out;
+  }
+
+  it('emits a 404 fake-ID test for singleton GET key endpoints, every one asserting 404', () => {
+    requireSuiteDir();
+    const blocks = collectBlocks();
+    // Non-vacuous: the pinned spec has ~31 eligible singleton GET endpoints.
+    expect(blocks.length).toBeGreaterThan(20);
+    // Representative singleton endpoints (numeric key + string id) must be present.
+    const ops = new Set(blocks.map((b) => b.operationId));
+    expect(ops.has('getProcessInstance')).toBe(true);
+    expect(ops.has('getGroup')).toBe(true);
+    // Class-scoped: every not-found-fake-id block asserts exactly 404 and
+    // nothing else (no 400/200 rides in under this kind).
+    const wrongStatus = blocks.filter((b) => !/,\s*404,/.test(b.block));
+    expect(wrongStatus.map((b) => `${b.operationId} @ ${b.file}`)).toEqual([]);
+  });
+
+  it('emits only GET (read-by-key) endpoints — mutating/command ops 503/400, not 404 (#279)', () => {
+    requireSuiteDir();
+    // v1 is scoped to safe, idempotent reads, which have unambiguous
+    // "resource not found" → 404 semantics. A missing key on a mutating or
+    // command endpoint (job completion, incident resolution, process-instance
+    // cancellation, user-task actions) is a command rejection (503) or a
+    // validation 400, not a clean 404. Class-scoped: assert no emitted block
+    // carries a non-GET method, so a future change can't silently re-admit
+    // them.
+    const nonGet = collectBlocks().filter((b) => !/method:\s*'GET'/.test(b.block));
+    expect(nonGet.map((b) => `${b.operationId} @ ${b.file}`)).toEqual([]);
+  });
+
+  it('excludes paginated-collection / search-under-parent endpoints — empty 200, not 404 (#372)', () => {
+    requireSuiteDir();
+    const ops = new Set(collectBlocks().map((b) => b.operationId));
+    // These declare a 404 in the spec but actually return an empty 200 for a
+    // nonexistent parent id (issue #372 pattern 3), so a fake-ID 404 test for
+    // them would be a false positive. The successIsCollection filter must
+    // keep them out.
+    for (const collectionOp of [
+      'searchUsersForGroup',
+      'searchClientsForGroup',
+      'searchMappingRulesForGroup',
+      'searchRolesForGroup',
+      'searchClientsForRole',
+      'searchGroupsForRole',
+      'searchUsersForRole',
+    ]) {
+      expect(ops.has(collectionOp)).toBe(false);
+    }
+  });
+});
+
 describeForThisConfig('bundled-spec invariants: emitted request-validation suite (#129)', () => {
   it('emits zero case-only enum mutations when enumCaseInsensitive is true', () => {
     // The camunda-oca config sets `enumCaseInsensitive: true` in

--- a/request-validation/scripts/generate.ts
+++ b/request-validation/scripts/generate.ts
@@ -22,6 +22,7 @@ import { generateEnumViolations } from '../src/analysis/enumViolations.js';
 import { generateMissingRequired } from '../src/analysis/missingRequired.js';
 import { generateMissingRequiredCombos } from '../src/analysis/missingRequiredCombos.js';
 import { generateMultipartMissingRequired } from '../src/analysis/multipartMissingRequired.js';
+import { generateNotFoundFakeId } from '../src/analysis/notFoundFakeId.js';
 import {
   generateDiscriminatorStructureMismatch,
   generateOneOfCrossBleed,
@@ -235,6 +236,16 @@ async function main() {
   if (wantKind('auth-deny')) {
     scenarios.push(
       ...generateAuthDeny(model.operations, {
+        onlyOperations: opts.onlyOperations,
+      }),
+    );
+  }
+  // not-found-fake-id (HTTP 404) scenarios are not "deep": they depend only on
+  // the operation's path params + declared responses, not on body shape. They
+  // are auth-independent and land in both profiles.
+  if (wantKind('not-found-fake-id')) {
+    scenarios.push(
+      ...generateNotFoundFakeId(model.operations, {
         onlyOperations: opts.onlyOperations,
       }),
     );

--- a/request-validation/src/analysis/notFoundFakeId.ts
+++ b/request-validation/src/analysis/notFoundFakeId.ts
@@ -28,7 +28,9 @@ const FAKE_NUMERIC_KEY = '9'.repeat(16);
 const FAKE_STRING_CANDIDATES = ['nonexistent-fake-id', 'nonexistent', 'zzzznonexistentzzzz'];
 
 function isNumericKeyParam(r: ResolvedParamSchema): boolean {
-  if (r.type === 'integer' || r.type === 'number') return true;
+  const t = r.type;
+  if (t === 'integer' || t === 'number') return true;
+  if (Array.isArray(t) && t.some((x) => x === 'integer' || x === 'number')) return true;
   return r.pattern === '^-?[0-9]+$';
 }
 

--- a/request-validation/src/analysis/notFoundFakeId.ts
+++ b/request-validation/src/analysis/notFoundFakeId.ts
@@ -1,0 +1,178 @@
+import type {
+  OperationModel,
+  ParameterModel,
+  SchemaFragment,
+  ValidationScenario,
+} from '../model/types.js';
+import {
+  buildValidValue,
+  isUrlCollapsingPathSegment,
+  type ResolvedParamSchema,
+  resolveParamSchema,
+} from '../util/paramSchema.js';
+import { makeId } from './common.js';
+
+interface Opts {
+  onlyOperations?: Set<string>;
+}
+
+// A syntactically-valid Camunda key (Java long serialized as string) that is
+// astronomically unlikely to resolve to a real resource in a fresh test
+// cluster: ~1e16, comfortably inside int64 range and far above the low
+// partition-base counters keys are minted from. Matches `^-?[0-9]+$` and fits
+// LongKey's `maxLength: 25`.
+const FAKE_NUMERIC_KEY = '9'.repeat(16);
+
+// Unlikely-to-exist string-id candidates, tried in order. The first that
+// satisfies the parameter's pattern/length constraints is used.
+const FAKE_STRING_CANDIDATES = ['nonexistent-fake-id', 'nonexistent', 'zzzznonexistentzzzz'];
+
+function isNumericKeyParam(r: ResolvedParamSchema): boolean {
+  if (r.type === 'integer' || r.type === 'number') return true;
+  return r.pattern === '^-?[0-9]+$';
+}
+
+/**
+ * Recursively decide whether a parameter schema can only be satisfied by a
+ * numeric Camunda key. The flat `resolveParamSchema` merge only follows the
+ * top-level `allOf`, so it misses keys whose numeric constraint lives behind a
+ * `oneOf` of `LongKey` aliases — e.g. `ResourceKey` is
+ * `oneOf:[ProcessDefinitionKey, DecisionRequirementsKey, FormKey,
+ * DecisionDefinitionKey]`, each an `allOf:[LongKey]`. Treating such a param as
+ * a string id synthesises `nonexistent-fake-id`, which the server rejects as a
+ * malformed key (400) instead of "not found" (404).
+ */
+function schemaImpliesNumericKey(s: SchemaFragment | undefined): boolean {
+  if (!s) return false;
+  if (s.pattern === '^-?[0-9]+$') return true;
+  const t = s.type;
+  if (t === 'integer' || t === 'number') return true;
+  if (Array.isArray(t) && t.some((x) => x === 'integer' || x === 'number')) return true;
+  if (Array.isArray(s.allOf) && s.allOf.some(schemaImpliesNumericKey)) return true;
+  // A oneOf is numeric only when *every* branch is numeric (any branch is a
+  // legal value, so a single non-numeric branch means a string could be valid).
+  if (Array.isArray(s.oneOf) && s.oneOf.length > 0 && s.oneOf.every(schemaImpliesNumericKey)) {
+    return true;
+  }
+  return false;
+}
+
+function satisfies(value: string, r: ResolvedParamSchema): boolean {
+  // A value that collapses the URL never reaches the resource lookup (Spring
+  // routes it elsewhere); it would 404 for the wrong reason. Reject it here so
+  // the 404 we assert is genuinely "resource not found". See issue #147.
+  if (isUrlCollapsingPathSegment(value)) return false;
+  if (typeof r.minLength === 'number' && value.length < r.minLength) return false;
+  if (typeof r.maxLength === 'number' && value.length > r.maxLength) return false;
+  if (r.pattern) {
+    try {
+      if (!new RegExp(r.pattern).test(value)) return false;
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+function clampToLength(value: string, r: ResolvedParamSchema, pad: string): string {
+  let out = value;
+  if (typeof r.minLength === 'number' && out.length < r.minLength) {
+    out = out.padEnd(r.minLength, pad);
+  }
+  if (typeof r.maxLength === 'number' && out.length > r.maxLength) {
+    out = out.slice(0, r.maxLength);
+  }
+  return out;
+}
+
+/**
+ * Synthesise a syntactically-valid but nonexistent value for a path
+ * parameter. Returns `undefined` when no value can be guaranteed valid (so
+ * the caller skips the scenario rather than emit a flaky 404 expectation):
+ * an enum parameter (any non-member is a 400, not a 404), or a pattern the
+ * candidate values can't satisfy.
+ */
+export function fakePathParamValue(p: ParameterModel): string | undefined {
+  const r = resolveParamSchema(p);
+  if (!r) return undefined;
+  // A closed enum can't be "missing-but-valid": a non-member is malformed
+  // (400), a member may exist. Skip.
+  if (r.enumValues?.length) return undefined;
+  if (schemaImpliesNumericKey(p.schema) || isNumericKeyParam(r)) {
+    const value = clampToLength(FAKE_NUMERIC_KEY, r, '9');
+    return satisfies(value, r) ? value : undefined;
+  }
+  for (const base of FAKE_STRING_CANDIDATES) {
+    const value = clampToLength(base, r, '0');
+    if (satisfies(value, r)) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Eligibility for a fake-ID 404 test (#381):
+ *   - the operation is a GET (read-by-key). v1 is scoped to safe, idempotent
+ *     reads, which have unambiguous "resource not found" → 404 semantics. A
+ *     missing key on a mutating/command endpoint (POST/PUT/PATCH/DELETE that
+ *     dispatches to the engine) surfaces as a command rejection (503) or a
+ *     validation 400, not a clean 404 — so those are deferred to the
+ *     field-site affordance follow-up (#279 / #368).
+ *   - has at least one path parameter,
+ *   - the contract declares a `404` response (don't assert a status the spec
+ *     doesn't allow),
+ *   - the success response is NOT a paginated collection — list/search
+ *     endpoints return an empty `200` for a nonexistent parent, not `404`
+ *     (#372 pattern 3),
+ *   - the operation does not require a request body — v1 sends no body, so a
+ *     required-body op would 400 on the missing body before the lookup runs.
+ */
+export function isNotFoundEligible(op: OperationModel): boolean {
+  if (op.method.toUpperCase() !== 'GET') return false;
+  if (!op.parameters.some((p) => p.in === 'path')) return false;
+  if (!op.responseCodes?.includes('404')) return false;
+  if (op.successIsCollection) return false;
+  if (op.bodyRequired) return false;
+  return true;
+}
+
+export function generateNotFoundFakeId(ops: OperationModel[], opts: Opts): ValidationScenario[] {
+  const out: ValidationScenario[] = [];
+  for (const op of ops) {
+    if (opts.onlyOperations && !opts.onlyOperations.has(op.operationId)) continue;
+    if (!isNotFoundEligible(op)) continue;
+    const pathParams = op.parameters.filter((p) => p.in === 'path');
+    const params: Record<string, string> = {};
+    let allFaked = true;
+    for (const p of pathParams) {
+      const fake = fakePathParamValue(p);
+      if (fake === undefined) {
+        allFaked = false;
+        break;
+      }
+      params[p.name] = fake;
+    }
+    if (!allFaked) continue;
+    // Populate required query params with valid placeholders so the request
+    // doesn't fail with an unrelated 400.
+    for (const q of op.parameters) {
+      if (q.in !== 'query' || !q.required) continue;
+      const r = resolveParamSchema(q);
+      params[q.name] = r ? buildValidValue(r) : 'x';
+    }
+    const target = pathParams.map((p) => p.name).join('+');
+    out.push({
+      id: makeId([op.operationId, 'notFound', target]),
+      operationId: op.operationId,
+      method: op.method,
+      path: op.path,
+      type: 'not-found-fake-id',
+      target,
+      params: Object.keys(params).length ? params : undefined,
+      expectedStatus: 404,
+      description: `Nonexistent ${target} returns 404`,
+      headersAuth: true,
+      source: 'path',
+    });
+  }
+  return out;
+}

--- a/request-validation/src/analysis/paramConstraintViolations.ts
+++ b/request-validation/src/analysis/paramConstraintViolations.ts
@@ -1,104 +1,16 @@
 import type { OperationModel, ParameterModel, ValidationScenario } from '../model/types.js';
+import {
+  buildValidValue,
+  isUrlCollapsingPathSegment,
+  type ResolvedParamSchema,
+  resolveParamSchema,
+} from '../util/paramSchema.js';
 import { buildGuaranteedPatternMismatch } from '../util/patternMismatch.js';
 import { makeId } from './common.js';
 
 interface Opts {
   onlyOperations?: Set<string>;
   capPerOperation?: number;
-}
-
-interface SchemaFragment {
-  type?: string;
-  pattern?: string;
-  minLength?: number;
-  maxLength?: number;
-  enum?: unknown[];
-  allOf?: SchemaFragment[];
-}
-
-function isSchemaFragment(v: unknown): v is SchemaFragment {
-  return !!v && typeof v === 'object' && !Array.isArray(v);
-}
-
-interface ResolvedParamSchema {
-  schema: SchemaFragment;
-  pattern?: string;
-  minLength?: number;
-  maxLength?: number;
-  enumValues?: unknown[];
-  type?: string;
-}
-
-// Very small resolver: follows allOf chains to merge top-level constraints.
-function resolveParamSchema(p: ParameterModel): ResolvedParamSchema | undefined {
-  const schema = isSchemaFragment(p.schema) ? p.schema : undefined;
-  if (!schema) return undefined;
-  const out: ResolvedParamSchema = { schema };
-  function merge(s: SchemaFragment | undefined) {
-    if (!s || typeof s !== 'object') return;
-    if (typeof s.pattern === 'string' && out.pattern === undefined) out.pattern = s.pattern;
-    if (typeof s.minLength === 'number' && out.minLength === undefined) out.minLength = s.minLength;
-    if (typeof s.maxLength === 'number' && out.maxLength === undefined) out.maxLength = s.maxLength;
-    if (Array.isArray(s.enum) && !out.enumValues) out.enumValues = s.enum.slice();
-    if (typeof s.type === 'string' && !out.type) out.type = s.type;
-  }
-  // Direct
-  merge(schema);
-  // allOf chain
-  if (Array.isArray(schema.allOf)) {
-    for (const part of schema.allOf) merge(part);
-  }
-  return out;
-}
-
-function buildValidValue(r: ResolvedParamSchema): string {
-  if (r.enumValues?.length) return String(r.enumValues[0]);
-  if (r.pattern) {
-    // If numeric-only pattern
-    if (/^\^-?\[0-9]\+\$$/.test(r.pattern) || r.pattern === '^-?[0-9]+$') return '1';
-  }
-  if (r.minLength && r.minLength > 1) return 'a'.repeat(r.minLength);
-  return 'x';
-}
-
-/**
- * Returns true if `value`, after URL substitution into a path template,
- * would not survive as a single non-empty path segment — making any
- * resulting 400 expectation noise (Spring's router resolves the request as
- * a different route and returns 404 from a static-resource handler before
- * the request validator runs).
- *
- * `buildUrl()` substitutes path-param values raw (no encoding), so the
- * predicate must reject any value that *literally* contains a routing-
- * significant character, plus any value whose `encodeURIComponent` form
- * contains an encoded segment splitter.
- *
- * Class-scoped check (issue #147 + PR #148 review):
- *   - empty segment
- *   - `.` / `..` (path traversal)
- *   - raw `/` or `\` (forward / back slash)
- *   - raw `?` or `#` (query / fragment delimiters)
- *   - already-encoded `%2F` / `%5C` (case-insensitive) in the value as
- *     supplied — the server may decode these to `/` or `\`
- *   - any value whose `encodeURIComponent` form contains `%2F`/`%5C`
- *     (catches values that contain raw separators not covered above —
- *     defence in depth in case the rules above drift).
- */
-function isUrlCollapsingPathSegment(value: string): boolean {
-  if (value.length === 0) return true;
-  if (value === '.' || value === '..') return true;
-  // Raw routing-significant characters (no encoding by buildUrl).
-  if (/[/\\?#]/.test(value)) return true;
-  // Already-encoded separators in the supplied value — buildUrl substitutes
-  // the value as-is, and the server (or any intermediate proxy) may decode
-  // %2F / %5C back to / or \. `encodeURIComponent` would re-encode the `%`
-  // to `%25`, so check the raw value directly.
-  if (/%2f|%5c/i.test(value)) return true;
-  // Defence in depth: catch any value whose canonical encoding contains a
-  // segment splitter not flagged above.
-  const encoded = encodeURIComponent(value);
-  if (/%2f|%5c/i.test(encoded)) return true;
-  return false;
 }
 
 function buildViolations(

--- a/request-validation/src/emit/qaEmitter.ts
+++ b/request-validation/src/emit/qaEmitter.ts
@@ -377,6 +377,8 @@ function buildBaseTitle(s: ValidationScenario): string {
       return `${s.operationId} - Missing authentication`;
     case 'auth-deny':
       return `${s.operationId} - Denied (no permission)`;
+    case 'not-found-fake-id':
+      return `${s.operationId} - Nonexistent ${s.target} returns 404`;
     default:
       return s.id; // Fallback is globally unique id
   }

--- a/request-validation/src/model/types.ts
+++ b/request-validation/src/model/types.ts
@@ -53,6 +53,21 @@ export interface OperationModel {
    * unauthenticated at runtime) yields `false`.
    */
   conditionalAuth?: boolean;
+  /**
+   * Response status codes the operation declares in its OpenAPI `responses`
+   * map (e.g. `['200','400','404','500']`). Used by the not-found-fake-id
+   * generator to emit a 404 test only when the contract actually allows a
+   * 404 (#381 / #279).
+   */
+  responseCodes?: string[];
+  /**
+   * True when the operation's success (2xx) JSON response schema is a
+   * paginated collection (its top-level object has an `items` or `page`
+   * property). Such list/search endpoints return an empty `200` — not a
+   * `404` — for a nonexistent parent id, so the not-found-fake-id generator
+   * excludes them (#372 pattern 3 / #381).
+   */
+  successIsCollection?: boolean;
 }
 
 export interface ParameterModel {
@@ -93,6 +108,7 @@ export type ScenarioKind =
   | 'discriminator-structure-mismatch'
   | 'allof-missing-required'
   | 'allof-conflict'
+  | 'not-found-fake-id'
   | 'auth-absent'
   | 'auth-deny';
 

--- a/request-validation/src/spec/loader.ts
+++ b/request-validation/src/spec/loader.ts
@@ -110,6 +110,29 @@ function buildParameter(raw: unknown): ParameterModel | undefined {
   };
 }
 
+function extractResponseInfo(op: Record<string, unknown>): {
+  responseCodes: string[];
+  successIsCollection: boolean;
+} {
+  const responses = isRecord(op.responses) ? op.responses : {};
+  const responseCodes = Object.keys(responses);
+  let successIsCollection = false;
+  for (const code of ['200', '201']) {
+    const r = responses[code];
+    if (!isRecord(r) || !isRecord(r.content)) continue;
+    const json = asSchemaFragment(r.content['application/json']);
+    const schema = json?.schema ? asSchemaFragment(json.schema) : undefined;
+    if (schema && isRecord(schema.properties)) {
+      const props = Object.keys(schema.properties);
+      if (props.includes('items') || props.includes('page')) {
+        successIsCollection = true;
+        break;
+      }
+    }
+  }
+  return { responseCodes, successIsCollection };
+}
+
 export async function loadSpec(file: string): Promise<SpecModel> {
   const api: unknown = await SwaggerParser.dereference(file);
   const operations: OperationModel[] = [];
@@ -170,6 +193,7 @@ export async function loadSpec(file: string): Promise<SpecModel> {
           discriminator = asDiscriminator(requestBodySchema.discriminator);
         }
       }
+      const { responseCodes, successIsCollection } = extractResponseInfo(op);
       operations.push({
         operationId,
         method,
@@ -184,6 +208,8 @@ export async function loadSpec(file: string): Promise<SpecModel> {
         multipartSchema,
         multipartRequiredProps,
         mediaTypes,
+        responseCodes,
+        successIsCollection,
         conditionalAuth:
           securityRequiresConditional(op.security, conditionalSchemes) ??
           securityRequiresConditional(pathLevelSecurity, conditionalSchemes) ??

--- a/request-validation/src/util/paramSchema.ts
+++ b/request-validation/src/util/paramSchema.ts
@@ -1,0 +1,107 @@
+import type { ParameterModel } from '../model/types.js';
+
+/**
+ * Minimal schema view used by the path/query parameter analysers. A
+ * parameter's `schema` is an arbitrary dereferenced OpenAPI fragment; these
+ * are the only fields the constraint/not-found generators read.
+ */
+export interface SchemaFragment {
+  type?: string;
+  pattern?: string;
+  minLength?: number;
+  maxLength?: number;
+  enum?: unknown[];
+  allOf?: SchemaFragment[];
+}
+
+export interface ResolvedParamSchema {
+  schema: SchemaFragment;
+  pattern?: string;
+  minLength?: number;
+  maxLength?: number;
+  enumValues?: unknown[];
+  type?: string;
+}
+
+function isSchemaFragment(v: unknown): v is SchemaFragment {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+/**
+ * Very small resolver: follows the top-level `allOf` chain to merge the
+ * constraint fields a parameter's value must satisfy. Camunda key types
+ * (e.g. `ProcessInstanceKey`) carry their numeric `pattern`/`maxLength`
+ * inside an `allOf: [LongKey]` branch, so a flat read of `p.schema` misses
+ * them — this merge surfaces them.
+ */
+export function resolveParamSchema(p: ParameterModel): ResolvedParamSchema | undefined {
+  const schema = isSchemaFragment(p.schema) ? p.schema : undefined;
+  if (!schema) return undefined;
+  const out: ResolvedParamSchema = { schema };
+  function merge(s: SchemaFragment | undefined): void {
+    if (!s || typeof s !== 'object') return;
+    if (typeof s.pattern === 'string' && out.pattern === undefined) out.pattern = s.pattern;
+    if (typeof s.minLength === 'number' && out.minLength === undefined) out.minLength = s.minLength;
+    if (typeof s.maxLength === 'number' && out.maxLength === undefined) out.maxLength = s.maxLength;
+    if (Array.isArray(s.enum) && !out.enumValues) out.enumValues = s.enum.slice();
+    if (typeof s.type === 'string' && !out.type) out.type = s.type;
+  }
+  merge(schema);
+  if (Array.isArray(schema.allOf)) {
+    for (const part of schema.allOf) merge(part);
+  }
+  return out;
+}
+
+/**
+ * Build a syntactically-valid value for a parameter (used to populate
+ * sibling params with non-violating placeholders).
+ */
+export function buildValidValue(r: ResolvedParamSchema): string {
+  if (r.enumValues?.length) return String(r.enumValues[0]);
+  if (r.pattern) {
+    if (/^\^-?\[0-9]\+\$$/.test(r.pattern) || r.pattern === '^-?[0-9]+$') return '1';
+  }
+  if (r.minLength && r.minLength > 1) return 'a'.repeat(r.minLength);
+  return 'x';
+}
+
+/**
+ * Returns true if `value`, after URL substitution into a path template,
+ * would not survive as a single non-empty path segment — making any
+ * resulting status expectation noise (Spring's router resolves the request
+ * as a different route and returns 404 from a static-resource handler before
+ * the request validator runs).
+ *
+ * `buildUrl()` substitutes path-param values raw (no encoding), so the
+ * predicate must reject any value that *literally* contains a routing-
+ * significant character, plus any value whose `encodeURIComponent` form
+ * contains an encoded segment splitter.
+ *
+ * Class-scoped check (issue #147 + PR #148 review):
+ *   - empty segment
+ *   - `.` / `..` (path traversal)
+ *   - raw `/` or `\` (forward / back slash)
+ *   - raw `?` or `#` (query / fragment delimiters)
+ *   - already-encoded `%2F` / `%5C` (case-insensitive) in the value as
+ *     supplied — the server may decode these to `/` or `\`
+ *   - any value whose `encodeURIComponent` form contains `%2F`/`%5C`
+ *     (catches values that contain raw separators not covered above —
+ *     defence in depth in case the rules above drift).
+ */
+export function isUrlCollapsingPathSegment(value: string): boolean {
+  if (value.length === 0) return true;
+  if (value === '.' || value === '..') return true;
+  // Raw routing-significant characters (no encoding by buildUrl).
+  if (/[/\\?#]/.test(value)) return true;
+  // Already-encoded separators in the supplied value — buildUrl substitutes
+  // the value as-is, and the server (or any intermediate proxy) may decode
+  // %2F / %5C back to / or \. `encodeURIComponent` would re-encode the `%`
+  // to `%25`, so check the raw value directly.
+  if (/%2f|%5c/i.test(value)) return true;
+  // Defence in depth: catch any value whose canonical encoding contains a
+  // segment splitter not flagged above.
+  const encoded = encodeURIComponent(value);
+  if (/%2f|%5c/i.test(encoded)) return true;
+  return false;
+}

--- a/request-validation/src/util/paramSchema.ts
+++ b/request-validation/src/util/paramSchema.ts
@@ -6,7 +6,7 @@ import type { ParameterModel } from '../model/types.js';
  * are the only fields the constraint/not-found generators read.
  */
 export interface SchemaFragment {
-  type?: string;
+  type?: string | string[];
   pattern?: string;
   minLength?: number;
   maxLength?: number;
@@ -20,7 +20,7 @@ export interface ResolvedParamSchema {
   minLength?: number;
   maxLength?: number;
   enumValues?: unknown[];
-  type?: string;
+  type?: string | string[];
 }
 
 function isSchemaFragment(v: unknown): v is SchemaFragment {
@@ -44,7 +44,7 @@ export function resolveParamSchema(p: ParameterModel): ResolvedParamSchema | und
     if (typeof s.minLength === 'number' && out.minLength === undefined) out.minLength = s.minLength;
     if (typeof s.maxLength === 'number' && out.maxLength === undefined) out.maxLength = s.maxLength;
     if (Array.isArray(s.enum) && !out.enumValues) out.enumValues = s.enum.slice();
-    if (typeof s.type === 'string' && !out.type) out.type = s.type;
+    if (s.type !== undefined && out.type === undefined) out.type = s.type;
   }
   merge(schema);
   if (Array.isArray(schema.allOf)) {

--- a/tests/request-validation/not-found-fake-id.test.ts
+++ b/tests/request-validation/not-found-fake-id.test.ts
@@ -89,6 +89,18 @@ describe('request-validation: 404 fake-ID value synthesis (#381)', () => {
     expect(/^-?[0-9]+$/.test(v)).toBe(true);
   });
 
+  it('OAS 3.1 array-typed numeric key (e.g. type: ["integer","null"]) → numeric fake', () => {
+    // OpenAPI 3.1 models nullable numeric types as a `type` array. The shared
+    // resolver must not drop array-typed `type` info: a flat read that only
+    // honoured `type: 'integer'` would mistake this for a free string and
+    // synthesise a malformed key.
+    const arrayTypeKeySchema = { type: ['integer', 'null'] };
+    const v = fakePathParamValue(pathParam('someKey', arrayTypeKeySchema));
+    expect(v).toBeDefined();
+    if (!v) return;
+    expect(/^-?[0-9]+$/.test(v)).toBe(true);
+  });
+
   it('unsynthesisable param (pattern no candidate satisfies) → undefined (caller skips)', () => {
     // Composite key `<digits>-<digits>` — neither a plain number nor the
     // string candidates match, so no guaranteed-valid value exists.

--- a/tests/request-validation/not-found-fake-id.test.ts
+++ b/tests/request-validation/not-found-fake-id.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fakePathParamValue,
+  generateNotFoundFakeId,
+  isNotFoundEligible,
+} from '../../request-validation/src/analysis/notFoundFakeId.js';
+import { renderScenarioForTest } from '../../request-validation/src/emit/qaEmitter.js';
+import type { OperationModel, ParameterModel } from '../../request-validation/src/model/types.js';
+
+/**
+ * Layer-2 fixtures for the 404 fake-ID emitter (issue #381, split from #279).
+ *
+ * The generator emits, for every singleton-resource endpoint with a path
+ * parameter, a well-formed request whose path id is replaced with a
+ * syntactically-valid-but-nonexistent value, asserting HTTP 404. Each `it`
+ * pins one named property:
+ *  - numeric LongKey path params get a big-number fake matching `^-?[0-9]+$`;
+ *  - a `oneOf` of LongKey aliases (e.g. `ResourceKey`) is still numeric;
+ *  - string-id path params get a pattern/length-valid fake;
+ *  - params for which no valid fake can be produced are skipped (no flaky 404);
+ *  - eligibility is restricted to GET (read-by-key) endpoints, and excludes
+ *    endpoints that don't declare 404, that return a paginated collection
+ *    (empty-200 for a missing parent, #372), or that require a request body.
+ */
+
+function pathParam(name: string, schema: ParameterModel['schema']): ParameterModel {
+  return { name, in: 'path', required: true, schema };
+}
+
+function op(
+  over: Partial<OperationModel> & Pick<OperationModel, 'operationId' | 'path'>,
+): OperationModel {
+  return {
+    method: 'GET',
+    tags: [],
+    parameters: [],
+    responseCodes: ['200', '404'],
+    successIsCollection: false,
+    ...over,
+  };
+}
+
+// A LongKey-style numeric key: pattern lives inside an allOf branch, exactly
+// as the bundled Camunda spec models `ProcessInstanceKey` etc.
+const longKeySchema = {
+  type: 'string',
+  allOf: [{ type: 'string', pattern: '^-?[0-9]+$', minLength: 1, maxLength: 25 }],
+};
+
+describe('request-validation: 404 fake-ID value synthesis (#381)', () => {
+  it('numeric LongKey path param → big-number fake matching the pattern and within maxLength', () => {
+    const v = fakePathParamValue(pathParam('processInstanceKey', longKeySchema));
+    expect(v).toBeDefined();
+    if (!v) return;
+    expect(/^-?[0-9]+$/.test(v)).toBe(true);
+    expect(v.length).toBeLessThanOrEqual(25);
+    // Long enough to sit well above sequentially-minted keys.
+    expect(v.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('string-id path param → fake satisfying its pattern and length bounds', () => {
+    const tenantIdSchema = {
+      type: 'string',
+      minLength: 1,
+      maxLength: 31,
+      pattern: '^(<default>|[\\w\\.\\-]{1,31})$',
+    };
+    const v = fakePathParamValue(pathParam('tenantId', tenantIdSchema));
+    expect(v).toBeDefined();
+    if (!v) return;
+    expect(new RegExp(tenantIdSchema.pattern).test(v)).toBe(true);
+    expect(v.length).toBeLessThanOrEqual(31);
+  });
+
+  it('oneOf of LongKey aliases (e.g. ResourceKey) → numeric fake, not a string id', () => {
+    // `ResourceKey` is `oneOf:[ProcessDefinitionKey, ...]`, each an
+    // `allOf:[LongKey]`. The numeric constraint is two levels deep; a flat
+    // read would mistake it for a free string and synthesise a malformed key.
+    const resourceKeySchema = {
+      type: 'string',
+      oneOf: [
+        { type: 'string', allOf: [{ type: 'string', pattern: '^-?[0-9]+$', maxLength: 25 }] },
+        { type: 'string', allOf: [{ type: 'string', pattern: '^-?[0-9]+$', maxLength: 25 }] },
+      ],
+    };
+    const v = fakePathParamValue(pathParam('resourceKey', resourceKeySchema));
+    expect(v).toBeDefined();
+    if (!v) return;
+    expect(/^-?[0-9]+$/.test(v)).toBe(true);
+  });
+
+  it('unsynthesisable param (pattern no candidate satisfies) → undefined (caller skips)', () => {
+    // Composite key `<digits>-<digits>` — neither a plain number nor the
+    // string candidates match, so no guaranteed-valid value exists.
+    const compositeSchema = { type: 'string', pattern: '^[0-9]+-[0-9]+$' };
+    expect(
+      fakePathParamValue(pathParam('decisionEvaluationInstanceKey', compositeSchema)),
+    ).toBeUndefined();
+  });
+
+  it('enum path param → undefined (a non-member would be 400, not 404)', () => {
+    const enumSchema = { type: 'string', enum: ['a', 'b', 'c'] };
+    expect(fakePathParamValue(pathParam('kind', enumSchema))).toBeUndefined();
+  });
+});
+
+describe('request-validation: 404 fake-ID eligibility (#381)', () => {
+  it('emits a 404 scenario for a singleton key endpoint that declares 404', () => {
+    const ops = [
+      op({
+        operationId: 'getProcessInstance',
+        path: '/process-instances/{processInstanceKey}',
+        parameters: [pathParam('processInstanceKey', longKeySchema)],
+      }),
+    ];
+    const out = generateNotFoundFakeId(ops, {});
+    expect(out).toHaveLength(1);
+    const s = out[0];
+    expect(s.type).toBe('not-found-fake-id');
+    expect(s.expectedStatus).toBe(404);
+    expect(s.headersAuth).toBe(true);
+    expect(s.requestBody).toBeUndefined();
+    expect(s.params?.processInstanceKey).toMatch(/^-?[0-9]+$/);
+  });
+
+  it('does NOT emit when the contract declares no 404', () => {
+    const o = op({
+      operationId: 'x',
+      path: '/r/{rKey}',
+      parameters: [pathParam('rKey', longKeySchema)],
+      responseCodes: ['200', '400'],
+    });
+    expect(isNotFoundEligible(o)).toBe(false);
+    expect(generateNotFoundFakeId([o], {})).toHaveLength(0);
+  });
+
+  it('does NOT emit for a non-GET (mutating/command) endpoint — v1 is read-only', () => {
+    const o = op({
+      operationId: 'cancelProcessInstance',
+      path: '/process-instances/{processInstanceKey}/cancellation',
+      method: 'POST',
+      parameters: [pathParam('processInstanceKey', longKeySchema)],
+    });
+    expect(isNotFoundEligible(o)).toBe(false);
+    expect(generateNotFoundFakeId([o], {})).toHaveLength(0);
+  });
+
+  it('does NOT emit for a paginated-collection (search/list) endpoint — empty 200, not 404 (#372)', () => {
+    const o = op({
+      operationId: 'searchUsersForGroup',
+      path: '/groups/{groupId}/users',
+      parameters: [pathParam('groupId', { type: 'string', minLength: 1, maxLength: 256 })],
+      successIsCollection: true,
+    });
+    expect(isNotFoundEligible(o)).toBe(false);
+    expect(generateNotFoundFakeId([o], {})).toHaveLength(0);
+  });
+
+  it('does NOT emit for an operation that requires a request body (v1 sends no body)', () => {
+    const o = op({
+      operationId: 'getThingWithBody',
+      path: '/things/{thingKey}',
+      parameters: [pathParam('thingKey', longKeySchema)],
+      bodyRequired: true,
+    });
+    expect(isNotFoundEligible(o)).toBe(false);
+    expect(generateNotFoundFakeId([o], {})).toHaveLength(0);
+  });
+
+  it('does NOT emit for an operation with no path parameter', () => {
+    const o = op({ operationId: 'listThings', path: '/things', parameters: [] });
+    expect(isNotFoundEligible(o)).toBe(false);
+  });
+});
+
+describe('request-validation: 404 fake-ID emitter rendering (#381)', () => {
+  it('renders a 404 assertion with the fake id substituted and no request body', () => {
+    const ops = [
+      op({
+        operationId: 'getGroup',
+        path: '/groups/{groupId}',
+        parameters: [pathParam('groupId', { type: 'string', minLength: 1, maxLength: 256 })],
+      }),
+    ];
+    const [s] = generateNotFoundFakeId(ops, {});
+    const code = renderScenarioForTest(s, 'getGroup - Nonexistent groupId returns 404');
+    expect(code).toContain('404');
+    expect(code).toContain('buildUrl("/groups/{groupId}"');
+    expect(code).toContain(s.params?.groupId ?? '__missing__');
+    expect(code).not.toContain('data: requestBody');
+  });
+});


### PR DESCRIPTION
## What

Adds a `not-found-fake-id` emitter to the **request-validation** workspace. For each eligible GET endpoint it substitutes a syntactically-valid-but-nonexistent value for every path id and asserts **HTTP 404**. Previously the generator emitted **0** such tests vs **127** upstream (umbrella #279).

**31 GET scenarios** are emitted and were **live-broker validated 31/31 → 404**.

## Why GET-only (v1)

Live validation of a broader draft (80 endpoints) showed **15 didn't cleanly 404**:
- **7× 503** — engine-command endpoints (job completion, incident resolution, process-instance cancellation, user-task actions). A missing key is a *command rejection*, not a 404.
- **8× 400** — misclassified numeric keys (now fixed, see below) plus mutation endpoints needing a body.

Distinguishing lookup-style mutations from command endpoints needs **field-site affordance metadata** the OpenAPI spec doesn't carry. Rather than emit false-positive tests (the #372 lesson), v1 is scoped to safe, idempotent **GET reads**, which have unambiguous "resource not found" → 404 semantics. Non-GET endpoints are deferred to the affordance follow-up (part of #279 / #368).

## Eligibility

A GET op with a path param, a declared `404` response, **not** a paginated collection (search-under-parent returns empty 200 for a missing parent — #372 pattern 3), and **not** requiring a request body (v1 sends none).

## Value synthesis

- Numeric LongKeys → big-number fake matching `^-?[0-9]+$`, clamped to `maxLength`.
- A `oneOf` of LongKey aliases (e.g. `ResourceKey = oneOf[ProcessDefinitionKey, …]`) is now detected as numeric via a recursive `allOf` (any-branch) / `oneOf` (all-branches) walk — previously misclassified as a string id and rejected as a malformed key (400).
- String ids → first pattern/length-valid candidate; enums & unsatisfiable patterns skipped (no flaky 404).
- URL-collapsing values rejected (#147).

## Refactor

Shared param-schema helpers (`resolveParamSchema`, `buildValidValue`, `isUrlCollapsingPathSegment`) extracted to `request-validation/src/util/paramSchema.ts` so `notFoundFakeId` and `paramConstraintViolations` share one implementation (per the AGENTS.md anti-parallel-implementation rule).

## Tests

- **11 unit fixtures** — value synthesis (incl. oneOf-numeric), GET-only eligibility, rendering.
- **2 Layer-3 invariants** over the regenerated suite — every emitted block asserts 404 and is a GET; collection search-under-parent ops excluded. The L3 block matcher now captures `scenarioKind` per test rather than via a lazy cross-test span, fixing a latent operationId-mislabelling bug.

All 712 tests pass; lint clean; all workspace + tests typechecks pass.

Closes #381. Part of #279.
