### PR TITLE
feat(hub): local dev setup, spec-pin bump, and run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,42 @@ Override the REST port with `CAMUNDA_REST_PORT`:
 CAMUNDA_REST_PORT=9080 docker compose up -d
 ```
 
+### Starting Camunda Hub (Web Modeler) — Self-Managed
+
+> First-time setup required — see `LOCAL_SETUP_NOTES.md` in the camunda-hub repo.
+> Expects `camunda-hub` to be cloned as a sibling directory alongside this repo.
+
+```bash
+# Start (Docker infrastructure + restapi + frontend)
+./docker/start-hub.sh
+
+# Stop
+./docker/start-hub.sh stop
+```
+
+The Hub UI will be available at `http://localhost:${HUB_UI_PORT:-8088}`. Log in with `demo` / `demo`.
+
+#### Generating and running Hub request-validation tests
+
+```bash
+# Generate hub request-validation tests
+CONFIG=camunda-hub npm run generate:request-validation
+
+# Get an OAuth token from Keycloak (hub uses Bearer auth, not Basic)
+TOKEN=$(curl -s -X POST "http://localhost:${KEYCLOAK_PORT:-18080}/auth/realms/camunda-platform/protocol/openid-connect/token" \
+  -d "client_id=c8-client&client_secret=c8-secret&grant_type=client_credentials" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
+
+# Run the generated tests
+# Unset Basic auth vars — if set, they take precedence over BEARER_TOKEN and hub tests will fail
+unset CAMUNDA_BASIC_AUTH_USER CAMUNDA_BASIC_AUTH_PASSWORD
+BEARER_TOKEN=$TOKEN \
+CORE_APPLICATION_URL=http://localhost:${HUB_UI_PORT:-8088}/api \
+CONFIG=camunda-hub npm run test:pw:request-validation
+```
+
+> The Hub server must be running with `CAMUNDA_MODELER_FEATURE_PUBLIC_API_V2_ENABLED=true` — set this in `camunda-hub/restapi/config/config-common/src/main/resources/application-common-local.yml` before starting.
+
 ### Running the Test Generator
 
 ```bash
@@ -100,10 +136,15 @@ npm run pipeline
 # Generate the negative request-validation suite (HTTP 400 tests, all supported scenario kinds)
 npm run generate:request-validation
 
-# Run the generated tests (requires running Camunda server)
+# Run the generated tests against a local OCA instance
+# (omit CAMUNDA_BASIC_AUTH_* if your instance has no auth enabled)
+CORE_APPLICATION_URL=http://localhost:8080 \
+CAMUNDA_BASIC_AUTH_USER=demo \
+CAMUNDA_BASIC_AUTH_PASSWORD=demo \
+npm run test:pw:request-validation    # negative request-validation only
+
 npm run test:pw                       # both suites (path-analyser + request-validation)
 npm run test:pw:path-analyser         # positive scenarios only
-npm run test:pw:request-validation    # negative request-validation only
 ```
 
 ## Project Structure

--- a/configs/camunda-hub/spec-pin.json
+++ b/configs/camunda-hub/spec-pin.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Spec pin for the camunda-hub config (spike). Mirrors the camunda-oca contract: specRef MUST be a 40-char commit SHA on camunda/camunda-hub, expectedSpecHash is the specHash printed in spec/camunda-hub/bundled/spec-metadata.json after bundling. The hub spec lives at restapi/public-api/src/main/resources/openapi/v2/ inside camunda/camunda-hub (private repo). Initial pin: latest main as of 2026-06-02.",
-  "specRef": "f6e7a8a124f58064610f0fa8e48e9915624414ee",
-  "expectedSpecHash": "sha256:9e0c24c2d0a549f6bf009e3328f612b16779f811f503a5ae39d3475f9ca13ab1"
+  "$comment": "Spec pin for the camunda-hub config. Mirrors the camunda-oca contract: specRef MUST be a 40-char commit SHA on camunda/camunda-hub, expectedSpecHash is the specHash printed in spec/camunda-hub/bundled/spec-metadata.json after bundling. The hub spec lives at restapi/public-api/src/main/resources/openapi/v2/ inside camunda/camunda-hub (private repo).",
+  "specRef": "4f9d95e05dc7ca66ac4d653fc302c554f8a30bc3",
+  "expectedSpecHash": "sha256:06cc66f665e0cba5ae8242bd71146d5c13cfc4390ad76a9b4557d1fd8a45c9af"
 }

