### PR TITLE
request-validation: 401 negatives for uniformly-secured APIs (Hub) — missing + invalid token

### DIFF
--- a/configs/camunda-hub/request-validation.json
+++ b/configs/camunda-hub/request-validation.json
@@ -1,4 +1,5 @@
 {
-  "$comment": "Per-config request-validation settings for camunda-hub. Hub does not (yet) declare a position on enum case-insensitivity; default `false` emits case-only mutations as 400-expecting tests, which is the conservative choice. Revisit if hub's parser turns out to accept enum values case-insensitively.",
-  "enumCaseInsensitive": false
+  "$comment": "Per-config request-validation settings for camunda-hub. enumCaseInsensitive: hub does not (yet) declare a position on enum case-insensitivity; default `false` emits case-only mutations as 400-expecting tests (conservative). authAbsentMode: 'all-secured' — the Hub Public API v2 is uniformly Bearer-authenticated via a single global `security: [{ bearerAuth: [] }]` requirement and declares no `x-enforcement: conditional` schemes, so the 401 auth-absent surface is every secured op (camunda/camunda-hub#25264).",
+  "enumCaseInsensitive": false,
+  "authAbsentMode": "all-secured"
 }

--- a/request-validation/scripts/generate.ts
+++ b/request-validation/scripts/generate.ts
@@ -11,7 +11,7 @@ import {
   generateUniqueItemsViolations,
 } from '../src/analysis/advancedSchema.js';
 import { generateAllOfConflicts, generateAllOfMissingRequired } from '../src/analysis/allOf.js';
-import { generateAuthAbsent } from '../src/analysis/authAbsent.js';
+import { generateAuthAbsent, generateAuthInvalid } from '../src/analysis/authAbsent.js';
 import { generateAuthDeny } from '../src/analysis/authDeny.js';
 import { generateBodyTopTypeMismatch, generateMissingBody } from '../src/analysis/bodyTopLevel.js';
 import { generateBodyTypeMismatch } from '../src/analysis/bodyTypeMismatch.js';
@@ -38,7 +38,7 @@ import {
 } from '../src/analysis/parameters.js';
 import { generateTypeMismatch } from '../src/analysis/typeMismatch.js';
 import { generateUnionViolations } from '../src/analysis/unionViolations.js';
-import { loadRequestValidationConfig } from '../src/config.js';
+import { loadRequestValidationConfig, type RequestValidationConfig } from '../src/config.js';
 import { emitQaTests } from '../src/emit/qaEmitter.js';
 import type { ValidationScenario } from '../src/model/types.js';
 import { loadSpec } from '../src/spec/loader.js';
