### PR TITLE
fix(codegen): emit format-valid literals for format-constrained scalars (#397)

### DIFF
--- a/materializer/src/playwright/support/env.ts
+++ b/materializer/src/playwright/support/env.ts
@@ -3,7 +3,8 @@ export function buildBaseUrl(): string {
 }
 
 export async function authHeaders(): Promise<Record<string, string>> {
-  // Local server requires empty headers (no Authorization)
   // Do not set Content-Type here; request options (data vs multipart) will determine it.
+  const bearer = process.env.BEARER_TOKEN;
+  if (bearer) return { Authorization: `Bearer ${bearer}` };
   return {};
 }

--- a/materializer/src/playwright/support/seed-rules.json
+++ b/materializer/src/playwright/support/seed-rules.json
@@ -3,6 +3,7 @@
     { "match": "/(correlation)/i", "template": "corr-${runId}-${counter:corr}-${rand:4}" },
     { "match": "/(key|id)$/i", "template": "${var}-${runId}-${counter:id}-${rand:6}" },
     { "match": "/name/i", "template": "${var}-${rand:8}" },
+    { "match": "/(email)/i", "template": "seed-${rand:6}@example.com" },
     { "match": "*", "template": "${var}-${rand:6}" }
   ]
 }

--- a/path-analyser/playwright.config.ts
+++ b/path-analyser/playwright.config.ts
@@ -16,5 +16,10 @@ export default defineConfig({
     // Base APIRequestContext is provided by Playwright's test fixture
     extraHTTPHeaders: {},
   },
-  reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
+  reporter: [
+    ['list'],
+    // outputFolder honours PLAYWRIGHT_HTML_REPORT so callers (e.g. scripts/e2e/run-hub.sh)
+    // can redirect the report to a per-config location; defaults to playwright-report/.
+    ['html', { open: 'never', outputFolder: process.env.PLAYWRIGHT_HTML_REPORT ?? 'playwright-report' }],
+  ],
 });

--- a/path-analyser/playwright.config.ts
+++ b/path-analyser/playwright.config.ts
@@ -9,6 +9,10 @@ const __dirname = dirname(__filename);
 // generated/<config>/playwright at the repo root.
 const repoRoot = resolve(__dirname, '..');
 
+// outputFolder honours PLAYWRIGHT_HTML_REPORT so callers (e.g. scripts/e2e/run-hub.sh)
+// can redirect the report to a per-config location; defaults to playwright-report/.
+const htmlOutputFolder = process.env.PLAYWRIGHT_HTML_REPORT ?? 'playwright-report';
+
 export default defineConfig({
   testDir: getPlaywrightSuiteDir(repoRoot),
   timeout: 60_000,
@@ -16,10 +20,5 @@ export default defineConfig({
     // Base APIRequestContext is provided by Playwright's test fixture
     extraHTTPHeaders: {},
   },
-  reporter: [
-    ['list'],
-    // outputFolder honours PLAYWRIGHT_HTML_REPORT so callers (e.g. scripts/e2e/run-hub.sh)
-    // can redirect the report to a per-config location; defaults to playwright-report/.
-    ['html', { open: 'never', outputFolder: process.env.PLAYWRIGHT_HTML_REPORT ?? 'playwright-report' }],
-  ],
+  reporter: [['list'], ['html', { open: 'never', outputFolder: htmlOutputFolder }]],
 });

--- a/path-analyser/playwright.config.ts
+++ b/path-analyser/playwright.config.ts
@@ -16,5 +16,5 @@ export default defineConfig({
     // Base APIRequestContext is provided by Playwright's test fixture
     extraHTTPHeaders: {},
   },
-  reporter: [['list']],
+  reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
 });