--- a/docker/docker-compose.hub.yml
+++ b/docker/docker-compose.hub.yml
@@ -1,0 +1,161 @@
+# Infrastructure services for running camunda-hub locally in Self-Managed mode.
+# The Hub app itself (restapi + frontend) is started separately via docker/start-hub.sh.
+#
+# Derived from camunda-hub/docker-compose.sm.yml (identity-db, identity, websockets)
+# and camunda-hub/docker-compose.yml (mailpit). Keep image pins in sync with those files.
+#
+# All host ports are configurable via env vars — set them in a .env file or export them
+# before running docker compose to resolve conflicts with other local stacks.
+# Keycloak is pinned to match camunda-hub/docker-compose.sm-keycloak.yml.
+# Identity and WebSockets default to SNAPSHOT (pull_policy: always); set PULL_POLICY=if_not_present to skip pulls.
+
+services:
+  modeler-db:
+    image: postgres:14.23-alpine@sha256:6765739f422606933bc2aece3a2288e40e491488fd7e7c14e3323dfeefb10e38
+    ports:
+      - "${MODELER_DB_PORT:-5432}:5432"
+    volumes:
+      - modeler-db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: pg_isready -d modeler-db -U modeler-db-user
+      interval: 5s
+      timeout: 1s
+      retries: 10
+    environment:
+      POSTGRES_DB: modeler-db
+      POSTGRES_USER: modeler-db-user
+      POSTGRES_PASSWORD: modeler-db-password
+
+  keycloak-db:
+    image: postgres:14.23-alpine@sha256:6765739f422606933bc2aece3a2288e40e491488fd7e7c14e3323dfeefb10e38
+    ports:
+      - "${KEYCLOAK_DB_PORT:-5433}:5432"
+    volumes:
+      - keycloak-db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: pg_isready -d keycloak-db -U keycloak-db-user
+      interval: 5s
+      timeout: 1s
+      retries: 10
+    environment:
+      POSTGRES_DB: keycloak-db
+      POSTGRES_USER: keycloak-db-user
+      POSTGRES_PASSWORD: keycloak-db-password
+
+  identity-db:
+    image: postgres:14.23-alpine@sha256:6765739f422606933bc2aece3a2288e40e491488fd7e7c14e3323dfeefb10e38
+    ports:
+      - "${IDENTITY_DB_PORT:-5434}:5432"
+    volumes:
+      - identity-db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: pg_isready -d identity-db -U identity-db-user
+      interval: 5s
+      timeout: 1s
+      retries: 10
+    environment:
+      POSTGRES_DB: identity-db
+      POSTGRES_USER: identity-db-user
+      POSTGRES_PASSWORD: identity-db-password
+
+  keycloak:
+    image: camunda/keycloak:26.3.3@sha256:e2e87917eb90a42ea6f718b1d4edaf470bb36ab9a3867089d1b7ca1f8a430b8a
+    depends_on:
+      keycloak-db:
+        condition: service_healthy
+    ports:
+      - "${KEYCLOAK_PORT:-18080}:8080"
+    environment:
+      KC_DB_URL: jdbc:postgresql://keycloak-db:5432/keycloak-db
+      KC_DB_USERNAME: keycloak-db-user
+      KC_DB_PASSWORD: keycloak-db-password
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KC_HTTP_RELATIVE_PATH: /auth
+      KC_HEALTH_ENABLED: "true"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:9000/auth/health/ready"]
+      interval: 5s
+      timeout: 1s
+      retries: 15
+      start_period: 15s
+
+  identity:
+    image: ${IDENTITY_IMAGE:-camunda/identity:SNAPSHOT}
+    pull_policy: ${PULL_POLICY:-always}
+    depends_on:
+      identity-db:
+        condition: service_healthy
+      keycloak:
+        condition: service_healthy
+    ports:
+      - "${IDENTITY_PORT:-8080}:8080"
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8082/actuator/health"]
+      interval: 5s
+      timeout: 1s
+      retries: 10
+    environment:
+      IDENTITY_DATABASE_HOST: identity-db
+      IDENTITY_DATABASE_NAME: identity-db
+      IDENTITY_DATABASE_PASSWORD: identity-db-password
+      IDENTITY_DATABASE_PORT: 5432
+      IDENTITY_DATABASE_USERNAME: identity-db-user
+      KEYCLOAK_URL: http://keycloak:8080/auth
+      IDENTITY_AUTH_PROVIDER_ISSUER_URL: http://localhost:${KEYCLOAK_PORT:-18080}/auth/realms/camunda-platform
+      IDENTITY_AUTH_PROVIDER_BACKEND_URL: http://keycloak:8080/auth/realms/camunda-platform
+      KEYCLOAK_INIT_WEBMODELER_ROOT_URL: http://localhost:${HUB_UI_PORT:-8088}
+      KEYCLOAK_USERS_0_FIRST_NAME: Demo
+      KEYCLOAK_USERS_0_LAST_NAME: User
+      KEYCLOAK_USERS_0_EMAIL: demo.user@example.com
+      KEYCLOAK_USERS_0_USERNAME: demo
+      KEYCLOAK_USERS_0_PASSWORD: demo
+      KEYCLOAK_USERS_0_ROLES_0: Identity
+      KEYCLOAK_USERS_0_ROLES_1: Web Modeler
+      KEYCLOAK_USERS_0_ROLES_2: Web Modeler Admin
+      # M2M client used by the Hub API tests (matches camunda-hub/docker-compose.sm-keycloak.yml)
+      KEYCLOAK_CLIENTS_0_NAME: c8-client
+      KEYCLOAK_CLIENTS_0_ID: c8-client
+      KEYCLOAK_CLIENTS_0_SECRET: c8-secret
+      KEYCLOAK_CLIENTS_0_TYPE: M2M
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_0_RESOURCE_SERVER_ID: web-modeler-public-api
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_0_DEFINITION: create:*
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_1_RESOURCE_SERVER_ID: web-modeler-public-api
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_1_DEFINITION: read:*
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_2_RESOURCE_SERVER_ID: web-modeler-public-api
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_2_DEFINITION: update:*
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_3_RESOURCE_SERVER_ID: web-modeler-public-api
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_3_DEFINITION: delete:*
+
+  websockets:
+    image: ${WEBSOCKETS_IMAGE:-registry.camunda.cloud/team-hub/hub-websockets:SNAPSHOT}  # set WEBSOCKETS_IMAGE to pin to a specific digest
+    pull_policy: ${PULL_POLICY:-if_not_present}
+    ports:
+      - "${WEBSOCKETS_PORT:-8060}:8060"
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8060/up"]
+      interval: 5s
+      timeout: 1s
+      retries: 10
+    environment:
+      APP_NAME: "Web Modeler Self-Managed WebSockets"
+      APP_DEBUG: "true"
+      PUSHER_APP_ID: "self-managed-pusher-app-id"
+      PUSHER_APP_KEY: "self-managed-pusher-key"
+      PUSHER_APP_SECRET: "self-managed-pusher-secret"
+
+  mailpit:
+    image: axllent/mailpit:v1.30.1@sha256:3bd7c2f2696deb35a4780d152b404dceec99cb041b942c0877b3b22384714f85
+    ports:
+      - "${MAILPIT_SMTP_PORT:-1025}:1025"
+      - "${MAILPIT_HTTP_PORT:-8025}:8025"
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8025"]
+      interval: 5s
+      timeout: 1s
+      retries: 10
+
+volumes:
+  modeler-db-data:
+  keycloak-db-data:
+  identity-db-data:

