### PR TITLE
feat(camunda-hub): Workspace + Project entity lifecycles (#25264 item 2)

### DIFF
--- a/configs/camunda-hub/ontology/entity-kinds.json
+++ b/configs/camunda-hub/ontology/entity-kinds.json
@@ -6,6 +6,26 @@
   "kinds": [
     {
       "@type": "EntityKind",
+      "name": "Workspace",
+      "shape": "entity",
+      "identifiers": ["WorkspaceKey"],
+      "establishedBy": "createWorkspace",
+      "observableVia": "getWorkspace",
+      "revokedBy": "deleteWorkspace",
+      "description": "A workspace entity, identified by its server-minted workspaceKey. Established via createWorkspace (POST /workspaces), observed via getWorkspace, revoked via deleteWorkspace."
+    },
+    {
+      "@type": "EntityKind",
+      "name": "Project",
+      "shape": "entity",
+      "identifiers": ["ProjectKey"],
+      "establishedBy": "createProject",
+      "observableVia": "getProject",
+      "revokedBy": "deleteProject",
+      "description": "A project (process application) entity, identified by its server-minted projectKey. Established via createProject (POST /projects), observed via getProject, revoked via deleteProject."
+    },
+    {
+      "@type": "EntityKind",
       "name": "File",
       "shape": "entity",
       "identifiers": ["FileKey"],


### PR DESCRIPTION
## What

Adds **Workspace** and **Project** as `shape: entity` kinds in the camunda-hub entity-kinds ABox, so the existing `EntityLifecycle` template generates their full lifecycle suites (establish → observe-present → revoke → observe-absent):

- **Workspace** — createWorkspace / getWorkspace / deleteWorkspace (`WorkspaceKey`)
- **Project** — createProject / getProject / deleteProject (`ProjectKey`)

Config-only — uses the machinery already on `main`.

## Validation

- Both lifecycle specs **pass against a live Hub**.
- OCA regression unaffected: **813 passing**; lint clean.

## Scope note (why no membership edge here)

This started as the edge/entity ABox salvaged from the closed #409. The **Workspace/Project entity lifecycles** are ready and land here. The **`WorkspaceMemberMembership` edge** (#25264 item 3) is **not** included: its observe op (`searchMembers`) scopes membership by `filter.workspaceKey` — a filter-body field the planner does not yet bind (blocked on the #168 filter setter-chain), so the search returns empty and the edge lifecycle can't pass. Filed separately.

Refs camunda-hub#25264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)