--- a/path-analyser/src/canonicalSchemas.ts
+++ b/path-analyser/src/canonicalSchemas.ts
@@ -25,6 +25,13 @@ export interface CanonicalNodeMeta {
    * `['placeholder']` element (#338).
    */
   itemEnum?: unknown[];
+  /**
+   * The OpenAPI `format` keyword for this scalar leaf node (e.g. `'email'`,
+   * `'uuid'`, `'date-time'`, `'uri'`). Captured so `buildRequestBodyFromCanonical`
+   * can emit a format-valid literal instead of a generic variable seed that
+   * fails server-side format validation (#397).
+   */
+  format?: string;
 }
 
 export interface OperationCanonicalShapes {
@@ -311,6 +318,10 @@ function walkSchema(
     // of seeding a `${var}` placeholder (#338). `schema` at this point
     // is already $ref/allOf-resolved by the recursive descent above.
     const enumValues = Array.isArray(schema.enum) ? schema.enum : undefined;
+    // Capture format (e.g. `email`, `uuid`, `date-time`) so the body
+    // builder can emit a format-valid literal instead of a generic seed
+    // that fails server-side format validation (#397).
+    const format = typeof schema.format === 'string' ? schema.format : undefined;
     acc.push({
       path: pathSoFar,
       pointer,
@@ -318,6 +329,7 @@ function walkSchema(
       required,
       semanticProvider: semantic,
       enum: enumValues,
+      format,
     });
   }
 }

--- a/path-analyser/src/canonicalSchemas.ts
+++ b/path-analyser/src/canonicalSchemas.ts
@@ -28,7 +28,8 @@ export interface CanonicalNodeMeta {
   /**
    * The OpenAPI `format` keyword for this scalar leaf node (e.g. `'email'`,
    * `'uuid'`, `'date-time'`, `'uri'`). Captured so `buildRequestBodyFromCanonical`
-   * can emit a format-valid literal instead of a generic variable seed that
+   * can emit a format-valid value — an inline literal for most formats, or
+   * runtime seeding for `email` — instead of a generic variable seed that
    * fails server-side format validation (#397).
    */
   format?: string;

--- a/path-analyser/src/extractSchemas.ts
+++ b/path-analyser/src/extractSchemas.ts
@@ -272,13 +272,16 @@ function findOneOfGroups(
       const fieldTypes: Record<string, string> = {};
       const fieldEnums: Record<string, unknown[]> = {};
       const fieldItemEnums: Record<string, unknown[]> = {};
+      const fieldFormats: Record<string, string> = {};
       for (const [fname, fsch] of Object.entries(props)) {
+        const rs = resolveSchema(fsch, components);
         const ft = effectiveType(fsch, components);
         if (ft && ft !== 'unknown') fieldTypes[fname] = ft;
         const enumValues = effectiveEnum(fsch, components);
         if (enumValues && enumValues.length > 0) fieldEnums[fname] = enumValues;
+        if (rs.format) fieldFormats[fname] = rs.format;
         if (ft === 'array') {
-          const itemSchema = resolveSchema(fsch, components).items;
+          const itemSchema = rs.items;
           if (itemSchema) {
             const itemEnum = effectiveEnum(itemSchema, components);
             if (itemEnum && itemEnum.length > 0) fieldItemEnums[fname] = itemEnum;
@@ -303,6 +306,7 @@ function findOneOfGroups(
         fieldTypes,
         fieldEnums: Object.keys(fieldEnums).length > 0 ? fieldEnums : undefined,
         fieldItemEnums: Object.keys(fieldItemEnums).length > 0 ? fieldItemEnums : undefined,
+        fieldFormats: Object.keys(fieldFormats).length > 0 ? fieldFormats : undefined,
         discriminator,
       };
     });

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1357,9 +1357,12 @@ function buildRequestBodyFromCanonical(
               template[name] = [synthesizeArrayElement(name, nodes)];
             }
           } else {
-            // #397 — check canonical node format before falling back to seed.
+            // #397 — for format-constrained scalars, emit a format-valid literal
+            // rather than a generic ${varName} seed that would fail server validation.
+            // Exception: email uses runtime seeding (seed rule: seed-<salt>@example.com)
+            // so values vary per call and unique-binding constraints can apply.
             const nodeFormat = nodes.find((n) => n.path === name)?.format;
-            const fmtLiteral = nodeFormat ? formatSeedLiteral(nodeFormat) : undefined;
+            const fmtLiteral = (nodeFormat && nodeFormat !== 'email') ? formatSeedLiteral(nodeFormat) : undefined;
             if (fmtLiteral !== undefined) {
               template[name] = fmtLiteral;
             } else {
@@ -1436,10 +1439,11 @@ function buildRequestBodyFromCanonical(
             template[leaf] = [synthesizeArrayElement(basePath, nodes)];
           }
         } else {
-          // #397 — for format-constrained scalars, embed a format-valid
-          // literal (e.g. format:email → "seed@example.com") so the body
-          // passes server-side format validation. No runtime binding needed.
-          const fmtLiteral = f.format ? formatSeedLiteral(f.format) : undefined;
+          // #397 — for format-constrained scalars, embed a format-valid literal
+          // so the body passes server-side format validation.
+          // Exception: email uses runtime seeding (seed rule: seed-<salt>@example.com)
+          // so values vary per call and unique-binding constraints can apply.
+          const fmtLiteral = (f.format && f.format !== 'email') ? formatSeedLiteral(f.format) : undefined;
           if (fmtLiteral !== undefined) {
             template[leaf] = fmtLiteral;
           } else {

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1365,7 +1365,8 @@ function buildRequestBodyFromCanonical(
             // so values vary per call and unique-binding constraints can apply.
             const nodeFormat =
               nodes.find((n) => n.path === name)?.format ?? chosenVariant?.fieldFormats?.[name];
-            const fmtLiteral = (nodeFormat && nodeFormat !== 'email') ? formatSeedLiteral(nodeFormat) : undefined;
+            const fmtLiteral =
+              nodeFormat && nodeFormat !== 'email' ? formatSeedLiteral(nodeFormat) : undefined;
             if (fmtLiteral !== undefined) {
               template[name] = fmtLiteral;
             } else {
@@ -1446,7 +1447,8 @@ function buildRequestBodyFromCanonical(
           // so the body passes server-side format validation.
           // Exception: email uses runtime seeding (seed rule: seed-<salt>@example.com)
           // so values vary per call and unique-binding constraints can apply.
-          const fmtLiteral = (f.format && f.format !== 'email') ? formatSeedLiteral(f.format) : undefined;
+          const fmtLiteral =
+            f.format && f.format !== 'email' ? formatSeedLiteral(f.format) : undefined;
           if (fmtLiteral !== undefined) {
             template[leaf] = fmtLiteral;
           } else {

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1173,6 +1173,13 @@ function synthesizeObjectFromPrefix(
     } else {
       // #397 — for format-constrained scalars, emit a format-valid literal
       // instead of 'placeholder' which fails server-side format validation.
+      // Unlike the top-level body branches, nested-object synthesis has no
+      // scenario.bindings context here, so it cannot route through runtime
+      // seeding — email therefore gets the fixed `seed@example.com` literal
+      // rather than the per-call `${emailVar}` seed. A nested required-and-
+      // unique email field could collide; no such field exists in the current
+      // specs, and the fixed literal is still strictly better than the old
+      // invalid 'placeholder'.
       obj[inner] = (n.format && formatSeedLiteral(n.format)) ?? 'placeholder';
     }
   }

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1320,7 +1320,6 @@ function buildRequestBodyFromCanonical(
   // Build template
   if (chosenCt === 'application/json') {
     const template: Record<string, unknown> = {};
-    const missing: string[] = [];
     if (requestGroups.length) {
       // oneOf-aware synthesis
       if (chosenVariantRequired?.length) {
@@ -1386,7 +1385,6 @@ function buildRequestBodyFromCanonical(
               scenario.bindings ||= {};
               if (!scenario.bindings[varName]) scenario.bindings[varName] = PENDING_BINDING;
               template[name] = `${'${'}${varName}}`;
-              if (!bindingMap[mappedName]) missing.push(name);
             }
           }
         }
@@ -1468,7 +1466,6 @@ function buildRequestBodyFromCanonical(
             scenario.bindings ||= {};
             if (!scenario.bindings[varName]) scenario.bindings[varName] = PENDING_BINDING;
             template[leaf] = `${'${'}${varName}}`;
-            if (!bindingMap[normalizedPath]) missing.push(normalizedPath);
           }
         }
       }

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1125,6 +1125,12 @@ type CanonicalNode = {
  * Map OpenAPI `format` keywords to format-valid seed literals (#397).
  * Returns `undefined` for formats that don't need a special literal (they
  * can safely fall through to the generic `${varName}` seed).
+ *
+ * Note on `email`: this returns a literal, but the top-level request-body
+ * branches deliberately do NOT call it for email — they route email through
+ * runtime seeding (the `seed-rules.json` rule) so addresses vary per call and
+ * `{ unique: true }` bindings still apply. The email literal here is used only
+ * by `synthesizeObjectFromPrefix`, where there is no binding context.
  */
 function formatSeedLiteral(format: string): string | undefined {
   switch (format) {

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1359,9 +1359,12 @@ function buildRequestBodyFromCanonical(
           } else {
             // #397 — for format-constrained scalars, emit a format-valid literal
             // rather than a generic ${varName} seed that would fail server validation.
+            // Canonical nodes don't descend oneOf variants, so fall back to the
+            // variant's own fieldFormats when the canonical lookup returns nothing.
             // Exception: email uses runtime seeding (seed rule: seed-<salt>@example.com)
             // so values vary per call and unique-binding constraints can apply.
-            const nodeFormat = nodes.find((n) => n.path === name)?.format;
+            const nodeFormat =
+              nodes.find((n) => n.path === name)?.format ?? chosenVariant?.fieldFormats?.[name];
             const fmtLiteral = (nodeFormat && nodeFormat !== 'email') ? formatSeedLiteral(nodeFormat) : undefined;
             if (fmtLiteral !== undefined) {
               template[name] = fmtLiteral;

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1357,10 +1357,17 @@ function buildRequestBodyFromCanonical(
               template[name] = [synthesizeArrayElement(name, nodes)];
             }
           } else {
-            scenario.bindings ||= {};
-            if (!scenario.bindings[varName]) scenario.bindings[varName] = PENDING_BINDING;
-            template[name] = `${'${'}${varName}}`;
-            if (!bindingMap[mappedName]) missing.push(name);
+            // #397 — check canonical node format before falling back to seed.
+            const nodeFormat = nodes.find((n) => n.path === name)?.format;
+            const fmtLiteral = nodeFormat ? formatSeedLiteral(nodeFormat) : undefined;
+            if (fmtLiteral !== undefined) {
+              template[name] = fmtLiteral;
+            } else {
+              scenario.bindings ||= {};
+              if (!scenario.bindings[varName]) scenario.bindings[varName] = PENDING_BINDING;
+              template[name] = `${'${'}${varName}}`;
+              if (!bindingMap[mappedName]) missing.push(name);
+            }
           }
         }
       }

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1053,7 +1053,14 @@ function camelCase(name: string) {
 type CanonicalShape = {
   requestByMediaType?: Record<
     string,
-    { path: string; type: string; required: boolean; enum?: unknown[]; itemEnum?: unknown[] }[]
+    {
+      path: string;
+      type: string;
+      required: boolean;
+      enum?: unknown[];
+      itemEnum?: unknown[];
+      format?: string;
+    }[]
   >;
 };
 
@@ -1111,7 +1118,31 @@ type CanonicalNode = {
   required: boolean;
   enum?: unknown[];
   itemEnum?: unknown[];
+  format?: string;
 };
+
+/**
+ * Map OpenAPI `format` keywords to format-valid seed literals (#397).
+ * Returns `undefined` for formats that don't need a special literal (they
+ * can safely fall through to the generic `${varName}` seed).
+ */
+function formatSeedLiteral(format: string): string | undefined {
+  switch (format) {
+    case 'email':
+      return 'seed@example.com';
+    case 'uuid':
+      return '00000000-0000-4000-8000-000000000001';
+    case 'date-time':
+      return '2024-01-01T00:00:00.000Z';
+    case 'date':
+      return '2024-01-01';
+    case 'uri':
+    case 'url':
+      return 'https://example.com';
+    default:
+      return undefined;
+  }
+}
 
 function synthesizeObjectFromPrefix(
   prefix: string,
@@ -1140,7 +1171,9 @@ function synthesizeObjectFromPrefix(
       // schema-honest.
       obj[inner] = [synthesizeArrayElement(`${prefix}${inner}`, nodes)];
     } else {
-      obj[inner] = 'placeholder';
+      // #397 — for format-constrained scalars, emit a format-valid literal
+      // instead of 'placeholder' which fails server-side format validation.
+      obj[inner] = (n.format && formatSeedLiteral(n.format)) ?? 'placeholder';
     }
   }
   return obj;
@@ -1396,10 +1429,18 @@ function buildRequestBodyFromCanonical(
             template[leaf] = [synthesizeArrayElement(basePath, nodes)];
           }
         } else {
-          scenario.bindings ||= {};
-          if (!scenario.bindings[varName]) scenario.bindings[varName] = PENDING_BINDING;
-          template[leaf] = `${'${'}${varName}}`;
-          if (!bindingMap[normalizedPath]) missing.push(normalizedPath);
+          // #397 — for format-constrained scalars, embed a format-valid
+          // literal (e.g. format:email → "seed@example.com") so the body
+          // passes server-side format validation. No runtime binding needed.
+          const fmtLiteral = f.format ? formatSeedLiteral(f.format) : undefined;
+          if (fmtLiteral !== undefined) {
+            template[leaf] = fmtLiteral;
+          } else {
+            scenario.bindings ||= {};
+            if (!scenario.bindings[varName]) scenario.bindings[varName] = PENDING_BINDING;
+            template[leaf] = `${'${'}${varName}}`;
+            if (!bindingMap[normalizedPath]) missing.push(normalizedPath);
+          }
         }
       }
       // For search-like empty-negative scenarios, allow provider-injected optional filters to drive an empty result

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -456,8 +456,10 @@ export interface RequestOneOfVariant {
   /**
    * OpenAPI `format` for scalar fields in this variant (e.g. `'email'`,
    * `'uuid'`, `'date-time'`). Used by `buildRequestBodyFromCanonical` to
-   * emit a format-valid literal for variant-only required fields whose
-   * format cannot be found in the top-level canonical nodes (#397).
+   * emit a format-valid value for variant-only required fields whose format
+   * cannot be found in the top-level canonical nodes (#397): an inline literal
+   * for most formats, or runtime seeding for `email` (so addresses vary per
+   * call — see `formatSeedLiteral`).
    */
   fieldFormats?: Record<string, string>;
   /**

--- a/path-analyser/src/types.ts
+++ b/path-analyser/src/types.ts
@@ -454,6 +454,13 @@ export interface RequestOneOfVariant {
    */
   fieldEnums?: Record<string, unknown[]>;
   /**
+   * OpenAPI `format` for scalar fields in this variant (e.g. `'email'`,
+   * `'uuid'`, `'date-time'`). Used by `buildRequestBodyFromCanonical` to
+   * emit a format-valid literal for variant-only required fields whose
+   * format cannot be found in the top-level canonical nodes (#397).
+   */
+  fieldFormats?: Record<string, string>;
+  /**
    * For `array` fields, enum values declared on the item schema (e.g.
    * `permissionTypes: { type: 'array', items: { enum: […] } }`). Used to
    * synthesise a one-element array containing an enum literal instead of

--- a/scripts/e2e/run-hub.sh
+++ b/scripts/e2e/run-hub.sh
@@ -89,7 +89,11 @@ if step run && [ -z "${SKIP_POSITIVE:-}" ]; then
   BEARER_TOKEN="$ADMIN_TOK" API_BASE_URL="$POS_URL" CONFIG="$CONFIG" \
     PLAYWRIGHT_HTML_REPORT="$OUT/pw-positive" \
     npx playwright test -c path-analyser/playwright.config.ts || true
-  echo "  ✓ positive suite report: $OUT/pw-positive/index.html"
+  if [ -f "$OUT/pw-positive/index.html" ]; then
+    echo "  ✓ positive suite report: $OUT/pw-positive/index.html"
+  else
+    echo "  ⚠ positive suite report not generated (Playwright run may have failed)"
+  fi
 fi
 
 # Playwright JSON report per request-validation profile (consumed by curl-compare)

--- a/scripts/e2e/run-hub.sh
+++ b/scripts/e2e/run-hub.sh
@@ -87,8 +87,9 @@ unset CAMUNDA_BASIC_AUTH_USER CAMUNDA_BASIC_AUTH_PASSWORD 2>/dev/null || true
 if step run && [ -z "${SKIP_POSITIVE:-}" ]; then
   echo "── run: positive lifecycle suite ────────"
   BEARER_TOKEN="$ADMIN_TOK" API_BASE_URL="$POS_URL" CONFIG="$CONFIG" \
+    PLAYWRIGHT_HTML_REPORT="$OUT/pw-positive" \
     npx playwright test -c path-analyser/playwright.config.ts || true
-  echo "  ✓ positive suite report: path-analyser/playwright-report/index.html"
+  echo "  ✓ positive suite report: $OUT/pw-positive/index.html"
 fi
 
 # Playwright JSON report per request-validation profile (consumed by curl-compare)

--- a/scripts/e2e/run-hub.sh
+++ b/scripts/e2e/run-hub.sh
@@ -87,7 +87,8 @@ unset CAMUNDA_BASIC_AUTH_USER CAMUNDA_BASIC_AUTH_PASSWORD 2>/dev/null || true
 if step run && [ -z "${SKIP_POSITIVE:-}" ]; then
   echo "── run: positive lifecycle suite ────────"
   BEARER_TOKEN="$ADMIN_TOK" API_BASE_URL="$POS_URL" CONFIG="$CONFIG" \
-    npx playwright test -c path-analyser/playwright.config.ts --reporter=list || true
+    npx playwright test -c path-analyser/playwright.config.ts || true
+  echo "  ✓ positive suite report: path-analyser/playwright-report/index.html"
 fi
 
 # Playwright JSON report per request-validation profile (consumed by curl-compare)

--- a/tests/codegen/seeding.test.ts
+++ b/tests/codegen/seeding.test.ts
@@ -111,3 +111,29 @@ describe('seeding: per-process runNonce for { unique: true } bindings (#304)', (
     expect(det).not.toBe(uniq);
   });
 });
+
+describe('seeding: format-aware seed rules (#397)', () => {
+  afterEach(() => {
+    initSpecSalt('');
+  });
+
+  test('emailVar seed is a syntactically valid email address', () => {
+    initSpecSalt('addCollaborator');
+    const val = seedBinding('emailVar');
+    expect(val).toMatch(/.+@.+\..+/);
+  });
+
+  test('email seed does not contain the literal string "emailVar"', () => {
+    initSpecSalt('addCollaborator');
+    const val = seedBinding('emailVar');
+    expect(val).not.toContain('emailVar');
+  });
+
+  test('different spec salts produce different email seeds', () => {
+    initSpecSalt('specA');
+    const valA = seedBinding('emailVar');
+    initSpecSalt('specB');
+    const valB = seedBinding('emailVar');
+    expect(valA).not.toBe(valB);
+  });
+});

--- a/tests/fixtures/planner/format-seed-literals.test.ts
+++ b/tests/fixtures/planner/format-seed-literals.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Canonical-schema format capture — camunda/api-test-generator#397.
+ *
+ * `path-analyser/src/canonicalSchemas.ts:walkSchema` captures the OpenAPI
+ * `format` keyword on leaf scalar nodes so that `buildRequestBodyFromCanonical`
+ * can emit format-valid literals (e.g. `"seed@example.com"` for `format: email`)
+ * instead of generic `${varName}` seeds that fail server-side format validation.
+ *
+ * Class-scoped invariant guarded here: a required scalar field with `format`
+ * declared in the OpenAPI spec must carry that format string on its
+ * `CanonicalNodeMeta.format` field after `buildCanonicalShapes`.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildCanonicalShapes } from '../../../path-analyser/src/canonicalSchemas.ts';
+
+interface ScratchDir {
+  root: string;
+  prevEnv: string | undefined;
+}
+
+function scratchSpec(spec: object): ScratchDir {
+  const root = mkdtempSync(join(tmpdir(), 'canonical-format-'));
+  const specPath = join(root, 'rest-api.bundle.json');
+  writeFileSync(specPath, JSON.stringify(spec));
+  const prevEnv = process.env.OPENAPI_SPEC_PATH;
+  process.env.OPENAPI_SPEC_PATH = specPath;
+  return { root, prevEnv };
+}
+
+function teardown(s: ScratchDir): void {
+  if (s.prevEnv === undefined) delete process.env.OPENAPI_SPEC_PATH;
+  else process.env.OPENAPI_SPEC_PATH = s.prevEnv;
+  rmSync(s.root, { recursive: true, force: true });
+}
+
+describe('canonicalSchemas: format keyword captured on leaf nodes (#397)', () => {
+  let scratch: ScratchDir | undefined;
+  afterEach(() => {
+    if (scratch) teardown(scratch);
+    scratch = undefined;
+  });
+
+  it('captures format: email on a required request body field', async () => {
+    scratch = scratchSpec({
+      openapi: '3.0.0',
+      info: { title: 'Test', version: '1.0.0' },
+      paths: {
+        '/workspaces/{workspaceKey}/collaborators': {
+          post: {
+            operationId: 'addCollaborator',
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    required: ['email', 'role'],
+                    properties: {
+                      email: { type: 'string', format: 'email' },
+                      role: { type: 'string', enum: ['workspace_admin', 'workspace_member'] },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+    });
+
+    const shapes = await buildCanonicalShapes(scratch.root);
+    const shape = shapes['addCollaborator'];
+    expect(shape, 'addCollaborator must be present in canonical shapes').toBeTruthy();
+
+    const nodes = shape?.requestByMediaType?.['application/json'] ?? [];
+    const emailNode = nodes.find((n) => n.path === 'email');
+    expect(emailNode, 'email field must be in canonical request nodes').toBeTruthy();
+    expect(emailNode?.format).toBe('email');
+    expect(emailNode?.required).toBe(true);
+  });
+
+  it('captures format: uuid', async () => {
+    scratch = scratchSpec({
+      openapi: '3.0.0',
+      info: { title: 'Test', version: '1.0.0' },
+      paths: {
+        '/items': {
+          post: {
+            operationId: 'createItem',
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    required: ['correlationKey'],
+                    properties: {
+                      correlationKey: { type: 'string', format: 'uuid' },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+    });
+
+    const shapes = await buildCanonicalShapes(scratch.root);
+    const nodes = shapes['createItem']?.requestByMediaType?.['application/json'] ?? [];
+    const node = nodes.find((n) => n.path === 'correlationKey');
+    expect(node?.format).toBe('uuid');
+  });
+
+  it('does not set format when the field has no format keyword', async () => {
+    scratch = scratchSpec({
+      openapi: '3.0.0',
+      info: { title: 'Test', version: '1.0.0' },
+      paths: {
+        '/items': {
+          post: {
+            operationId: 'createItem',
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    required: ['name'],
+                    properties: {
+                      name: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+    });
+
+    const shapes = await buildCanonicalShapes(scratch.root);
+    const nodes = shapes['createItem']?.requestByMediaType?.['application/json'] ?? [];
+    const node = nodes.find((n) => n.path === 'name');
+    expect(node?.format).toBeUndefined();
+  });
+});

--- a/tests/fixtures/planner/format-seed-literals.test.ts
+++ b/tests/fixtures/planner/format-seed-literals.test.ts
@@ -73,7 +73,7 @@ describe('canonicalSchemas: format keyword captured on leaf nodes (#397)', () =>
     });
 
     const shapes = await buildCanonicalShapes(scratch.root);
-    const shape = shapes['addCollaborator'];
+    const shape = shapes.addCollaborator;
     expect(shape, 'addCollaborator must be present in canonical shapes').toBeTruthy();
 
     const nodes = shape?.requestByMediaType?.['application/json'] ?? [];
@@ -112,7 +112,7 @@ describe('canonicalSchemas: format keyword captured on leaf nodes (#397)', () =>
     });
 
     const shapes = await buildCanonicalShapes(scratch.root);
-    const nodes = shapes['createItem']?.requestByMediaType?.['application/json'] ?? [];
+    const nodes = shapes.createItem?.requestByMediaType?.['application/json'] ?? [];
     const node = nodes.find((n) => n.path === 'correlationKey');
     expect(node?.format).toBe('uuid');
   });
@@ -146,7 +146,7 @@ describe('canonicalSchemas: format keyword captured on leaf nodes (#397)', () =>
     });
 
     const shapes = await buildCanonicalShapes(scratch.root);
-    const nodes = shapes['createItem']?.requestByMediaType?.['application/json'] ?? [];
+    const nodes = shapes.createItem?.requestByMediaType?.['application/json'] ?? [];
     const node = nodes.find((n) => n.path === 'name');
     expect(node?.format).toBeUndefined();
   });

--- a/tests/fixtures/planner/format-seed-literals.test.ts
+++ b/tests/fixtures/planner/format-seed-literals.test.ts
@@ -3,8 +3,11 @@
  *
  * `path-analyser/src/canonicalSchemas.ts:walkSchema` captures the OpenAPI
  * `format` keyword on leaf scalar nodes so that `buildRequestBodyFromCanonical`
- * can emit format-valid literals (e.g. `"seed@example.com"` for `format: email`)
- * instead of generic `${varName}` seeds that fail server-side format validation.
+ * can emit format-valid literals (e.g. `"00000000-0000-4000-8000-000000000001"`
+ * for `format: uuid`) instead of generic `${varName}` seeds that fail
+ * server-side format validation. `format: email` is the one exception: it is
+ * routed through the `seed-rules.json` runtime rule (`seed-${rand:6}@example.com`)
+ * so addresses vary per call and `{ unique: true }` bindings still apply.
  *
  * Class-scoped invariant guarded here: a required scalar field with `format`
  * declared in the OpenAPI spec must carry that format string on its


### PR DESCRIPTION
## Summary

- **Root cause**: `buildRequestBodyFromCanonical` generated `${emailVar}` placeholders for required scalar fields with OpenAPI `format` constraints (e.g. `format: email`). At runtime, `seedBinding('emailVar')` fell through to the wildcard rule and returned `emailVar-<salt>` — not a valid email — causing `addCollaborator` (and any other op with a format-constrained required body field) to 400 with "Request body is not readable".
- **Fix**: format-aware request-body synthesis, mirrors the enum literal fix from #338:
  1. `canonicalSchemas.ts` — capture `format` on leaf scalar nodes (alongside existing `enum` capture)
  2. `path-analyser/src/index.ts` — propagate `format` through `CanonicalNode`; in `buildRequestBodyFromCanonical` and `synthesizeObjectFromPrefix`, emit a format-valid **literal** for `uuid` / `date-time` / `date` / `uri`-`url` (`"00000000-0000-4000-8000-000000000001"`, `"2024-01-01T00:00:00.000Z"`, …). **`email` is intentionally excluded from the literal path** and routed to runtime seeding instead (see point 3), so each call gets a distinct address and `{ unique: true }` bindings still work.
  3. `seed-rules.json` — add `/(email)/i → seed-${rand:6}@example.com` so the `${emailVar}` binding resolves to a valid, unique-per-call email.
  4. oneOf variants: canonical request shapes don't descend `oneOf`, so `RequestOneOfVariant` now carries `fieldFormats`; the oneOf-aware synthesis branch consults it as a fallback so variant-only required fields (e.g. a `format: uuid` field present only inside a variant) still get a format-valid literal.

## Affected formats

| format | handling |
|---|---|
| `email` | runtime seed rule → `seed-<salt>@example.com` (unique per call) |
| `uuid` · `date-time` · `date` · `uri` / `url` | inline format-valid literal |

## Test plan

- [x] Unit tests: `seeding.test.ts` (email seed rule produces a valid, varying email); `tests/fixtures/planner/format-seed-literals.test.ts` (email + uuid format captured in canonical nodes, absent format → undefined)
- [x] All 792 tests pass (4 skipped)
- [x] Re-generate camunda-hub positive suite and verify `addCollaborator` body resolves to a valid email at runtime (via `${emailVar}` + seed rule), not the literal `emailVar-<salt>`

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)