--- a/docker/docker-compose.hub.yml
+++ b/docker/docker-compose.hub.yml
@@ -7,7 +7,7 @@
 # All host ports are configurable via env vars — set them in a .env file or export them
 # before running docker compose to resolve conflicts with other local stacks.
 # Keycloak is pinned to match camunda-hub/docker-compose.sm-keycloak.yml.
-# Identity and WebSockets default to SNAPSHOT (pull_policy: always); set PULL_POLICY=if_not_present to skip pulls.
+# Identity and WebSockets default to SNAPSHOT (pull_policy: if_not_present); set PULL_POLICY=always to refresh.
 
 services:
   modeler-db:
@@ -82,7 +82,7 @@ services:
 
   identity:
     image: ${IDENTITY_IMAGE:-camunda/identity:SNAPSHOT}
-    pull_policy: ${PULL_POLICY:-always}
+    pull_policy: ${PULL_POLICY:-if_not_present}
     depends_on:
       identity-db:
         condition: service_healthy

--- a/docker/start-hub.sh
+++ b/docker/start-hub.sh
@@ -64,9 +64,7 @@ fix_keycloak() {
     sleep 2
   done
 
-  local realm_url="${keycloak_url}/auth/admin/realms/camunda-platform"
-
-  # 1. Fix web-modeler audience mapper: Identity 8.8.0-alpha7 sets included.client.audience=web-modeler
+  # 1. Fix web-modeler audience mapper: Identity seeds included.client.audience=web-modeler
   #    but the restapi validates aud=web-modeler-api. Patch the mapper to point to web-modeler-api.
   local wm_client_uuid mapper_id
   wm_client_uuid=$(curl -sf -H "Authorization: Bearer ${admin_token}" \
@@ -101,7 +99,7 @@ for m in json.load(sys.stdin):
   echo "Keycloak: fixed web-modeler audience mapper → web-modeler-api"
 
   # 2. Assign Web Modeler / Web Modeler Admin / Identity roles to the demo user.
-  #    Identity 8.8.0-alpha7 creates the roles but does not assign them to seeded users.
+  #    Identity creates the roles but does not assign them to seeded users.
   local demo_user_id
   demo_user_id=$(curl -sf -H "Authorization: Bearer ${admin_token}" \
     "${realm_url}/users?username=demo" \

--- a/docker/start-hub.sh
+++ b/docker/start-hub.sh
@@ -10,16 +10,19 @@ COMPOSE_FILE="$SCRIPT_DIR/docker-compose.hub.yml"
 PID_FILE="$REPO_ROOT/test-results/.hub.pid"
 LOG_FILE="$REPO_ROOT/test-results/.hub.log"
 
-if [ ! -d "$HUB_REPO" ]; then
-  echo "Error: camunda-hub not found at $HUB_REPO"
-  echo "Clone it as a sibling directory: git clone git@github.com:camunda/camunda-hub.git ../camunda-hub"
-  exit 1
-fi
-
-if [ -z "${JAVA_HOME:-}" ]; then
-  echo "Error: JAVA_HOME is not set. Set it to a JDK 21+ installation before running this script."
-  exit 1
-fi
+# Preconditions for building/running the Hub app. Only `start` needs these;
+# `stop` just kills the PID and tears down Docker, so it must not require them.
+check_start_preconditions() {
+  if [ ! -d "$HUB_REPO" ]; then
+    echo "Error: camunda-hub not found at $HUB_REPO"
+    echo "Clone it as a sibling directory: git clone git@github.com:camunda/camunda-hub.git ../camunda-hub"
+    exit 1
+  fi
+  if [ -z "${JAVA_HOME:-}" ]; then
+    echo "Error: JAVA_HOME is not set. Set it to a JDK 21+ installation before running this script."
+    exit 1
+  fi
+}
 
 fix_keycloak() {
   local keycloak_port="${KEYCLOAK_PORT:-18080}"
@@ -123,6 +126,7 @@ import json as j; print(j.dumps(result))
 
 case "${1:-start}" in
   start)
+    check_start_preconditions
     if [ -f "$PID_FILE" ]; then
       EXISTING_PID=$(cat "$PID_FILE")
       if kill -0 "$EXISTING_PID" 2>/dev/null; then

--- a/docker/start-hub.sh
+++ b/docker/start-hub.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Start or stop camunda-hub (Web Modeler) in Self-Managed mode.
+# Expects camunda-hub to be cloned as a sibling directory: ../camunda-hub
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HUB_REPO="$REPO_ROOT/../camunda-hub"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.hub.yml"
+PID_FILE="$REPO_ROOT/test-results/.hub.pid"
+LOG_FILE="$REPO_ROOT/test-results/.hub.log"
+
+if [ ! -d "$HUB_REPO" ]; then
+  echo "Error: camunda-hub not found at $HUB_REPO"
+  echo "Clone it as a sibling directory: git clone git@github.com:camunda/camunda-hub.git ../camunda-hub"
+  exit 1
+fi
+
+if [ -z "${JAVA_HOME:-}" ]; then
+  echo "Error: JAVA_HOME is not set. Set it to a JDK 21+ installation before running this script."
+  exit 1
+fi
+
+fix_keycloak() {
+  local keycloak_port="${KEYCLOAK_PORT:-18080}"
+  local keycloak_url="http://localhost:${keycloak_port}"
+  local token_url="${keycloak_url}/auth/realms/master/protocol/openid-connect/token"
+
+  # docker compose up -d already waits for Keycloak to be healthy (Identity depends_on it),
+  # but the management health port (9000) is not published to the host. Poll the admin token
+  # endpoint on the published port instead — it becomes available once Keycloak is ready.
+  # Then wait for Identity to finish initialising the camunda-platform realm and web-modeler client.
+  echo "Waiting for Keycloak admin API..."
+  local admin_token attempts=0
+  until admin_token=$(curl -sf -X POST "$token_url" \
+      -d "client_id=admin-cli&username=admin&password=admin&grant_type=password" \
+      | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null) \
+      && [ -n "$admin_token" ]; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 30 ]; then
+      echo "Error: Keycloak admin API did not become available within 30 attempts."
+      return 1
+    fi
+    sleep 2
+  done
+
+  echo "Waiting for Identity to initialise the camunda-platform realm..."
+  local realm_url="${keycloak_url}/auth/admin/realms/camunda-platform"
+  attempts=0
+  until curl -sf -H "Authorization: Bearer ${admin_token}" \
+      "${realm_url}/clients?clientId=web-modeler" \
+      | python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if d else 1)" 2>/dev/null; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 60 ]; then
+      echo "Error: camunda-platform realm / web-modeler client not ready within 60 attempts."
+      return 1
+    fi
+    # Admin token expires after 60 s — refresh it periodically
+    if [ $((attempts % 25)) -eq 0 ]; then
+      admin_token=$(curl -sf -X POST "$token_url" \
+        -d "client_id=admin-cli&username=admin&password=admin&grant_type=password" \
+        | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null) || true
+    fi
+    sleep 2
+  done
+
+  local realm_url="${keycloak_url}/auth/admin/realms/camunda-platform"
+
+  # 1. Fix web-modeler audience mapper: Identity 8.8.0-alpha7 sets included.client.audience=web-modeler
+  #    but the restapi validates aud=web-modeler-api. Patch the mapper to point to web-modeler-api.
+  local wm_client_uuid mapper_id
+  wm_client_uuid=$(curl -sf -H "Authorization: Bearer ${admin_token}" \
+    "${realm_url}/clients?clientId=web-modeler" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['id'])")
+  mapper_id=$(curl -sf -H "Authorization: Bearer ${admin_token}" \
+    "${realm_url}/clients/${wm_client_uuid}/protocol-mappers/models" \
+    | python3 -c "
+import sys,json
+for m in json.load(sys.stdin):
+    if m.get('protocolMapper') == 'oidc-audience-mapper':
+        print(m['id']); break
+")
+  curl -sf -X PUT \
+    -H "Authorization: Bearer ${admin_token}" \
+    -H "Content-Type: application/json" \
+    "${realm_url}/clients/${wm_client_uuid}/protocol-mappers/models/${mapper_id}" \
+    -d "{
+      \"id\": \"${mapper_id}\",
+      \"name\": \"web-modeler Audience Mapper\",
+      \"protocol\": \"openid-connect\",
+      \"protocolMapper\": \"oidc-audience-mapper\",
+      \"consentRequired\": false,
+      \"config\": {
+        \"included.client.audience\": \"web-modeler-api\",
+        \"id.token.claim\": \"false\",
+        \"access.token.claim\": \"true\",
+        \"introspection.token.claim\": \"true\",
+        \"userinfo.token.claim\": \"false\"
+      }
+    }" > /dev/null
+  echo "Keycloak: fixed web-modeler audience mapper → web-modeler-api"
+
+  # 2. Assign Web Modeler / Web Modeler Admin / Identity roles to the demo user.
+  #    Identity 8.8.0-alpha7 creates the roles but does not assign them to seeded users.
+  local demo_user_id
+  demo_user_id=$(curl -sf -H "Authorization: Bearer ${admin_token}" \
+    "${realm_url}/users?username=demo" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['id'])")
+  local roles_json
+  roles_json=$(curl -sf -H "Authorization: Bearer ${admin_token}" \
+    "${realm_url}/roles" \
+    | python3 -c "
+import sys,json
+needed = {'Identity','Web Modeler','Web Modeler Admin'}
+result = [{'id':r['id'],'name':r['name']} for r in json.load(sys.stdin) if r['name'] in needed]
+import json as j; print(j.dumps(result))
+")
+  curl -sf -X POST \
+    -H "Authorization: Bearer ${admin_token}" \
+    -H "Content-Type: application/json" \
+    "${realm_url}/users/${demo_user_id}/role-mappings/realm" \
+    -d "${roles_json}" > /dev/null
+  echo "Keycloak: assigned Web Modeler / Web Modeler Admin / Identity roles to demo user"
+}
+
+case "${1:-start}" in
+  start)
+    if [ -f "$PID_FILE" ]; then
+      EXISTING_PID=$(cat "$PID_FILE")
+      if kill -0 "$EXISTING_PID" 2>/dev/null; then
+        echo "Error: Hub app is already running (PID $EXISTING_PID). Run './docker/start-hub.sh stop' first."
+        exit 1
+      else
+        echo "Warning: Stale PID file found (PID $EXISTING_PID is not running). Removing."
+        rm -f "$PID_FILE"
+      fi
+    fi
+    mkdir -p "$(dirname "$PID_FILE")"
+    # Clear any orphaned processes on the Hub ports left by a previous unclean stop.
+    hub_ui_port="${HUB_UI_PORT:-8088}"
+    stale_pids=$(lsof -ti ":${hub_ui_port}" 2>/dev/null || true)
+    if [ -n "$stale_pids" ]; then
+      echo "Warning: Clearing orphaned processes on port ${hub_ui_port}: $stale_pids"
+      echo "$stale_pids" | xargs kill 2>/dev/null || true
+    fi
+    echo "Starting Hub infrastructure..."
+    docker compose -f "$COMPOSE_FILE" up -d
+    fix_keycloak
+    echo "Starting Hub app (restapi + frontend)..."
+    cd "$HUB_REPO"
+    make local-self-managed > "$LOG_FILE" 2>&1 &
+    echo $! > "$PID_FILE"
+    echo "Hub app started (PID $(cat "$PID_FILE")). Logs: $LOG_FILE"
+    echo "Run './docker/start-hub.sh stop' to stop."
+    ;;
+  stop)
+    if [ -f "$PID_FILE" ]; then
+      MAKE_PID=$(cat "$PID_FILE")
+      if kill -0 "$MAKE_PID" 2>/dev/null; then
+        if ps -p "$MAKE_PID" -o args= 2>/dev/null | grep -qE "local[-:]self-managed"; then
+          echo "Stopping Hub app (PID $MAKE_PID)..."
+          # Kill the full process tree: make spawns npm/webpack/spring-boot as grandchildren
+          # that pkill -P misses. Kill by process group so the whole subtree is reaped.
+          MAKE_PGID=$(ps -p "$MAKE_PID" -o pgid= 2>/dev/null | tr -d ' ')
+          if [ -n "$MAKE_PGID" ] && [ "$MAKE_PGID" != "$$" ]; then
+            kill -- "-$MAKE_PGID" 2>/dev/null || true
+          else
+            pkill -P "$MAKE_PID" 2>/dev/null || true
+            kill "$MAKE_PID" 2>/dev/null || true
+          fi
+        else
+          echo "Warning: PID $MAKE_PID does not look like a Hub process (PID may have been recycled). Skipping kill."
+        fi
+      else
+        echo "PID file found but process $MAKE_PID is not running (stale PID file)."
+      fi
+      rm -f "$PID_FILE"
+    else
+      echo "No PID file at $PID_FILE — Hub app may not be running."
+    fi
+    echo "Stopping Hub infrastructure..."
+    docker compose -f "$COMPOSE_FILE" down
+    ;;
+  *)
+    echo "Usage: ./docker/start-hub.sh [start|stop]"
+    exit 1
+    ;;
+esac

