### PR TITLE
Bump camunda-oca spec to latest; model the agent-instance domain

### DIFF
--- a/configs/camunda-oca/ontology/entity-kinds.json
+++ b/configs/camunda-oca/ontology/entity-kinds.json
@@ -188,6 +188,16 @@
         }
       ],
       "description": "#305 Phase 5d-4 / #189 — a process instance, identified by its server-minted processInstanceKey. NOTE on shape: ProcessInstance is the direct response of createProcessInstance, not strictly a side-effect 'runtime-emitted' entity in the strict #305 sense; we classify it as a runtime-entity here purely so it can participate in the StateTransitionVisibleAfterAction template (which requires fetcher+stateField+transitions). The cancelProcessInstance transition (ACTIVE → CANCELED) is verified by read-back through getProcessInstance. Selection of the deployment fixture is driven by `requires: [ModelHasCancellationBlocker]` on the cancelProcessInstance op, which forces the planner to choose bpmn/cancellable-blocked.bpmn (a service task wired to a unique job type that no other test activates) so the instance stays ACTIVE until the test cancels it explicitly. No mutators[]. See #281 for the orthogonal EntityLifecycle two-revoker design that may later relocate ProcessInstance into a richer shape; this row scopes ProcessInstance to the state-transition concern only."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "AgentInstanceIteration",
+      "shape": "immutable-entity",
+      "identifiers": [
+        "IterationId"
+      ],
+      "establishedBy": "createAgentInstanceHistoryItem",
+      "description": "#386 — a logical grouping of one LLM call, its tool dispatches, and their results within an agent instance's conversation history. Identified by a client-minted IterationId supplied in the createAgentInstanceHistoryItem body (so IterationId is a clientMintedIdentifier via the upstream x-semantic-establishes annotation, not a producer-chained key). Append-only: once written it is never updated or deleted, and it is read back only via searchAgentInstanceHistory (no canonical get-by-id), so it carries neither the CRUD triple nor a runtime fetcher — hence shape: immutable-entity."
     }
   ]
 }

--- a/configs/camunda-oca/ontology/semantics.json
+++ b/configs/camunda-oca/ontology/semantics.json
@@ -25,7 +25,36 @@
     },
     {
       "name": "JobKey",
-      "witnesses": "JobAvailableForActivation"
+      "kind": "runtimeEmission",
+      "witnesses": "JobAvailableForActivation",
+      "emittedBy": {
+        "predecessor": "ProcessInstanceExists",
+        "guardedBy": [
+          "ModelHasServiceTaskType"
+        ]
+      },
+      "discoveredVia": {
+        "operationId": "activateJobs",
+        "extractKey": "jobKey",
+        "consistency": "eventual"
+      },
+      "$comment": "#388 — server-minted job key. Emitted after a deployment whose BPMN contains a service task of a known job type (ModelHasServiceTaskType) reaches that element during a process instance run. Discovered via activateJobs (the activated jobs[] carry jobKey + elementInstanceKey). Unlike searchUserTasks/searchIncidents, activateJobs filters by jobType (bound via the JobAvailableForActivation runtime-state valueBinding, request.jobType <- ModelHasServiceTaskType.jobType), not processInstanceKey — hence no discoveredVia.filterBy: the discovery step builds its normal activate body and the producer auto-derive extracts jobs[0].jobKey. Mirrors the #305 Phase 3 runtimeEmission pattern."
+    },
+    {
+      "name": "ElementInstanceKey",
+      "kind": "runtimeEmission",
+      "emittedBy": {
+        "predecessor": "ProcessInstanceExists",
+        "guardedBy": [
+          "ModelHasServiceTaskType"
+        ]
+      },
+      "discoveredVia": {
+        "operationId": "activateJobs",
+        "extractKey": "elementInstanceKey",
+        "consistency": "eventual"
+      },
+      "$comment": "#388 — server-minted key of the element instance (BPMN flow-node activation) a job belongs to. Co-emitted with JobKey: the same activateJobs call surfaces jobs[].elementInstanceKey alongside jobs[].jobKey, both extracted by the producer auto-derive. Required (with JobKey) in the agent-instance write bodies (updateAgentInstance, createAgentInstanceHistoryItem)."
     },
     {
       "name": "ElementId",
@@ -66,11 +95,6 @@
       "kind": "attribute",
       "clientMinted": true,
       "$comment": "Free-form correlation identifier attached to a process instance (createProcessInstance.businessId, searchProcessInstances.filter.businessId, etc.). Like Tag: client-minted, no producer endpoint, no first-order entity retrievable by it. The planner mints a deterministic value at the setter site; filter-consumer reuse is deferred (see #168)."
-    },
-    {
-      "name": "AgentInstanceKey",
-      "kind": "serverEmergent",
-      "$comment": "Server-minted lifecycle key for AI agent instances. No client API directly creates an AgentInstance with a returned key \u2014 instances emerge from agent runtime activity and are discoverable only via search/get. Used as a search-filter input; the planner mints a deterministic placeholder so the request validates and an empty result set is acceptable. See #162 PR 5."
     },
     {
       "name": "AuditLogKey",

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -580,7 +580,7 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
       semanticTypes?: Array<{
         name: string;
         kind?: string;
-        discoveredVia?: { operationId?: string };
+        discoveredVia?: { operationId?: string; filterBy?: string };
       }>;
     };
     const runtimeEmissionByName = new Map<string, string>();
