### PR TITLE
feat(hub): authenticate + target a per-config base URL in the positive suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,14 @@ CAMUNDA_REST_PORT=9080 docker compose up -d
 > Expects `camunda-hub` to be cloned as a sibling directory alongside this repo.
 
 ```bash
-# Start (Docker infrastructure + restapi + frontend)
+# Start (Docker infrastructure + restapi + frontend); waits until the UI is ready
 ./docker/start-hub.sh
 
 # Stop
 ./docker/start-hub.sh stop
+
+# Status (infra + app process)
+./docker/start-hub.sh status
 ```
 
 The Hub UI will be available at `http://localhost:${HUB_UI_PORT:-8088}`. Log in with `demo` / `demo`.

--- a/configs/camunda-hub/codegen/playwright/config.json
+++ b/configs/camunda-hub/codegen/playwright/config.json
@@ -1,3 +1,4 @@
 {
-  "recordResponses": false
+  "recordResponses": false,
+  "defaultBaseUrl": "http://localhost:8088/api/v2"
 }

--- a/docker/start-hub.sh
+++ b/docker/start-hub.sh
@@ -59,7 +59,9 @@ sync_frontend_deps() {
   echo "Frontend dependencies up to date."
 }
 
-# Poll until the Hub UI responds with HTTP 200.
+# Poll until the Hub UI responds successfully. `curl -sf` treats any 2xx/3xx as
+# success and only fails on HTTP >= 400 (or connection errors), so this waits for
+# the login page to be served (a redirect counts as ready).
 wait_for_ready() {
   local hub_ui_port="${HUB_UI_PORT:-8088}"
   local url="http://localhost:${hub_ui_port}/login"
@@ -237,8 +239,14 @@ case "${1:-start}" in
     fi
     echo "Starting Hub infrastructure..."
     docker compose -f "$COMPOSE_FILE" up -d
-    sync_frontend_deps
-    fix_keycloak
+    # The stack is up now; if frontend-dep sync or Keycloak setup fails, tear it
+    # back down so a failed start doesn't leave a half-started environment
+    # (ports bound, containers running) behind.
+    if ! sync_frontend_deps || ! fix_keycloak; then
+      echo "Error: Hub setup failed — tearing down infrastructure." >&2
+      docker compose -f "$COMPOSE_FILE" down || true
+      exit 1
+    fi
     echo "Starting Hub app (restapi + frontend)..."
     cd "$HUB_REPO"
     # Launch make in its OWN process group (job-control mode) so the recorded PID

--- a/docker/start-hub.sh
+++ b/docker/start-hub.sh
@@ -65,12 +65,15 @@ sync_frontend_deps() {
 wait_for_ready() {
   local hub_ui_port="${HUB_UI_PORT:-8088}"
   local url="http://localhost:${hub_ui_port}/login"
+  # A cold restapi (Spring Boot) + frontend (webpack) build can take well over
+  # 3 min, so default to ~8 min; override with HUB_READY_ATTEMPTS (×2s each).
+  local max="${HUB_READY_ATTEMPTS:-240}"
   local attempts=0
-  echo "Waiting for Hub UI at ${url}..."
+  echo "Waiting for Hub UI at ${url} (up to $((max * 2))s)..."
   until curl -sf -o /dev/null "$url"; do
     attempts=$((attempts + 1))
-    if [ "$attempts" -ge 90 ]; then
-      echo "Error: Hub UI did not become ready within 90 attempts (≈3 min). Check $LOG_FILE for details."
+    if [ "$attempts" -ge "$max" ]; then
+      echo "Error: Hub UI did not become ready within ${max} attempts (≈$((max * 2))s). Check $LOG_FILE for details."
       return 1
     fi
     sleep 2
@@ -270,7 +273,9 @@ case "${1:-start}" in
     # with a stale PID file — reuse the stop path to tear everything down.
     if ! wait_for_ready; then
       echo "Error: Hub UI did not become ready — tearing down. Check $LOG_FILE." >&2
-      "$0" stop || true
+      # Absolute path: by here we've `cd`'d into $HUB_REPO, so a relative $0
+      # ("./docker/start-hub.sh") would no longer resolve.
+      "$SCRIPT_DIR/start-hub.sh" stop || true
       exit 1
     fi
     echo "Run './docker/start-hub.sh stop' to stop."

--- a/docker/start-hub.sh
+++ b/docker/start-hub.sh
@@ -266,7 +266,13 @@ case "${1:-start}" in
       exit 1
     fi
     echo "Hub app starting (PID $MAKE_PID). Logs: $LOG_FILE"
-    wait_for_ready
+    # If the UI never comes up, don't leave the app process + docker stack running
+    # with a stale PID file — reuse the stop path to tear everything down.
+    if ! wait_for_ready; then
+      echo "Error: Hub UI did not become ready — tearing down. Check $LOG_FILE." >&2
+      "$0" stop || true
+      exit 1
+    fi
     echo "Run './docker/start-hub.sh stop' to stop."
     ;;
   stop)

--- a/docker/start-hub.sh
+++ b/docker/start-hub.sh
@@ -45,8 +45,17 @@ check_start_preconditions() {
 # not yet reflected in node_modules) from causing webpack compile failures.
 sync_frontend_deps() {
   echo "Syncing frontend dependencies (npm ci)..."
-  npm ci --workspace=apps/hub --prefix "$HUB_REPO/frontend" 2>&1 \
-    | grep -v "^npm warn\|^npm notice" || true
+  # Capture output so a genuine `npm ci` failure aborts (declare then assign —
+  # `local log=$(...)` would mask the command's exit status behind `local`'s).
+  # The previous `… | grep … || true` pipeline swallowed failures and still
+  # printed success, risking a start with broken frontend deps.
+  local log
+  if ! log="$(npm ci --workspace=apps/hub --prefix "$HUB_REPO/frontend" 2>&1)"; then
+    echo "$log" | grep -v "^npm warn\|^npm notice" || true
+    echo "Error: 'npm ci' failed for the Hub frontend (see output above)." >&2
+    return 1
+  fi
+  echo "$log" | grep -v "^npm warn\|^npm notice" || true
   echo "Frontend dependencies up to date."
 }
 

--- a/docker/start-hub.sh
+++ b/docker/start-hub.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
-# Start or stop camunda-hub (Web Modeler) in Self-Managed mode.
+# Start, stop, or check the status of camunda-hub (Web Modeler) in Self-Managed mode.
 # Expects camunda-hub to be cloned as a sibling directory: ../camunda-hub
+#
+# Usage:
+#   ./docker/start-hub.sh [start|stop|status]
+#
+# Environment variables (all optional):
+#   HUB_UI_PORT      Frontend port (default: 8088)
+#   KEYCLOAK_PORT    Keycloak port (default: 18080)
+#   JAVA_HOME        Must point to a JDK 21+ installation
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -14,7 +22,7 @@ LOG_FILE="$REPO_ROOT/test-results/.hub.log"
 # `stop` just kills the PID and tears down Docker, so it must not require them.
 check_start_preconditions() {
   local missing=()
-  for cmd in docker curl python3 lsof make; do
+  for cmd in docker curl python3 lsof make npm; do
     command -v "$cmd" >/dev/null 2>&1 || missing+=("$cmd")
   done
   if [ "${#missing[@]}" -gt 0 ]; then
@@ -30,6 +38,33 @@ check_start_preconditions() {
     echo "Error: JAVA_HOME is not set. Set it to a JDK 21+ installation before running this script."
     exit 1
   fi
+}
+
+# Sync frontend node_modules to the lockfile before starting the dev server.
+# This prevents stale installs (e.g. a package updated in package-lock.json but
+# not yet reflected in node_modules) from causing webpack compile failures.
+sync_frontend_deps() {
+  echo "Syncing frontend dependencies (npm ci)..."
+  npm ci --workspace=apps/hub --prefix "$HUB_REPO/frontend" 2>&1 \
+    | grep -v "^npm warn\|^npm notice" || true
+  echo "Frontend dependencies up to date."
+}
+
+# Poll until the Hub UI responds with HTTP 200.
+wait_for_ready() {
+  local hub_ui_port="${HUB_UI_PORT:-8088}"
+  local url="http://localhost:${hub_ui_port}/login"
+  local attempts=0
+  echo "Waiting for Hub UI at ${url}..."
+  until curl -sf -o /dev/null "$url"; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 90 ]; then
+      echo "Error: Hub UI did not become ready within 90 attempts (≈3 min). Check $LOG_FILE for details."
+      return 1
+    fi
+    sleep 2
+  done
+  echo "Hub UI is ready at http://localhost:${hub_ui_port}"
 }
 
 fix_keycloak() {
@@ -109,7 +144,45 @@ for m in json.load(sys.stdin):
     }" > /dev/null
   echo "Keycloak: fixed web-modeler audience mapper → web-modeler-api"
 
-  # 2. Assign Web Modeler / Web Modeler Admin / Identity roles to the demo user.
+  # 2a. Idempotently add web-modeler-api audience mapper to c8-client (M2M test client).
+  #     The API test suite authenticates as c8-client; its JWT must carry aud=web-modeler-api
+  #     so the restapi's resource-server security accepts it for /v2/* endpoints.
+  local c8_client_uuid
+  c8_client_uuid=$(curl -sf -H "Authorization: Bearer ${admin_token}" \
+    "${realm_url}/clients?clientId=c8-client" \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); print(d[0]['id'] if d else '')")
+  if [ -n "$c8_client_uuid" ]; then
+    local already_has_mapper
+    already_has_mapper=$(curl -sf -H "Authorization: Bearer ${admin_token}" \
+      "${realm_url}/clients/${c8_client_uuid}/protocol-mappers/models" \
+      | python3 -c "
+import sys,json
+for m in json.load(sys.stdin):
+    if m.get('config',{}).get('included.client.audience') == 'web-modeler-api':
+        print('yes'); break
+") || true
+    if [ "${already_has_mapper:-}" != "yes" ]; then
+      curl -sf -X POST \
+        -H "Authorization: Bearer ${admin_token}" \
+        -H "Content-Type: application/json" \
+        "${realm_url}/clients/${c8_client_uuid}/protocol-mappers/models" \
+        -d '{
+          "name": "web-modeler-api Audience Mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "web-modeler-api",
+            "access.token.claim": "true",
+            "id.token.claim": "false"
+          }
+        }' > /dev/null
+      echo "Keycloak: added web-modeler-api audience mapper to c8-client"
+    else
+      echo "Keycloak: c8-client already has web-modeler-api audience mapper (skipped)"
+    fi
+  fi
+
+  # 2b. Assign Web Modeler / Web Modeler Admin / Identity roles to the demo user.
   #    Identity creates the roles but does not assign them to seeded users.
   local demo_user_id
   demo_user_id=$(curl -sf -H "Authorization: Bearer ${admin_token}" \
@@ -155,6 +228,7 @@ case "${1:-start}" in
     fi
     echo "Starting Hub infrastructure..."
     docker compose -f "$COMPOSE_FILE" up -d
+    sync_frontend_deps
     fix_keycloak
     echo "Starting Hub app (restapi + frontend)..."
     cd "$HUB_REPO"
@@ -174,7 +248,8 @@ case "${1:-start}" in
       echo "Error: Hub app exited immediately. Check $LOG_FILE for details."
       exit 1
     fi
-    echo "Hub app started (PID $MAKE_PID). Logs: $LOG_FILE"
+    echo "Hub app starting (PID $MAKE_PID). Logs: $LOG_FILE"
+    wait_for_ready
     echo "Run './docker/start-hub.sh stop' to stop."
     ;;
   stop)
@@ -205,8 +280,33 @@ case "${1:-start}" in
     echo "Stopping Hub infrastructure..."
     docker compose -f "$COMPOSE_FILE" down
     ;;
+  status)
+    hub_ui_port="${HUB_UI_PORT:-8088}"
+    echo "=== Hub status ==="
+    if [ -f "$PID_FILE" ]; then
+      MAKE_PID=$(cat "$PID_FILE")
+      if kill -0 "$MAKE_PID" 2>/dev/null; then
+        echo "App process : running (PID $MAKE_PID)"
+      else
+        echo "App process : stopped (stale PID file — run start)"
+      fi
+    else
+      echo "App process : no PID file (not started via this script)"
+    fi
+    if curl -sf -o /dev/null "http://localhost:${hub_ui_port}/login" 2>/dev/null; then
+      echo "Hub UI      : http://localhost:${hub_ui_port}  ✓ responding"
+    else
+      echo "Hub UI      : http://localhost:${hub_ui_port}  ✗ not responding"
+    fi
+    if curl -sf -o /dev/null "http://localhost:${KEYCLOAK_PORT:-18080}/auth/" 2>/dev/null; then
+      echo "Keycloak    : http://localhost:${KEYCLOAK_PORT:-18080}  ✓ responding"
+    else
+      echo "Keycloak    : http://localhost:${KEYCLOAK_PORT:-18080}  ✗ not responding"
+    fi
+    echo "Logs        : $LOG_FILE"
+    ;;
   *)