--- a/docker/start-hub.sh
+++ b/docker/start-hub.sh
@@ -150,9 +150,23 @@ case "${1:-start}" in
     fix_keycloak
     echo "Starting Hub app (restapi + frontend)..."
     cd "$HUB_REPO"
+    # Launch make in its OWN process group (job-control mode) so the recorded PID
+    # is also the process-group ID. stop can then signal the whole subtree via
+    # `kill -- -PID` without any risk of hitting the caller's shell/terminal.
+    set -m
     make local-self-managed > "$LOG_FILE" 2>&1 &
-    echo $! > "$PID_FILE"
-    echo "Hub app started (PID $(cat "$PID_FILE")). Logs: $LOG_FILE"
+    MAKE_PID=$!
+    set +m
+    echo "$MAKE_PID" > "$PID_FILE"
+    # Detect an immediate failure (bad config, missing deps): make backgrounded with
+    # set -e won't surface it, so check the process is still alive after a moment.
+    sleep 2
+    if ! kill -0 "$MAKE_PID" 2>/dev/null; then
+      rm -f "$PID_FILE"
+      echo "Error: Hub app exited immediately. Check $LOG_FILE for details."
+      exit 1
+    fi
+    echo "Hub app started (PID $MAKE_PID). Logs: $LOG_FILE"
     echo "Run './docker/start-hub.sh stop' to stop."
     ;;
   stop)