@@ -134,7 +134,10 @@ async function main() {
   // workflow did not require repoRoot for anything.
   const repoRoot = findRepoRoot(process.cwd());
   let configName = '(unknown)';
-  let rvConfig = { enumCaseInsensitive: false };
+  let rvConfig: RequestValidationConfig = {
+    enumCaseInsensitive: false,
+    authAbsentMode: 'conditional',
+  };
   if (repoRoot) {
     configName = getActiveConfigName(repoRoot);
     rvConfig = loadRequestValidationConfig(repoRoot, configName);
@@ -146,7 +149,7 @@ async function main() {
   }
   console.log(
     `[generate] Active config: ${configName} ` +
-      `(enumCaseInsensitive=${rvConfig.enumCaseInsensitive})`,
+      `(enumCaseInsensitive=${rvConfig.enumCaseInsensitive}, authAbsentMode=${rvConfig.authAbsentMode})`,
   );
   const { specPath, specProvenance, source } = resolveSpecSource();
   console.log(`[generate] Using spec from ${source}: ${specPath}`);
@@ -221,12 +224,25 @@ async function main() {
     );
   }
   // auth-absent (HTTP 401) scenarios are not "deep": they depend only on the
-  // operation's conditional-auth status, not on body/parameter shape. They are
-  // emitted exclusively into the `secured` profile (see profile split below).
+  // operation's auth status, not on body/parameter shape — `conditionalAuth`
+  // (default) or `secured` under `authAbsentMode: 'all-secured'`. Emitted
+  // exclusively into the `secured` profile (see profile split below).
   if (wantKind('auth-absent')) {
     scenarios.push(
       ...generateAuthAbsent(model.operations, {
         onlyOperations: opts.onlyOperations,
+        allSecured: rvConfig.authAbsentMode === 'all-secured',
+      }),
+    );
+  }
+  // auth-invalid (HTTP 401) scenarios send a well-formed Authorization header
+  // with an invalid/unknown credential (vs auth-absent's no-credentials). Same
+  // operation surface; also `secured`-only.
+  if (wantKind('auth-invalid')) {
+    scenarios.push(
+      ...generateAuthInvalid(model.operations, {
+        onlyOperations: opts.onlyOperations,
+        allSecured: rvConfig.authAbsentMode === 'all-secured',
       }),
     );
   }
@@ -642,9 +658,10 @@ async function main() {
 
   // ---- Profile split: parallel unsecured / secured / rbac suites ----
   // The negative-validation tests (400s) are deployment-mode-agnostic and run
-  // in both unsecured and secured. The auth-absent (401) tests only make sense
-  // against a server started in secured mode, so they go into `secured` only.
-  // The auth-deny (403) tests are read-side RBAC deny-tests (#359): they need an
+  // in both unsecured and secured. The 401 tests — auth-absent (no credentials)
+  // and auth-invalid (invalid/unknown credential) — only make sense against a server
+  // started in secured mode, so both go into `secured` only. The auth-deny
+  // (403) tests are read-side RBAC deny-tests (#359): they need an
   // authorizations-enabled broker + a provisioned zero-grant probe user, so they
   // live in their own `rbac` profile and are excluded from unsecured/secured.
   //
@@ -653,13 +670,17 @@ async function main() {
   //   generated/<config>/request-validation/rbac/         — 403 deny tests only
   //
   // Each subdir is a self-contained standalone suite (own scaffolding +
-  // support). When the bundled spec carries no `x-enforcement: conditional`
-  // annotations (no conditionally-secured ops), the auth-absent set is empty
-  // and the unsecured/secured suites are byte-identical.
+  // support). The 401 surface is empty — making the unsecured/secured suites
+  // byte-identical — only when no operation is targeted in the active
+  // `authAbsentMode`: in `'conditional'` (default) that means no
+  // `x-enforcement: conditional` op; in `'all-secured'` it means no op mandates
+  // auth (e.g. an entirely public API).
   const PROFILES = [
     {
       name: 'unsecured',
-      scenarios: deduped.filter((s) => s.type !== 'auth-absent' && s.type !== 'auth-deny'),
+      scenarios: deduped.filter(
+        (s) => s.type !== 'auth-absent' && s.type !== 'auth-invalid' && s.type !== 'auth-deny',
+      ),
     },
     { name: 'secured', scenarios: deduped.filter((s) => s.type !== 'auth-deny') },
     { name: 'rbac', scenarios: deduped.filter((s) => s.type === 'auth-deny') },

--- a/request-validation/src/analysis/authAbsent.ts
+++ b/request-validation/src/analysis/authAbsent.ts
@@ -3,27 +3,56 @@ import { makeId } from './common.js';
 
 interface Opts {
   onlyOperations?: Set<string>;
+  /**
+   * When `true` (config `authAbsentMode: 'all-secured'`), target every
+   * operation whose effective `security` *mandates* authentication
+   * (`OperationModel.secured` — every OR-alternative names a scheme; excludes
+   * `security: []` and any anonymous `{}` alternative), not only the
+   * conditionally-secured ones. For APIs uniformly authenticated via a single
+   * global scheme (e.g. Hub) — which declare no `x-enforcement: conditional`
+   * schemes — this is the only way the 401 surface is non-empty. Default
+   * `false` preserves the OCA behaviour.
+   */
+  allSecured?: boolean;
+}
+
+/**
+ * Is `op` part of the 401 surface under the active mode? Shared by the
+ * auth-absent (no credentials) and auth-invalid (garbage token) generators so
+ * they target an identical operation set.
+ *
+ * By default targets every operation conditionally secured on the `auth` axis
+ * (`OperationModel.conditionalAuth`, derived from `x-enforcement: conditional`
+ * security schemes + the operation's `security` block — camunda/camunda#53708).
+ * Under `allSecured` (config `authAbsentMode: 'all-secured'`) it instead targets
+ * every operation whose effective `security` mandates authentication
+ * (`OperationModel.secured`: every OR-alternative names a scheme — not
+ * `security: []` nor an anonymous `{}` alternative) — for APIs uniformly
+ * authenticated via one global scheme (e.g. Hub's `security: [{ bearerAuth: [] }]`).
+ */
+function isAuthTargeted(op: OperationModel, opts: Opts): boolean {
+  if (opts.onlyOperations && !opts.onlyOperations.has(op.operationId)) return false;
+  return opts.allSecured ? op.secured === true : op.conditionalAuth === true;
 }
 
 /**
  * Generate auth-absent (HTTP 401) scenarios for the secured-server profile.
  *
- * For every operation that is conditionally secured on the `auth` axis
- * (`OperationModel.conditionalAuth`, derived from `x-enforcement: conditional`
- * security schemes + the operation's `security` block — camunda/camunda#53708),
- * emit a single scenario that issues the request WITHOUT any credentials
- * (`headersAuth: false`) and expects the server — when started in secured mode —
- * to reject it with 401 before any body/parameter validation runs.
+ * Targets the {@link isAuthTargeted} operation set. Each scenario issues the
+ * request WITHOUT any credentials (`headersAuth: false`) and asserts 401 — the
+ * contract that a secured server rejects an unauthenticated request before any
+ * body/parameter validation runs.
  *
- * Operations that are unconditionally public (`security: []`) or not secured at
- * all yield no scenario, so against an unsecured server this generator's output
- * is empty and the two emitted profiles coincide.
+ * Emptiness is a property of the SPEC, not the runtime server: operations that
+ * are explicitly public (`security: []` or an anonymous `{}` alternative) or
+ * carry no effective security requirement yield no scenario. When the spec
+ * secures no operation (in the active mode), this generator emits nothing and
+ * the `secured` profile is byte-identical to `unsecured`.
  */
 export function generateAuthAbsent(ops: OperationModel[], opts: Opts): ValidationScenario[] {
   const out: ValidationScenario[] = [];
   for (const op of ops) {
-    if (opts.onlyOperations && !opts.onlyOperations.has(op.operationId)) continue;
-    if (!op.conditionalAuth) continue;
+    if (!isAuthTargeted(op, opts)) continue;
     out.push({
       id: makeId([op.operationId, 'auth-absent']),
       operationId: op.operationId,
@@ -33,6 +62,43 @@ export function generateAuthAbsent(ops: OperationModel[], opts: Opts): Validatio
       params: buildDummyParams(op.path),
       expectedStatus: 401,
       description: 'Request without authentication is rejected with 401 (secured mode)',
+      headersAuth: false,
+    });
+  }
+  return out;
+}
+
+/**
+ * Generate auth-invalid (HTTP 401) scenarios for the secured-server profile.
+ *
+ * Targets the same operation set as {@link generateAuthAbsent}, but instead of
+ * omitting credentials it sends an `Authorization` header carrying an
+ * invalid/unknown credential (rendered by the emitter as a well-formed
+ * `Bearer <garbage-token>`; `headersAuth: false` — it is NOT the admin token).
+ * Where auth-absent proves an endpoint is protected
+ * at all, auth-invalid exercises the *invalid/unknown credential* path: the
+ * server must reject a present-but-bad Authorization header, not just a missing
+ * one. The generator is not scheme-aware, so for Bearer/JWT-secured APIs this
+ * specifically demonstrates token validation (a resource server that required an
+ * Authorization header but skipped signature/audience checks would pass
+ * auth-absent yet wrongly accept the garbage token); for other schemes
+ * (Basic/apiKey/…) it is simply the invalid-credential path. Empirically every
+ * Camunda Hub v2 op (Bearer/JWT) returns 401 for an invalid/unknown token.
+ */
+export function generateAuthInvalid(ops: OperationModel[], opts: Opts): ValidationScenario[] {
+  const out: ValidationScenario[] = [];
+  for (const op of ops) {
+    if (!isAuthTargeted(op, opts)) continue;
+    out.push({
+      id: makeId([op.operationId, 'auth-invalid']),
+      operationId: op.operationId,
+      method: op.method,
+      path: op.path,
+      type: 'auth-invalid',
+      params: buildDummyParams(op.path),
+      expectedStatus: 401,
+      description:
+        'Request with an invalid/unknown Authorization credential is rejected with 401 (secured mode)',
       headersAuth: false,
     });
   }

--- a/request-validation/src/config.ts
+++ b/request-validation/src/config.ts
@@ -28,10 +28,29 @@ export interface RequestValidationConfig {
    * camunda/camunda#52409).
    */
   enumCaseInsensitive: boolean;
+  /**
+   * Which operations the 401 generators — auth-absent (no credentials) and
+   * auth-invalid (invalid/unknown bearer credential) — target in the `secured` profile.
+   *
+   * - `'conditional'` (default) — only operations secured on the conditional
+   *   `auth` axis (a `security` requirement referencing an
+   *   `x-enforcement: conditional` scheme — camunda/camunda#53708). This is the
+   *   OCA model, where most of the API is unconditionally public and only a
+   *   subset is conditionally secured.
+   * - `'all-secured'` — every operation whose effective `security` *mandates*
+   *   authentication (`OperationModel.secured`: every OR-alternative names a
+   *   scheme; `false` for `security: []` and for any anonymous `{}` alternative
+   *   like `[{}, { bearerAuth: [] }]`, which permits unauthenticated access).
+   *   For an API uniformly authenticated via a single global scheme (e.g.
+   *   Camunda Hub's `security: [{ bearerAuth: [] }]`, which declares no
+   *   `x-enforcement`), this emits a no-credentials → 401 probe per secured op.
+   */
+  authAbsentMode: 'conditional' | 'all-secured';
 }
 
 const DEFAULTS: RequestValidationConfig = {
   enumCaseInsensitive: false,
+  authAbsentMode: 'conditional',
 };
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
@@ -74,6 +93,15 @@ export function loadRequestValidationConfig(
       );
     }
     merged.enumCaseInsensitive = v;
+  }
+  if ('authAbsentMode' in parsed) {
+    const v = parsed.authAbsentMode;
+    if (v !== 'conditional' && v !== 'all-secured') {
+      throw new Error(
+        `Invalid ${configPath}: "authAbsentMode" must be "conditional" or "all-secured", got ${JSON.stringify(v)}.`,
+      );
+    }
+    merged.authAbsentMode = v;
   }
   return merged;
 }

--- a/request-validation/src/emit/qaEmitter.ts
+++ b/request-validation/src/emit/qaEmitter.ts
@@ -209,15 +209,23 @@ function renderScenario(s: ValidationScenario, title: string, standalone: boolea
     }
   }
   const headersExpr =
-    s.type === 'auth-deny'
-      ? // Read-side RBAC deny: authenticate as the zero-grant probe user,
-        // never the admin, so the authorizations-enabled server denies the request.
-        'denyProbeHeaders()'
-      : s.headersAuth
-        ? s.bodyEncoding === 'multipart'
-          ? 'authHeaders()'
-          : 'jsonHeaders()'
-        : '{}';
+    s.type === 'auth-invalid'
+      ? // Auth-invalid: a well-formed Authorization header carrying a garbage
+        // credential (`Bearer invalid-token`). Exercises the invalid/unknown-
+        // credential path — the server must reject a present-but-bad header,
+        // not just a missing one.
+        // For Bearer/JWT APIs this exercises token validation specifically; for
+        // other schemes it's just an invalid credential. No helper needed.
+        "{ Authorization: 'Bearer invalid-token' }"
+      : s.type === 'auth-deny'
+        ? // Read-side RBAC deny: authenticate as the zero-grant probe user,
+          // never the admin, so the authorizations-enabled server denies the request.
+          'denyProbeHeaders()'
+        : s.headersAuth
+          ? s.bodyEncoding === 'multipart'
+            ? 'authHeaders()'
+            : 'jsonHeaders()'
+          : '{}';
   const dataPart =
     s.bodyEncoding === 'multipart' && s.multipartForm
       ? ',\n      multipart: formData'
@@ -375,6 +383,8 @@ function buildBaseTitle(s: ValidationScenario): string {
       return `${s.operationId} - allOf conflict`;
     case 'auth-absent':
       return `${s.operationId} - Missing authentication`;
+    case 'auth-invalid':
+      return `${s.operationId} - Invalid authentication token`;
     case 'auth-deny':
       return `${s.operationId} - Denied (no permission)`;
     case 'not-found-fake-id':

--- a/request-validation/src/model/types.ts
+++ b/request-validation/src/model/types.ts
@@ -54,6 +54,20 @@ export interface OperationModel {
    */
   conditionalAuth?: boolean;
   /**
+   * True when the operation's effective `security` requirement (its own, the
+   * path item's, or the global `security`, by OpenAPI precedence) *mandates*
+   * authentication — i.e. it is a non-empty array in which EVERY alternative
+   * names at least one scheme, regardless of `x-enforcement`.
+   *
+   * The `security` array is an OR: an empty Security Requirement Object `{}`
+   * (or an empty array `[]`) permits anonymous access, so either makes this
+   * `false`. Distinct from `conditionalAuth`: this is the "does this op require
+   * auth at all" signal, used by BOTH 401 generators (auth-absent and
+   * auth-invalid) under `authAbsentMode: 'all-secured'` for APIs uniformly
+   * authenticated via a single global scheme (e.g. Hub).
+   */
+  secured?: boolean;
+  /**
    * Response status codes the operation declares in its OpenAPI `responses`
    * map (e.g. `['200','400','404','500']`). Used by the not-found-fake-id
    * generator to emit a 404 test only when the contract actually allows a
@@ -110,6 +124,7 @@ export type ScenarioKind =
   | 'allof-conflict'
   | 'not-found-fake-id'
   | 'auth-absent'
+  | 'auth-invalid'
   | 'auth-deny';
 
 export interface ValidationScenario {
@@ -125,10 +140,14 @@ export interface ValidationScenario {
   description: string;
   /**
    * Whether to send the configured *admin* credentials, i.e. authHeaders()
-   * (multipart) / jsonHeaders() (JSON). false → no headers ({}).
-   * NOTE: this flag does not govern `auth-deny` scenarios — those always
-   * authenticate as the zero-grant probe user via denyProbeHeaders() (a
-   * different principal) regardless of this value, which they leave false.
+   * (multipart) / jsonHeaders() (JSON). false → no admin credentials.
+   * NOTE: some scenario kinds render their own `Authorization` header
+   * regardless of this flag (which they leave `false`):
+   *   - `auth-deny` authenticates as the zero-grant probe user via
+   *     denyProbeHeaders() (a different principal);
+   *   - `auth-invalid` sends a well-formed header carrying an invalid/unknown
+   *     credential (`Bearer invalid-token`).
+   * For all other kinds, `false` → no headers (`{}`).
    */
   headersAuth: boolean;
   source?: 'body' | 'query' | 'path' | 'header' | 'cookie';

--- a/request-validation/src/spec/loader.ts
+++ b/request-validation/src/spec/loader.ts
@@ -94,6 +94,32 @@ function securityRequiresConditional(
   return false;
 }
 
+/**
+ * Evaluate whether a `security` requirement list *mandates* authentication.
+ *
+ * The OpenAPI `security` array is an OR of Security Requirement Objects. An
+ * empty object `{}` is the "anonymous access permitted" alternative, so its
+ * presence — like an empty array `[]` — means auth is NOT required even if a
+ * sibling alternative names a scheme. Authentication is mandatory only when
+ * EVERY alternative demands at least one scheme.
+ *
+ * - `true`      — non-empty list AND every alternative references ≥1 scheme.
+ * - `false`     — `security: []`, OR any `{}` (anonymous) alternative present.
+ * - `undefined` — no `security` declared at this level; the caller should fall
+ *                 back to the path-item / global `security`.
+ *
+ * Mirrors `securityRequiresConditional`'s precedence contract but is agnostic
+ * to `x-enforcement` — it drives the `authAbsentMode: 'all-secured'` 401
+ * surface for uniformly-authenticated APIs (e.g. Hub).
+ */
+function securityRequiresAuth(security: unknown): boolean | undefined {
+  if (!Array.isArray(security)) return undefined;
+  if (security.length === 0) return false;
+  return security.every(
+    (requirement) => isRecord(requirement) && Object.keys(requirement).length > 0,
+  );
+}
+
 function buildParameter(raw: unknown): ParameterModel | undefined {
   if (!isRecord(raw)) return undefined;
   const name = asString(raw.name);
@@ -214,6 +240,11 @@ export async function loadSpec(file: string): Promise<SpecModel> {
           securityRequiresConditional(op.security, conditionalSchemes) ??
           securityRequiresConditional(pathLevelSecurity, conditionalSchemes) ??
           securityRequiresConditional(globalSecurity, conditionalSchemes) ??
+          false,
+        secured:
+          securityRequiresAuth(op.security) ??
+          securityRequiresAuth(pathLevelSecurity) ??
+          securityRequiresAuth(globalSecurity) ??
           false,
       });
     }

--- a/tests/request-validation/auth-absent.test.ts
+++ b/tests/request-validation/auth-absent.test.ts
@@ -2,7 +2,10 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { generateAuthAbsent } from '../../request-validation/src/analysis/authAbsent.js';
+import {
+  generateAuthAbsent,
+  generateAuthInvalid,
+} from '../../request-validation/src/analysis/authAbsent.js';
 import { renderScenarioForTest } from '../../request-validation/src/emit/qaEmitter.js';
 import type {
   OperationModel,
@@ -96,6 +99,107 @@ describe('request-validation: auth-absent loader derivation (#346)', () => {
     expect(byId.get('publicOp')?.conditionalAuth).toBe(false);
     expect(byId.get('unconditionalOp')?.conditionalAuth).toBe(false);
     expect(byId.get('noSecurityOp')?.conditionalAuth).toBe(false);
+  });
+
+  it('derives `secured` from auth-mandating effective security (every alternative names a scheme), independent of x-enforcement (#25264)', async () => {
+    const model = await loadSpec(specPath);
+    const byId = new Map(model.operations.map((o) => [o.operationId, o]));
+    // conditional bearer/basic → secured
+    expect(byId.get('securedOp')?.secured).toBe(true);
+    // references a NON-conditional scheme (apiKey) → not conditionalAuth, but still secured
+    expect(byId.get('unconditionalOp')?.secured).toBe(true);
+    expect(byId.get('unconditionalOp')?.conditionalAuth).toBe(false);
+    // explicit public override
+    expect(byId.get('publicOp')?.secured).toBe(false);
+    // no security declared anywhere (no global) → not secured
+    expect(byId.get('noSecurityOp')?.secured).toBe(false);
+  });
+
+  it('treats an anonymous `{}` alternative in the security OR as not-secured (#391 review)', async () => {
+    const optionalAuthPath = join(tmp, 'spec-optional-auth.json');
+    writeFileSync(
+      optionalAuthPath,
+      JSON.stringify({
+        openapi: '3.0.3',
+        info: { title: 'fixture', version: '1.0.0' },
+        components: {
+          securitySchemes: { BearerAuth: { type: 'http', scheme: 'bearer' } },
+        },
+        paths: {
+          // `{}` OR `{BearerAuth}` ⇒ anonymous is allowed ⇒ NOT secured (no 401).
+          '/optional': {
+            get: {
+              operationId: 'optionalAuthOp',
+              security: [{}, { BearerAuth: [] }],
+              responses: { '200': { description: 'ok' } },
+            },
+          },
+          // every alternative names a scheme ⇒ secured.
+          '/required': {
+            get: {
+              operationId: 'requiredAuthOp',
+              security: [{ BearerAuth: [] }],
+              responses: { '200': { description: 'ok' } },
+            },
+          },
+        },
+      }),
+    );
+    const model = await loadSpec(optionalAuthPath);
+    const byId = new Map(model.operations.map((o) => [o.operationId, o]));
+    expect(byId.get('optionalAuthOp')?.secured).toBe(false);
+    expect(byId.get('requiredAuthOp')?.secured).toBe(true);
+  });
+
+  it('derives `secured` via op ?? pathItem ?? global precedence, honouring `security: []` at each level (#391 review)', async () => {
+    const precedencePath = join(tmp, 'spec-secured-precedence.json');
+    writeFileSync(
+      precedencePath,
+      JSON.stringify({
+        openapi: '3.0.3',
+        info: { title: 'fixture', version: '1.0.0' },
+        // Global default: secured. (Plain bearer, no x-enforcement — `secured`
+        // is enforcement-agnostic.)
+        security: [{ BearerAuth: [] }],
+        components: {
+          securitySchemes: { BearerAuth: { type: 'http', scheme: 'bearer' } },
+        },
+        paths: {
+          // op + path declare nothing → inherit secured global.
+          '/inherits-global': {
+            get: { operationId: 'securedViaGlobal', responses: { '200': { description: 'ok' } } },
+          },
+          // op-level `security: []` overrides the secured global → public.
+          '/op-public': {
+            get: {
+              operationId: 'opPublic',
+              security: [],
+              responses: { '200': { description: 'ok' } },
+            },
+          },
+          // path-level `security: []` overrides the secured global (op absent) → public.
+          '/path-public': {
+            security: [],
+            get: { operationId: 'pathPublic', responses: { '200': { description: 'ok' } } },
+          },
+          // op-level security takes precedence over a public path-level → secured.
+          '/op-over-path': {
+            security: [],
+            get: {
+              operationId: 'opSecuredOverPathPublic',
+              security: [{ BearerAuth: [] }],
+              responses: { '200': { description: 'ok' } },
+            },
+          },
+        },
+      }),
+    );
+    const model = await loadSpec(precedencePath);
+    const byId = new Map(model.operations.map((o) => [o.operationId, o]));
+    expect(byId.get('securedViaGlobal')?.secured).toBe(true);
+    expect(byId.get('opPublic')?.secured).toBe(false);
+    expect(byId.get('pathPublic')?.secured).toBe(false);
+    expect(byId.get('opSecuredOverPathPublic')?.secured).toBe(true);
   });
 
   it('falls back to the global security requirement when an op declares none', async () => {
@@ -229,6 +333,49 @@ describe('request-validation: generateAuthAbsent contract (#346)', () => {
     const scenarios = generateAuthAbsent(ops, { onlyOperations: new Set(['securedOp']) });
     expect(scenarios.map((s) => s.operationId)).toEqual(['securedOp']);
   });
+
+  it('under allSecured, targets every `secured` op (incl. non-conditional) — Hub model (#25264)', () => {
+    const hubOps: OperationModel[] = [
+      // conditionally secured (also secured)
+      {
+        operationId: 'condSecured',
+        method: 'GET',
+        path: '/a',
+        tags: [],
+        parameters: [],
+        conditionalAuth: true,
+        secured: true,
+      },
+      // secured via a plain global bearer scheme (Hub) — no x-enforcement
+      {
+        operationId: 'plainSecured',
+        method: 'POST',
+        path: '/b',
+        tags: [],
+        parameters: [],
+        conditionalAuth: false,
+        secured: true,
+      },
+      // explicit public
+      {
+        operationId: 'publicOp',
+        method: 'GET',
+        path: '/c',
+        tags: [],
+        parameters: [],
+        conditionalAuth: false,
+        secured: false,
+      },
+    ];
+    // all-secured mode: both secured ops, not the public one
+    expect(
+      generateAuthAbsent(hubOps, { allSecured: true })
+        .map((s) => s.operationId)
+        .sort(),
+    ).toEqual(['condSecured', 'plainSecured']);
+    // default (conditional) mode: only the conditionally-secured op
+    expect(generateAuthAbsent(hubOps, {}).map((s) => s.operationId)).toEqual(['condSecured']);
+  });
 });
 
 describe('request-validation: auth-absent emitter shape (#346)', () => {
@@ -250,6 +397,71 @@ describe('request-validation: auth-absent emitter shape (#346)', () => {
     expect(rendered).not.toContain('jsonHeaders()');
     expect(rendered).toContain('assertResponseStatus(testInfo, res, 401');
     // No request body is emitted.
+    expect(rendered).not.toContain('const requestBody');
+  });
+});
+
+describe('request-validation: generateAuthInvalid contract + emitter (#25264)', () => {
+  const ops: OperationModel[] = [
+    {
+      operationId: 'securedOp',
+      method: 'POST',
+      path: '/secured',
+      tags: [],
+      parameters: [],
+      conditionalAuth: true,
+      secured: true,
+    },
+    {
+      operationId: 'withPath',
+      method: 'GET',
+      path: '/items/{itemKey}',
+      tags: [],
+      parameters: [],
+      conditionalAuth: false,
+      secured: true,
+    },
+    {
+      operationId: 'publicOp',
+      method: 'GET',
+      path: '/public',
+      tags: [],
+      parameters: [],
+      conditionalAuth: false,
+      secured: false,
+    },
+  ];
+
+  it('targets the same secured ops as auth-absent (well-formed 401 scenarios)', () => {
+    // all-secured mode (Hub): both secured ops, not the public one.
+    const scenarios = generateAuthInvalid(ops, { allSecured: true });
+    expect(scenarios.map((s) => s.operationId).sort()).toEqual(['securedOp', 'withPath']);
+    for (const s of scenarios) {
+      expect(s.type).toBe('auth-invalid');
+      expect(s.expectedStatus).toBe(401);
+      expect(s.headersAuth).toBe(false);
+      expect(s.requestBody).toBeUndefined();
+    }
+    // conditional mode (OCA default): only the conditionally-secured op.
+    expect(generateAuthInvalid(ops, {}).map((s) => s.operationId)).toEqual(['securedOp']);
+  });
+
+  it('emitter sends an invalid/unknown bearer credential and asserts 401 (not jsonHeaders/denyProbe/{})', () => {
+    const scenario: ValidationScenario = {
+      id: 'securedOp__auth_invalid',
+      operationId: 'securedOp',
+      method: 'POST',
+      path: '/secured',
+      type: 'auth-invalid',
+      expectedStatus: 401,
+      description: 'invalid token',
+      headersAuth: false,
+    };
+    const rendered = renderScenarioForTest(scenario, 'securedOp - Invalid authentication token');
+    expect(rendered).toContain("Authorization: 'Bearer invalid-token'");
+    expect(rendered).toContain('assertResponseStatus(testInfo, res, 401');
+    expect(rendered).not.toContain('jsonHeaders()');
+    expect(rendered).not.toContain('denyProbeHeaders()');
     expect(rendered).not.toContain('const requestBody');
   });
 });


### PR DESCRIPTION
First negative-suite layer for the Camunda Hub API test coverage plan (camunda/camunda-hub#25264): **401 unauthenticated** tests.

## Problem
The auth-absent (401) generator only fired for operations conditionally secured on the `auth` axis (`conditionalAuth`, derived from `x-enforcement: conditional` schemes — camunda/camunda#53708). The **Hub Public API v2** is uniformly Bearer-authenticated via a single global `security: [{ bearerAuth: [] }]` and declares **no** `x-enforcement` annotations, so it received **zero** 401 coverage.

## Change
A per-config `authAbsentMode` (`'conditional'` default | `'all-secured'`):
- **loader**: derives a new `OperationModel.secured` = any non-empty effective `security` requirement (op ?? path ?? global; `security: []` → `false`), independent of `x-enforcement`.
- **generator**: under `allSecured`, `generateAuthAbsent` targets `secured` ops instead of only `conditionalAuth` ones — same no-credentials → 401 probe.
- **camunda-hub** opts in (`authAbsentMode: 'all-secured'`).

## Result
- **29 auth-absent (401) tests** in the hub `secured` profile — one per secured op (incl. `/info`, which inherits the global scheme).
- **OCA**: the *auth-absent* layer is unchanged (defaults to `'conditional'` — identical targeting). See the auth-invalid note below for the one OCA-affecting change.
- Unit coverage added for the `secured` derivation and the all-secured generator (`auth-absent.test.ts`, 10 tests pass).

## Security model basis
From the Hub `restapi` (assessed for #25264): v2 is OAuth2 Bearer/JWT; **401** on missing/invalid/expired token or wrong audience. 403 (missing CRUD permission) is the **follow-up** — tracked separately (needs a reduced-permission probe token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Update: added `auth-invalid` (malformed-token 401)
Folds in a second 401 flavor alongside `auth-absent`: a syntactically-bogus `Authorization: Bearer …` → 401. It proves the server actually **validates** the token (signature/audience), not just that an Authorization header is present. Shares auth-absent's targeting (so the same 29 Hub ops), lands in `secured` only, needs no token-minting (static garbage string).

**Validated against a live secured Hub:** 29 auth-absent + 29 auth-invalid all return 401; cross-checked independently with curl (every v2 op → 401 for both no-token and garbage-token).

**OCA impact (intentional):** `auth-invalid` is ungated, mirroring the existing ungated `auth-absent`, so OCA's `secured` profile gains **190 auth-invalid specs** alongside its 190 pre-existing auth-absent (one per conditionally-secured op) — additive 401 coverage, symmetric with auth-absent, not a regression. CI generates + lints these specs (it does not execute the Playwright request-validation suites), and is green. `unsecured` is unaffected.

