### PR TITLE
feat(camunda-hub): positive-suite lifecycle ontology (entity + edge) — #25264 items 2 & 3

### DIFF
--- a/.github/workflows/nightly-camunda-hub.yml
+++ b/.github/workflows/nightly-camunda-hub.yml
@@ -183,6 +183,10 @@ jobs:
       # always() steps below still capture the report + write the summary.
       - name: Generate + run negative suite
         env:
+          # run-hub.sh runs the positive suite by default (local/dev). The
+          # nightly pins it OFF: the File/Folder/Version family 403s on the
+          # unfixed camunda/camunda-hub#25302, which would red the nightly on a
+          # known upstream bug. Drop this once #25302/#25146 land.
           SKIP_POSITIVE: '1'
           STEPS: 'generate run'
           RV_PROFILES: 'secured rbac'

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ dist/
 /generated/
 external-spec/
 test-results/
+playwright-report/
+__pycache__/
 *.tsbuildinfo
 .claw/

--- a/configs/camunda-hub/fixtures/catalog/README.md
+++ b/configs/camunda-hub/fixtures/catalog/README.md
@@ -1,0 +1,18 @@
+---
+template: element-template.json
+category: Test
+tags:
+  - apitest
+  - generated
+---
+## Description
+
+Catalog asset fixture for the generated API-test positive suite. Paired with
+`element-template.json` (referenced above by file name, per the
+ingestCatalogAssets contract).
+
+## Usage
+
+Ingested by the generated `ingestCatalogAssets` positive test to exercise the
+`PUT /catalog/assets/ingestion` multipart upload. Not intended for production
+catalogs.

--- a/configs/camunda-hub/fixtures/catalog/element-template.json
+++ b/configs/camunda-hub/fixtures/catalog/element-template.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://unpkg.com/@camunda/element-templates-json-schema@0.12.0/resources/schema.json",
+  "name": "Generated Test Asset",
+  "id": "com.camunda.hub.apitest.asset",
+  "version": 1,
+  "description": "Element template fixture for the generated positive suite (ingestCatalogAssets).",
+  "appliesTo": ["bpmn:Task"],
+  "elementType": {
+    "value": "bpmn:ServiceTask"
+  },
+  "properties": [
+    {
+      "label": "Implementation",
+      "type": "Hidden",
+      "value": "=apitest",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      }
+    }
+  ]
+}

--- a/configs/camunda-hub/ontology/edges.json
+++ b/configs/camunda-hub/ontology/edges.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://camunda.github.io/api-test-generator/ns/v1/edge.schema.json",
+  "@context": {
+    "@vocab": "https://camunda.github.io/api-test-generator/ns/v1/",
+    "edges": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/edges",
+      "@container": "@set"
+    },
+    "endpoints": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/endpoints"
+    },
+    "identifiedBy": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/identifiedBy",
+      "@container": "@list"
+    },
+    "establishedBy": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/establishedBy"
+    },
+    "observableVia": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/observableVia"
+    },
+    "revokedBy": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/revokedBy"
+    }
+  },
+  "version": 1,
+  "edges": [
+    {
+      "@type": "Edge",
+      "name": "WorkspaceMemberMembership",
+      "endpoints": {
+        "from": "Workspace",
+        "to": "Member"
+      },
+      "identifiedBy": [
+        "WorkspaceKey",
+        "MemberEmail"
+      ],
+      "establishedBy": "addMember",
+      "revokedBy": "removeMember",
+      "observableVia": "searchMembers",
+      "description": "Edge between a Workspace and a Member, identified by the (workspaceKey, email) tuple. Established by addMember, observable via searchMembers (the workspace-scoped member search), revoked by removeMember."
+    }
+  ]
+}

--- a/configs/camunda-hub/ontology/entity-kinds.json
+++ b/configs/camunda-hub/ontology/entity-kinds.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://camunda.github.io/api-test-generator/ns/v1/entity-kinds.schema.json",
+  "@context": "https://camunda.github.io/api-test-generator/ns/v1/context.jsonld",
+  "version": 1,
+  "kinds": [
+    {
+      "@type": "EntityKind",
+      "name": "Workspace",
+      "shape": "entity",
+      "identifiers": ["WorkspaceKey"],
+      "establishedBy": "createWorkspace",
+      "observableVia": "getWorkspace",
+      "revokedBy": "deleteWorkspace",
+      "description": "A workspace entity, identified by its server-minted workspaceKey."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "Project",
+      "shape": "entity",
+      "identifiers": ["ProjectKey"],
+      "establishedBy": "createProject",
+      "observableVia": "getProject",
+      "revokedBy": "deleteProject",
+      "description": "A project (process application) entity, identified by its server-minted projectKey."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "Folder",
+      "shape": "entity",
+      "identifiers": ["FolderKey"],
+      "establishedBy": "createFolder",
+      "observableVia": "getFolder",
+      "revokedBy": "deleteFolder",
+      "description": "A folder entity, identified by its server-minted folderKey."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "File",
+      "shape": "entity",
+      "identifiers": ["FileKey"],
+      "establishedBy": "createFile",
+      "observableVia": "getFile",
+      "revokedBy": "deleteFile",
+      "description": "A file entity, identified by its server-minted fileKey."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "Version",
+      "shape": "entity",
+      "identifiers": ["VersionKey"],
+      "establishedBy": "createVersion",
+      "observableVia": "getVersion",
+      "revokedBy": "deleteVersion",
+      "description": "A file version entity, identified by its server-minted versionKey."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "Member",
+      "shape": "external-entity",
+      "identifiers": ["MemberEmail"],
+      "description": "A workspace member, identified by their client-supplied email address (minted outside the Hub API). Endpoint of the WorkspaceMemberMembership edge; has no in-API create/get/delete of its own."
+    }
+  ]
+}