@@ -161,13 +175,13 @@ case "${1:-start}" in
       if kill -0 "$MAKE_PID" 2>/dev/null; then
         if ps -p "$MAKE_PID" -o args= 2>/dev/null | grep -qE "local[-:]self-managed"; then
           echo "Stopping Hub app (PID $MAKE_PID)..."
-          # Kill the full process tree: make spawns npm/webpack/spring-boot as grandchildren
-          # that pkill -P misses. Kill by process group so the whole subtree is reaped.
-          MAKE_PGID=$(ps -p "$MAKE_PID" -o pgid= 2>/dev/null | tr -d ' ')
-          if [ -n "$MAKE_PGID" ] && [ "$MAKE_PGID" != "$$" ]; then
-            kill -- "-$MAKE_PGID" 2>/dev/null || true
+          # start launches make as its own process-group leader (set -m), so the
+          # recorded PID is also the PGID. `kill -- -PID` reaps the whole subtree
+          # (make + npm/webpack/spring-boot) and can never hit the caller's shell.
+          # Only fall back to a single-PID kill if this group is somehow gone.
+          if [ "$(ps -p "$MAKE_PID" -o pgid= 2>/dev/null | tr -d ' ')" = "$MAKE_PID" ]; then
+            kill -- "-$MAKE_PID" 2>/dev/null || true
           else
