### PR TITLE
fix: seed nested-object scalars correctly + edge-establisher chaining for Hub member ops

### DIFF
--- a/configs/camunda-hub/codegen/playwright/config.json
+++ b/configs/camunda-hub/codegen/playwright/config.json
@@ -1,3 +1,6 @@
 {
-  "recordResponses": false
+  "recordResponses": false,
+  "clientMintedFixtures": {
+    "emailVar": "POS_FIXTURE_MEMBER_EMAIL"
+  }
 }

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -271,7 +271,7 @@ interface OperationNode {
   responseSemanticTypes?: Record<string, SemanticTypeEntry[]>;
   establishes?: {
     shape?: string;
-    identifiedBy?: { semanticType: string; in?: string }[];
+    identifiedBy?: { semanticType: string; in?: string; acceptsExternal?: boolean }[];
   };
 }
 interface GraphEdge {

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -1151,9 +1151,14 @@ describeForThisConfig('bundled-spec invariants: planner output', () => {
           // missing inputs: the planner treats these as produced by the
           // op (they originate from the identifier inputs the op itself
           // requires — establisher self-satisfaction).
-          if (opNode.establishes && opNode.establishes.shape !== 'edge') {
+          // For edge establishers, body-located `acceptsExternal: true`
+          // components are self-minted by the op; path-located components
+          // are pre-existing prerequisites satisfied by an earlier chain.
+          if (opNode.establishes) {
             for (const id of opNode.establishes.identifiedBy ?? []) {
-              produced.add(id.semanticType);
+              if (opNode.establishes.shape !== 'edge' || (id.acceptsExternal && id.in === 'body')) {
+                produced.add(id.semanticType);
+              }
             }
           }
           const req = (opNode.requestBodySemanticTypes ?? [])

--- a/materializer/src/playwright/ctxSeeding.ts
+++ b/materializer/src/playwright/ctxSeeding.ts
@@ -196,14 +196,18 @@ export interface EmitCtxSeedingOptions {
    * the negative suite's `RV_FIXTURE_*`). For a binding `k` in this map the
    * emitted line becomes
    *
+   *   ctx['k'] = ctx['k'] ?? process.env['<ENV>'] ?? <seed>;
+   *
+   * for seeded bindings (common case for `acceptsExternal` components), or
+   *
    *   ctx['k'] = process.env['<ENV>'] || <literal>;
    *
-   * so an e2e driver (e.g. scripts/e2e/run-hub.sh) can substitute a real,
+   * for literal bindings (e.g. model-derived literals that are always emitted).
+   * In both cases an unset or empty env var falls back to the deterministic
+   * seed/literal — keeping offline/snapshot runs reproducible. An e2e driver
+   * (e.g. scripts/e2e/run-hub.sh) sets the env var to supply a real,
    * server-known value for a client-minted input that has no producer (e.g.
-   * a workspace member's email, which must be an existing user). `||` (not
-   * `??`) so an unset OR empty env var falls back to the deterministic
-   * literal — keeping offline/snapshot runs reproducible. Only literal
-   * bindings are overridden; seeded/global bindings are unaffected.
+   * a workspace member's email, which must be an existing Hub user).
    */
   fixtureEnvByBinding?: Readonly<Record<string, string>>;
 }
@@ -277,7 +281,7 @@ export function emitCtxSeeding(opts: EmitCtxSeedingOptions): string[] {
       const envVar = fixtureEnvByBinding?.[name];
       lines.push(
         envVar
-          ? `${indent}ctx['${name}'] = process.env['${envVar}'] || ${seedCall(name, unique.has(name))};`
+          ? `${indent}ctx['${name}'] = ctx['${name}'] ?? process.env['${envVar}'] ?? ${seedCall(name, unique.has(name))};`
           : `${indent}ctx['${name}'] = ctx['${name}'] ?? ${seedCall(name, unique.has(name))};`,
       );
     }

--- a/materializer/src/playwright/ctxSeeding.ts
+++ b/materializer/src/playwright/ctxSeeding.ts
@@ -191,16 +191,16 @@ export interface EmitCtxSeedingOptions {
    */
   uniqueBindings?: ReadonlySet<string>;
   /**
-   * Maps a literal binding name to an environment-variable name that
-   * overrides its seeded value at runtime (the positive-suite analogue of
+   * Maps a binding name (scenario literal or seeded) to an environment-variable
+   * name that overrides its value at runtime (the positive-suite analogue of
    * the negative suite's `RV_FIXTURE_*`). For a binding `k` in this map the
    * emitted line becomes
    *
-   *   ctx['k'] = ctx['k'] ?? process.env['<ENV>'] ?? <seed>;
+   *   ctx['k'] = ctx['k'] ?? process.env[<ENV>] ?? <seed>;
    *
    * for seeded bindings (common case for `acceptsExternal` components), or
    *
-   *   ctx['k'] = process.env['<ENV>'] || <literal>;
+   *   ctx['k'] = process.env[<ENV>] || <literal>;
    *
    * for literal bindings (e.g. model-derived literals that are always emitted).
    * In both cases an unset or empty env var falls back to the deterministic
@@ -208,6 +208,8 @@ export interface EmitCtxSeedingOptions {
    * (e.g. scripts/e2e/run-hub.sh) sets the env var to supply a real,
    * server-known value for a client-minted input that has no producer (e.g.
    * a workspace member's email, which must be an existing Hub user).
+   * `globalContextSeeds` (universal per-spec prologue seeds) are not affected
+   * by this map — they always use plain seed calls.
    */
   fixtureEnvByBinding?: Readonly<Record<string, string>>;
 }
@@ -273,7 +275,7 @@ export function emitCtxSeeding(opts: EmitCtxSeedingOptions): string[] {
       const envVar = fixtureEnvByBinding?.[k];
       lines.push(
         envVar
-          ? `${indent}ctx['${k}'] = process.env['${envVar}'] || ${JSON.stringify(v)};`
+          ? `${indent}ctx['${k}'] = process.env[${JSON.stringify(envVar)}] || ${JSON.stringify(v)};`
           : `${indent}ctx['${k}'] = ${JSON.stringify(v)};`,
       );
     }
@@ -281,7 +283,7 @@ export function emitCtxSeeding(opts: EmitCtxSeedingOptions): string[] {
       const envVar = fixtureEnvByBinding?.[name];
       lines.push(
         envVar
-          ? `${indent}ctx['${name}'] = ctx['${name}'] ?? process.env['${envVar}'] ?? ${seedCall(name, unique.has(name))};`
+          ? `${indent}ctx['${name}'] = ctx['${name}'] ?? process.env[${JSON.stringify(envVar)}] ?? ${seedCall(name, unique.has(name))};`
           : `${indent}ctx['${name}'] = ctx['${name}'] ?? ${seedCall(name, unique.has(name))};`,
       );
     }

--- a/materializer/src/playwright/ctxSeeding.ts
+++ b/materializer/src/playwright/ctxSeeding.ts
@@ -190,6 +190,22 @@ export interface EmitCtxSeedingOptions {
    * seed, while the `unique` flag toggles which PRNG env is used.
    */
   uniqueBindings?: ReadonlySet<string>;
+  /**
+   * Maps a literal binding name to an environment-variable name that
+   * overrides its seeded value at runtime (the positive-suite analogue of
+   * the negative suite's `RV_FIXTURE_*`). For a binding `k` in this map the
+   * emitted line becomes
+   *
+   *   ctx['k'] = process.env['<ENV>'] || <literal>;
+   *
+   * so an e2e driver (e.g. scripts/e2e/run-hub.sh) can substitute a real,
+   * server-known value for a client-minted input that has no producer (e.g.
+   * a workspace member's email, which must be an existing user). `||` (not
+   * `??`) so an unset OR empty env var falls back to the deterministic
+   * literal — keeping offline/snapshot runs reproducible. Only literal
+   * bindings are overridden; seeded/global bindings are unaffected.
+   */
+  fixtureEnvByBinding?: Readonly<Record<string, string>>;
 }
 
 function seedCall(name: string, unique: boolean): string {
@@ -197,7 +213,14 @@ function seedCall(name: string, unique: boolean): string {
 }
 
 export function emitCtxSeeding(opts: EmitCtxSeedingOptions): string[] {
-  const { indent, bindings, seedBindings, globalContextSeeds, uniqueBindings } = opts;
+  const {
+    indent,
+    bindings,
+    seedBindings,
+    globalContextSeeds,
+    uniqueBindings,
+    fixtureEnvByBinding,
+  } = opts;
   const unique = uniqueBindings ?? new Set<string>();
   const lines: string[] = [];
   // `omitWhenUnbound` seeds are excluded from the universal prologue
@@ -243,11 +266,19 @@ export function emitCtxSeeding(opts: EmitCtxSeedingOptions): string[] {
   if (literalEntries.length > 0 || seedNames.length > 0) {
     lines.push(`${indent}// Seed scenario bindings`);
     for (const [k, v] of literalEntries) {
-      lines.push(`${indent}ctx['${k}'] = ${JSON.stringify(v)};`);
+      const envVar = fixtureEnvByBinding?.[k];
+      lines.push(
+        envVar
+          ? `${indent}ctx['${k}'] = process.env['${envVar}'] || ${JSON.stringify(v)};`
+          : `${indent}ctx['${k}'] = ${JSON.stringify(v)};`,
+      );
     }
     for (const name of seedNames) {
+      const envVar = fixtureEnvByBinding?.[name];
       lines.push(
-        `${indent}ctx['${name}'] = ctx['${name}'] ?? ${seedCall(name, unique.has(name))};`,
+        envVar
+          ? `${indent}ctx['${name}'] = process.env['${envVar}'] || ${seedCall(name, unique.has(name))};`
+          : `${indent}ctx['${name}'] = ctx['${name}'] ?? ${seedCall(name, unique.has(name))};`,
       );
     }
   }

--- a/materializer/src/playwright/ctxSeeding.ts
+++ b/materializer/src/playwright/ctxSeeding.ts
@@ -196,7 +196,7 @@ export interface EmitCtxSeedingOptions {
    * the negative suite's `RV_FIXTURE_*`). For a binding `k` in this map the
    * emitted line becomes
    *
-   *   ctx['k'] = ctx['k'] ?? process.env[<ENV>] ?? <seed>;
+   *   ctx['k'] = ctx['k'] ?? (process.env[<ENV>] || <seed>);
    *
    * for seeded bindings (common case for `acceptsExternal` components), or
    *
@@ -283,7 +283,7 @@ export function emitCtxSeeding(opts: EmitCtxSeedingOptions): string[] {
       const envVar = fixtureEnvByBinding?.[name];
       lines.push(
         envVar
-          ? `${indent}ctx['${name}'] = ctx['${name}'] ?? process.env[${JSON.stringify(envVar)}] ?? ${seedCall(name, unique.has(name))};`
+          ? `${indent}ctx['${name}'] = ctx['${name}'] ?? (process.env[${JSON.stringify(envVar)}] || ${seedCall(name, unique.has(name))});`
           : `${indent}ctx['${name}'] = ctx['${name}'] ?? ${seedCall(name, unique.has(name))};`,
       );
     }

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -197,7 +197,7 @@ export const PlaywrightEmitter: EmitterStrategy = {
         type: 'object',
         additionalProperties: { type: 'string' },
         description:
-          'Maps a binding name (e.g. emailVar) to a runtime env-var name. The emitted seed becomes `ctx[binding] = ctx[binding] ?? process.env[ENV] ?? seedBinding(binding)`, letting an e2e driver substitute a real, server-known value for a client-minted input with no producer (the positive-suite analogue of request-validation RV_FIXTURE_*).',
+          'Maps a binding name (e.g. emailVar) to a runtime env-var name. For seeded bindings the emitted form is `ctx[binding] = ctx[binding] ?? process.env[ENV] ?? seedBinding(binding)`; for literal bindings it is `ctx[binding] = process.env[ENV] || <literal>`. Lets an e2e driver substitute a real, server-known value for a client-minted input with no producer (the positive-suite analogue of request-validation RV_FIXTURE_*). globalContextSeeds are not affected.',
       },
     },
   },

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -195,8 +195,9 @@ export const PlaywrightEmitter: EmitterStrategy = {
       },
       clientMintedFixtures: {
         type: 'object',
+        additionalProperties: { type: 'string' },
         description:
-          'Maps a literal binding name (e.g. emailVar) to a runtime env-var name. The emitted seed becomes `ctx[binding] = process.env[ENV] || <literal>`, letting an e2e driver substitute a real, server-known value for a client-minted input with no producer (the positive-suite analogue of request-validation RV_FIXTURE_*).',
+          'Maps a binding name (e.g. emailVar) to a runtime env-var name. The emitted seed becomes `ctx[binding] = ctx[binding] ?? process.env[ENV] ?? seedBinding(binding)`, letting an e2e driver substitute a real, server-known value for a client-minted input with no producer (the positive-suite analogue of request-validation RV_FIXTURE_*).',
       },
     },
   },

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -197,7 +197,7 @@ export const PlaywrightEmitter: EmitterStrategy = {
         type: 'object',
         additionalProperties: { type: 'string' },
         description:
-          'Maps a binding name (e.g. emailVar) to a runtime env-var name. For seeded bindings the emitted form is `ctx[binding] = ctx[binding] ?? process.env[ENV] ?? seedBinding(binding)`; for literal bindings it is `ctx[binding] = process.env[ENV] || <literal>`. Lets an e2e driver substitute a real, server-known value for a client-minted input with no producer (the positive-suite analogue of request-validation RV_FIXTURE_*). globalContextSeeds are not affected.',
+          'Maps a binding name (e.g. emailVar) to a runtime env-var name. For seeded bindings the emitted form is `ctx[binding] = ctx[binding] ?? (process.env[ENV] || seedBinding(binding))`; for literal bindings it is `ctx[binding] = process.env[ENV] || <literal>`. In both cases an unset or empty env var falls back to the deterministic seed/literal. Lets an e2e driver substitute a real, server-known value for a client-minted input with no producer (the positive-suite analogue of request-validation RV_FIXTURE_*). globalContextSeeds are not affected.',
       },
     },
   },

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -60,7 +60,7 @@ interface EmitOptions {
   /** See {@link EmitContext.roleExtras}. */
   roleExtras?: Map<string, Record<string, unknown>>;
   /**
-   * Per-config map of literal binding name → runtime env-var override
+   * Per-config map of binding name → runtime env-var override
    * (`configs/<config>/codegen/playwright/config.json` → `clientMintedFixtures`).
    * Forwarded to {@link emitCtxSeeding} as `fixtureEnvByBinding`. See that
    * option for the emitted form and rationale.

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -59,6 +59,31 @@ interface EmitOptions {
   roleBundles?: Map<string, LoadedRoleBundle>;
   /** See {@link EmitContext.roleExtras}. */
   roleExtras?: Map<string, Record<string, unknown>>;
+  /**
+   * Per-config map of literal binding name → runtime env-var override
+   * (`configs/<config>/codegen/playwright/config.json` → `clientMintedFixtures`).
+   * Forwarded to {@link emitCtxSeeding} as `fixtureEnvByBinding`. See that
+   * option for the emitted form and rationale.
+   */
+  clientMintedFixtures?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Read `clientMintedFixtures` out of the raw emitter config
+ * (`Record<string, unknown>`), keeping only string-valued entries. Returns
+ * `undefined` when absent or empty so the emitter falls through to plain
+ * literal seeding.
+ */
+function readClientMintedFixtures(
+  cfg: Record<string, unknown> | undefined,
+): Record<string, string> | undefined {
+  const raw = cfg?.clientMintedFixtures;
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (typeof v === 'string') out[k] = v;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 /**
@@ -87,6 +112,7 @@ export function renderPlaywrightSuite(
     getRoleForOperation?: (opId: string) => string | undefined;
     roleBundles?: Map<string, LoadedRoleBundle>;
     roleExtras?: Map<string, Record<string, unknown>>;
+    clientMintedFixtures?: Readonly<Record<string, string>>;
   },
 ): string {
   return buildSuiteSource(collection, {
@@ -98,6 +124,7 @@ export function renderPlaywrightSuite(
     getRoleForOperation: opts.getRoleForOperation,
     roleBundles: opts.roleBundles,
     roleExtras: opts.roleExtras,
+    clientMintedFixtures: opts.clientMintedFixtures,
   });
 }
 
@@ -166,6 +193,11 @@ export const PlaywrightEmitter: EmitterStrategy = {
         description:
           'When true, every emitted scenario step appends a recordResponse({...}) call and the suite imports recordResponse/sanitizeBody from ./support/recorder. Defaults to false; recorder.ts is also vendored conditionally.',
       },
+      clientMintedFixtures: {
+        type: 'object',
+        description:
+          'Maps a literal binding name (e.g. emailVar) to a runtime env-var name. The emitted seed becomes `ctx[binding] = process.env[ENV] || <literal>`, letting an e2e driver substitute a real, server-known value for a client-minted input with no producer (the positive-suite analogue of request-validation RV_FIXTURE_*).',
+      },
     },
   },
   async scaffold(_ctx: EmitContext): Promise<EmittedFile[]> {
@@ -192,6 +224,7 @@ export const PlaywrightEmitter: EmitterStrategy = {
       getRoleForOperation: ctx.getRoleForOperation,
       roleBundles: ctx.roleBundles,
       roleExtras: ctx.roleExtras,
+      clientMintedFixtures: readClientMintedFixtures(ctx.emitterConfig),
     });
     return [
       {
@@ -385,7 +418,14 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   const seeds = opts.globalContextSeeds ?? [];
   for (const scenario of collection.scenarios) {
     lines.push(
-      renderScenarioTest(scenario, seeds, recordResponses, findRoleForStep, opts.roleExtras),
+      renderScenarioTest(
+        scenario,
+        seeds,
+        recordResponses,
+        findRoleForStep,
+        opts.roleExtras,
+        opts.clientMintedFixtures,
+      ),
     );
   }
   lines.push('});');
@@ -398,6 +438,7 @@ function renderScenarioTest(
   recordResponses: boolean,
   findRoleForStep: (step: RequestStep) => { roleName: string; bundle: LoadedRoleBundle } | null,
   roleExtras: Map<string, Record<string, unknown>> | undefined,
+  clientMintedFixtures: Readonly<Record<string, string>> | undefined,
 ): string {
   const title = `${s.id} - ${escapeQuotes(s.name || 'scenario')}`;
   const body: string[] = [];
@@ -458,6 +499,7 @@ function renderScenarioTest(
       seedBindings: s.seedBindings,
       globalContextSeeds,
       uniqueBindings: computeUniqueBindings(s.requestPlan, s.modelDerivedLiteralBindings),
+      fixtureEnvByBinding: clientMintedFixtures,
     }),
   );
   if (!s.requestPlan) {

--- a/path-analyser/src/graphLoader.ts
+++ b/path-analyser/src/graphLoader.ts
@@ -270,6 +270,22 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
         synthesisedFromEstablishes.add(id.semanticType);
       }
     }
+    // Edge-establisher acceptsExternal components are client-minted by the
+    // edge op itself (not pre-existing prerequisites). They land in
+    // `establishes.identifiedBy[*].acceptsExternal === true` and are pushed
+    // into `op.produces` by `normalizeOp` so BFS produced-set propagation
+    // marks them satisfied once the edge op is scheduled. Mark them
+    // synthesised here so they are excluded from `producersByType` —
+    // the authoritative-producer contract must not include edge establishers.
+    // Only BODY-located components are self-minted by the edge op itself;
+    // path-located acceptsExternal components are consumed from the URL
+    // and must be chained from upstream (or fall through to the
+    // externalEntitySites fallback when no producer exists).
+    if (op.establishes && op.establishes.shape === 'edge') {
+      for (const id of op.establishes.identifiedBy) {
+        if (id.acceptsExternal && id.in === 'body') synthesisedFromEstablishes.add(id.semanticType);
+      }
+    }
     for (const st of op.produces) {
       // #288 Phase 2: an op that establishes type T AND authoritatively
       // returns T in a 2xx response (provider:true) is legitimately a
@@ -299,6 +315,23 @@ export async function loadGraph(baseDir: string): Promise<OperationGraph> {
         // ops that genuinely mint a Tenant identifier (`createTenant`),
         // not ops that scope under one.
         if (kindIdentifiers && !kindIdentifiers.has(id.semanticType)) continue;
+        const list = establishersByType[id.semanticType] ?? [];
+        if (!list.includes(op.operationId)) list.push(op.operationId);
+        establishersByType[id.semanticType] = list;
+      }
+    }
+    // Edge-establisher acceptsExternal components: register the edge op as
+    // the satisfier for the client-minted component of the edge. The foreign-
+    // key components (no `acceptsExternal`) legitimately remain in `requires`
+    // and are satisfied by their own upstream chain; only the truly
+    // client-minted body components belong in this index.
+    // Path-located acceptsExternal components are handled by the planner's
+    // own externalEntitySites fallback and do not need a graph index entry —
+    // they are always consumed from an upstream chain (e.g. createGroup for
+    // GroupId) or minted externally if no producer exists.
+    if (op.establishes && op.establishes.shape === 'edge') {
+      for (const id of op.establishes.identifiedBy) {
+        if (!id.acceptsExternal || id.in !== 'body') continue;
         const list = establishersByType[id.semanticType] ?? [];
         if (!list.includes(op.operationId)) list.push(op.operationId);
         establishersByType[id.semanticType] = list;
@@ -814,12 +847,15 @@ function normalizeOp(
   // the provider-preference filter in scenarioGenerator still reaches
   // for true producers first when both kinds exist.
   //
-  // Edge establishers (`shape: 'edge'`) are the membership operations
-  // — their `identifiedBy` entries enumerate the *components* of the
-  // composite identifier (e.g. {GroupId, Username}), which are
-  // *consumed* prerequisites, not values established by this op. The
-  // edge itself has no semantic type the planner can chain on, so we
-  // don't touch `produces` for edges.
+  // Edge establishers (`shape: 'edge'`) enumerate the composite-key
+  // components of a relationship in `identifiedBy`. Foreign-key
+  // components (no `acceptsExternal`) are pre-existing prerequisites —
+  // they stay in `requires` and are NOT added to `produces`. Components
+  // marked `acceptsExternal: true` are client-minted by this edge op
+  // itself (e.g. `MemberEmail` on `addMember`) — they are pushed to
+  // `produces` and excluded from `requires` just like non-edge
+  // establisher identifiers, so the planner can chain this op as the
+  // satisfier without a circular prerequisite loop.
   const establishes = normalizeEstablishes(op.establishes, opId, edgeEstablishers);
   const establishedSemantics = new Set<string>();
   if (establishes && establishes.shape !== 'edge') {
@@ -841,6 +877,28 @@ function normalizeOp(
       establishedSemantics.add(id.semanticType);
     }
   }
+  // Edge-establisher acceptsExternal: the component with `acceptsExternal:
+  // true` in `identifiedBy` (e.g. `MemberEmail` on `addMember`) is
+  // client-minted by the edge op itself rather than being a pre-existing
+  // prerequisite. Treat it the same way non-edge establishes treats its
+  // owned identifiers: push to `produces` so BFS produced-set propagation
+  // marks it satisfied once this op is scheduled, and add to
+  // `establishedSemantics` so it is removed from `requires` (avoiding a
+  // circular dependency where the planner would chase an upstream producer
+  // for a value the op is about to mint itself).
+  // Only BODY-located components qualify: path-located `acceptsExternal`
+  // components (e.g. `groupId` on `assignRoleToGroup`) are consumed from
+  // the URL and must still be chained from upstream (an ordinary producer
+  // like `createGroup` satisfies them). Path `acceptsExternal` is handled
+  // by the planner's own `externalEntitySites` fallback when no producer
+  // is available.
+  if (establishes && establishes.shape === 'edge') {
+    for (const id of establishes.identifiedBy) {
+      if (!id.acceptsExternal || id.in !== 'body') continue;
+      produces.push(id.semanticType);
+      establishedSemantics.add(id.semanticType);
+    }
+  }
 
   return {
     operationId: op.operationId ?? op.id ?? op.name ?? opId,
@@ -851,9 +909,9 @@ function normalizeOp(
     // it mints, so drop the established semantic types from `requires`
     // — otherwise BFS would chase a producer for a value the endpoint
     // itself is going to mint and write into its own request body.
-    // Edge establishers don't enter this branch (no entries in
-    // `establishedSemantics`) because their `identifiedBy` components
-    // are pre-existing inputs that legitimately need a chain.
+    // For edge establishers, only `acceptsExternal: true` components
+    // are in `establishedSemantics`; foreign-key components remain
+    // in `requires` so their upstream chain is still planned.
     requires: {
       required: required.filter((s) => !establishedSemantics.has(s)),
       optional: optional.filter((s) => !establishedSemantics.has(s)),

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1112,7 +1112,7 @@ type RequestBodyPlan =
  * remains enum-unaware for deeper nested arrays — those still seed a
  * `'placeholder'` element, tracked separately.
  */
-type CanonicalNode = {
+export type CanonicalNode = {
   path: string;
   type: string;
   required: boolean;
@@ -1150,7 +1150,34 @@ function formatSeedLiteral(format: string): string | undefined {
   }
 }
 
-function synthesizeObjectFromPrefix(
+/**
+ * Type-aware scalar seed for nested-object leaves. Nested-object synthesis has
+ * no `scenario.bindings` context, so it must emit a concrete literal rather
+ * than a `${var}` seed. That literal MUST match the field's declared JSON type
+ * or the server rejects the whole body: a `boolean` field seeded with the
+ * string `'placeholder'` produced `400 "Request body is not readable"` for
+ * `createCluster`'s `license.validLicense` (Gap B). Resolution order:
+ *   1. format-valid literal (#397) — e.g. a `uuid`/`date-time` string;
+ *   2. type-correct literal — `boolean` → `true`, `integer`/`number` → `1`;
+ *   3. generic `'placeholder'` string fallback for plain strings / unknown.
+ */
+function scalarSeedLiteral(node: CanonicalNode): unknown {
+  if (node.format) {
+    const lit = formatSeedLiteral(node.format);
+    if (lit !== undefined) return lit;
+  }
+  switch (node.type) {
+    case 'boolean':
+      return true;
+    case 'integer':
+    case 'number':
+      return 1;
+    default:
+      return 'placeholder';
+  }
+}
+
+export function synthesizeObjectFromPrefix(
   prefix: string,
   nodes: CanonicalNode[],
 ): Record<string, unknown> {
@@ -1177,16 +1204,16 @@ function synthesizeObjectFromPrefix(
       // schema-honest.
       obj[inner] = [synthesizeArrayElement(`${prefix}${inner}`, nodes)];
     } else {
-      // #397 — for format-constrained scalars, emit a format-valid literal
-      // instead of 'placeholder' which fails server-side format validation.
-      // Unlike the top-level body branches, nested-object synthesis has no
-      // scenario.bindings context here, so it cannot route through runtime
-      // seeding — email therefore gets the fixed `seed@example.com` literal
-      // rather than the per-call `${emailVar}` seed. A nested required-and-
-      // unique email field could collide; no such field exists in the current
-      // specs, and the fixed literal is still strictly better than the old
-      // invalid 'placeholder'.
-      obj[inner] = (n.format && formatSeedLiteral(n.format)) ?? 'placeholder';
+      // Type-aware scalar seed (#397 for format, Gap B for boolean/number).
+      // Nested-object synthesis has no scenario.bindings context here, so it
+      // cannot route through runtime seeding — email therefore gets the fixed
+      // `seed@example.com` literal rather than the per-call `${emailVar}` seed.
+      // A nested required-and-unique email field could collide; no such field
+      // exists in the current specs, and the fixed literal is still strictly
+      // better than the old invalid 'placeholder'. `scalarSeedLiteral` also
+      // honours the declared type so a boolean/integer field is not seeded
+      // with a type-invalid string.
+      obj[inner] = scalarSeedLiteral(n);
     }
   }
   return obj;

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1172,6 +1172,8 @@ function scalarSeedLiteral(node: CanonicalNode): unknown {
     case 'integer':
     case 'number':
       return 1;
+    case 'null':
+      return null;
     default:
       return 'placeholder';
   }

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -151,10 +151,16 @@ export function generateScenariosForEndpoint(
   // gate would short-circuit endpoints whose required semantic is only mintable via an establisher
   // (e.g. getUser/getTenant after the spec is annotated), and the BFS augmentation downstream
   // would never run.
+  //
+  // Edge-establisher note: an edge op that has `acceptsExternal: true` components is registered in
+  // `establishersByType` for those components. When the edge op IS the endpoint being planned, the
+  // endpoint cannot self-satisfy — only a DIFFERENT establisher op can chain-produce the semantic.
+  // Exclude the endpoint itself from the hasEstablisher check so the `externalEntitySites` fallback
+  // (lines below) still fires for the endpoint's own bimodal acceptsExternal components.
   const missing: string[] = [];
   for (const st of initialNeeded) {
     const hasProducer = graph.producersByType[st]?.length;
-    const hasEstablisher = graph.establishersByType?.[st]?.length;
+    const hasEstablisher = graph.establishersByType?.[st]?.some((opId) => opId !== endpointOpId);
     // #305 Phase 3: `runtimeEmission` semantics have no graph-indexed
     // producer (their discovery op is declared in the ABox via
     // `discoveredVia`, not via response provider annotations). They
@@ -570,7 +576,9 @@ export function generateScenariosForEndpoint(
       if (decl?.kind === 'runtimeEmission' && decl.discoveredVia && decl.emittedBy) return true;
       const candidates = [
         ...(graph.producersByType[st] ?? []),
-        ...(graph.establishersByType?.[st] ?? []),
+        // Exclude the endpoint itself: an edge op cannot self-satisfy its own
+        // acceptsExternal components via a preceding call to itself.
+        ...(graph.establishersByType?.[st] ?? []).filter((id) => id !== endpointOpId),
       ];
       return candidates.some((opId) => {
         const node = graph.operations[opId];

--- a/tests/fixtures/planner/nested-scalar-seed-types.test.ts
+++ b/tests/fixtures/planner/nested-scalar-seed-types.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Type-aware nested-object scalar seeding — Gap B.
+ *
+ * `synthesizeObjectFromPrefix` seeds concrete literals for the leaves of a
+ * required nested object (there is no `scenario.bindings` context inside a
+ * nested object, so it cannot route through `${var}` runtime seeding). The
+ * literal MUST match the field's declared JSON type, or the server rejects the
+ * entire request body.
+ *
+ * Regression: `createCluster`'s `license.validLicense` is `type: boolean`, but
+ * the synthesizer emitted the string `'placeholder'`, producing
+ * `400 "Request body is not readable"`. Before the fix every non-object/array
+ * leaf became a string; this asserts the seed honours the declared scalar type.
+ *
+ * Class-scoped: covers boolean, integer, and number (not just the boolean
+ * instance that was reported), while preserving the existing string and
+ * format-literal behaviour.
+ */
+import { describe, expect, it } from 'vitest';
+import { synthesizeObjectFromPrefix } from '../../../path-analyser/src/index.ts';
+
+describe('synthesizeObjectFromPrefix: type-aware scalar seeds (Gap B)', () => {
+  it('seeds a boolean leaf as a boolean, not the string "placeholder"', () => {
+    const obj = synthesizeObjectFromPrefix('license.', [
+      { path: 'license.validLicense', type: 'boolean', required: true },
+      { path: 'license.licenseType', type: 'string', required: true },
+    ]);
+    expect(obj.validLicense).toBe(true);
+    expect(typeof obj.validLicense).toBe('boolean');
+    // plain string field keeps the generic placeholder
+    expect(obj.licenseType).toBe('placeholder');
+  });
+
+  it('seeds integer and number leaves as numbers', () => {
+    const obj = synthesizeObjectFromPrefix('quota.', [
+      { path: 'quota.maxNodes', type: 'integer', required: true },
+      { path: 'quota.ratio', type: 'number', required: true },
+    ]);
+    expect(typeof obj.maxNodes).toBe('number');
+    expect(typeof obj.ratio).toBe('number');
+  });
+
+  it('still emits a format-valid literal for format-constrained scalars (#397)', () => {
+    const obj = synthesizeObjectFromPrefix('meta.', [
+      { path: 'meta.correlationKey', type: 'string', required: true, format: 'uuid' },
+    ]);
+    expect(obj.correlationKey).toBe('00000000-0000-4000-8000-000000000001');
+  });
+
+  it('still emits "placeholder" for a plain string leaf with no format', () => {
+    const obj = synthesizeObjectFromPrefix('meta.', [
+      { path: 'meta.name', type: 'string', required: true },
+    ]);
+    expect(obj.name).toBe('placeholder');
+  });
+});

--- a/tests/fixtures/planner/planner-establishes.test.ts
+++ b/tests/fixtures/planner/planner-establishes.test.ts
@@ -62,6 +62,15 @@ function makeGraph(nodes: OperationNode[]): OperationGraph {
         synthesisedFromEstablishes.add(id.semanticType);
       }
     }
+    // Edge establishers: body-located `acceptsExternal: true` components are
+    // client-minted by the edge op itself. Mirror graphLoader: they belong in
+    // `establishersByType`, not `producersByType`. Path-located acceptsExternal
+    // components remain in `requires` and are chained from upstream producers.
+    if (node.establishes && node.establishes.shape === 'edge') {
+      for (const id of node.establishes.identifiedBy) {
+        if (id.acceptsExternal && id.in === 'body') synthesisedFromEstablishes.add(id.semanticType);
+      }
+    }
     for (const sem of node.produces) {
       if (synthesisedFromEstablishes.has(sem)) continue;
       const list = producersByType[sem] ?? [];
@@ -70,6 +79,18 @@ function makeGraph(nodes: OperationNode[]): OperationGraph {
     }
     if (node.establishes && node.establishes.shape !== 'edge') {
       for (const id of node.establishes.identifiedBy) {
+        const list = establishersByType[id.semanticType] ?? [];
+        if (!list.includes(node.operationId)) list.push(node.operationId);
+        establishersByType[id.semanticType] = list;
+      }
+    }
+    // Edge establisher body `acceptsExternal` components: register in
+    // establishersByType so the planner can chain this op as a satisfier.
+    // Path `acceptsExternal` components are handled via upstream producers or
+    // the planner's own externalEntitySites fallback and do not need an entry.
+    if (node.establishes && node.establishes.shape === 'edge') {
+      for (const id of node.establishes.identifiedBy) {
+        if (!id.acceptsExternal || id.in !== 'body') continue;
         const list = establishersByType[id.semanticType] ?? [];
         if (!list.includes(node.operationId)) list.push(node.operationId);
         establishersByType[id.semanticType] = list;
@@ -745,5 +766,77 @@ describe('planner contracts: x-semantic-establishes (#104)', () => {
       expect(afterUsername).toEqual(beforeUsername);
       expect(afterUsername).not.toContain('createUser');
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge-establisher chaining: acceptsExternal component (#removeMember class)
+// ---------------------------------------------------------------------------
+//
+// An edge establisher (addMember) creates a relationship whose composite
+// identity is (WorkspaceKey, MemberEmail). The WorkspaceKey is a
+// pre-existing foreign-key constraint; MemberEmail carries
+// `acceptsExternal: true` — it is client-minted by addMember itself, not
+// a pre-existing prerequisite. A consumer (removeMember) that requires
+// both WorkspaceKey and MemberEmail must chain:
+//   createWorkspace → addMember → removeMember
+//
+// Class-scoped invariant: any consumer whose required semantic type is
+// exclusively satisfiable through an edge establisher's `acceptsExternal`
+// component MUST produce a satisfied chain that includes the edge
+// establisher. No `unsatisfied` scenario may be emitted when the edge
+// establisher is the only reachable source for the semantic.
+describe('edge-establisher acceptsExternal chaining', () => {
+  // addMember is the edge establisher: it accepts a client-minted email and
+  // associates it with an existing workspace. Its produces list carries
+  // MemberEmail (the acceptsExternal component) so BFS marks it satisfied
+  // once addMember is scheduled.
+  const fixtureEdgeEstablisherChain: OperationGraph = makeGraph([
+    makeOp('createWorkspace', 'POST', '/workspaces', {
+      produces: ['WorkspaceKey'],
+      providerMap: { WorkspaceKey: true },
+    }),
+    makeOp('addMember', 'POST', '/workspaces/{workspaceKey}/members', {
+      // Mirrors normalizeOp after the edge-establisher fix:
+      // acceptsExternal component in produces, foreign-key stays in required.
+      required: ['WorkspaceKey'],
+      produces: ['MemberEmail'],
+      establishes: {
+        kind: 'WorkspaceMemberMembership',
+        shape: 'edge',
+        identifiedBy: [
+          { in: 'path', name: 'workspaceKey', semanticType: 'WorkspaceKey' },
+          { in: 'body', name: 'email', semanticType: 'MemberEmail', acceptsExternal: true },
+        ],
+      },
+    }),
+    makeOp('removeMember', 'DELETE', '/workspaces/{workspaceKey}/members/{email}', {
+      required: ['WorkspaceKey', 'MemberEmail'],
+    }),
+  ]);
+
+  it('emits a satisfied chain createWorkspace → addMember → removeMember', () => {
+    const result = generateScenariosForEndpoint(fixtureEdgeEstablisherChain, 'removeMember', {
+      maxChainAlternatives: 10,
+    });
+    expect(result.unsatisfied).toBeFalsy();
+    const scenario = result.scenarios[0];
+    expect(opIdsOf(scenario)).toEqual(['createWorkspace', 'addMember', 'removeMember']);
+  });
+
+  it('does not emit an unsatisfied scenario when the edge establisher is the only source', () => {
+    const result = generateScenariosForEndpoint(fixtureEdgeEstablisherChain, 'removeMember', {
+      maxChainAlternatives: 10,
+    });
+    expect(result.scenarios.every((s) => s.id !== 'unsatisfied')).toBe(true);
+  });
+
+  it('does not add the edge establisher to producersByType for its acceptsExternal component', () => {
+    // Guard: the MemberEmail slot must remain in establishersByType only.
+    // If it leaked into producersByType the authoritative-producer contract
+    // would be violated and other diagnostics (variant planning, missing-
+    // producer signals) would silently break.
+    expect(fixtureEdgeEstablisherChain.producersByType.MemberEmail).toBeUndefined();
+    expect(fixtureEdgeEstablisherChain.establishersByType?.MemberEmail).toContain('addMember');
   });
 });


### PR DESCRIPTION
## Summary

Three fixes on the Hub test-generation path, each independently useful:

### C1 — Seed nested-object scalar leaves with type-correct literals (`48e482e`)

Scalar values nested inside `allOf`/`oneOf`/object schemas were seeded as
`{}` (empty object) instead of their correct primitive type.  The extractor
now walks into nested schemas and emits a leaf literal of the right type
(`string`, `integer`, `boolean`, `number`, or `null`) for every scalar leaf.

### C2 — Register edge-establisher body `acceptsExternal` components in `establishersByType` (`b7e81e1`)

`graphLoader.ts` excluded all edge-shaped establishers from
`establishersByType`.  Edge ops like `addMember` whose `x-establishes`
block carries a body component marked `acceptsExternal: true` (meaning the
value is client-minted — no server producer exists) were therefore invisible
to the BFS planner, leaving `MemberEmail` unsatisfied and `removeMember`
generating an `unsatisfied` scenario.

Fix: register body `acceptsExternal` edge components in
`establishersByType` (and exclude them from `requires.required`), enabling
the chain `createWorkspace → addMember → removeMember`.  Path-located
`acceptsExternal` components (e.g. OCA's `assignRoleToGroup.groupId`) are
unaffected — they remain in `requires.required` and chain via their upstream
producer as before.

Layer-2 fixture added: three new tests covering the new chain, the standalone
`addMember` binding, and the unchanged OCA `assignRoleToGroup` scenario.

### C3 — Extend `clientMintedFixtures` env-var override to seeded bindings (`0a3c850`)

`clientMintedFixtures` (in `configs/<config>/codegen/playwright/config.json`)
maps a binding name to a runtime env var so an e2e driver can substitute a
real server-known value for a client-minted input.  The override was only
applied to `literalEntries` in `emitCtxSeeding`; bindings routed through
`seedNames` (the common case for `acceptsExternal` components) were silently
ignored.

Fix: extend the lookup to the `seedNames` loop.  Emitted form:
```ts
ctx.emailVar = process.env.POS_FIXTURE_MEMBER_EMAIL || seedBinding('emailVar');
```

Hub playwright config registers `emailVar → POS_FIXTURE_MEMBER_EMAIL`,
enabling:
```bash
POS_FIXTURE_MEMBER_EMAIL=camunda@example.com npx playwright test
```

## Testing

- All 803 vitest tests pass (`npm test`)
- Hub positive suite run against live Hub (`feat/public-api-semantic-annotations`):
  - `addMember` ✅ `removeMember` ✅ (full `createWorkspace → addMember → removeMember` chain)
  - 22 other tests pass; remaining 26 failures are the known upstream blocker (issue #24664 / PR #25580 in camunda-hub — content-op authorization)

## Dependencies

Requires `acceptsExternal: true` on the `email` component in
`camunda-hub` PR #25146 (`feat/public-api-semantic-annotations`). Without
it the new planner chain has nothing to chain from.