--- a/configs/camunda-hub/ontology/scenario-templates.json
+++ b/configs/camunda-hub/ontology/scenario-templates.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://camunda.github.io/api-test-generator/ns/v1/scenario-template.schema.json",
+  "@context": {
+    "@vocab": "https://camunda.github.io/api-test-generator/ns/v1/",
+    "templates": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/templates",
+      "@container": "@set"
+    },
+    "appliesTo": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/appliesTo"
+    },
+    "steps": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/steps",
+      "@container": "@list"
+    },
+    "kind": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/kind"
+    },
+    "op": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/op"
+    },
+    "for": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/for"
+    },
+    "expect": {
+      "@id": "https://camunda.github.io/api-test-generator/ns/v1/expect"
+    }
+  },
+  "version": 1,
+  "templates": [
+    {
+      "@type": "ScenarioTemplate",
+      "name": "EntityLifecycle",
+      "appliesTo": { "kind": "Entity" },
+      "description": "Establish an entity instance (create), verify it is visible by GET-by-id (status 200), revoke it (delete), verify it is no longer visible by GET-by-id (status 404). Applies to every shape: 'entity' kind in the entity-kinds ABox; consumes establishedBy, observableVia, revokedBy.",
+      "steps": [
+        { "kind": "PrereqChain", "for": "establishedBy" },
+        { "kind": "Invoke", "op": "establishedBy" },
+        { "kind": "Observe", "op": "observableVia", "expect": "present" },
+        { "kind": "Invoke", "op": "revokedBy" },
+        { "kind": "Observe", "op": "observableVia", "expect": "absent" }
+      ]
+    },
+    {
+      "@type": "ScenarioTemplate",
+      "name": "EdgeLifecycle",
+      "appliesTo": { "kind": "Edge" },
+      "description": "Establish an edge instance, verify it is observable via the edge's observableVia operation, revoke the edge instance, verify it is no longer observable. Applies to every edge in the edges ABox; consumes establishedBy, revokedBy, and observableVia.",
+      "steps": [
+        { "kind": "PrereqChain", "for": "establishedBy" },
+        { "kind": "Invoke", "op": "establishedBy" },
+        { "kind": "Observe", "op": "observableVia", "expect": "present" },
+        { "kind": "Invoke", "op": "revokedBy" },
+        { "kind": "Observe", "op": "observableVia", "expect": "absent" }
+      ]
+    }
+  ]
+}

--- a/configs/camunda-hub/positive-suppress.json
+++ b/configs/camunda-hub/positive-suppress.json
@@ -1,0 +1,9 @@
+{
+  "$comment": "Per-config positive-suite suppression list. Each entry removes an operation's feature/variant spec from the generated positive suite because the planner cannot produce a passing test for it AND no scenario-template covers it. Use sparingly and document the reason + the upstream tracking issue; revisit when the gap is closed.",
+  "suppress": [
+    {
+      "operationId": "deleteCatalogAsset",
+      "reason": "No in-API producer for assetKey: ingestCatalogAssets returns 204 with no body, and the v2 API exposes no catalog list/get/search. A positive (204) delete test therefore cannot obtain a real assetKey — the planner emits an unresolved ${assetKey} placeholder that 404s. Tracked upstream in camunda/camunda-hub#25576 (expose asset keys from ingest, or add a catalog list/get)."
+    }
+  ]
+}

--- a/configs/camunda-hub/request-defaults.json
+++ b/configs/camunda-hub/request-defaults.json
@@ -1,0 +1,11 @@
+{
+  "$comment": "Per-config request defaults for camunda-hub. operations.<opId>.multipartFiles maps a multipart/form-data binary part name (a `format: binary` array field in the request schema) to a fixture under configs/camunda-hub/fixtures/, emitted as @@FILE:<rel> and resolved at runtime. ingestCatalogAssets requires named parts `readme` + `template` (catalog.yaml): the README's YAML frontmatter `template:` must reference the element-template file BY NAME, and the emitted multipart part filename is the fixture basename — so README.md frontmatter `template: element-template.json` matches the template part's filename.",
+  "operations": {
+    "ingestCatalogAssets": {
+      "multipartFiles": {
+        "readme": "catalog/README.md",
+        "template": "catalog/element-template.json"
+      }
+    }
+  }
+}

