### PR TITLE
fix(generator): chain update/delete-by-key + fill required nested body fields

### DIFF
--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1304,10 +1304,11 @@ function buildRequestBodyFromCanonical(
             const values = chosenVariant.fieldEnums[name];
             template[name] = values[0];
           } else if ((declaredTypeByLeaf[name] ?? chosenVariant?.fieldTypes?.[name]) === 'object') {
-            // Object-typed required field with no binding: emit {} rather than seeding
-            // a string placeholder. An empty object is always a valid JSON value and
-            // avoids "Request property [X] cannot be parsed" broker errors (#174 sub-class 1).
-            template[name] = {};
+            // Object-typed required field: recursively fill its OWN required
+            // children rather than a bare {}, which drops required nested fields
+            // and triggers a server 400 (see the non-oneOf branch below). Yields
+            // {} unchanged when there are no required children.
+            template[name] = synthesizeObjectFromPrefix(`${name}.`, nodes);
           } else if ((declaredTypeByLeaf[name] ?? chosenVariant?.fieldTypes?.[name]) === 'array') {
             // #326 — emit a synthesised one-element array honouring the
             // item schema's own required set rather than `[]`, which
@@ -1335,6 +1336,13 @@ function buildRequestBodyFromCanonical(
       for (const f of requiredFields) {
         // Array nodes are recorded as 'field[]'; strip the suffix for the template key.
         const leaf = f.path.replace(/\[\]$/, '').split('.').pop() ?? '';
+        // A required NESTED field (path contains '.', e.g. `filter.workspaceKey`)
+        // is filled by its required parent object via synthesizeObjectFromPrefix
+        // (the `f.type === 'object'` branch below). Projecting its leaf here would
+        // both HOIST it to the body root and leave the parent as an empty `{}` —
+        // producing `{ filter: {}, workspaceKey: … }` and a server 400
+        // ("filter.workspaceKey must not be null"). Skip it; the parent owns it.
+        if (f.path.replace(/\[\]$/, '').includes('.')) continue;
         if (allowedFields && !allowedFields.has(leaf)) continue;
         const viaProvider = resolveProvider(opId, leaf, scenario);
         if (viaProvider !== undefined) {
@@ -1365,10 +1373,13 @@ function buildRequestBodyFromCanonical(
           // `${var}` placeholder that the server rejects with 400.
           template[leaf] = f.enum[0];
         } else if (f.type === 'object') {
-          // Object-typed required field with no binding: emit {} rather than seeding
-          // a string placeholder. An empty object is always a valid JSON value and
-          // avoids "Request property [X] cannot be parsed" broker errors (#174 sub-class 1).
-          template[leaf] = {};
+          // Object-typed required field: recursively fill its OWN required
+          // children (synthesizeObjectFromPrefix) rather than emitting a bare
+          // {}. A bare {} silently drops required NESTED fields — e.g. a search
+          // body's required `filter.workspaceKey` — which the server then
+          // rejects with 400 ("filter.workspaceKey must not be null"). When the
+          // object has no required children, this still yields {} (unchanged).
+          template[leaf] = synthesizeObjectFromPrefix(`${normalizedPath}.`, nodes);
         } else if (f.type === 'array') {
           // #326 — see synthesizeArrayElement docblock. `f.path` is
           // recorded as `<field>[]` for top-level arrays; strip the

--- a/semantic-graph-extractor/schema-analyzer.ts
+++ b/semantic-graph-extractor/schema-analyzer.ts
@@ -916,8 +916,46 @@ export class SchemaAnalyzer {
       return (spec.components?.requestBodies?.[requestBodyName] as T | undefined) ?? null;
     }
 
+    // Generic fallback: resolve any other local JSON Pointer (RFC 6901) by
+    // walking it against the document. This covers intra-document refs that
+    // schema bundlers emit when they DEDUPLICATE identical objects across the
+    // spec — e.g. a PATCH/DELETE operation whose `parameters` entry was replaced
+    // with `{ $ref: "#/paths/~1workspaces~1{workspaceKey}/get/parameters/0" }`
+    // because it was byte-identical to the GET operation's parameter. Without
+    // this, those parameters silently vanish, the operation loses its path-key
+    // requirement, and no producer chain is planned for it (#395).
+    if (ref.startsWith('#/')) {
+      const resolved = this.resolveJsonPointer(ref, spec);
+      if (resolved !== null) {
+        // biome-ignore lint/plugin: single boundary where untyped JSON is narrowed; caller declares expected schema type
+        return resolved as T;
+      }
+    }
+
     console.warn(`Unable to resolve reference: ${ref}`);
     return null;
+  }
+
+  /**
+   * Resolve a local JSON Pointer (RFC 6901) against the spec document, decoding
+   * the `~1` → `/` and `~0` → `~` escapes. Returns null if any segment is
+   * missing. Used as the generic fallback in {@link resolveReference} for refs
+   * the component-specific branches don't cover (notably bundler-deduplicated
+   * `#/paths/.../parameters/N` refs — #395).
+   */
+  private resolveJsonPointer(ref: string, spec: OpenAPISpec): unknown {
+    const tokens = ref
+      .slice(2) // drop the leading "#/"
+      .split('/')
+      .map((t) => t.replace(/~1/g, '/').replace(/~0/g, '~'));
+    let current: unknown = spec;
+    for (const token of tokens) {
+      if (current === null || typeof current !== 'object') return null;
+      // biome-ignore lint/plugin: single boundary where the untyped JSON document is indexed by a pointer segment
+      current = (current as Record<string, unknown>)[token];
+      if (current === undefined) return null;
+    }
+    return current ?? null;
   }
 
   /**

--- a/tests/fixtures/extractor/extractor-constructs.test.ts
+++ b/tests/fixtures/extractor/extractor-constructs.test.ts
@@ -34,6 +34,13 @@ function extractResponseFor(spec: OpenAPISpec, opId: string): SemanticTypeRefere
   return out;
 }
 
+function extractParametersFor(spec: OpenAPISpec, opId: string) {
+  const ops = new SchemaAnalyzer().extractOperations(spec);
+  const op = ops.find((o) => o.operationId === opId);
+  if (!op) throw new Error(`fixture: operation ${opId} not present in extracted spec`);
+  return op.parameters;
+}
+
 // ---------------------------------------------------------------------------
 // Fixture #31 — optional ancestor demotes a leaf to optional.
 //
@@ -451,6 +458,64 @@ describe('extractor construct fixtures', () => {
       const leaf = refs.find((r) => r.fieldPath === 'keys[][]');
       expect(leaf, 'expected nested-array leaf keys[][] to be extracted').toBeDefined();
       expect(leaf?.provider).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Fixture #395 — bundler-deduplicated parameter $ref (intra-document pointer).
+  //
+  // Schema bundlers replace a parameter that is byte-identical across
+  // operations with a JSON-pointer $ref into the FIRST occurrence, e.g. the
+  // PATCH op's `parameters[0]` becomes
+  //   { $ref: '#/paths/~1things~1{thingKey}/get/parameters/0' }
+  // The extractor must follow that pointer; otherwise the parameter (and its
+  // path-key requirement) vanishes, no producer chain is planned, and the
+  // emitted test calls the endpoint with an unbound `${thingKey}` → 404.
+  // -------------------------------------------------------------------------
+  describe('bundler-deduplicated parameter $ref into #/paths/.../parameters/N (#395)', () => {
+    const fixtureDedupedParamRef: OpenAPISpec = {
+      openapi: '3.0.3',
+      info: { title: 'fixture-deduped-param-ref', version: '0.0.0' },
+      paths: {
+        '/things/{thingKey}': {
+          get: {
+            operationId: 'getThing',
+            parameters: [
+              {
+                name: 'thingKey',
+                in: 'path',
+                required: true,
+                schema: { type: 'string', 'x-semantic-type': 'ThingKey' },
+              },
+            ],
+            responses: { '200': { description: 'ok' } },
+          },
+          patch: {
+            operationId: 'updateThing',
+            // The bundler collapsed this identical param to a pointer into GET.
+            parameters: [{ $ref: '#/paths/~1things~1{thingKey}/get/parameters/0' }],
+            requestBody: {
+              required: true,
+              content: { 'application/json': { schema: { type: 'object' } } },
+            },
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+    };
+
+    it('GET keeps its inline path param (control)', () => {
+      const params = extractParametersFor(fixtureDedupedParamRef, 'getThing');
+      expect(params.map((p) => [p.name, p.location, p.semanticType])).toEqual([
+        ['thingKey', 'path', 'ThingKey'],
+      ]);
+    });
+
+    it('PATCH resolves the deduped pointer ref to the same path param', () => {
+      const params = extractParametersFor(fixtureDedupedParamRef, 'updateThing');
+      expect(params.map((p) => [p.name, p.location, p.semanticType])).toEqual([
+        ['thingKey', 'path', 'ThingKey'],
+      ]);
     });
   });
 });


### PR DESCRIPTION
## What

Two generator fixes surfaced by running the **camunda-hub positive (lifecycle) suite** against a live server. Both are generator-side; together they take the suite from **11 → 21 / 41 passing**.

### 1. Extractor — resolve bundler-deduplicated parameter `$ref`s (Closes #395)
Schema bundlers replace a parameter that is byte-identical across operations with an intra-document JSON pointer:
```json
{ "$ref": "#/paths/~1workspaces~1{workspaceKey}/get/parameters/0" }
```
`resolveReference` only handled `#/components/...` refs and **dropped** these → PATCH/DELETE-by-key ops lost their path-key requirement → no producer chain → the emitted test called an unbound `${workspaceKey}` → **404**. Adds a generic RFC-6901 JSON-pointer fallback; regression fixture added in `extractor-constructs.test.ts`.

### 2. Request-body builder — fill required *nested* fields, don't hoist them
`buildRequestBodyFromCanonical` projected every required node to its leaf name, so a nested required field (e.g. a search body's `filter.workspaceKey`) was written at the body **root** while its parent was emitted as `{}` — producing `{ filter: {}, workspaceKey: … }` and a server **400** (`filter.workspaceKey must not be null`). Now: required object fields recurse via `synthesizeObjectFromPrefix`, and nested required nodes are skipped in the top-level loop (the parent owns them) → `{ filter: { workspaceKey } }`.

## Validation

- **Live camunda-hub:** positive suite **11 → 21 / 41**. Fixed: all update/delete-by-key ops (#395) and all search ops (nested filter). The remaining 20 failures are **not** generator-side — 19 are a Hub controller bug (camunda-hub#25302, file/folder create 403 cascade) and 1 is an unrelated invalid-`email` seed (tracked separately).
- **OCA regression-invariants + full unit suite: 775 pass**, no regression. (Two `ontology-roundtrip` failures are pre-existing/env — present on baseline.)
- Lint clean.

## Notes

- Filling the search filter key with the *real bound* key (vs a `placeholder`) is a quality follow-up that pairs with the `x-semantic-type` annotations in camunda-hub#25146; the 400 itself is fixed here independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)