-            pkill -P "$MAKE_PID" 2>/dev/null || true
             kill "$MAKE_PID" 2>/dev/null || true
           fi
         else

--- a/docker/start-hub.sh
+++ b/docker/start-hub.sh
@@ -13,6 +13,14 @@ LOG_FILE="$REPO_ROOT/test-results/.hub.log"
 # Preconditions for building/running the Hub app. Only `start` needs these;
 # `stop` just kills the PID and tears down Docker, so it must not require them.
 check_start_preconditions() {
+  local missing=()
+  for cmd in docker curl python3 lsof make; do
+    command -v "$cmd" >/dev/null 2>&1 || missing+=("$cmd")
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    echo "Error: required command(s) not found on PATH: ${missing[*]}"
+    exit 1
+  fi
   if [ ! -d "$HUB_REPO" ]; then
     echo "Error: camunda-hub not found at $HUB_REPO"
     echo "Clone it as a sibling directory: git clone git@github.com:camunda/camunda-hub.git ../camunda-hub"

--- a/request-validation/templates/support/env.ts
+++ b/request-validation/templates/support/env.ts
@@ -44,6 +44,8 @@ export const denyProbeCredentials: ProbeCredentials = {
   password: process.env.RBAC_DENY_PROBE_PASSWORD || 'rbac-deny-probe-pw',
 };
 
+let partialCredsWarned = false;
+
 function encode(value: string): string {
   return Buffer.from(value).toString('base64');
 }
@@ -64,13 +66,25 @@ export function denyProbeHeaders(): Record<string, string> {
 /**
  * Build the Authorization header from configured credentials.
  *
+ * Basic auth (CAMUNDA_BASIC_AUTH_USER / CAMUNDA_BASIC_AUTH_PASSWORD) takes
+ * precedence when set. BEARER_TOKEN is used only when Basic creds are absent
+ * AND RV_PROFILE is not 'rbac' — the rbac suite relies on Basic-only auth;
+ * a stray BEARER_TOKEN in the environment must not silently satisfy it.
  * Returns an empty object when no credentials are supplied so the suite
  * can run unauthenticated against dev clusters without manual editing.
  */
 export function authHeaders(): Record<string, string> {
   const { username, password } = credentials;
-  if (!username || !password) return {};
-  return { Authorization: `Basic ${encode(`${username}:${password}`)}` };
+  if (username && password) return { Authorization: `Basic ${encode(`${username}:${password}`)}` };
+  if ((username || password) && !partialCredsWarned) {
+    partialCredsWarned = true;
+    console.warn(
+      '[auth] Only one of CAMUNDA_BASIC_AUTH_USER / CAMUNDA_BASIC_AUTH_PASSWORD is set — Basic auth requires both. The partial credential is ignored.',
+    );
+  }
+  const bearerToken = process.env.BEARER_TOKEN;
+  if (bearerToken && process.env.RV_PROFILE !== 'rbac') return { Authorization: `Bearer ${bearerToken}` };
+  return {};
 }
 
 export function jsonHeaders(): Record<string, string> {

--- a/tests/request-validation/env-auth-headers.test.ts
+++ b/tests/request-validation/env-auth-headers.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression coverage for authHeaders() precedence rules in the env template.
+ *
+ * The module reads CAMUNDA_BASIC_AUTH_* at import time (credentials object),
+ * so vi.resetModules() + dynamic import is required to isolate each case.
+ */
+
+const ENV_KEYS = [
+  'CAMUNDA_BASIC_AUTH_USER',
+  'CAMUNDA_BASIC_AUTH_PASSWORD',
+  'BEARER_TOKEN',
+  'RV_PROFILE',
+] as const;
+
+beforeEach(() => {
+  vi.resetModules();
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+  vi.restoreAllMocks();
+});
+
+async function loadAuthHeaders() {
+  const mod = await import('../../request-validation/templates/support/env.js');
+  return mod.authHeaders;
+}
+
+describe('authHeaders() precedence', () => {
+  it('returns Basic when both CAMUNDA_BASIC_AUTH_* are set', async () => {
+    process.env.CAMUNDA_BASIC_AUTH_USER = 'alice';
+    process.env.CAMUNDA_BASIC_AUTH_PASSWORD = 'secret';
+    const authHeaders = await loadAuthHeaders();
+    const encoded = Buffer.from('alice:secret').toString('base64');
+    expect(authHeaders()).toEqual({ Authorization: `Basic ${encoded}` });
+  });
+
+  it('returns Bearer when only BEARER_TOKEN is set and RV_PROFILE is not rbac', async () => {
+    process.env.BEARER_TOKEN = 'tok123';
+    const authHeaders = await loadAuthHeaders();
+    expect(authHeaders()).toEqual({ Authorization: 'Bearer tok123' });
+  });
+
+  it('returns {} when RV_PROFILE=rbac even if BEARER_TOKEN is set', async () => {
+    process.env.BEARER_TOKEN = 'tok123';
+    process.env.RV_PROFILE = 'rbac';
+    const authHeaders = await loadAuthHeaders();
+    expect(authHeaders()).toEqual({});
+  });
+
+  it('returns {} and warns exactly once when only one Basic auth var is set', async () => {
+    process.env.CAMUNDA_BASIC_AUTH_USER = 'alice';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const authHeaders = await loadAuthHeaders();
+    expect(authHeaders()).toEqual({});
+    expect(authHeaders()).toEqual({});
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('partial credential is ignored');
+  });
+});

--- a/tests/request-validation/env-auth-headers.test.ts
+++ b/tests/request-validation/env-auth-headers.test.ts
@@ -38,6 +38,15 @@ describe('authHeaders() precedence', () => {
     expect(authHeaders()).toEqual({ Authorization: `Basic ${encoded}` });
   });
 
+  it('prefers Basic over BEARER_TOKEN when both Basic creds and a bearer token are set', async () => {
+    process.env.CAMUNDA_BASIC_AUTH_USER = 'alice';
+    process.env.CAMUNDA_BASIC_AUTH_PASSWORD = 'secret';
+    process.env.BEARER_TOKEN = 'tok123';
+    const authHeaders = await loadAuthHeaders();
+    const encoded = Buffer.from('alice:secret').toString('base64');
+    expect(authHeaders()).toEqual({ Authorization: `Basic ${encoded}` });
+  });
+
   it('returns Bearer when only BEARER_TOKEN is set and RV_PROFILE is not rbac', async () => {
     process.env.BEARER_TOKEN = 'tok123';
     const authHeaders = await loadAuthHeaders();


### PR DESCRIPTION
## Summary

- **`docker/docker-compose.hub.yml`**: Docker infrastructure (Postgres ×3, Keycloak, Identity, WebSockets, Mailpit) for running Hub locally in Self-Managed mode — derived from \`camunda-hub/docker-compose.sm.yml\` and \`docker-compose.yml\`. All host ports configurable via env vars; named volumes for all Postgres services; SNAPSHOT images overridable via \`IDENTITY_IMAGE\`/\`WEBSOCKETS_IMAGE\`; \`pull_policy\` defaults to \`if_not_present\`.
- **`docker/start-hub.sh`**: convenience script to start/stop Hub (Docker infra + restapi + frontend via \`make local-self-managed\`). Uses a PID file (\`test-results/.hub.pid\`) for deterministic process management — guards against double-start, detects stale/recycled PIDs, logs to \`test-results/.hub.log\`.
- **`request-validation/templates/support/env.ts`**: adds BEARER_TOKEN support to \`authHeaders()\` (used by Hub which requires OAuth2 Bearer auth). Basic creds take precedence when set; BEARER_TOKEN is suppressed when \`RV_PROFILE=rbac\` to avoid silently satisfying the RBAC suite. Partial Basic creds warn once per process.
- **`configs/camunda-hub/spec-pin.json`**: bump spec pin from stale Files+Folders-only commit to \`4f9d95e\` (all 19 paths: Files, Folders, Projects, Versions, Workspaces, Collaborators).
- **`README.md`**: document Hub startup, Hub test generation/run (\`CONFIG=camunda-hub\`, \`BEARER_TOKEN\`, \`HUB_UI_PORT\`, \`KEYCLOAK_PORT\`, feature flag), and OCA test run env vars in the existing section.
- **`tests/request-validation/env-auth-headers.test.ts`**: unit tests for \`authHeaders()\` precedence — Basic wins over Bearer, RBAC profile suppresses Bearer, warn-once on partial Basic creds.

## Test plan

- [ ] \`docker/start-hub.sh\` starts Hub infrastructure and app without errors
- [ ] \`docker/start-hub.sh stop\` tears everything down cleanly
- [ ] Running \`start\` a second time prints an error instead of orphaning the first process
- [ ] \`CONFIG=camunda-hub npm run generate:request-validation\` generates tests for all 6 resource groups
- [ ] Hub tests run with \`BEARER_TOKEN\` + \`CORE_APPLICATION_URL=http://localhost:\${HUB_UI_PORT:-8088}/api CONFIG=camunda-hub npm run test:pw:request-validation\`
- [ ] \`npm test\` passes (includes the four new \`authHeaders()\` unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)