@@ -694,12 +694,24 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
       semanticTypes?: Array<{
         name: string;
         kind?: string;
-        discoveredVia?: { operationId?: string };
+        discoveredVia?: { operationId?: string; filterBy?: string };
       }>;
     };
+    // Phase A governs the filter-style discovery regime (searchUserTasks /
+    // searchIncidents): a forward-bound `{ filter: { [filterBy]: <bound> } }`
+    // body. Only emissions that declare `discoveredVia.filterBy` belong to
+    // that regime. Filterless discovery ops (#388 — e.g. `activateJobs`, whose
+    // jobType is bound by the runtime-state valueBinding, not a forward-bound
+    // filter) intentionally build their normal request body and extract keys
+    // via the producer auto-derive, so they are NOT subject to the filter
+    // wrapper guard below.
     const discoveryOpIds = new Set<string>();
     for (const t of semantics.semanticTypes ?? []) {
-      if (t.kind === 'runtimeEmission' && t.discoveredVia?.operationId) {
+      if (
+        t.kind === 'runtimeEmission' &&
+        t.discoveredVia?.operationId &&
+        t.discoveredVia.filterBy
+      ) {
         discoveryOpIds.add(t.discoveredVia.operationId);
       }
     }

--- a/configs/camunda-oca/spec-pin.json
+++ b/configs/camunda-oca/spec-pin.json
@@ -1,5 +1,5 @@
 {
   "$comment": "Spec pin for the bundled-spec invariants regression layer. The invariants in configs/camunda-oca/regression-invariants.test.ts assert named properties of the upstream spec content fingerprinted by `expectedSpecHash`. `specRef` MUST be a full 40-char commit SHA on camunda/camunda (not a branch like `main`) so the baseline does not drift on every upstream merge. CI fetches the spec at `specRef` (requires camunda-schema-bundler >= 2.1.0 for SHA support) and aborts early via tests/regression/spec-pin.setup.ts if its hash drifts, so reviewers see a clear 'spec changed upstream — re-pin' signal instead of confusing invariant failures. To bump: pick a newer SHA, run `SPEC_REF=<sha> npm run fetch-spec:ref`, regenerate the pipeline, update any invariants whose values legitimately changed, then update both fields below in the same PR.",
-  "specRef": "d29d64495dc65ec1829646648ac6bf0b93c8d3f2",
-  "expectedSpecHash": "sha256:35f4e14406903c7dcf45afad4c17b1981904957b41397fb335c22d2a113cdf59"
+  "specRef": "06073e00fea50e518cf670b12c455baba76a05df",
+  "expectedSpecHash": "sha256:26f2149071b5d3b472ac5cbebadeed03e4eac7ee29f5f90cb2d9f54fd2f0c16a"
 }

--- a/ontology/vocabulary/entity-kinds.schema.json
+++ b/ontology/vocabulary/entity-kinds.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://camunda.github.io/api-test-generator/ns/v1/entity-kinds.schema.json",
   "title": "Entity-kinds ABox (api-test-generator ontology, v1)",
-  "description": "TBox JSON Schema for an ABox file describing the entity kinds (the domain nouns) of a single API. Each entry asserts: an entity kind exists; it has one of three shapes (`entity` for in-API-managed with full CRUD, `external-entity` for identifiers minted outside the API, `runtime-entity` for entities emitted by the runtime as a side-effect of other operations); and a list of semantic identifier-type names that identify it. `shape: \"entity\"` kinds carry an all-or-nothing CRUD triple (`establishedBy`/`observableVia`/`revokedBy`) consumed by the EntityLifecycle scenario template (#280) — asymmetric subsets surface as ABox-load validation errors. `shape: \"external-entity\"` kinds (e.g. Client) must NOT carry the CRUD triple. `shape: \"runtime-entity\"` kinds (#305 Phase 4 / Phase 5d, e.g. UserTask, Incident) carry a `fetcher` plus at least one of `mutators[]` (consumed by `UpdatedFieldVisibleOnReadBack`) or `transitions[]` + `stateField` (consumed by `StateTransitionVisibleAfterAction`, #189); the if/then/else below enforces that runtime-entity kinds carry the required combination and that entity/external-entity kinds carry none of these. The schema is intentionally agnostic to which API ships the kinds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/entity-kinds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (kind names appearing in operation `produces[]`/`requires[]`, identifier types being live, CRUD op methods being POST/GET/DELETE, etc.) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them.",
+  "description": "TBox JSON Schema for an ABox file describing the entity kinds (the domain nouns) of a single API. Each entry asserts: an entity kind exists; it has one of four shapes (`entity` for in-API-managed with full CRUD, `external-entity` for identifiers minted outside the API, `runtime-entity` for entities emitted by the runtime as a side-effect of other operations, `immutable-entity` for entities created in-API but never updated or deleted and observed only via search); and a list of semantic identifier-type names that identify it. `shape: \"entity\"` kinds carry an all-or-nothing CRUD triple (`establishedBy`/`observableVia`/`revokedBy`) consumed by the EntityLifecycle scenario template (#280) — asymmetric subsets surface as ABox-load validation errors. `shape: \"external-entity\"` kinds (e.g. Client) must NOT carry the CRUD triple. `shape: \"runtime-entity\"` kinds (#305 Phase 4 / Phase 5d, e.g. UserTask, Incident) carry a `fetcher` plus at least one of `mutators[]` (consumed by `UpdatedFieldVisibleOnReadBack`) or `transitions[]` + `stateField` (consumed by `StateTransitionVisibleAfterAction`, #189); `shape: \"immutable-entity\"` kinds (#386, e.g. AgentInstanceIteration) carry only `establishedBy` (client-minted identifier supplied at creation; no observe/revoke/mutate); the if/then/else below enforces that runtime-entity kinds carry the required combination and that entity/external-entity/immutable-entity kinds carry only their permitted fields. The schema is intentionally agnostic to which API ships the kinds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/entity-kinds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (kind names appearing in operation `produces[]`/`requires[]`, identifier types being live, CRUD op methods being POST/GET/DELETE, etc.) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -59,9 +59,10 @@
           "enum": [
             "entity",
             "external-entity",
-            "runtime-entity"
+            "runtime-entity",
+            "immutable-entity"
           ],
-          "description": "`entity`: in-API-managed (producer + consumer ops both inside the API). `external-entity`: identifier minted outside the API; planner treats `identifiers[]` as `externalBoundary` (client-mintable, no upstream producer required). `runtime-entity` (#305 Phase 4 / Phase 5d): entity emitted by the runtime as a side-effect of another operation (e.g. UserTask from a process instance, Incident from a failing process instance); discovered via runtimeEmission and re-read via `fetcher`. Carries `mutators[]` (consumed by `UpdatedFieldVisibleOnReadBack`) and/or `transitions[]`+`stateField` (consumed by `StateTransitionVisibleAfterAction`, #189)."
+          "description": "`entity`: in-API-managed (producer + consumer ops both inside the API). `external-entity`: identifier minted outside the API; planner treats `identifiers[]` as `externalBoundary` (client-mintable, no upstream producer required). `runtime-entity` (#305 Phase 4 / Phase 5d): entity emitted by the runtime as a side-effect of another operation (e.g. UserTask from a process instance, Incident from a failing process instance); discovered via runtimeEmission and re-read via `fetcher`. Carries `mutators[]` (consumed by `UpdatedFieldVisibleOnReadBack`) and/or `transitions[]`+`stateField` (consumed by `StateTransitionVisibleAfterAction`, #189). `immutable-entity` (#386): created in-API (`establishedBy`) but never updated or deleted, and observed only via a search/list op rather than a canonical get-by-id (e.g. AgentInstanceIteration — an append-only conversation-history record identified by a client-minted IterationId). Carries `establishedBy` only; its identifier is supplied by the client at creation (classified as a clientMintedIdentifier via the upstream `x-semantic-establishes` annotation), so no CRUD triple, no mutators/transitions, and no fetcher apply."
         },
         "identifiers": {
           "type": "array",
@@ -249,6 +250,54 @@
                 {
                   "required": [
                     "revokedBy"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "shape": {
+                "const": "immutable-entity"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "establishedBy"
+            ],
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "observableVia"
+                  ]
+                },
+                {
+                  "required": [
+                    "revokedBy"
+                  ]
+                },
+                {
+                  "required": [
+                    "mutators"
+                  ]
+                },
+                {
+                  "required": [
+                    "transitions"
+                  ]
+                },
+                {
+                  "required": [
+                    "stateField"
+                  ]
+                },
+                {
+                  "required": [
+                    "fetcher"
                   ]
                 }
               ]