-    echo "Usage: ./docker/start-hub.sh [start|stop]"
+    echo "Usage: ./docker/start-hub.sh [start|stop|status]"
     exit 1
     ;;
 esac

--- a/docker/start-hub.sh
+++ b/docker/start-hub.sh
@@ -8,7 +8,8 @@
 # Environment variables (all optional):
 #   HUB_UI_PORT      Frontend port (default: 8088)
 #   KEYCLOAK_PORT    Keycloak port (default: 18080)
-#   JAVA_HOME        Must point to a JDK 21+ installation
+#   JAVA_HOME        JDK matching camunda-hub/.tool-versions (currently Java 25).
+#                    Auto-selected from ~/.asdf if unset; validated before build.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -34,8 +35,38 @@ check_start_preconditions() {
     echo "Clone it as a sibling directory: git clone git@github.com:camunda/camunda-hub.git ../camunda-hub"
     exit 1
   fi
+  ensure_jdk
+}
+
+# The Hub restapi build targets a specific JDK (maven.compiler.release). Rather
+# than hardcode it, read camunda-hub's asdf pin (.tool-versions) so this never
+# drifts, auto-select that JDK from ~/.asdf when JAVA_HOME is unset, and fail
+# fast on a version mismatch — instead of a cryptic Maven "release version N not
+# supported" several minutes into the build.
+ensure_jdk() {
+  local tv="$HUB_REPO/.tool-versions"
+  local pin="" required=21
+  if [ -f "$tv" ]; then
+    pin="$(awk '$1=="java"{print $2}' "$tv")"          # e.g. openjdk-25.0.1
+    local m; m="$(printf '%s' "$pin" | grep -oE '[0-9]+' | head -1)"
+    [ -n "$m" ] && required="$m"
+  fi
+  # Auto-select the asdf-pinned JDK if JAVA_HOME isn't already set.
+  if [ -z "${JAVA_HOME:-}" ] && [ -n "$pin" ] && [ -d "$HOME/.asdf/installs/java/$pin" ]; then
+    export JAVA_HOME="$HOME/.asdf/installs/java/$pin"
+    echo "JAVA_HOME not set — using camunda-hub's pinned JDK: $JAVA_HOME"
+  fi
   if [ -z "${JAVA_HOME:-}" ]; then
-    echo "Error: JAVA_HOME is not set. Set it to a JDK 21+ installation before running this script."
+    echo "Error: JAVA_HOME is not set and the pinned JDK was not found."
+    echo "  The restapi build needs JDK ${required} (camunda-hub/.tool-versions: java ${pin:-openjdk-${required}.x})."
+    [ -n "$pin" ] && echo "  e.g. export JAVA_HOME=\"\$HOME/.asdf/installs/java/${pin}\""
+    exit 1
+  fi
+  local actual; actual="$("$JAVA_HOME/bin/java" -version 2>&1 | head -1 | grep -oE '[0-9]+' | head -1)"
+  if [ -z "$actual" ] || [ "$actual" -lt "$required" ]; then
+    echo "Error: JAVA_HOME points to Java ${actual:-?}, but the Hub restapi build needs Java ${required}+"
+    echo "  (maven.compiler.release=${required}; camunda-hub/.tool-versions pins java ${pin:-openjdk-${required}.x})."
+    [ -n "$pin" ] && echo "  export JAVA_HOME=\"\$HOME/.asdf/installs/java/${pin}\""
     exit 1
   fi
 }

