### PR TITLE
feat: enable Camunda Hub positive suite + config-driven fetch-spec

### DIFF
--- a/configs.json
+++ b/configs.json
@@ -17,7 +17,7 @@
       }
     },
     "camunda-hub": {
-      "description": "Camunda Hub Public API V2 (spike — request-validation only)",
+      "description": "Camunda Hub Public API V2 (request-validation + positive Playwright suite)",
       "spec": {
         "source": "github:camunda/camunda-hub",
         "localSpecDir": "../camunda-hub/restapi/public-api/src/main/resources/openapi/v2",
@@ -25,7 +25,7 @@
         "$comment": "Local-bundle mode: the hub spec lives in the private camunda/camunda-hub repo at restapi/public-api/src/main/resources/openapi/v2/ — a non-default in-repo path the bundler's network-fetch CLI cannot target. fetch-spec instead passes --spec-dir <localSpecDir> (resolved relative to the repo root) and bundles from the sibling clone, matching docker/start-hub.sh's ../camunda-hub convention. SPEC_REF is ignored in this mode; check out the desired ref in the sibling clone before running fetch-spec. Pinned ref + expected hash live in configs/camunda-hub/spec-pin.json."
       },
       "planner": {
-        "$comment": "Same caps as camunda-oca; not load-bearing for request-validation, but kept consistent so a future positive-suite extension does not need a config edit.",
+        "$comment": "Same caps as camunda-oca; load-bearing for the positive (Playwright) suite's BFS chain planning.",
         "maxChainAlternatives": 20,
         "maxVariantsPerEndpoint": 20
       }

--- a/configs.json
+++ b/configs.json
@@ -6,7 +6,9 @@
       "description": "Camunda 8 Orchestration Cluster API",
       "spec": {
         "source": "github:camunda/camunda",
-        "$comment": "Pinned ref + expected hash live in configs/camunda-oca/spec-pin.json (kept as a separate file to preserve the spec-pin bump procedure documented in tests/regression/spec-pin.setup.ts)."
+        "repoUrl": "https://github.com/camunda/camunda.git",
+        "entryFile": "rest-api.yaml",
+        "$comment": "Network-fetch mode: fetch-spec passes --ref $SPEC_REF and --repo-url to camunda-schema-bundler. The in-repo spec path (zeebe/gateway-protocol/src/main/proto/v2) is derived from the ref by the bundler itself and cannot be overridden via the CLI. Pinned ref + expected hash live in configs/camunda-oca/spec-pin.json (kept as a separate file to preserve the spec-pin bump procedure documented in tests/regression/spec-pin.setup.ts)."
       },
       "planner": {
         "$comment": "Per-config planner caps (#292). Field names mirror the internal option keys (`maxChainAlternatives`, `maxVariantsPerEndpoint`) so the config key === the option key — no translation layer. The two inner `maxChainAlternatives: 1` caps inside variant planning are NOT exposed here; they are load-bearing strategy constants (one producer chain per variant leaf) documented in path-analyser/src/scenarioGenerator.ts.",
@@ -18,7 +20,9 @@
       "description": "Camunda Hub Public API V2 (spike — request-validation only)",
       "spec": {
         "source": "github:camunda/camunda-hub",
-        "$comment": "Hub spec lives at restapi/public-api/src/main/resources/openapi/v2/ in the (private) camunda/camunda-hub repo. Pinned ref + expected hash live in configs/camunda-hub/spec-pin.json. This config currently exercises only the request-validation (negative) suite; positive-test ABox authoring is deferred — see the camunda-hub config README/issue."
+        "localSpecDir": "../camunda-hub/restapi/public-api/src/main/resources/openapi/v2",
+        "entryFile": "rest-api.yaml",
+        "$comment": "Local-bundle mode: the hub spec lives in the private camunda/camunda-hub repo at restapi/public-api/src/main/resources/openapi/v2/ — a non-default in-repo path the bundler's network-fetch CLI cannot target. fetch-spec instead passes --spec-dir <localSpecDir> (resolved relative to the repo root) and bundles from the sibling clone, matching docker/start-hub.sh's ../camunda-hub convention. SPEC_REF is ignored in this mode; check out the desired ref in the sibling clone before running fetch-spec. Pinned ref + expected hash live in configs/camunda-hub/spec-pin.json."
       },
       "planner": {
         "$comment": "Same caps as camunda-oca; not load-bearing for request-validation, but kept consistent so a future positive-suite extension does not need a config edit.",

--- a/configs/camunda-hub/codegen/emitters.json
+++ b/configs/camunda-hub/codegen/emitters.json
@@ -1,0 +1,3 @@
+{
+  "emitters": ["playwright"]
+}

--- a/configs/camunda-hub/codegen/playwright/config.json
+++ b/configs/camunda-hub/codegen/playwright/config.json
@@ -1,0 +1,3 @@
+{
+  "recordResponses": false
+}

--- a/materializer/src/playwright/materialize-support.ts
+++ b/materializer/src/playwright/materialize-support.ts
@@ -466,6 +466,21 @@ export async function materializeFixtures(
   // the vendored copy across successive codegen runs.
   await fs.rm(destDir, { recursive: true, force: true });
 
+  // A config that ships no deployment artifacts (e.g. a file/folder
+  // management API like Camunda Hub) legitimately has no fixtures source
+  // directory. Treat a missing source as "no fixtures": create the empty
+  // destination so `@@FILE:` resolution still has a stable directory, and
+  // return without copying. Any other error (e.g. EACCES) still propagates.
+  try {
+    await fs.access(srcDir);
+  } catch (err) {
+    if (err !== null && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+      await fs.mkdir(destDir, { recursive: true });
+      return destDir;
+    }
+    throw err;
+  }
+
   async function copyDir(src: string, dest: string): Promise<void> {
     await fs.mkdir(dest, { recursive: true });
     for (const entry of await fs.readdir(src, { withFileTypes: true })) {

--- a/path-analyser/src/configResolver.ts
+++ b/path-analyser/src/configResolver.ts
@@ -285,12 +285,13 @@ export function getActiveSpecSource(repoRoot: string): SpecSource {
   for (const key of SPEC_SOURCE_KEYS) {
     if (!Object.hasOwn(spec, key)) continue;
     const v = spec[key];
-    if (typeof v !== 'string' || v.length === 0) {
+    const trimmed = typeof v === 'string' ? v.trim() : undefined;
+    if (trimmed === undefined || trimmed.length === 0) {
       throw new Error(
         `Malformed configs.json: configs.${name}.spec.${key} must be a non-empty string when present.`,
       );
     }
-    out[key] = v;
+    out[key] = trimmed;
   }
   return out;
 }

--- a/path-analyser/src/configResolver.ts
+++ b/path-analyser/src/configResolver.ts
@@ -239,3 +239,58 @@ export function getActivePlannerConfig(repoRoot: string): PlannerConfig {
       PLANNER_DEFAULTS.maxVariantsPerEndpoint,
   };
 }
+
+/**
+ * Per-config spec source declaration (read from `configs.<name>.spec`).
+ *
+ * Two fetch modes, selected by which fields are present:
+ *
+ *   - **Network fetch** (`camunda-oca`): `repoUrl` + (optional) `entryFile`.
+ *     `fetch-spec` passes `--ref $SPEC_REF` and `--repo-url` to
+ *     `camunda-schema-bundler`, which sparse-clones the repo. NOTE: the
+ *     bundler CLI derives the *in-repo* spec subdirectory from the ref
+ *     (`zeebe/gateway-protocol/src/main/proto/v2` for `camunda/camunda`) and
+ *     exposes no flag to override it — so network fetch only works for repos
+ *     that ship the spec at that default path. A repo with a different
+ *     in-repo path must use `localSpecDir` instead (tracked as an upstream
+ *     bundler gap).
+ *
+ *   - **Local bundle** (`camunda-hub`): `localSpecDir` + (optional)
+ *     `entryFile`. `fetch-spec` passes `--spec-dir <localSpecDir>` (resolved
+ *     relative to the repo root) and skips the network entirely. Used when
+ *     the spec lives in a private repo and/or at a non-default in-repo path;
+ *     the spec directory is expected to be a sibling clone (e.g.
+ *     `../camunda-hub/restapi/public-api/src/main/resources/openapi/v2`,
+ *     matching `docker/start-hub.sh`'s `../camunda-hub` convention).
+ */
+export interface SpecSource {
+  repoUrl?: string;
+  entryFile?: string;
+  localSpecDir?: string;
+}
+
+const SPEC_SOURCE_KEYS = ['repoUrl', 'entryFile', 'localSpecDir'] as const;
+
+export function getActiveSpecSource(repoRoot: string): SpecSource {
+  const index = loadConfigsIndex(repoRoot);
+  const name = resolveActiveConfigName(index);
+  const entry = index.configs[name];
+  if (!isRecord(entry)) return {};
+  const spec = entry.spec;
+  if (spec === undefined) return {};
+  if (!isRecord(spec)) {
+    throw new Error(`Malformed configs.json: configs.${name}.spec must be an object when present.`);
+  }
+  const out: SpecSource = {};
+  for (const key of SPEC_SOURCE_KEYS) {
+    if (!Object.hasOwn(spec, key)) continue;
+    const v = spec[key];
+    if (typeof v !== 'string' || v.length === 0) {
+      throw new Error(
+        `Malformed configs.json: configs.${name}.spec.${key} must be a non-empty string when present.`,
+      );
+    }
+    out[key] = v;
+  }
+  return out;
+}

--- a/scripts/fetch-spec.ts
+++ b/scripts/fetch-spec.ts
@@ -18,7 +18,7 @@ import { mkdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
-import { getSpecBundleDir } from '../path-analyser/src/configResolver.ts';
+import { getActiveSpecSource, getSpecBundleDir } from '../path-analyser/src/configResolver.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = resolve(dirname(__filename), '..');
@@ -27,8 +27,15 @@ function main(): void {
   const argv = process.argv.slice(2);
   const refRequired = argv.includes('--ref-required');
 
+  const spec = getActiveSpecSource(REPO_ROOT);
+  const localSpecDir = spec.localSpecDir;
+  const useLocalSpecDir = localSpecDir !== undefined;
   const ref = process.env.SPEC_REF;
-  if (refRequired && (!ref || ref.trim() === '')) {
+
+  // SPEC_REF is only meaningful in network-fetch mode. In local-bundle mode
+  // the spec directory is whatever the sibling clone has checked out, so a
+  // ref is neither required nor used.
+  if (refRequired && !useLocalSpecDir && (!ref || ref.trim() === '')) {
     console.error('fetch-spec:ref requires SPEC_REF=<sha-or-ref> to be set');
     process.exit(2);
   }
@@ -37,14 +44,29 @@ function main(): void {
   mkdirSync(bundleDir, { recursive: true });
 
   const args: string[] = [];
-  if (ref && ref.trim() !== '') {
-    args.push('--ref', ref);
+  if (localSpecDir !== undefined) {
+    // Local bundle: skip the network fetch, bundle straight from the
+    // configured (sibling-clone) spec directory.
+    args.push('--spec-dir', resolve(REPO_ROOT, localSpecDir));
+  } else {
+    if (ref && ref.trim() !== '') {
+      args.push('--ref', ref);
+    }
+    if (spec.repoUrl) {
+      args.push('--repo-url', spec.repoUrl);
+    }
+  }
+  if (spec.entryFile) {
+    args.push('--entry-file', spec.entryFile);
   }
   args.push('--output-spec', join(bundleDir, 'rest-api.bundle.json'));
   args.push('--output-metadata', join(bundleDir, 'spec-metadata.json'));
   args.push('--output-semantic-kinds', join(bundleDir, 'semantic-kinds.json'));
 
-  console.error(`[fetch-spec] writing to ${bundleDir}${ref ? ` (ref ${ref})` : ''}`);
+  const sourceDesc = useLocalSpecDir
+    ? `local spec-dir ${spec.localSpecDir}`
+    : `${spec.repoUrl ?? 'default repo'}${ref ? ` @ ${ref}` : ''}`;
+  console.error(`[fetch-spec] writing to ${bundleDir} (source: ${sourceDesc})`);
 
   const child = spawn('npx', ['camunda-schema-bundler', ...args], {
     stdio: 'inherit',

--- a/scripts/fetch-spec.ts
+++ b/scripts/fetch-spec.ts
@@ -30,12 +30,13 @@ function main(): void {
   const spec = getActiveSpecSource(REPO_ROOT);
   const localSpecDir = spec.localSpecDir;
   const useLocalSpecDir = localSpecDir !== undefined;
-  const ref = process.env.SPEC_REF;
+  const rawRef = process.env.SPEC_REF;
+  const ref = rawRef?.trim() ?? '';
 
   // SPEC_REF is only meaningful in network-fetch mode. In local-bundle mode
   // the spec directory is whatever the sibling clone has checked out, so a
   // ref is neither required nor used.
-  if (refRequired && !useLocalSpecDir && (!ref || ref.trim() === '')) {
+  if (refRequired && !useLocalSpecDir && ref === '') {
     console.error('fetch-spec:ref requires SPEC_REF=<sha-or-ref> to be set');
     process.exit(2);
   }
@@ -49,7 +50,7 @@ function main(): void {
     // configured (sibling-clone) spec directory.
     args.push('--spec-dir', resolve(REPO_ROOT, localSpecDir));
   } else {
-    if (ref && ref.trim() !== '') {
+    if (ref !== '') {
       args.push('--ref', ref);
     }
     if (spec.repoUrl) {
@@ -65,7 +66,7 @@ function main(): void {
 
   const sourceDesc = useLocalSpecDir
     ? `local spec-dir ${spec.localSpecDir}`
-    : `${spec.repoUrl ?? 'default repo'}${ref ? ` @ ${ref}` : ''}`;
+    : `${spec.repoUrl ?? 'default repo'}${ref !== '' ? ` @ ${ref}` : ''}`;
   console.error(`[fetch-spec] writing to ${bundleDir} (source: ${sourceDesc})`);
 
   const child = spawn('npx', ['camunda-schema-bundler', ...args], {

--- a/semantic-graph-extractor/schema-analyzer.ts
+++ b/semantic-graph-extractor/schema-analyzer.ts
@@ -466,7 +466,7 @@ export class SchemaAnalyzer {
     const named = new Set(providerFields);
     const leafOf = (fieldPath: string): string => {
       const last = fieldPath.split('.').pop() ?? fieldPath;
-      return last.replace(/\[\]$/, '');
+      return last.replace(/(\[\])+$/, '');
     };
     for (const entries of Object.values(responseSemanticTypes)) {
       for (const entry of entries) {

--- a/semantic-graph-extractor/schema-analyzer.ts
+++ b/semantic-graph-extractor/schema-analyzer.ts
@@ -163,6 +163,13 @@ export class SchemaAnalyzer {
     // Extract response semantic types
     const responseSemanticTypes = this.extractResponseSemanticTypes(operation.responses, spec);
 
+    // Operation-level x-semantic-provider (Camunda Hub style): the operation
+    // names the response leaf fields it authoritatively produces. Upgrade the
+    // matching response semantic entries to provider:true. This is the
+    // operation-level counterpart of the schema-level array form honoured in
+    // extractSemanticTypesFromSchemaReference (#33).
+    this.applyOperationLevelProviders(operation['x-semantic-provider'], responseSemanticTypes);
+
     // #305 Phase 4: collect every primitive response leaf path per
     // status code (regardless of `x-semantic-type`). Powers the
     // UpdatedFieldVisibleOnReadBack instantiator's name-based bridge
@@ -435,6 +442,37 @@ export class SchemaAnalyzer {
     }
 
     return semanticTypes;
+  }
+
+  /**
+   * Mark response semantic entries named by an operation-level
+   * `x-semantic-provider` array as authoritative providers.
+   *
+   * The Camunda Hub Public API V2 places the provider declaration on the
+   * operation (a sibling of `operationId`) rather than on the response
+   * object schema. Each array element is a response leaf-field name; any
+   * extracted response semantic whose `fieldPath` leaf segment matches is
+   * upgraded to `provider: true`. Leaf-segment matching (last `.`-segment,
+   * with any trailing `[]` stripped) mirrors how the schema-level array
+   * form names child properties, and is robust to nested response shapes
+   * (e.g. `result.projectKey`). Never downgrades an entry already flagged
+   * by a schema-level annotation.
+   */
+  private applyOperationLevelProviders(
+    providerFields: string[] | undefined,
+    responseSemanticTypes: Record<string, SemanticTypeReference[]>,
+  ): void {
+    if (!Array.isArray(providerFields) || providerFields.length === 0) return;
+    const named = new Set(providerFields);
+    const leafOf = (fieldPath: string): string => {
+      const last = fieldPath.split('.').pop() ?? fieldPath;
+      return last.replace(/\[\]$/, '');
+    };
+    for (const entries of Object.values(responseSemanticTypes)) {
+      for (const entry of entries) {
+        if (named.has(leafOf(entry.fieldPath))) entry.provider = true;
+      }
+    }
   }
 
   /**

--- a/semantic-graph-extractor/types.ts
+++ b/semantic-graph-extractor/types.ts
@@ -65,6 +65,15 @@ export interface OperationObject {
   'x-operation-kind'?: OperationMetadata | OperationMetadata[];
   'x-conditional-idempotency'?: ConditionalIdempotencySpec;
   'x-semantic-establishes'?: EstablishesSpec;
+  // Operation-level provider declaration: an array of response leaf-field
+  // names whose semantic type this operation authoritatively produces. Used
+  // by the Camunda Hub Public API V2, which annotates providers on the
+  // operation rather than on the response object schema. The extractor maps
+  // each named field onto the matching response semantic entry and flags it
+  // `provider: true` — the operation-level counterpart of the schema-level
+  // array form (`Schema['x-semantic-provider']`; see #33). The boolean form
+  // is not meaningful at the operation level and is ignored.
+  'x-semantic-provider'?: string[];
 }
 
 // `x-semantic-establishes` declares that running this operation establishes a

--- a/tests/codegen/materialize-support.test.ts
+++ b/tests/codegen/materialize-support.test.ts
@@ -196,6 +196,18 @@ describe('materializeFixtures', () => {
     await expect(materializeFixtures(tmp)).resolves.toBe(path.join(tmp, FIXTURES_DIR_NAME));
   });
 
+  test('a missing fixtures source dir yields an empty fixtures/ dir, not an error', async () => {
+    // A config with no deployment artifacts (e.g. the Camunda Hub
+    // file/folder API) has no fixtures source directory. materializeFixtures
+    // must treat this as "no fixtures": create the empty destination and
+    // return it rather than throwing ENOENT.
+    const missingSrc = path.join(tmp, 'does-not-exist');
+    const destDir = await materializeFixtures(tmp, missingSrc);
+    expect(destDir).toBe(path.join(tmp, FIXTURES_DIR_NAME));
+    expect(existsSync(destDir), 'fixtures/ destination should exist').toBe(true);
+    expect(await fs.readdir(destDir), 'fixtures/ should be empty').toEqual([]);
+  });
+
   test('here-relative candidate path resolves to a materialized file when here is <outDir>/support/', async () => {
     // Guard against regressions to the fixture resolution path used by
     // support/fixtures.ts. That file calls:

--- a/tests/fixtures/extractor/extractor-constructs.test.ts
+++ b/tests/fixtures/extractor/extractor-constructs.test.ts
@@ -269,6 +269,57 @@ const fixtureProviderBooleanLeaf: OpenAPISpec = {
 };
 
 // ---------------------------------------------------------------------------
+// Fixture: operation-level array form of x-semantic-provider.
+//
+// The Camunda Hub Public API V2 annotates providers on the OPERATION
+// (`x-semantic-provider: ['projectKey']` as a sibling of `operationId`)
+// rather than on the response object schema. The named fields are response
+// leaves whose semantic type this operation authoritatively produces. The
+// extractor must honour this placement and flag the matching response
+// semantic entries `provider: true`, exactly as it does for the
+// schema-level array form (#33).
+// ---------------------------------------------------------------------------
+const fixtureProviderOperationLevel: OpenAPISpec = {
+  openapi: '3.0.3',
+  info: { title: 'fixture-provider-operation-level', version: '0.0.0' },
+  paths: {
+    '/projects': {
+      post: {
+        operationId: 'createProjectOpLevel',
+        // Operation-level provider declaration (Camunda Hub style).
+        'x-semantic-provider': ['projectKey'],
+        responses: {
+          '200': {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    projectKey: {
+                      // No schema-level provider flag here — the only
+                      // provider signal is the operation-level array.
+                      type: 'string',
+                      'x-semantic-type': 'ProjectKey',
+                    },
+                    workspaceKey: {
+                      // NOT listed in the operation-level array, so this
+                      // echoed foreign key must stay provider:false.
+                      type: 'string',
+                      'x-semantic-type': 'WorkspaceKey',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
 
 describe('extractor construct fixtures', () => {
   describe('optional ancestor demotes leaf to optional (#31)', () => {
@@ -328,6 +379,22 @@ describe('extractor construct fixtures', () => {
       const refs = extractResponseFor(fixtureProviderBooleanLeaf, 'createThingBooleanProvider');
       const leaf = refs.find((r) => r.semanticType === 'ProcessDefinitionKey');
       expect(leaf?.provider).toBe(true);
+    });
+  });
+
+  describe('operation-level array form of x-semantic-provider (Camunda Hub style)', () => {
+    it('a response leaf named in the operation-level array is flagged provider:true', () => {
+      const refs = extractResponseFor(fixtureProviderOperationLevel, 'createProjectOpLevel');
+      const key = refs.find((r) => r.semanticType === 'ProjectKey');
+      expect(key, 'expected projectKey to be extracted').toBeDefined();
+      expect(key?.provider).toBe(true);
+    });
+
+    it('a response leaf NOT named in the operation-level array stays provider:false', () => {
+      const refs = extractResponseFor(fixtureProviderOperationLevel, 'createProjectOpLevel');
+      const foreign = refs.find((r) => r.semanticType === 'WorkspaceKey');
+      expect(foreign, 'expected echoed workspaceKey to be extracted').toBeDefined();
+      expect(foreign?.provider).toBe(false);
     });
   });
 });

--- a/tests/fixtures/extractor/extractor-constructs.test.ts
+++ b/tests/fixtures/extractor/extractor-constructs.test.ts
@@ -320,6 +320,52 @@ const fixtureProviderOperationLevel: OpenAPISpec = {
 };
 
 // ---------------------------------------------------------------------------
+// Fixture: operation-level provider naming a NESTED-array leaf.
+//
+// A response property that is an array-of-array of keys yields the field
+// path `keys[][]`. The operation-level array names the bare property
+// (`keys`), so leaf-segment matching must strip *all* trailing `[]`
+// groups, not just one — otherwise `keys[]` would never equal `keys` and
+// the provider flag would be silently dropped for nested array leaves.
+// ---------------------------------------------------------------------------
+const fixtureProviderOperationLevelNestedArray: OpenAPISpec = {
+  openapi: '3.0.3',
+  info: { title: 'fixture-provider-operation-level-nested-array', version: '0.0.0' },
+  paths: {
+    '/batches': {
+      post: {
+        operationId: 'createBatchOpLevel',
+        'x-semantic-provider': ['keys'],
+        responses: {
+          '200': {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    keys: {
+                      type: 'array',
+                      items: {
+                        type: 'array',
+                        items: {
+                          type: 'string',
+                          'x-semantic-type': 'ProjectKey',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
 
 describe('extractor construct fixtures', () => {
   describe('optional ancestor demotes leaf to optional (#31)', () => {
@@ -395,6 +441,16 @@ describe('extractor construct fixtures', () => {
       const foreign = refs.find((r) => r.semanticType === 'WorkspaceKey');
       expect(foreign, 'expected echoed workspaceKey to be extracted').toBeDefined();
       expect(foreign?.provider).toBe(false);
+    });
+
+    it('a nested-array leaf (keys[][]) named by the bare property is flagged provider:true', () => {
+      const refs = extractResponseFor(
+        fixtureProviderOperationLevelNestedArray,
+        'createBatchOpLevel',
+      );
+      const leaf = refs.find((r) => r.fieldPath === 'keys[][]');
+      expect(leaf, 'expected nested-array leaf keys[][] to be extracted').toBeDefined();
+      expect(leaf?.provider).toBe(true);
     });
   });
 });

--- a/tests/fixtures/loader/configresolver.test.ts
+++ b/tests/fixtures/loader/configresolver.test.ts
@@ -20,6 +20,7 @@ import {
   getActiveConfigDir,
   getActiveConfigName,
   getActivePlannerConfig,
+  getActiveSpecSource,
 } from '../../../path-analyser/src/configResolver.ts';
 
 let workdir: string;
@@ -162,4 +163,61 @@ describe('configResolver: per-config planner caps (#292)', () => {
     writeConfig({ maxVariantsPerEndpoint: 0 });
     expect(() => getActivePlannerConfig(workdir)).toThrow(/must be a positive integer/);
   });
+});
+
+describe('configResolver: per-config spec source (config-driven fetch-spec)', () => {
+  // fetch-spec reads the active config's `spec` block to decide between
+  // network fetch (repoUrl) and local bundling (localSpecDir). Class-scoped
+  // guards: (1) absent block yields an empty source (network fetch with
+  // defaults); (2) string fields pass through; (3) any non-string / empty
+  // field is rejected up front so a config typo can't silently spawn the
+  // bundler with a bogus path or url.
+  function writeSpec(spec: unknown): void {
+    writeFileSync(
+      join(workdir, 'configs.json'),
+      JSON.stringify({
+        default: 'camunda-oca',
+        configs: { 'camunda-oca': spec === undefined ? {} : { spec } },
+      }),
+    );
+  }
+
+  it('returns an empty source when no spec block is present', () => {
+    writeSpec(undefined);
+    expect(getActiveSpecSource(workdir)).toEqual({});
+  });
+
+  it('passes through repoUrl + entryFile (network-fetch mode)', () => {
+    writeSpec({
+      source: 'github:camunda/camunda',
+      repoUrl: 'https://x/y.git',
+      entryFile: 'r.yaml',
+    });
+    expect(getActiveSpecSource(workdir)).toEqual({
+      repoUrl: 'https://x/y.git',
+      entryFile: 'r.yaml',
+    });
+  });
+
+  it('passes through localSpecDir (local-bundle mode) and ignores unknown keys', () => {
+    writeSpec({ localSpecDir: '../sibling/spec', entryFile: 'r.yaml', source: 'github:o/r' });
+    expect(getActiveSpecSource(workdir)).toEqual({
+      localSpecDir: '../sibling/spec',
+      entryFile: 'r.yaml',
+    });
+  });
+
+  it('throws when spec is not an object', () => {
+    writeSpec(42);
+    expect(() => getActiveSpecSource(workdir)).toThrow(/spec must be an object/);
+  });
+
+  for (const key of ['repoUrl', 'entryFile', 'localSpecDir']) {
+    for (const bad of [0, null, true, '', {}]) {
+      it(`throws when spec.${key} is ${JSON.stringify(bad)}`, () => {
+        writeSpec({ [key]: bad });
+        expect(() => getActiveSpecSource(workdir)).toThrow(/must be a non-empty string/);
+      });
+    }
+  }
 });

--- a/tests/fixtures/loader/configresolver.test.ts
+++ b/tests/fixtures/loader/configresolver.test.ts
@@ -212,8 +212,19 @@ describe('configResolver: per-config spec source (config-driven fetch-spec)', ()
     expect(() => getActiveSpecSource(workdir)).toThrow(/spec must be an object/);
   });
 
+  it('trims surrounding whitespace from string fields', () => {
+    writeSpec({ repoUrl: '  https://x/y.git  ', localSpecDir: '\t../sibling/spec\n' });
+    expect(getActiveSpecSource(workdir)).toEqual({
+      repoUrl: 'https://x/y.git',
+      localSpecDir: '../sibling/spec',
+    });
+  });
+
   for (const key of ['repoUrl', 'entryFile', 'localSpecDir']) {
-    for (const bad of [0, null, true, '', {}]) {
+    // Whitespace-only is treated as empty (class-scoped: a config typo
+    // like `" "` must fail fast, not silently produce an invalid
+    // url/path passed verbatim to the bundler).
+    for (const bad of [0, null, true, '', '   ', '\t', {}]) {
       it(`throws when spec.${key} is ${JSON.stringify(bad)}`, () => {
         writeSpec({ [key]: bad });
         expect(() => getActiveSpecSource(workdir)).toThrow(/must be a non-empty string/);


### PR DESCRIPTION
## What

Enables positive (happy-path Playwright) test generation for the **Camunda Hub Public API V2** config, and makes `fetch-spec` config-driven so each named config declares its own spec source.

Previously only the negative (request-validation) suite could be generated for `camunda-hub`: the hub branch annotates response-key providers with an **operation-level** `x-semantic-provider: [keyField]` array, which the extractor didn't recognise, so create operations resolved to `provider:false`, `producersByType` stayed empty, and the planner couldn't build dependency chains.

## Changes

- **`feat(extractor)`** — consume operation-level `x-semantic-provider` arrays. `applyOperationLevelProviders` upgrades a response semantic entry to `provider:true` when its fieldPath leaf segment is named in the operation-level array. Red/green/class-scoped Layer-1 fixture added (named leaf → `provider:true`; non-named echoed key → `provider:false`).
- **`fix(materializer)`** — `materializeFixtures` tolerates a missing `fixtures/` source dir (the hub config ships no deployment artifacts): on ENOENT it creates an empty destination dir and returns; other errors propagate. Covering test added.
- **`feat(hub)`** — minimal codegen config (`configs/camunda-hub/codegen/`): single `playwright` emitter, default role, no special hooks.
- **`feat(fetch-spec)`** — config-driven spec source. `fetch-spec` reads the active config's `spec` block:
  - **Network fetch** (camunda-oca): `repoUrl` + `entryFile` → `--ref $SPEC_REF` + `--repo-url`.
  - **Local bundle** (camunda-hub): `localSpecDir` + `entryFile` → `--spec-dir <resolved sibling-clone path>`, skipping the network and the `SPEC_REF` requirement.

  Adds `SpecSource` + `getActiveSpecSource()` to `configResolver.ts` (mirrors the planner-config validation pattern) with class-scoped tests.

### Note on the bundler fetch-path limitation

`camunda-schema-bundler`'s network-fetch CLI derives the in-repo spec subdirectory from the ref and exposes no flag to override it. The hub spec lives in the **private** `camunda/camunda-hub` repo at a **non-default** in-repo path, so it must be bundled from a sibling clone via `localSpecDir` (matching `docker/start-hub.sh`'s `../camunda-hub` convention). This is documented inline in `configs.json` and `SpecSource`'s doc comment, and is an upstream bundler gap, not worked around here.

## Verification

- Hub local-bundle: `CONFIG=camunda-hub npm run fetch-spec` (no `SPEC_REF`) bundles 29 ops from the sibling clone; `createProject` → `ProjectKey.provider:true`. Full positive suite generates (34 spec files).
- OCA network fetch: `SPEC_REF=<pin> npm run fetch-spec:ref` still works; bundled **spec hash matches the pin** (no behaviour change).
- `npm run lint` clean (200 files); all workspace + tests typechecks pass; `configresolver.test.ts` 44/44.