--- a/materializer/src/index.ts
+++ b/materializer/src/index.ts
@@ -209,6 +209,41 @@ function loadEmitterConfig(configDir: string, emitter: EmitterStrategy): Record<
 }
 
 /**
+ * Load the per-config positive-suite suppression list from
+ * `configs/<config>/positive-suppress.json` (optional). Each `{ operationId,
+ * reason }` entry removes that operation's feature/variant spec from the
+ * positive suite — for operations the planner CANNOT generate a passing test
+ * for and which no scenario-template covers. The canonical case is an op whose
+ * required path key has no in-API producer and whose value carries no
+ * `x-semantic-type` (so the planner doesn't even flag it `unsatisfied`) — e.g.
+ * Hub's `deleteCatalogAsset`, whose `assetKey` is never minted by any v2 op.
+ * Returns `[]` when the file is absent.
+ */
+function loadPositiveSuppressions(configDir: string): { operationId: string; reason: string }[] {
+  const p = path.join(configDir, 'positive-suppress.json');
+  if (!fsSync.existsSync(p)) return [];
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fsSync.readFileSync(p, 'utf8'));
+  } catch (err) {
+    throw new Error(`Failed to read ${p}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (typeof raw !== 'object' || raw === null) return [];
+  const list = Reflect.get(raw, 'suppress');
+  if (!Array.isArray(list)) return [];
+  const out: { operationId: string; reason: string }[] = [];
+  for (const e of list) {
+    if (typeof e !== 'object' || e === null) continue;
+    const opId = Reflect.get(e, 'operationId');
+    const reason = Reflect.get(e, 'reason');
+    if (typeof opId === 'string' && opId.length > 0) {
+      out.push({ operationId: opId, reason: typeof reason === 'string' ? reason : '' });
+    }
+  }
+  return out;
+}
+
+/**
  * Minimal JSON-Schema validator covering only the constructs used by
  * built-in emitter configSchemas (object, additionalProperties=false,
  * top-level `properties` map with leaf `type` values from the subset
@@ -657,6 +692,13 @@ async function runForTarget(emitter: EmitterStrategy, env: TargetRunEnv): Promis
         templatesAboxPath: path.join(configDir, 'ontology', 'scenario-templates.json'),
         templateNames,
       });
+      // Union explicit per-config suppressions (ops with no satisfiable
+      // positive test and no template coverage) on top of the template-derived
+      // set. Logged with their reason so a dropped op is never silent.
+      for (const s of loadPositiveSuppressions(configDir)) {
+        coverage.suppressedOpIds.add(s.operationId);
+        console.log(`  ⏭  positive-suppress: ${s.operationId} — ${s.reason}`);
+      }
     }
     let count = 0;
     let suppressedCount = 0;

--- a/path-analyser/playwright.config.ts
+++ b/path-analyser/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@playwright/test';
+import type { ReporterDescription } from '@playwright/test';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 import { getPlaywrightSuiteDir } from './src/configResolver.js';
@@ -13,6 +14,18 @@ const repoRoot = resolve(__dirname, '..');
 // can redirect the report to a per-config location; defaults to playwright-report/.
 const htmlOutputFolder = process.env.PLAYWRIGHT_HTML_REPORT ?? 'playwright-report';
 
+// Mirror the request-validation config: emit a machine-readable JSON report
+// when PLAYWRIGHT_JSON_OUTPUT_FILE is set, so callers (scripts/e2e/run-hub.sh)
+// can feed per-test results to the positive curl-compare oracle. Unset (the
+// default, e.g. `test:pw:path-analyser`) → list + html only, unchanged.
+const reporter: ReporterDescription[] = [
+  ['list'],
+  ['html', { open: 'never', outputFolder: htmlOutputFolder }],
+];
+if (process.env.PLAYWRIGHT_JSON_OUTPUT_FILE) {
+  reporter.push(['json', { outputFile: process.env.PLAYWRIGHT_JSON_OUTPUT_FILE }]);
+}
+
 export default defineConfig({
   testDir: getPlaywrightSuiteDir(repoRoot),
   timeout: 60_000,
@@ -20,5 +33,5 @@ export default defineConfig({
     // Base APIRequestContext is provided by Playwright's test fixture
     extraHTTPHeaders: {},
   },
-  reporter: [['list'], ['html', { open: 'never', outputFolder: htmlOutputFolder }]],
+  reporter,
 });

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1688,6 +1688,30 @@ function buildRequestBodyFromCanonical(
       }
       template.files.resources = fileRef;
     }
+    // Generic binary multipart parts (#413): beyond the OCA deployment
+    // `resources[]` convention handled above (registry-backed), any
+    // `format: binary` array part resolves to a fixture declared per-operation
+    // in request-defaults.json under `multipartFiles` ({ <partName>:
+    // "<fixture-rel-path>" }). This covers configs whose multipart upload is
+    // not a deployment — e.g. Hub catalog ingest's `readme[]` + `template[]`.
+    // The emitted part filename is the fixture basename, so a fixture whose
+    // name is referenced cross-part (Hub's README frontmatter names the
+    // template file) just needs matching content. Skips parts the deployment
+    // block already filled, so the OCA path is untouched.
+    const multipartFiles = getRequestDefaultsForOperation(opId)?.multipartFiles;
+    if (isPlainRecord(multipartFiles)) {
+      const binaryParts = new Set(
+        nodes
+          .filter((n) => n.format === 'binary')
+          .map((n) => (n.path.endsWith('[]') ? n.path.slice(0, -2) : n.path))
+          .filter((name) => name.length > 0 && !name.includes('.') && !name.includes('[]')),
+      );
+      for (const [part, rel] of Object.entries(multipartFiles)) {
+        if (typeof rel !== 'string' || !binaryParts.has(part)) continue;
+        if (template.files[part] !== undefined) continue; // never override the deployment registry
+        template.files[part] = rel.startsWith('@@FILE:') ? rel : `@@FILE:${rel}`;
+      }
+    }
     // Wire global context seeds (e.g. tenantIdVar) into multipart fields by
     // matching the seed's `fieldName` against the canonical schema nodes.
     // Each match seeds the planner binding with `__PENDING__` (resolved at

--- a/path-analyser/src/ontology/observeArrayPath.ts
+++ b/path-analyser/src/ontology/observeArrayPath.ts
@@ -63,6 +63,16 @@ export function findMembershipArrayPath(
   // this the helper would match the FIRST in iteration order and could assert
   // on the container key rather than the member. Empty preserves the prior
   // iteration-order behaviour (e.g. OCA RoleUserMembership → username).
+  //
+  // Selection rule:
+  //   Pass 1 — return the first response entry whose semantic is BOTH in
+  //            `preferred` AND in `identifiedBy` and is array-nested.
+  //   Pass 2 — only if pass 1 finds nothing (empty `preferred`, or no
+  //            preferred semantic is array-nested): return the first
+  //            array-nested `identifiedBy` entry in iteration order.
+  // So `preferred` overrides iteration order only when it actually resolves
+  // to an array-nested, identifiedBy-declared field; otherwise the legacy
+  // behaviour is unchanged.
   preferred: readonly string[] = [],
 ): MembershipArrayPath | null {
   if (!op) return null;

--- a/path-analyser/src/ontology/observeArrayPath.ts
+++ b/path-analyser/src/ontology/observeArrayPath.ts
@@ -56,27 +56,51 @@ export function findMembershipArrayPath(
     | { responseSemanticTypes?: Record<string, { semanticType: string; fieldPath: string }[]> }
     | undefined,
   identifiedBy: readonly string[],
+  // Membership identifier(s) to prefer — typically the edge's `to`-endpoint
+  // identifier(s) (the entity added to the container). When the observation
+  // response echoes more than one identifiedBy semantic array-nested (e.g.
+  // Hub's searchMembers items carry both `workspaceKey` and `email`), without
+  // this the helper would match the FIRST in iteration order and could assert
+  // on the container key rather than the member. Empty preserves the prior
+  // iteration-order behaviour (e.g. OCA RoleUserMembership → username).
+  preferred: readonly string[] = [],
 ): MembershipArrayPath | null {
   if (!op) return null;
   const responses = op.responseSemanticTypes?.['200'] ?? [];
   const identifiedSet = new Set(identifiedBy);
-  for (const entry of responses) {
-    if (!identifiedSet.has(entry.semanticType)) continue;
-    if (!entry.fieldPath.includes('[]')) continue;
+
+  const toLocator = (entry: {
+    semanticType: string;
+    fieldPath: string;
+  }): MembershipArrayPath | null => {
+    if (!entry.fieldPath.includes('[]')) return null;
     const idx = entry.fieldPath.indexOf('[]');
     const before = entry.fieldPath.slice(0, idx);
     const after = entry.fieldPath.slice(idx + 2);
     // Strip a leading '.' from the post-`[]` remainder so a path like
     // `items[].username` yields elementField='username' not '.username'.
     const elementField = after.startsWith('.') ? after.slice(1) : after;
-    if (!elementField) continue;
+    if (!elementField) return null;
     const arrayPath = before.split('.').filter((s) => s.length > 0);
-    if (arrayPath.length === 0) continue;
-    return {
-      arrayPath,
-      elementField,
-      membershipSemanticType: entry.semanticType,
-    };
+    if (arrayPath.length === 0) return null;
+    return { arrayPath, elementField, membershipSemanticType: entry.semanticType };
+  };
+
+  // Pass 1: prefer the `to`-endpoint membership identifier(s).
+  const preferredSet = new Set(preferred);
+  if (preferredSet.size > 0) {
+    for (const entry of responses) {
+      if (!preferredSet.has(entry.semanticType)) continue;
+      if (!identifiedSet.has(entry.semanticType)) continue;
+      const loc = toLocator(entry);
+      if (loc) return loc;
+    }
+  }
+  // Pass 2: any identifiedBy semantic, in iteration order (legacy behaviour).
+  for (const entry of responses) {
+    if (!identifiedSet.has(entry.semanticType)) continue;
+    const loc = toLocator(entry);
+    if (loc) return loc;
   }
   return null;
 }

--- a/path-analyser/src/scenarioTemplateInstantiator.ts
+++ b/path-analyser/src/scenarioTemplateInstantiator.ts
@@ -93,6 +93,7 @@ function compileEdgeLifecycle(
   edge: Edge,
   graph: OperationGraph,
   canonical: CanonicalScenarioMap,
+  entityKinds: EntityKindsAbox | null,
 ): { scenario: TemplateScenario } | { error: string } {
   const establishScenario = canonical.get(edge.establishedBy);
   const revokeScenario = canonical.get(edge.revokedBy);
@@ -208,7 +209,13 @@ function compileEdgeLifecycle(
   // to keep the instantiator drop-in for future configs whose
   // edges might not yet satisfy the precondition.
   const observeOp = graph.operations[edge.observableVia];
-  const locator = findMembershipArrayPath(observeOp, edge.identifiedBy);
+  // Prefer the `to`-endpoint identifier as the membership key — the entity
+  // added to the container. When the observe response also echoes the
+  // container/`from` key (e.g. Hub's searchMembers items carry workspaceKey
+  // AND email), this asserts membership on the member (email), not the
+  // container (workspaceKey).
+  const toKind = entityKinds?.kinds.find((k) => k.name === edge.endpoints.to);
+  const locator = findMembershipArrayPath(observeOp, edge.identifiedBy, toKind?.identifiers ?? []);
   if (!locator) {
     return {
       error: `${template.name} × ${edge.name}: findMembershipArrayPath returned null for observableVia='${edge.observableVia}'; an edge with no array-nested identifiedBy semantic on its observation op cannot be observed via present/absent membership`,
@@ -1011,7 +1018,7 @@ export function instantiateAllTemplates(
         );
       }
       for (const edge of edges.edges) {
-        const compiled = compileEdgeLifecycle(tpl, edge, graph, canonical);
+        const compiled = compileEdgeLifecycle(tpl, edge, graph, canonical, entityKinds);
         if ('error' in compiled) {
           errors.push(compiled.error);
           continue;

--- a/path-analyser/src/scenarioTemplateInstantiator.ts
+++ b/path-analyser/src/scenarioTemplateInstantiator.ts
@@ -157,34 +157,63 @@ function compileEdgeLifecycle(
   // identifiedBy entries are present, not that the table is
   // minimal — keeping it inclusive matches the EndpointScenario
   // contract.
+  // Binding names for the edge's identifiers follow the request-body /
+  // URL-emitter convention — keyed on the establisher's FIELD/PARAM
+  // `name`, NOT on the semantic type. For most identifiers
+  // `camelCase(name) === camelCase(semantic)` so `bindingNameFor` agrees,
+  // but where they diverge the field name wins: Hub's `email` body field
+  // carries semantic `MemberEmail`, so the request-body builder seeds
+  // `emailVar` (not `memberEmailVar`). Every step and the binding table
+  // must use the field-derived name to stay consistent with the canonical
+  // establish scenario, otherwise the emitter can't resolve the membership
+  // semantic back to a binding. Derive both directions from the
+  // establisher's `establishes.identifiedBy` (which carries name +
+  // semanticType per identifier).
+  const establishOp = graph.operations[edge.establishedBy];
+  const bindingNameBySemantic = new Map<string, string>();
+  const semanticByBindingName = new Map<string, string>();
+  for (const id of establishOp?.establishes?.identifiedBy ?? []) {
+    const bindName = `${camelCase(id.name)}Var`;
+    bindingNameBySemantic.set(id.semanticType, bindName);
+    semanticByBindingName.set(bindName, id.semanticType);
+  }
+  const bindingNameForEdge = (semantic: string): string =>
+    bindingNameBySemantic.get(semantic) ?? bindingNameFor(semantic);
+
   const bindings: Record<string, string> = {};
   const aggregateBindingNames = new Set<string>([
     ...Object.keys(establishScenario.bindings ?? {}),
     ...(establishScenario.seedBindings ?? []),
   ]);
   for (const bindName of aggregateBindingNames) {
-    // Recover the semantic type by stripping the trailing 'Var' and
-    // upper-casing the first letter. This matches the inverse of
-    // `bindingNameFor`. A binding name that doesn't end in 'Var'
-    // (none exist today) would be passed through as-is so the
-    // emitter still sees a stable round-trip key.
-    const sem = bindName.endsWith('Var')
-      ? bindName.slice(0, -3).charAt(0).toUpperCase() + bindName.slice(0, -3).slice(1)
-      : bindName;
+    // Prefer the establisher's authoritative semantic for any
+    // field-derived identifier binding (so `emailVar → MemberEmail`, not
+    // the lossy `Email` the reverse-engineering below would produce).
+    // Otherwise recover the semantic type by stripping the trailing 'Var'
+    // and upper-casing the first letter — the inverse of `bindingNameFor`
+    // — for seeded extras (e.g. `roleVar → Role`) with no identifiedBy
+    // entry. A binding name that doesn't end in 'Var' (none exist today)
+    // is passed through as-is so the emitter still sees a stable key.
+    const sem =
+      semanticByBindingName.get(bindName) ??
+      (bindName.endsWith('Var')
+        ? bindName.slice(0, -3).charAt(0).toUpperCase() + bindName.slice(0, -3).slice(1)
+        : bindName);
     bindings[sem] = bindName;
   }
 
   // Helper: map an op's required semantics to {semanticType: bindingName}.
   // Used by Invoke and Observe alike. We consult the graph for the
-  // op's `requires.required`; the bindingName follows the camelCase
-  // convention so callers don't need to inspect the canonical scenario
-  // bindings (the union table built above is the source of truth at
-  // emit time; this map is the per-step view onto it).
+  // op's `requires.required`; the bindingName follows the establisher's
+  // field-derived convention (`bindingNameForEdge`) so callers don't need
+  // to inspect the canonical scenario bindings (the union table built
+  // above is the source of truth at emit time; this map is the per-step
+  // view onto it).
   const inputsFor = (opId: string): Record<string, string> => {
     const op = graph.operations[opId];
     const result: Record<string, string> = {};
     for (const sem of op?.requires.required ?? []) {
-      result[sem] = bindingNameFor(sem);
+      result[sem] = bindingNameForEdge(sem);
     }
     return result;
   };
@@ -233,7 +262,7 @@ function compileEdgeLifecycle(
   for (const sem of edge.identifiedBy) {
     if (sem === locator.membershipSemanticType) continue;
     if (!observeRequired.has(sem)) continue;
-    observeInputs[sem] = bindingNameFor(sem);
+    observeInputs[sem] = bindingNameForEdge(sem);
   }
 
   const lastOf = (plan: RequestStep[]): RequestStep => plan[plan.length - 1];

--- a/scripts/e2e/curl_compare.py
+++ b/scripts/e2e/curl_compare.py
@@ -169,8 +169,17 @@ def run_curl(method, url, headers, body_json, multipart):
     for h in headers:
         cmd += ["-H", h]
     if multipart is not None:
-        for k, v in multipart.items():
-            cmd += ["-F", f"{k}={v}"]
+        if multipart:
+            for k, v in multipart.items():
+                cmd += ["-F", f"{k}={v}"]
+        else:
+            # Empty multipart: still emit a multipart/form-data body (with a
+            # closing boundary) so the server runs part-validation — matching
+            # Playwright's `request.put(url, { multipart: {} })`, which yields
+            # 400 "required part missing" rather than a bodyless 415.
+            boundary = "----curlcompareEMPTY"
+            cmd += ["-H", f"Content-Type: multipart/form-data; boundary={boundary}",
+                    "--data-binary", f"--{boundary}--\r\n"]
     elif body_json is not None:
         cmd += ["--data-binary", body_json]
     try:
@@ -268,8 +277,217 @@ def write_html(path, rows, meta, max_body=1000):
     Path(path).write_text("".join(out), encoding="utf-8")
 
 
+# ======================================================================
+# POSITIVE suite (lifecycle / feature / variant) — multi-step chain replay
+# ----------------------------------------------------------------------
+# Negative specs are one request per test; positive specs are ORDERED
+# `test.step(...)` chains that thread server-minted ids forward via
+# `extractInto(ctx, 'fooVar', json?.foo)`. To curl them faithfully we:
+#   1. evaluate the spec's seed bindings through the suite's OWN
+#      `seedBinding` (via tsx) so client-minted values match;
+#   2. for each step: resolve the `url` template + `body` literal through
+#      node with the live `ctx` in scope, curl it, compare status to the
+#      step's `expect(...).toBe(N)`, and on a 2xx apply the step's
+#      `extractInto` calls so the next step sees the real ids.
+# A test PASSES (curl) when every step's status matches; the first
+# mismatching step is recorded as the failure (the suite stops there too).
+# Observe steps' membership body-assertion (toContain) is NOT re-checked —
+# this oracle compares STATUS, the same axis as the negative report.
+# ======================================================================
+POS_TEST_RE = re.compile(r"\btest\(\s*(['\"])(?P<title>.*?)\1\s*,\s*async", re.S)
+POS_STEP_RE = re.compile(r"test\.step\(\s*(['\"])(?P<name>.*?)\1\s*,\s*async", re.S)
+SALT_RE = re.compile(r"initSpecSalt\(\s*['\"]([^'\"]+)['\"]\s*\)")
+SEED_RE = re.compile(
+    r"ctx\.\w+\s*=\s*ctx\.\w+\s*\?\?\s*seedBinding\(\s*['\"](?P<name>\w+)['\"]\s*"
+    r"(?:,\s*(?P<opts>\{[^}]*\}))?\s*\)"
+)
+URL_RE = re.compile(r"const\s+url\s*=\s*(?P<expr>.+?);\s*\n", re.S)
+REQ_RE = re.compile(r"request\.(?P<m>get|post|put|patch|delete)\(")
+BODY_RE = re.compile(r"const\s+body\d*\s*=\s*(?P<expr>\{.*?\});\s*\n", re.S)
+EXPECT_RE = re.compile(r"expect\(\s*resp\w*\.status\(\)\s*\)\.toBe\(\s*(\d{3})\s*\)")
+EXTRACT_RE = re.compile(r"extractInto\(\s*ctx,\s*['\"](?P<var>\w+)['\"]\s*,\s*\w+\?\.(?P<field>\w+)")
+MULTIPART_RE = re.compile(r"multipart:\s*multipart")
+
+# Evaluate a JS expression (url template or body object literal) with the
+# live `baseUrl` + `ctx` in scope. A string result (url) is emitted raw; an
+# object (body) is JSON-stringified — exactly what curl needs for each.
+EVAL_JS = r"""
+const baseUrl = process.argv[1];
+const ctx = JSON.parse(process.argv[2]);
+const __v = (__EXPR__);
+process.stdout.write(typeof __v === "string" ? __v : JSON.stringify(__v));
+"""
+
+# tsx harness: import the suite's real seeding module by file URL and resolve
+# every seed binding under the spec's own salt, so values match the suite.
+SEED_TS = r"""
+const mod = await import(process.argv[2]);
+mod.initSpecSalt(process.argv[3]);
+const specs = JSON.parse(process.argv[4]);
+const out = {};
+for (const s of specs) out[s.name] = mod.seedBinding(s.name, s.opts);
+process.stdout.write(JSON.stringify(out));
+"""
+
+
+def eval_js(expr, base, ctx):
+    return node(EVAL_JS.replace("__EXPR__", expr), base, json.dumps(ctx))
+
+
+def eval_seeds(seeding_path, salt, seeds):
+    """Resolve seed bindings via the suite's own seedBinding (tsx)."""
+    if not seeds:
+        return {}
+    url = Path(seeding_path).resolve().as_uri()
+    specs = [{"name": n, "opts": ({"unique": True} if o and "unique" in o and "true" in o else {})}
+             for n, o in seeds]
+    tmp = Path(seeding_path).parent / ".curl_seed_eval.mts"
+    try:
+        tmp.write_text(SEED_TS, encoding="utf-8")
+        out = subprocess.run(["npx", "tsx", str(tmp), url, salt, json.dumps(specs)],
+                             capture_output=True, text=True, timeout=60)
+        if out.returncode != 0:
+            return {}
+        return json.loads(out.stdout)
+    except Exception:
+        return {}
+    finally:
+        try: tmp.unlink()
+        except Exception: pass
+
+
+def parse_positive_steps(test_body):
+    """Yield ordered step dicts from a test() body."""
+    starts = [(m.start(), m.group("name")) for m in POS_STEP_RE.finditer(test_body)]
+    for i, (pos, name) in enumerate(starts):
+        end = starts[i + 1][0] if i + 1 < len(starts) else len(test_body)
+        blk = test_body[pos:end]
+        um = URL_RE.search(blk)
+        if not um:
+            continue
+        rm = REQ_RE.search(blk)
+        em = EXPECT_RE.search(blk)
+        bm = BODY_RE.search(blk)
+        yield {
+            "name": name,
+            "url_expr": um.group("expr").strip(),
+            "method": (rm.group("m").upper() if rm else "GET"),
+            "expected": int(em.group(1)) if em else None,
+            "body_expr": bm.group("expr") if bm else None,
+            "multipart": bool(MULTIPART_RE.search(blk)),
+            "extracts": EXTRACT_RE.findall(blk),  # list of (var, field)
+        }
+
+
+def replay_positive_test(title, test_body, salt, seeding_path, base, admin_header):
+    seeds = SEED_RE.findall(test_body)  # list of (name, opts)
+    ctx = eval_seeds(seeding_path, salt, seeds)
+    headers = [admin_header] if admin_header else []
+    steps = list(parse_positive_steps(test_body))
+    last = None
+    for st in steps:
+        url = eval_js(st["url_expr"], base, ctx)
+        if url is None:
+            return {"title": title, "ok": False, "fail": st["name"], "expected": st["expected"],
+                    "curl": None, "method": st["method"], "url": "<url-eval-failed>", "body": ""}
+        body_json, multipart = None, None
+        if st["multipart"]:
+            # Reconstruct the multipart body the same way the emitted suite does:
+            # the body literal is `{ fields: {...}, files: {...} }` where each
+            # file value is an `@@FILE:<rel>` marker. Resolve fields to plain
+            # form values and files to `@<abs fixture path>` so curl attaches the
+            # real bytes (basename = part filename, matching e.g. the README's
+            # template reference). Empty → falls through to run_curl's empty-
+            # multipart boundary so the server still runs part-validation.
+            multipart = {}
+            mp = json.loads(eval_js(st["body_expr"], base, ctx)) if st["body_expr"] else {}
+            fixtures_dir = Path(seeding_path).resolve().parent.parent / "fixtures"
+            for k, v in (mp.get("fields") or {}).items():
+                if v is not None:
+                    multipart[k] = str(v)
+            for k, v in (mp.get("files") or {}).items():
+                if isinstance(v, str) and v.startswith("@@FILE:"):
+                    multipart[k] = "@" + str((fixtures_dir / v[len("@@FILE:"):]).resolve())
+                elif v is not None:
+                    multipart[k] = str(v)
+        elif st["body_expr"] is not None:
+            body_json = eval_js(st["body_expr"], base, ctx)
+        jhdr = headers + (["Content-Type: application/json"] if body_json is not None else [])
+        code, rbody = run_curl(st["method"], url, jhdr, body_json, multipart)
+        last = {"title": title, "expected": st["expected"], "curl": code, "method": st["method"],
+                "url": url, "body": rbody, "fail": st["name"]}
+        if code != st["expected"]:
+            return {**last, "ok": False}
+        # success → thread extracted ids forward for subsequent steps
+        if rbody and 200 <= (code or 0) < 300:
+            try:
+                j = json.loads(rbody)
+                for var, field in st["extracts"]:
+                    if isinstance(j, dict) and j.get(field) is not None:
+                        ctx[var] = j[field]
+            except Exception:
+                pass
+    return {**(last or {"title": title, "expected": None, "curl": None, "method": "", "url": "",
+                        "body": ""}), "ok": True, "fail": "all-pass"}
+
+
+def main_positive(args):
+    pw = load_pw(args.pw_json)
+    specdir = Path(args.spec_dir)
+    seeding = specdir / "support" / "seeding.ts"
+    specs = sorted(p for p in specdir.rglob("*.spec.ts")
+                   if not p.name.endswith("-validation-api-tests.spec.ts"))
+    rows = []
+    for spec in specs:
+        src = spec.read_text(encoding="utf-8")
+        sm = SALT_RE.search(src)
+        salt = sm.group(1) if sm else spec.stem
+        tm = [(m.start(), m.group("title")) for m in POS_TEST_RE.finditer(src)]
+        for i, (pos, title) in enumerate(tm):
+            end = tm[i + 1][0] if i + 1 < len(tm) else len(src)
+            r = replay_positive_test(title, src[pos:end], salt, str(seeding),
+                                     args.base_url, args.admin_header)
+            pw_rec = pw.get(title, {})
+            pw_status = ("pass" if pw_rec.get("ok") else f"FAIL({pw_rec.get('received')})") if pw_rec else "—"
+            rows.append({
+                "title": title, "expected": r["expected"], "pw": pw_status, "curl": r["curl"],
+                "match": r["ok"], "method": r["method"], "url": r["url"],
+                "kind": r["fail"], "body": r["body"],
+            })
+
+    total = len(rows)
+    ok = sum(1 for r in rows if r["match"])
+    label = args.label or "positive"
+    print(f"\n### {label} — curl chain replay vs Playwright ###")
+    print(f"\n{'TEST':<52} {'STEP':<22} {'EXP':>4} {'PW':>10} {'CURL':>5}  OK")
+    print("-" * 100)
+    for r in rows:
+        print(f"{r['title'][:52]:<52} {r['kind'][:22]:<22} {str(r['expected']):>4} "
+              f"{r['pw']:>10} {str(r['curl']):>5}  {'✓' if r['match'] else '✗'}")
+    print("-" * 100)
+    print(f"curl chain vs suite: {ok}/{total} pass, {total - ok} fail")
+
+    if args.show_body:
+        for r in rows:
+            if not r["match"] and r["body"]:
+                print(f"\n• {r['title']}  [fails at {r['kind']}]\n  {r['method']} {r['url']}\n"
+                      f"  expected {r['expected']}, curl {r['curl']}\n  body: {r['body'].strip()[:args.max_body]}")
+
+    if args.html:
+        write_html(args.html, rows, {"label": label, "spec_dir": args.spec_dir,
+                                     "base_url": args.base_url, "total": total, "ok": ok,
+                                     "skipped": 0, "specs": [s.name for s in specs]})
+        print(f"HTML report: {args.html}")
+    if total == 0:
+        print(f"✗ no positive tests parsed under {args.spec_dir}", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(1 if (total - ok) else 0)
+
+
 def main():
     ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=["negative", "positive"], default="negative",
+                    help="negative: one-request RV specs (default). positive: multi-step chains.")
     ap.add_argument("--spec-dir", required=True)
     ap.add_argument("--base-url", required=True)
     ap.add_argument("--api-version", default="v2")
@@ -281,6 +499,8 @@ def main():
     ap.add_argument("--html", default="", help="also write a self-contained HTML report here")
     ap.add_argument("--label", default="", help="human label for the run (config/profile/suite)")
     args = ap.parse_args()
+    if args.mode == "positive":
+        return main_positive(args)
     label = args.label or args.spec_dir
 
     pw = load_pw(args.pw_json)

--- a/scripts/e2e/run-hub.sh
+++ b/scripts/e2e/run-hub.sh
@@ -34,8 +34,11 @@ HUB_UI_PORT="${HUB_UI_PORT:-8088}"
 KEYCLOAK_PORT="${KEYCLOAK_PORT:-18080}"
 RV_PROFILES="${RV_PROFILES:-secured rbac}"
 STEPS="${STEPS:-generate run curl}"
-# TODO: remove once camunda/camunda-hub#25146 is merged
-SKIP_POSITIVE="${SKIP_POSITIVE:-1}"
+# Positive suite runs by default for local/manual e2e. The nightly still
+# pins SKIP_POSITIVE=1 explicitly (see nightly-camunda-hub.yml) because the
+# File/Folder/Version family 403s on the unfixed camunda/camunda-hub#25302 —
+# drop that pin once #25302/#25146 land and the positive suite is green.
+SKIP_POSITIVE="${SKIP_POSITIVE:-}"
 KC="http://localhost:${KEYCLOAK_PORT}/auth/realms/camunda-platform/protocol/openid-connect/token"
 CORE_URL="http://localhost:${HUB_UI_PORT}/api"        # request-validation base (buildUrl adds /v2)
 POS_URL="http://localhost:${HUB_UI_PORT}/api/v2"       # positive suite base
@@ -111,7 +114,8 @@ fi
 # ============================ 1. GENERATE ============================
 if step generate; then
   echo "── generate ─────────────────────────────"
-  # Positive tests are skipped for Hub until camunda/camunda-hub#25146 is merged.
+  # Positive suite generated unless SKIP_POSITIVE is set (nightly pins it; see
+  # the SKIP_POSITIVE default above).
   if [ -z "${SKIP_POSITIVE:-}" ]; then
     CONFIG="$CONFIG" npm run extract-graph >/dev/null
     CONFIG="$CONFIG" npm run generate:scenarios >/dev/null
@@ -127,16 +131,34 @@ fi
 
 # ====================== 2. RUN (Playwright) ==========================
 unset CAMUNDA_BASIC_AUTH_USER CAMUNDA_BASIC_AUTH_PASSWORD 2>/dev/null || true
-# Positive tests are skipped for Hub until camunda/camunda-hub#25146 is merged.
+# Positive suite + its curl-compare run unless SKIP_POSITIVE is set (nightly
+# pins it until #25302/#25146 land; see the SKIP_POSITIVE default above).
 if step run && [ -z "${SKIP_POSITIVE:-}" ]; then
   echo "── run: positive lifecycle suite ────────"
+  pos_abs="$(cd "$OUT" && pwd)"
+  # JSON path must be absolute: Playwright resolves reporter outputs relative
+  # to the config dir, not cwd (same reason as run_rv below).
   BEARER_TOKEN="$ADMIN_TOK" API_BASE_URL="$POS_URL" CONFIG="$CONFIG" \
-    PLAYWRIGHT_HTML_REPORT="$OUT/pw-positive" \
+    PLAYWRIGHT_HTML_REPORT="$pos_abs/pw-positive" \
+    PLAYWRIGHT_JSON_OUTPUT_FILE="$pos_abs/pw-positive.json" \
     npx playwright test -c path-analyser/playwright.config.ts || true
   if [ -f "$OUT/pw-positive/index.html" ]; then
     echo "  ✓ positive suite report: $OUT/pw-positive/index.html"
   else
     echo "  ⚠ positive suite report not generated (Playwright run may have failed)"
+  fi
+  # Independent curl oracle for the positive multi-step chains — replays each
+  # lifecycle/feature/variant chain with curl (threading server-minted ids)
+  # and tabulates expected vs Playwright vs curl status, same as the negative
+  # report. DIAGNOSTIC ONLY: `|| true` so a mismatch never gates the run.
+  if step curl; then
+    python3 scripts/e2e/curl_compare.py --mode positive \
+      --spec-dir "generated/${CONFIG}/playwright" --base-url "$POS_URL" \
+      --admin-header "Authorization: Bearer $ADMIN_TOK" \
+      --pw-json "$pos_abs/pw-positive.json" --show-body \
+      --html "$pos_abs/curl-positive.html" --label "$CONFIG positive" \
+      2>&1 | tee "$pos_abs/curl-positive.txt" || true
+    [ -f "$pos_abs/curl-positive.html" ] && echo "  ✓ positive curl-compare: $OUT/curl-positive.html"
   fi
 fi
 

--- a/tests/fixtures/planner/observe-array-path-preference.test.ts
+++ b/tests/fixtures/planner/observe-array-path-preference.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { findMembershipArrayPath } from '../../../path-analyser/src/ontology/observeArrayPath.ts';
+
+/**
+ * Focused unit tests for `findMembershipArrayPath`'s identifier-selection
+ * rule — Layer 2 of the layered test strategy, pinning the pure helper
+ * that both the #269 feasibility invariant and the #270 planner
+ * instantiator share for locating the membership identifier in an
+ * edge-observation response.
+ *
+ * # Defect class pinned here
+ *
+ * When an observation response echoes MORE THAN ONE of the edge's
+ * `identifiedBy` semantics array-nested (Hub's `searchMembers` items
+ * carry both `workspaceKey` (the container) and `email` (the member)),
+ * the membership assertion must key off the MEMBER, not the container —
+ * otherwise the EdgeLifecycle observe step asserts on the workspace key,
+ * which every item in a workspace-scoped search trivially satisfies, so
+ * the present/absent assertion is vacuous.
+ *
+ * The fix added a `preferred` list (the edge's `to`-endpoint
+ * identifier(s)) consulted in pass 1 before the legacy iteration-order
+ * scan in pass 2. These fixtures guard both passes:
+ *
+ *   - pass 1 honours `preferred` even when a non-preferred identifiedBy
+ *     semantic appears earlier in the response (the Hub regression);
+ *   - pass 2 reproduces the legacy first-in-iteration-order behaviour
+ *     when `preferred` is empty or none of the preferred semantics are
+ *     array-nested (the OCA `RoleUserMembership → items[].username`
+ *     shape, which predates `preferred`).
+ *
+ * A silent revert of the preference logic — e.g. a refactor that drops
+ * pass 1 — flips the Hub membership assertion back onto `workspaceKey`
+ * and would be caught here.
+ */
+
+// `searchMembers`-shaped response: container key listed BEFORE the member
+// key in iteration order, so iteration-order alone would pick the wrong one.
+const membersResponse = {
+  responseSemanticTypes: {
+    '200': [
+      { semanticType: 'WorkspaceKey', fieldPath: 'items[].workspaceKey' },
+      { semanticType: 'MemberEmail', fieldPath: 'items[].email' },
+    ],
+  },
+};
+
+describe('findMembershipArrayPath identifier selection', () => {
+  it('prefers the to-endpoint member identifier over an earlier container key (pass 1)', () => {
+    const loc = findMembershipArrayPath(
+      membersResponse,
+      ['WorkspaceKey', 'MemberEmail'],
+      ['MemberEmail'],
+    );
+    expect(loc).toEqual({
+      arrayPath: ['items'],
+      elementField: 'email',
+      membershipSemanticType: 'MemberEmail',
+    });
+  });
+
+  it('falls back to first-in-iteration-order when preferred is empty (legacy pass 2)', () => {
+    const loc = findMembershipArrayPath(membersResponse, ['WorkspaceKey', 'MemberEmail'], []);
+    expect(loc).toEqual({
+      arrayPath: ['items'],
+      elementField: 'workspaceKey',
+      membershipSemanticType: 'WorkspaceKey',
+    });
+  });
+
+  it('ignores a preferred semantic that is not array-nested and falls through to pass 2', () => {
+    // `WorkspaceKey` here is preferred but appears as a scalar (no `[]`),
+    // so pass 1 finds nothing and pass 2 selects the first array-nested
+    // identifiedBy semantic instead.
+    const loc = findMembershipArrayPath(
+      {
+        responseSemanticTypes: {
+          '200': [
+            { semanticType: 'WorkspaceKey', fieldPath: 'workspaceKey' },
+            { semanticType: 'MemberEmail', fieldPath: 'items[].email' },
+          ],
+        },
+      },
+      ['WorkspaceKey', 'MemberEmail'],
+      ['WorkspaceKey'],
+    );
+    expect(loc).toEqual({
+      arrayPath: ['items'],
+      elementField: 'email',
+      membershipSemanticType: 'MemberEmail',
+    });
+  });
+
+  it('ignores a preferred semantic that is not in identifiedBy (pass 1 requires both)', () => {
+    // `MemberEmail` is preferred and array-nested, but NOT declared in
+    // identifiedBy — pass 1 must skip it and pass 2 picks the declared one.
+    const loc = findMembershipArrayPath(membersResponse, ['WorkspaceKey'], ['MemberEmail']);
+    expect(loc).toEqual({
+      arrayPath: ['items'],
+      elementField: 'workspaceKey',
+      membershipSemanticType: 'WorkspaceKey',
+    });
+  });
+
+  it('parses a nested array path and dotted element field', () => {
+    const loc = findMembershipArrayPath(
+      {
+        responseSemanticTypes: {
+          '200': [{ semanticType: 'Username', fieldPath: 'data.items[].member.username' }],
+        },
+      },
+      ['Username'],
+    );
+    expect(loc).toEqual({
+      arrayPath: ['data', 'items'],
+      elementField: 'member.username',
+      membershipSemanticType: 'Username',
+    });
+  });
+
+  it('rejects an array marker with no element field', () => {
+    const loc = findMembershipArrayPath(
+      { responseSemanticTypes: { '200': [{ semanticType: 'Username', fieldPath: 'items[]' }] } },
+      ['Username'],
+    );
+    expect(loc).toBeNull();
+  });
+
+  it('returns null when no identifiedBy semantic is array-nested', () => {
+    const loc = findMembershipArrayPath(
+      {
+        responseSemanticTypes: {
+          '200': [{ semanticType: 'WorkspaceKey', fieldPath: 'workspaceKey' }],
+        },
+      },
+      ['WorkspaceKey'],
+    );
+    expect(loc).toBeNull();
+  });
+
+  it('returns null for an undefined operation', () => {
+    expect(findMembershipArrayPath(undefined, ['WorkspaceKey'])).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Generates the **camunda-hub positive suite** — entity + edge lifecycle plus feature/variant tests (camunda-hub#25264 items 2 & 3) — and makes that suite observable and faithful end-to-end against live Hub.

### Ontology ABox
- `configs/camunda-hub/ontology/entity-kinds.json` — Workspace/Project/Folder/File/Version (entities, full CRUD) + Member (external-entity, client-minted `MemberEmail`).
- `configs/camunda-hub/ontology/edges.json` — `WorkspaceMemberMembership` (Workspace→Member; addMember / searchMembers / removeMember).
- `configs/camunda-hub/ontology/scenario-templates.json` — generic `EntityLifecycle` + `EdgeLifecycle` templates.

### Generator fixes
- **Edge membership identifier** — `findMembershipArrayPath` prefers the edge's `to`-endpoint identifier as the membership key. Hub's `searchMembers` rows carry both `workspaceKey` and `email`; the observe step now asserts on the *member* (`email`), not the container. OCA `RoleUserMembership` unaffected (still `username`). Pinned by `observe-array-path-preference.test.ts`.
- **Edge binding-name consistency** — derive edge identifier binding names from the establisher's `establishes.identifiedBy[].name` (matching the request-body/URL builders) so the bindings table, invoke inputs and observe assertion agree. Hub's `email` field (semantic `MemberEmail`) is the first case where field name ≠ camelCase(semantic); without this codegen failed on the membership lookup.

### Catalog ops
- **ingestCatalogAssets** — multipart builder generalized beyond OCA's `resources[]` convention to resolve any `format: binary` array part from a per-op `multipartFiles` map in `request-defaults.json` (additive; OCA deployment-registry path untouched). Ships catalog fixtures (element-template + README whose frontmatter references it). **204 vs live Hub.**
- **deleteCatalogAsset** — new per-config `positive-suppress.json` mechanism; suppressed because `assetKey` has no in-API producer (ingest returns 204 no-body; no v2 catalog list/get/search). Filed camunda/camunda-hub#25576; un-suppress once it lands.

### Positive curl-compare oracle
- `curl_compare.py --mode positive` replays each multi-step chain with curl (real `seedBinding` via tsx, threaded `extractInto` ids, resolved `@@FILE` multipart parts) and tabulates **expected / Playwright / curl** status into the same HTML report as the negative oracle (`curl-positive.html`).
- `run-hub.sh` runs the positive suite + its curl-compare by default (local/dev); the nightly keeps its explicit `SKIP_POSITIVE=1` pin while #25302 is open. `playwright.config.ts` gains a conditional json reporter.

## Result

6 lifecycle suites (5 entity + 1 edge) + feature/variant suites generate. Against live Hub the positive suite is **15/31 pass**, and an independent curl oracle reproduces **every** status (0 curl-vs-Playwright mismatches), so the suite faithfully reflects Hub. The 16 reds are real, curl-confirmed Hub behaviour, not generator faults:
- File/Folder/Version family → **403** (camunda-hub#25302).
- `WorkspaceMemberMembership` edge → **404** (server-minted `workspaceKey` seeded, not created — #408; also needs a real member email).

Workspace + Project entity lifecycles, the searches, updateProject/Workspace, getInfo, and ingestCatalogAssets are green today.

## Validation
- Unit/regression suite green (vitest); OCA regression invariants + deployment/multipart tests pass — the shared planner changes are additive.
- Positive suite + curl oracle run vs live Hub (prebuilt camunda/hub image): 0 status mismatches.

## Known follow-ups (tracked in #408, NOT in this PR)
Deep BFS-planner work for **server-minted keys** (OCA's identifiers are client-minted, so it doesn't hit these): dependent-entity prereqs prefer `searchProjects` over the `createProject` chain; the edge establisher seeds its server-minted `workspaceKey` instead of chaining `createWorkspace`; nested-body search-filter binding emits a `placeholder`. The File/Folder/Version + edge suites generate but won't pass end-to-end until #408 (and Hub #25302) land.

Depends on the Hub spec annotations in camunda/camunda-hub#25146 (the semantic markers this ontology references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)