--- a/path-analyser/src/canonicalSchemas.ts
+++ b/path-analyser/src/canonicalSchemas.ts
@@ -109,6 +109,9 @@ export async function buildCanonicalShapes(
             nodes,
             new Set(),
             components,
+            false,
+            0,
+            true, // descend oneOf/anyOf variants in the response shape
           );
           entry.response = nodes;
         }
@@ -152,13 +155,39 @@ function walkSchema(
   components: Record<string, SchemaObject>,
   required = false,
   depth = 0,
+  descendUnions = false,
 ) {
   if (!schema || depth > 25) return;
   if (schema.$ref) {
     const resolved = resolveSchema(schema, components);
     if (seen.has(resolved)) return; // prevent cycles
     seen.add(resolved);
-    return walkSchema(resolved, pointer, pathSoFar, acc, seen, components, required, depth + 1);
+    return walkSchema(
+      resolved,
+      pointer,
+      pathSoFar,
+      acc,
+      seen,
+      components,
+      required,
+      depth + 1,
+      descendUnions,
+    );
+  }
+  // Descend discriminated/union variants for the RESPONSE shape so semantic
+  // provider leaves nested inside a oneOf/anyOf branch (e.g. the DOCUMENT
+  // variant's `content[].documentReference.documentId` on
+  // AgentInstanceMessageContent) appear in the canonical response shape — the
+  // extractor lifts those leaves by walking every branch, so the shape must
+  // enumerate them too or the canonical-path validator reports a false
+  // extractor↔bundler divergence. NOT done for request shapes: merging
+  // mutually-exclusive variants would synthesise invalid request bodies.
+  if (descendUnions && !schema.type && (schema.oneOf || schema.anyOf)) {
+    const variants = [...(schema.oneOf ?? []), ...(schema.anyOf ?? [])];
+    for (const variant of variants) {
+      walkSchema(variant, pointer, pathSoFar, acc, seen, components, required, depth + 1, true);
+    }
+    return;
   }
   const type =
     schema.type ||
@@ -168,7 +197,17 @@ function walkSchema(
     const resolved = resolveSchema(schema, components);
     if (resolved && resolved !== schema && !seen.has(resolved)) {
       seen.add(resolved);
-      return walkSchema(resolved, pointer, pathSoFar, acc, seen, components, required, depth + 1);
+      return walkSchema(
+        resolved,
+        pointer,
+        pathSoFar,
+        acc,
+        seen,
+        components,
+        required,
+        depth + 1,
+        descendUnions,
+      );
     }
   }
   if (type === 'object' && schema.properties) {
@@ -188,7 +227,17 @@ function walkSchema(
     for (const [k, v] of Object.entries(schema.properties)) {
       const childPath = pathSoFar ? `${pathSoFar}.${k}` : k;
       const childPointer = `${pointer}/properties/${escapeJsonPointer(k)}`;
-      walkSchema(v, childPointer, childPath, acc, seen, components, reqSet.has(k), depth + 1);
+      walkSchema(
+        v,
+        childPointer,
+        childPath,
+        acc,
+        seen,
+        components,
+        reqSet.has(k),
+        depth + 1,
+        descendUnions,
+      );
     }
     return;
   }
@@ -212,7 +261,17 @@ function walkSchema(
         : undefined,
       itemEnum,
     });
-    walkSchema(schema.items, childPointer, childPath, acc, seen, components, false, depth + 1);
+    walkSchema(
+      schema.items,
+      childPointer,
+      childPath,
+      acc,
+      seen,
+      components,
+      false,
+      depth + 1,
+      descendUnions,
+    );
     return;
   }
   if (pathSoFar) {

--- a/path-analyser/src/canonicalSchemas.ts
+++ b/path-analyser/src/canonicalSchemas.ts
@@ -182,12 +182,35 @@ function walkSchema(
   // enumerate them too or the canonical-path validator reports a false
   // extractor↔bundler divergence. NOT done for request shapes: merging
   // mutually-exclusive variants would synthesise invalid request bodies.
-  if (descendUnions && !schema.type && (schema.oneOf || schema.anyOf)) {
+  //
+  // Done regardless of whether `type` is also declared: OpenAPI permits
+  // `type` alongside `oneOf`/`anyOf` (e.g. a `type: 'object'` base whose
+  // variants add fields), so gating on `!schema.type` would skip variant-
+  // nested provider leaves on such schemas. When a co-declared `type` is
+  // present we fall through after descending so the object/array branch
+  // below still walks the schema's own `properties`/`items`; for a pure
+  // union (no `type`) the variants ARE the whole shape, so we return.
+  if (descendUnions && (schema.oneOf || schema.anyOf)) {
     const variants = [...(schema.oneOf ?? []), ...(schema.anyOf ?? [])];
     for (const variant of variants) {
-      walkSchema(variant, pointer, pathSoFar, acc, seen, components, required, depth + 1, true);
+      // Each variant is a sibling branch: give it an independent copy of the
+      // ancestry-visited set so a schema shared across variants (e.g. two
+      // variants both nesting the same DocumentReference) is walked in each,
+      // not skipped after the first. `seen` tracks cycles along one path, not
+      // a global "visited anywhere" set. See #389 review.
+      walkSchema(
+        variant,
+        pointer,
+        pathSoFar,
+        acc,
+        new Set(seen),
+        components,
+        required,
+        depth + 1,
+        true,
+      );
     }
-    return;
+    if (!schema.type) return;
   }
   const type =
     schema.type ||
@@ -227,12 +250,17 @@ function walkSchema(
     for (const [k, v] of Object.entries(schema.properties)) {
       const childPath = pathSoFar ? `${pathSoFar}.${k}` : k;
       const childPointer = `${pointer}/properties/${escapeJsonPointer(k)}`;
+      // Each property is a sibling branch: give it an independent copy of the
+      // ancestry-visited set. `seen` is for cycle detection along one path, not
+      // a global "visited anywhere" set — two properties referencing the same
+      // component schema must both be walked, else the second's paths go
+      // missing from the canonical shape (#389 review).
       walkSchema(
         v,
         childPointer,
         childPath,
         acc,
-        seen,
+        new Set(seen),
         components,
         reqSet.has(k),
         depth + 1,

--- a/path-analyser/src/ontology/entityKindsSchema.ts
+++ b/path-analyser/src/ontology/entityKindsSchema.ts
@@ -82,7 +82,7 @@ export const entityKindsSchema = {
   $id: 'https://camunda.github.io/api-test-generator/ns/v1/entity-kinds.schema.json',
   title: 'Entity-kinds ABox (api-test-generator ontology, v1)',
   description:
-    'TBox JSON Schema for an ABox file describing the entity kinds (the domain nouns) of a single API. Each entry asserts: an entity kind exists; it has one of three shapes (`entity` for in-API-managed with full CRUD, `external-entity` for identifiers minted outside the API, `runtime-entity` for entities emitted by the runtime as a side-effect of other operations); and a list of semantic identifier-type names that identify it. `shape: "entity"` kinds carry an all-or-nothing CRUD triple (`establishedBy`/`observableVia`/`revokedBy`) consumed by the EntityLifecycle scenario template (#280) — asymmetric subsets surface as ABox-load validation errors. `shape: "external-entity"` kinds (e.g. Client) must NOT carry the CRUD triple. `shape: "runtime-entity"` kinds (#305 Phase 4 / Phase 5d, e.g. UserTask, Incident) carry a `fetcher` plus at least one of `mutators[]` (consumed by `UpdatedFieldVisibleOnReadBack`) or `transitions[]` + `stateField` (consumed by `StateTransitionVisibleAfterAction`, #189); the if/then/else below enforces that runtime-entity kinds carry the required combination and that entity/external-entity kinds carry none of these. The schema is intentionally agnostic to which API ships the kinds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/entity-kinds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (kind names appearing in operation `produces[]`/`requires[]`, identifier types being live, CRUD op methods being POST/GET/DELETE, etc.) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them.',
+    'TBox JSON Schema for an ABox file describing the entity kinds (the domain nouns) of a single API. Each entry asserts: an entity kind exists; it has one of four shapes (`entity` for in-API-managed with full CRUD, `external-entity` for identifiers minted outside the API, `runtime-entity` for entities emitted by the runtime as a side-effect of other operations, `immutable-entity` for entities created in-API but never updated or deleted and observed only via search); and a list of semantic identifier-type names that identify it. `shape: "entity"` kinds carry an all-or-nothing CRUD triple (`establishedBy`/`observableVia`/`revokedBy`) consumed by the EntityLifecycle scenario template (#280) — asymmetric subsets surface as ABox-load validation errors. `shape: "external-entity"` kinds (e.g. Client) must NOT carry the CRUD triple. `shape: "runtime-entity"` kinds (#305 Phase 4 / Phase 5d, e.g. UserTask, Incident) carry a `fetcher` plus at least one of `mutators[]` (consumed by `UpdatedFieldVisibleOnReadBack`) or `transitions[]` + `stateField` (consumed by `StateTransitionVisibleAfterAction`, #189); `shape: "immutable-entity"` kinds (#386, e.g. AgentInstanceIteration) carry only `establishedBy` (client-minted identifier supplied at creation; no observe/revoke/mutate); the if/then/else below enforces that runtime-entity kinds carry the required combination and that entity/external-entity/immutable-entity kinds carry only their permitted fields. The schema is intentionally agnostic to which API ships the kinds — instance-data lives in the per-config ABox file (e.g. configs/camunda-oca/ontology/entity-kinds.json). The optional top-level `@context` and per-entry `@type` are JSON-LD metadata only; no runtime in this repo interprets them, but they are reserved so an external SPARQL/SHACL consumer can ingest the file unchanged. Cross-references against the bundled spec (kind names appearing in operation `produces[]`/`requires[]`, identifier types being live, CRUD op methods being POST/GET/DELETE, etc.) are enforced as L3 invariants in configs/<name>/regression-invariants.test.ts rather than being re-encoded here, because Draft-07 cannot express them.',
   type: 'object',
   additionalProperties: false,
   required: ['version', 'kinds'],
@@ -122,9 +122,9 @@ export const entityKindsSchema = {
         },
         shape: {
           type: 'string',
-          enum: ['entity', 'external-entity', 'runtime-entity'],
+          enum: ['entity', 'external-entity', 'runtime-entity', 'immutable-entity'],
           description:
-            '`entity`: in-API-managed (producer + consumer ops both inside the API). `external-entity`: identifier minted outside the API; planner treats `identifiers[]` as `externalBoundary` (client-mintable, no upstream producer required). `runtime-entity` (#305 Phase 4 / Phase 5d): entity emitted by the runtime as a side-effect of another operation (e.g. UserTask from a process instance, Incident from a failing process instance); discovered via runtimeEmission and re-read via `fetcher`. Carries `mutators[]` (consumed by `UpdatedFieldVisibleOnReadBack`) and/or `transitions[]`+`stateField` (consumed by `StateTransitionVisibleAfterAction`, #189).',
+            '`entity`: in-API-managed (producer + consumer ops both inside the API). `external-entity`: identifier minted outside the API; planner treats `identifiers[]` as `externalBoundary` (client-mintable, no upstream producer required). `runtime-entity` (#305 Phase 4 / Phase 5d): entity emitted by the runtime as a side-effect of another operation (e.g. UserTask from a process instance, Incident from a failing process instance); discovered via runtimeEmission and re-read via `fetcher`. Carries `mutators[]` (consumed by `UpdatedFieldVisibleOnReadBack`) and/or `transitions[]`+`stateField` (consumed by `StateTransitionVisibleAfterAction`, #189). `immutable-entity` (#386): created in-API (`establishedBy`) but never updated or deleted, and observed only via a search/list op rather than a canonical get-by-id (e.g. AgentInstanceIteration — an append-only conversation-history record identified by a client-minted IterationId). Carries `establishedBy` only; its identifier is supplied by the client at creation (classified as a clientMintedIdentifier via the upstream `x-semantic-establishes` annotation), so no CRUD triple, no mutators/transitions, and no fetcher apply.',
         },
         identifiers: {
           type: 'array',
@@ -244,6 +244,29 @@ export const entityKindsSchema = {
                 { required: ['establishedBy'] },
                 { required: ['observableVia'] },
                 { required: ['revokedBy'] },
+              ],
+            },
+          },
+        },
+        {
+          // #386 — `immutable-entity` carries only `establishedBy` (the create
+          // op). No CRUD triple (never observed by-id or revoked), no
+          // in-place mutators/transitions, no runtime fetcher. Its identifier
+          // is client-minted at creation and classified via the upstream
+          // `x-semantic-establishes` annotation, so the catalog entry is pure
+          // domain bookkeeping — no scenario template consumes it today.
+          if: { properties: { shape: { const: 'immutable-entity' } } },
+          // biome-ignore lint/suspicious/noThenProperty: JSON Schema Draft-07 `then` keyword (paired with `if`), not a Promise-like.
+          then: {
+            required: ['establishedBy'],
+            not: {
+              anyOf: [
+                { required: ['observableVia'] },
+                { required: ['revokedBy'] },
+                { required: ['mutators'] },
+                { required: ['transitions'] },
+                { required: ['stateField'] },
+                { required: ['fetcher'] },
               ],
             },
           },

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -545,8 +545,39 @@ export function generateScenariosForEndpoint(
       continue;
     }
 
-    // Choose a semantic type to target next
-    const targetSemantic = remaining[0];
+    // Choose a semantic type to target next.
+    //
+    // #388 — prefer a target that can make immediate progress over the
+    // bare `remaining[0]`. The naive pick dead-ends when `remaining[0]`'s
+    // only producer has a required input that is ALSO still in `needed`:
+    // `deferForMissingPrereqs` then skips it without re-enqueueing (the
+    // deferred signature would equal the current one), and because the
+    // loop only ever targets `remaining[0]`, the unblocking prerequisite
+    // is never expanded. Example: `updateAgentInstance` needs
+    // `AgentInstanceKey` (producer `createAgentInstance`, which itself
+    // requires `ElementInstanceKey`) AND `ElementInstanceKey` (a
+    // runtimeEmission). Targeting `AgentInstanceKey` first dead-ends;
+    // targeting the runtimeEmission first builds the job context, after
+    // which `createAgentInstance` becomes chainable.
+    //
+    // A target is "actionable" when it is a runtimeEmission (always
+    // expandable via discovery) or has a producer/establisher whose
+    // required semantic inputs are already produced. This only reorders
+    // when `remaining[0]` is itself blocked, so endpoints whose first
+    // target is already actionable are unaffected.
+    const isActionableTarget = (st: string): boolean => {
+      const decl = graph.domain?.semanticTypes?.[st];
+      if (decl?.kind === 'runtimeEmission' && decl.discoveredVia && decl.emittedBy) return true;
+      const candidates = [
+        ...(graph.producersByType[st] ?? []),
+        ...(graph.establishersByType?.[st] ?? []),
+      ];
+      return candidates.some((opId) => {
+        const node = graph.operations[opId];
+        return !!node && hasSatisfiedRequiredInputs(node, state.produced);
+      });
+    };
+    const targetSemantic = remaining.find(isActionableTarget) ?? remaining[0];
 
     // #305 Phase 3 — `runtimeEmission` semantics declare a discovery
     // operation (ABox `discoveredVia.operationId`) that surfaces the

--- a/tests/fixtures/planner/canonical-oneof-response.test.ts
+++ b/tests/fixtures/planner/canonical-oneof-response.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Canonical-schema oneOf/anyOf response descent — camunda/api-test-generator#388.
+ *
+ * `path-analyser/src/canonicalSchemas.ts:walkSchema` originally resolved only
+ * `allOf`; a `oneOf`/`anyOf` composition was recorded as a single leaf and its
+ * variant branches were never walked. The semantic-graph extractor, by contrast,
+ * descends every union branch when lifting provider leaves. On a spec with a
+ * semantic provider nested inside a discriminated-union variant (e.g.
+ * camunda/camunda's `searchAgentInstanceHistory`, whose
+ * `AgentInstanceMessageContent` DOCUMENT variant carries
+ * `content[].documentReference.documentId`), that divergence made the
+ * canonical-path validator report a false extractor↔bundler mismatch and abort
+ * the positive pipeline.
+ *
+ * Guarded here:
+ *   1. the RESPONSE shape descends `oneOf`/`anyOf` so variant-nested paths
+ *      (incl. provider leaves) appear, matching the extractor;
+ *   2. the REQUEST shape does NOT descend unions — merging mutually-exclusive
+ *      variants would synthesise invalid request bodies.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildCanonicalShapes } from '../../../path-analyser/src/canonicalSchemas.ts';
+
+interface ScratchDir {
+  root: string;
+  specPath: string;
+  prevEnv: string | undefined;
+}
+
+function scratchSpec(spec: object): ScratchDir {
+  const root = mkdtempSync(join(tmpdir(), 'canonical-oneof-'));
+  const specPath = join(root, 'rest-api.bundle.json');
+  writeFileSync(specPath, JSON.stringify(spec));
+  const prevEnv = process.env.OPENAPI_SPEC_PATH;
+  process.env.OPENAPI_SPEC_PATH = specPath;
+  return { root, specPath, prevEnv };
+}
+
+function teardown(s: ScratchDir): void {
+  if (s.prevEnv === undefined) delete process.env.OPENAPI_SPEC_PATH;
+  else process.env.OPENAPI_SPEC_PATH = s.prevEnv;
+  rmSync(s.root, { recursive: true, force: true });
+}
+
+describe('canonicalSchemas: oneOf/anyOf response descent (#388)', () => {
+  let scratch: ScratchDir | undefined;
+  afterEach(() => {
+    if (scratch) teardown(scratch);
+    scratch = undefined;
+  });
+
+  it('descends oneOf variants in the response shape so a variant-nested provider leaf appears', async () => {
+    scratch = scratchSpec({
+      openapi: '3.0.0',
+      paths: {
+        '/history/search': {
+          post: {
+            operationId: 'searchHistory',
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/HistorySearchResult' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          HistorySearchResult: {
+            type: 'object',
+            properties: {
+              items: { type: 'array', items: { $ref: '#/components/schemas/HistoryItem' } },
+            },
+          },
+          HistoryItem: {
+            type: 'object',
+            properties: {
+              content: { type: 'array', items: { $ref: '#/components/schemas/MessageContent' } },
+            },
+          },
+          // Discriminated union: the DOCUMENT variant carries the provider leaf.
+          MessageContent: {
+            oneOf: [
+              { $ref: '#/components/schemas/TextContent' },
+              { $ref: '#/components/schemas/DocumentContent' },
+            ],
+          },
+          TextContent: { type: 'object', properties: { text: { type: 'string' } } },
+          DocumentContent: {
+            type: 'object',
+            properties: { documentReference: { $ref: '#/components/schemas/DocumentReference' } },
+          },
+          DocumentReference: {
+            type: 'object',
+            properties: {
+              documentId: { type: 'string', 'x-semantic-provider': true },
+            },
+          },
+        },
+      },
+    });
+
+    const shapes = await buildCanonicalShapes('/unused-because-env-overrides');
+    const response = shapes.searchHistory?.response;
+    expect(response).toBeDefined();
+    const paths = (response ?? []).map((n) => n.path);
+    // The provider leaf nested inside the DOCUMENT oneOf variant must surface.
+    expect(paths).toContain('items[].content[].documentReference.documentId');
+    // The sibling TEXT variant's leaf is also reachable (union of branches).
+    expect(paths).toContain('items[].content[].text');
+  });
+
+  it('does NOT descend a oneOf in the request shape (variants stay un-merged)', async () => {
+    scratch = scratchSpec({
+      openapi: '3.0.0',
+      paths: {
+        '/things': {
+          post: {
+            operationId: 'createThing',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/ThingCreate' },
+                },
+              },
+            },
+            responses: { '201': { description: 'ok' } },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          ThingCreate: {
+            type: 'object',
+            properties: { payload: { $ref: '#/components/schemas/PayloadUnion' } },
+          },
+          PayloadUnion: {
+            oneOf: [
+              { $ref: '#/components/schemas/VariantA' },
+              { $ref: '#/components/schemas/VariantB' },
+            ],
+          },
+          VariantA: { type: 'object', properties: { aOnly: { type: 'string' } } },
+          VariantB: { type: 'object', properties: { bOnly: { type: 'string' } } },
+        },
+      },
+    });
+
+    const shapes = await buildCanonicalShapes('/unused-because-env-overrides');
+    const request = shapes.createThing?.requestByMediaType?.['application/json'];
+    expect(request).toBeDefined();
+    const paths = (request ?? []).map((n) => n.path);
+    // The request walk must NOT merge mutually-exclusive variant props.
+    expect(paths).not.toContain('payload.aOnly');
+    expect(paths).not.toContain('payload.bOnly');
+  });
+
+  it('descends oneOf variants even when the schema also declares an explicit `type`', async () => {
+    // OpenAPI permits `type` alongside `oneOf`/`anyOf` (a base object whose
+    // variants add fields). The descent must still walk the variants so a
+    // provider leaf nested in one is not skipped, while the base object's own
+    // properties are also walked.
+    scratch = scratchSpec({
+      openapi: '3.0.0',
+      paths: {
+        '/events/search': {
+          post: {
+            operationId: 'searchEvents',
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/EventEnvelope' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          // Base object (own property `kind`) that is ALSO a oneOf union.
+          EventEnvelope: {
+            type: 'object',
+            properties: { kind: { type: 'string' } },
+            oneOf: [
+              { $ref: '#/components/schemas/CreatedEvent' },
+              { $ref: '#/components/schemas/DeletedEvent' },
+            ],
+          },
+          CreatedEvent: {
+            type: 'object',
+            properties: {
+              createdResourceKey: { type: 'string', 'x-semantic-provider': true },
+            },
+          },
+          DeletedEvent: { type: 'object', properties: { deletedAt: { type: 'string' } } },
+        },
+      },
+    });
+
+    const shapes = await buildCanonicalShapes('/unused-because-env-overrides');
+    const paths = (shapes.searchEvents?.response ?? []).map((n) => n.path);
+    // Base object's own property is walked...
+    expect(paths).toContain('kind');
+    // ...AND the provider leaf nested in a variant is not skipped.
+    expect(paths).toContain('createdResourceKey');
+  });
+
+  it('walks a component schema referenced under two sibling paths (seen is per-branch, not global)', async () => {
+    // `seen` guards against $ref cycles along one path; it must NOT act as a
+    // global "visited anywhere" set, or a schema referenced under two sibling
+    // properties (or two oneOf variants) would be walked once and the second
+    // occurrence's paths would silently vanish from the canonical shape —
+    // reintroducing the extractor↔bundler divergence (#389 review).
+    scratch = scratchSpec({
+      openapi: '3.0.0',
+      paths: {
+        '/refs/search': {
+          post: {
+            operationId: 'searchRefs',
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/RefPair' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          RefPair: {
+            type: 'object',
+            properties: {
+              left: { $ref: '#/components/schemas/DocRef' },
+              right: { $ref: '#/components/schemas/DocRef' },
+            },
+          },
+          DocRef: {
+            type: 'object',
+            properties: { documentId: { type: 'string', 'x-semantic-provider': true } },
+          },
+        },
+      },
+    });
+
+    const shapes = await buildCanonicalShapes('/unused-because-env-overrides');
+    const paths = (shapes.searchRefs?.response ?? []).map((n) => n.path);
+    // Both sibling references to the shared DocRef schema must be walked.
+    expect(paths).toContain('left.documentId');
+    expect(paths).toContain('right.documentId');
+  });
+});


### PR DESCRIPTION
Bumps the `camunda-oca` spec pin to latest `main` (`06073e0`) and adds the generator support the new **agent-instance** domain needs. Closes #386, closes #388.

Bumping the pin surfaced a new upstream domain (agent instances) that the generator couldn't model; this PR adds that support across three layers.

## 1. Divergence fix — oneOf/anyOf variant paths in canonical response shape
`searchAgentInstanceHistory` carries a semantic provider inside a discriminated-union variant (`content[].documentReference.documentId` on `AgentInstanceMessageContent`). The canonical response-shape builder only descended `allOf`, so it disagreed with the extractor (which walks every union branch) and the canonical-path validator aborted the positive pipeline. Now the **response** walk descends `oneOf`/`anyOf` variants (request walk unchanged — merging mutually-exclusive variants would synthesise invalid bodies). Neutral on the prior pin.

## 2. New `immutable-entity` shape + catalog `AgentInstanceIteration`
`AgentInstanceIteration` is created in-API but never updated or deleted, and observed only via search — which no existing shape (`entity`/`external-entity`/`runtime-entity`) can express. Adds a fourth shape `immutable-entity` (carries `establishedBy` only) and catalogs the entity (client-minted `IterationId`). Clears the #210 catalog invariants.

## 3. Chain a job-activation context for agent-instance write endpoints
`updateAgentInstance` / `createAgentInstanceHistoryItem` require runtime-emitted `ElementInstanceKey`/`JobKey` in their bodies, and `createAgentInstance` itself requires `ElementInstanceKey` — so positive coverage needs a 5-op chain:
`createDeployment → createProcessInstance → activateJobs → createAgentInstance → <write op>`. Three sub-changes:
- **ABox**: declare `JobKey`/`ElementInstanceKey` as `runtimeEmission` via `activateJobs` (filterless — jobType is bound by the existing `JobAvailableForActivation` runtime-state valueBinding; the producer auto-derive extracts `jobs[0].jobKey`/`jobs[0].elementInstanceKey`). Remove the now-stale `serverEmergent` `AgentInstanceKey` entry (the bumped spec returns it `provider:true`).
- **#309 invariant**: only enforce the `{ filter: { [filterBy]: <bound> } }` discovery-body shape for emissions that declare `filterBy`; filterless `activateJobs` builds its normal body.
- **planner BFS**: prefer an *actionable* remaining target (a runtimeEmission, or a producer whose inputs are already produced) over a bare `remaining[0]`. Fixes the dead-end where a producer's runtimeEmission prereq was also directly needed. Only reorders when `remaining[0]` is blocked.

**Side win:** job-by-key endpoints (`updateJob`, `completeJob`, …), previously unsatisfiable, now get positive coverage via the same `JobKey` runtimeEmission.

## Validation
- All 193 `camunda-oca` regression invariants pass (was 2 failing: #54, #162).
- New unit test `tests/fixtures/planner/canonical-oneof-response.test.ts` covers the oneOf/anyOf response-shape descent (provider leaf nested in a union variant surfaces; request walk does not merge variants).
- The `immutable-entity` + divergence-fix changes are neutral on the prior pin.
- camunda-hub is unaffected (request-validation only; its spec content was unchanged at latest `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