--- a/materializer/src/index.ts
+++ b/materializer/src/index.ts
@@ -521,7 +521,9 @@ async function runForTarget(emitter: EmitterStrategy, env: TargetRunEnv): Promis
     const recordResponses =
       typeof emitterConfig.recordResponses === 'boolean' ? emitterConfig.recordResponses : false;
     const excludeSupportFiles = recordResponses ? undefined : ['recorder.ts'];
-    await materializeSupport(outDir, undefined, excludeSupportFiles);
+    const defaultBaseUrl =
+      typeof emitterConfig.defaultBaseUrl === 'string' ? emitterConfig.defaultBaseUrl : undefined;
+    await materializeSupport(outDir, undefined, excludeSupportFiles, { defaultBaseUrl });
     // Lift 12 / #231: load per-role bundles. Vendoring the role helper
     // files into <outDir>/support/ is deferred until after the role-hook
     // loop below populates `roleExtras` — templated helpers

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -166,6 +166,11 @@ export const PlaywrightEmitter: EmitterStrategy = {
         description:
           'When true, every emitted scenario step appends a recordResponse({...}) call and the suite imports recordResponse/sanitizeBody from ./support/recorder. Defaults to false; recorder.ts is also vendored conditionally.',
       },
+      defaultBaseUrl: {
+        type: 'string',
+        description:
+          'Default base URL baked into support/env.ts at codegen time. Used as the fallback when API_BASE_URL is not set at runtime. Overrides the generic http://localhost:8080/v2 default for configs whose server is not at that address.',
+      },
     },
   },
   async scaffold(_ctx: EmitContext): Promise<EmittedFile[]> {

--- a/materializer/src/playwright/materialize-support.ts
+++ b/materializer/src/playwright/materialize-support.ts
@@ -166,15 +166,23 @@ export async function materializeSupport(
   //
   // env.ts is rendered via Mustache so per-config options (e.g. defaultBaseUrl)
   // can be baked in at codegen time rather than threaded through every suite.
-  // Resolve defaultBaseUrl with `??` rather than spreading `templateView` over the
-  // fallback: callers pass `{ defaultBaseUrl: undefined }` when the config omits
-  // the field, and a plain spread would overwrite the fallback with `undefined` →
-  // Mustache renders `{{{defaultBaseUrl}}}` as '' → buildBaseUrl() returns '' when
-  // API_BASE_URL is unset.
-  const envView = {
-    ...templateView,
-    defaultBaseUrl: templateView?.defaultBaseUrl ?? 'http://localhost:8080/v2',
-  };
+  //
+  // Resolve with `??` (a plain spread would let `{ defaultBaseUrl: undefined }`
+  // from the omitted-config path overwrite the fallback → '' → buildBaseUrl()
+  // returns '' when API_BASE_URL is unset).
+  //
+  // env.ts interpolates the value INSIDE a single-quoted TS string literal
+  // (`'{{{defaultBaseUrl}}}'`); the quotes stay because the template is itself
+  // typechecked by the materializer build, so we can't drop to a bare
+  // JSON literal. Escape for that single-quoted context so a value containing a
+  // quote / backslash / newline can't emit invalid TS or inject code.
+  const rawBaseUrl = templateView?.defaultBaseUrl ?? 'http://localhost:8080/v2';
+  const defaultBaseUrl = rawBaseUrl
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n');
+  const envView = { ...templateView, defaultBaseUrl };
   for (const name of SUPPORT_TEMPLATE_FILES) {
     const dest = path.join(destDir, name);
     if (exclude.has(name)) {

--- a/materializer/src/playwright/materialize-support.ts
+++ b/materializer/src/playwright/materialize-support.ts
@@ -131,12 +131,19 @@ function defaultProjectTemplatesDir(): string {
  *                            is also removed, so re-running the materializer
  *                            over an existing suite cannot leave a stale
  *                            helper behind.
+ * @param templateView        Optional Mustache view applied when rendering
+ *                            `env.ts`. Supported keys:
+ *                            - `defaultBaseUrl`: overrides the fallback URL
+ *                              that `buildBaseUrl()` returns when `API_BASE_URL`
+ *                              is not set. When absent, falls back to
+ *                              `http://localhost:8080/v2`.
  * @returns                   Path to the support directory under `outDir`.
  */
 export async function materializeSupport(
   outDir: string,
   templatesDir?: string,
   excludeSupportFiles?: readonly string[],
+  templateView?: { defaultBaseUrl?: string },
 ): Promise<string> {
   const srcDir = templatesDir ?? defaultTemplatesDir();
   const destDir = path.join(outDir, SUPPORT_DIR_NAME);
@@ -156,13 +163,22 @@ export async function materializeSupport(
   // For excluded names, actively remove any pre-existing destination file
   // so a previous run with the helper enabled does not leave a stale copy
   // behind. `fs.rm({ force: true })` is a no-op when the file is absent.
+  //
+  // env.ts is rendered via Mustache so per-config options (e.g. defaultBaseUrl)
+  // can be baked in at codegen time rather than threaded through every suite.
+  const envView = { defaultBaseUrl: 'http://localhost:8080/v2', ...templateView };
   for (const name of SUPPORT_TEMPLATE_FILES) {
     const dest = path.join(destDir, name);
     if (exclude.has(name)) {
       await fs.rm(dest, { force: true });
       continue;
     }
-    await fs.copyFile(path.join(srcDir, name), dest);
+    if (name === 'env.ts') {
+      const src = await fs.readFile(path.join(srcDir, name), 'utf8');
+      await fs.writeFile(dest, Mustache.render(src, envView), 'utf8');
+    } else {
+      await fs.copyFile(path.join(srcDir, name), dest);
+    }
   }
 
   return destDir;

--- a/materializer/src/playwright/materialize-support.ts
+++ b/materializer/src/playwright/materialize-support.ts
@@ -166,7 +166,15 @@ export async function materializeSupport(
   //
   // env.ts is rendered via Mustache so per-config options (e.g. defaultBaseUrl)
   // can be baked in at codegen time rather than threaded through every suite.
-  const envView = { defaultBaseUrl: 'http://localhost:8080/v2', ...templateView };
+  // Resolve defaultBaseUrl with `??` rather than spreading `templateView` over the
+  // fallback: callers pass `{ defaultBaseUrl: undefined }` when the config omits
+  // the field, and a plain spread would overwrite the fallback with `undefined` →
+  // Mustache renders `{{{defaultBaseUrl}}}` as '' → buildBaseUrl() returns '' when
+  // API_BASE_URL is unset.
+  const envView = {
+    ...templateView,
+    defaultBaseUrl: templateView?.defaultBaseUrl ?? 'http://localhost:8080/v2',
+  };
   for (const name of SUPPORT_TEMPLATE_FILES) {
     const dest = path.join(destDir, name);
     if (exclude.has(name)) {

--- a/materializer/src/playwright/materialize-support.ts
+++ b/materializer/src/playwright/materialize-support.ts
@@ -181,7 +181,11 @@ export async function materializeSupport(
     .replace(/\\/g, '\\\\')
     .replace(/'/g, "\\'")
     .replace(/\r/g, '\\r')
-    .replace(/\n/g, '\\n');
+    .replace(/\n/g, '\\n')
+    // U+2028/U+2029 are JS/TS line terminators too — escape them so they can't
+    // break the single-quoted string literal even though \r/\n are handled.
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
   const envView = { ...templateView, defaultBaseUrl };
   for (const name of SUPPORT_TEMPLATE_FILES) {
     const dest = path.join(destDir, name);

--- a/materializer/src/playwright/support/env.ts
+++ b/materializer/src/playwright/support/env.ts
@@ -4,7 +4,10 @@ export function buildBaseUrl(): string {
 
 export async function authHeaders(): Promise<Record<string, string>> {
   // Do not set Content-Type here; request options (data vs multipart) will determine it.
-  const token = process.env.BEARER_TOKEN;
+  // Trim: a BEARER_TOKEN pasted from a .env file or terminal often carries a
+  // trailing newline / surrounding whitespace, which would otherwise emit an
+  // invalid `Authorization: Bearer <token>\n` header.
+  const token = process.env.BEARER_TOKEN?.trim();
   if (token) {
     return { Authorization: `Bearer ${token}` };
   }

--- a/materializer/src/playwright/support/env.ts
+++ b/materializer/src/playwright/support/env.ts
@@ -1,9 +1,12 @@
 export function buildBaseUrl(): string {
-  return process.env.API_BASE_URL || 'http://localhost:8080/v2';
+  return process.env.API_BASE_URL || '{{{defaultBaseUrl}}}';
 }
 
 export async function authHeaders(): Promise<Record<string, string>> {
-  // Local server requires empty headers (no Authorization)
   // Do not set Content-Type here; request options (data vs multipart) will determine it.
+  const token = process.env.BEARER_TOKEN;
+  if (token) {
+    return { Authorization: `Bearer ${token}` };
+  }
   return {};
 }

--- a/tests/codegen/materialize-support.test.ts
+++ b/tests/codegen/materialize-support.test.ts
@@ -124,6 +124,44 @@ describe('materializeSupport', () => {
       await fs.rm(fakeSrc, { recursive: true, force: true });
     }
   });
+
+  // The env.ts template interpolates defaultBaseUrl via Mustache; these guard the
+  // rendered output (PR #398 review): no unresolved marker, correct fallback,
+  // and injection-safe escaping inside the single-quoted TS literal.
+  const readEnv = async () => fs.readFile(path.join(tmp, SUPPORT_DIR_NAME, 'env.ts'), 'utf8');
+
+  test('env.ts renders the built-in fallback URL when no defaultBaseUrl is given', async () => {
+    await materializeSupport(tmp);
+    const env = await readEnv();
+    expect(env).not.toContain('{{{'); // no unresolved Mustache marker
+    expect(env).toContain("'http://localhost:8080/v2'");
+  });
+
+  test('env.ts falls back when templateView passes defaultBaseUrl: undefined', async () => {
+    await materializeSupport(tmp, undefined, undefined, { defaultBaseUrl: undefined });
+    const env = await readEnv();
+    expect(env).not.toContain('{{{');
+    expect(env).toContain("'http://localhost:8080/v2'");
+  });
+
+  test('env.ts bakes in a provided per-config defaultBaseUrl', async () => {
+    await materializeSupport(tmp, undefined, undefined, {
+      defaultBaseUrl: 'http://localhost:8088/api/v2',
+    });
+    const env = await readEnv();
+    expect(env).not.toContain('{{{');
+    expect(env).toContain("'http://localhost:8088/api/v2'");
+  });
+
+  test("env.ts escapes a defaultBaseUrl containing a single quote (can't break the TS literal)", async () => {
+    await materializeSupport(tmp, undefined, undefined, {
+      defaultBaseUrl: "http://x/v2'; throw new Error('x'); //",
+    });
+    const env = await readEnv();
+    // the single quote is escaped, so the string literal stays intact
+    expect(env).toContain("\\'");
+    expect(env).not.toContain("'http://x/v2'; throw"); // no un-escaped break-out
+  });
 });
 
 describe('loadProjectScaffoldingFiles (#233 Step 7)', () => {

--- a/tests/codegen/materialize-support.test.ts
+++ b/tests/codegen/materialize-support.test.ts
@@ -162,6 +162,17 @@ describe('materializeSupport', () => {
     expect(env).toContain("\\'");
     expect(env).not.toContain("'http://x/v2'; throw"); // no un-escaped break-out
   });
+
+  test('env.ts escapes U+2028/U+2029 line separators (no raw terminator in the literal)', async () => {
+    await materializeSupport(tmp, undefined, undefined, {
+      defaultBaseUrl: 'http://x/v2\u2028\u2029',
+    });
+    const env = await readEnv();
+    expect(env).toContain('\\u2028');
+    expect(env).toContain('\\u2029');
+    expect(env).not.toContain('\u2028'); // not emitted raw
+    expect(env).not.toContain('\u2029');
+  });
 });
 
 describe('positive-suite support env.ts authHeaders() (#398)', () => {
@@ -183,6 +194,18 @@ describe('positive-suite support env.ts authHeaders() (#398)', () => {
   });
 
   test('returns no auth header when BEARER_TOKEN is unset', async () => {
+    const { authHeaders } = await import('../../materializer/src/playwright/support/env.ts');
+    expect(await authHeaders()).toEqual({});
+  });
+
+  test('trims surrounding whitespace/newlines from BEARER_TOKEN', async () => {
+    process.env[KEY] = '  tok-123\n';
+    const { authHeaders } = await import('../../materializer/src/playwright/support/env.ts');
+    expect(await authHeaders()).toEqual({ Authorization: 'Bearer tok-123' });
+  });
+
+  test('treats a whitespace-only BEARER_TOKEN as unset', async () => {
+    process.env[KEY] = '   \n';
     const { authHeaders } = await import('../../materializer/src/playwright/support/env.ts');
     expect(await authHeaders()).toEqual({});
   });

--- a/tests/codegen/materialize-support.test.ts
+++ b/tests/codegen/materialize-support.test.ts
@@ -164,6 +164,30 @@ describe('materializeSupport', () => {
   });
 });
 
+describe('positive-suite support env.ts authHeaders() (#398)', () => {
+  const KEY = 'BEARER_TOKEN';
+  let saved: string | undefined;
+  beforeEach(() => {
+    saved = process.env[KEY];
+    delete process.env[KEY];
+  });
+  afterEach(() => {
+    if (saved === undefined) delete process.env[KEY];
+    else process.env[KEY] = saved;
+  });
+
+  test('returns a Bearer header when BEARER_TOKEN is set', async () => {
+    process.env[KEY] = 'tok-123';
+    const { authHeaders } = await import('../../materializer/src/playwright/support/env.ts');
+    expect(await authHeaders()).toEqual({ Authorization: 'Bearer tok-123' });
+  });
+
+  test('returns no auth header when BEARER_TOKEN is unset', async () => {
+    const { authHeaders } = await import('../../materializer/src/playwright/support/env.ts');
+    expect(await authHeaders()).toEqual({});
+  });
+});
+
 describe('loadProjectScaffoldingFiles (#233 Step 7)', () => {
   test('returns all PROJECT_TEMPLATE_FILES as in-memory EmittedFiles in declaration order', async () => {
     const files = await loadProjectScaffoldingFiles();


### PR DESCRIPTION
## What

Enables the generated **camunda-hub positive (lifecycle) suite to run against a live Hub** — a follow-up to #393 (which enabled positive *generation*). Separate from #396 (generator-logic fixes); this is runtime/support wiring plus `start-hub.sh` hardening.

## Changes

**Positive-suite runtime (materializer + config)**
- **`materializer/.../support/env.ts`** — send `Authorization: Bearer ${BEARER_TOKEN}` when set (Hub is Bearer-auth; the suite previously sent none), with the token **trimmed** (a pasted trailing newline/whitespace would corrupt the header). Base URL read from a templated per-config `defaultBaseUrl`.
- **`materializer/src/index.ts`, `.../materialize-support.ts`, `.../emitter.ts`** — thread a per-config `defaultBaseUrl` (`configs/<config>/codegen/playwright/config.json`) into the vendored `env.ts` and declare it in the emitter config schema. The value is **escaped** for the single-quoted TS literal (backslash, quote, CR, LF, U+2028/U+2029) and resolved with `??` so an absent config can't blank it.
- **`configs/camunda-hub/codegen/playwright/config.json`** — `defaultBaseUrl: http://localhost:8088/api/v2`.

**`docker/start-hub.sh` robustness**
- **JDK guard** — reads the required Java major from `camunda-hub/.tool-versions`, **auto-selects** `~/.asdf/installs/java/<pin>` when `JAVA_HOME` is unset, and **validates the version before building**, failing fast with the exact `export` command (the restapi build targets Java 25; previously a wrong JDK only surfaced ~4 min in as a cryptic Maven error).
- `status` subcommand; frontend dep sync (`npm ci`, surfaces failures instead of swallowing them); **UI readiness poll** (configurable via `HUB_READY_ATTEMPTS`, ~8 min default — a cold restapi+frontend build exceeds 3 min); Keycloak audience-mapper for the public-API M2M token.
- On a setup/readiness failure, **tears the stack down** (reusing the `stop` path, via an absolute script path) rather than leaving a half-started environment.

**Docs & tests**
- **`README.md`** — `start-hub.sh status` + readiness behaviour.
- **`tests/codegen/materialize-support.test.ts`** — regression coverage: `env.ts` render (fallback, baked URL, no unresolved Mustache marker, quote/U+2028 escaping) and `authHeaders()` Bearer + trim.

## Isolation (OCA unaffected)

`defaultBaseUrl` is resolved **per active config**. OCA's own `config.json` declares none, so it keeps the built-in fallback (`http://localhost:8080/v2`). `API_BASE_URL` still overrides at runtime for any config.

## Validation

- `tsc` + `lint` clean; codegen + OCA `regression-invariants` suites pass (the 2 `ontology-roundtrip` failures are pre-existing/env); `shellcheck` clean on `start-hub.sh`.
- **Full `stop → start` cycle** exercised end-to-end against a live Hub with `JAVA_HOME` **unset**: clean teardown → JDK auto-selected (`openjdk-25.0.1`) → **`BUILD SUCCESS`** → UI `200` → `POST /v2/projects/search → 200`.
- Live positive suite reaches **21/41** (remaining failures are camunda-hub#25302 and the seed-format gap #397 — both out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
