### PR TITLE
feat(request-validation): add getGlobalTaskListener to RBAC read-deny slice (#373)

### DIFF
--- a/request-validation/src/analysis/authDeny.ts
+++ b/request-validation/src/analysis/authDeny.ts
@@ -40,8 +40,7 @@ const SLICE: Record<string, Record<string, string>> = {
   getRole: { roleId: 'rbac-probe-role' },
   getMappingRule: { mappingRuleId: 'rbac-probe-mapping' },
   getGlobalClusterVariable: { name: 'rbac-probe-clustervar' },
-  // getGlobalTaskListener deferred: its create body (`type`, `eventTypes`) isn't
-  // confirmed; add once the fixture create is verified.
+  getGlobalTaskListener: { id: 'rbac-probe-gtl' },
 };
 
 // An unauthorized get-by-key on an existing resource is forbidden with 403 — the

--- a/request-validation/templates/support/global-setup.ts
+++ b/request-validation/templates/support/global-setup.ts
@@ -70,6 +70,11 @@ const FIXTURES: ReadonlyArray<{ label: string; path: string; body: unknown }> = 
     path: '/v2/cluster-variables/global',
     body: { name: 'rbac-probe-clustervar', value: 'rbac-probe' },
   },
+  {
+    label: 'global-task-listener',
+    path: '/v2/global-task-listeners',
+    body: { id: 'rbac-probe-gtl', type: 'rbac-probe-listener', eventTypes: ['all'] },
+  },
 ];
 
 async function globalSetup(): Promise<void> {

--- a/tests/request-validation/auth-deny.test.ts
+++ b/tests/request-validation/auth-deny.test.ts
@@ -21,6 +21,7 @@ const SLICE_OPS = [
   'getRole',
   'getMappingRule',
   'getGlobalClusterVariable',
+  'getGlobalTaskListener',
 ];
 
 const ops: OperationModel[] = [
@@ -45,6 +46,13 @@ const ops: OperationModel[] = [
     operationId: 'getGlobalClusterVariable',
     method: 'GET',
     path: '/cluster-variables/global/{name}',
+    tags: [],
+    parameters: [],
+  },
+  {
+    operationId: 'getGlobalTaskListener',
+    method: 'GET',
+    path: '/global-task-listeners/{id}',
     tags: [],
     parameters: [],
   },


### PR DESCRIPTION
## What

Completes the **client-minted get-by-key tier** of the read-side RBAC deny-tests by adding `getGlobalTaskListener`. #379 broadened the deny slice from 1 → 6 ops but deferred this one because its create body was unconfirmed.

## Why it was deferrable, and why it no longer is

The only hard part of a deny-test is having a **real existing instance** to fetch (so the probe's failure is a genuine authorization denial, not a 404 everyone gets). For `getGlobalTaskListener` that needs a working `createGlobalTaskListener` body. The bundled spec confirms the required fields: `id`, `type` (free string), and `eventTypes` (enum: `all|creating|assigning|updating|completing|canceling`).

## Changes

- **`authDeny.ts`** — add `getGlobalTaskListener: { id: 'rbac-probe-gtl' }` to the slice; drop the deferral comment.
- **`global-setup.ts`** — provision one listener as admin: `{ id: 'rbac-probe-gtl', type: 'rbac-probe-listener', eventTypes: ['all'] }` (idempotent, accepts 2xx/409).
- **tests** — extend the auth-deny unit fixtures to cover the new slice op.

## Verification (live, authorizations-enabled `docker-compose.rbac.yml`)

| step | result |
|---|---|
| admin `POST /v2/global-task-listeners` | **201** |
| admin `GET /v2/global-task-listeners/rbac-probe-gtl` | **200** (after export lag) |
| zero-grant probe `GET …/rbac-probe-gtl` | **403** — `Unauthorized to perform operation 'READ_TASK_LISTENER' on resource 'GLOBAL_LISTENER'` |

Full `rbac` Playwright suite: **7/7 pass** (incl. the new `getGlobalTaskListener - Denied (no permission)`). `npm run lint` clean; all workspace + tests typechecks pass; `npm test` 730 pass.

## Scope

This finishes #373's client-minted tier. The remaining tiers stay tracked separately:
- server-minted keys (Authorization, Document) → #377
- deploy/runtime (~15 ops) → #378

Closes #373.
