### PR TITLE
fix(planner): recover stranded variant/chaining fixes lost after #414 squash-merge

### DIFF
--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1071,7 +1071,7 @@ function camelCase(name: string) {
   return name.charAt(0).toLowerCase() + name.slice(1);
 }
 
-type CanonicalShape = {
+export type CanonicalShape = {
   requestByMediaType?: Record<
     string,
     {
@@ -1254,7 +1254,7 @@ function synthesizeArrayElement(basePath: string, nodes: CanonicalNode[]): unkno
   return synthesizeObjectFromPrefix(prefix, nodes);
 }
 
-function buildRequestBodyFromCanonical(
+export function buildRequestBodyFromCanonical(
   opId: string,
   scenario: EndpointScenario,
   graph: OperationGraph,
@@ -1544,11 +1544,28 @@ function buildRequestBodyFromCanonical(
     // the leaf name (e.g. `nameVar`). The server then rejects the request
     // with 400 "Request property [name] cannot be parsed". This is the
     // same defect class as #174 sub-class 1.
+    // #416 — a sub-shape variant exercises its leaf ONLY on the endpoint
+    // under test (injected by mergePopulatesSubShapeIntoFinalBody). A
+    // prerequisite step must NOT opportunistically fill an optional field of
+    // the same leaf from the variant's binding: the binding is __PENDING__
+    // (or resolved only by a later producer step), so the prereq would send a
+    // not-yet-created key. e.g. updateFile's folderKey variant chains
+    // createFile → createFolder → updateFile; without this guard createFile
+    // sends the seeded folderKey before createFolder runs → 403.
+    const variantLeafNames =
+      !isEndpoint && scenario.populatesSubShape
+        ? new Set(
+            (scenario.populatesSubShape.leafPaths ?? []).map(
+              (p) => p.replace(/\[\]$/, '').split('.').pop() ?? '',
+            ),
+          )
+        : undefined;
     for (const f of nodes.filter(
       (n) => !n.required && !n.path.includes('[]') && !n.path.includes('.'),
     )) {
       const leaf = f.path.split('.').pop() ?? '';
       if (allowedFields && !allowedFields.has(leaf)) continue;
+      if (variantLeafNames?.has(leaf)) continue;
       const varBase = `${camelCase(bindingMap[f.path] || leaf || 'value')}Var`;
       if (!template[leaf]) {
         if (scenario.bindings?.[varBase]) {

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -2149,9 +2149,27 @@ export function generateOptionalSubShapeVariants(
       // searchElementInstances → ElementId).
       const authoritative = graph.producersByType[leaf.semantic] ?? [];
       const inclusive = graph.responseProducersByType?.[leaf.semantic] ?? [];
-      const producerCandidates = unique(
+      const externalCandidates = unique(
         authoritative.length > 0 ? authoritative : inclusive,
       ).filter((id) => id !== endpointOpId);
+      // #416 follow-up — self-referential OPTIONAL leaf. When the endpoint op
+      // is the ONLY producer of this semantic (e.g. createFolder's optional
+      // `parentFolderKey`, a FolderKey that only createFolder mints), allow a
+      // DISTINCT prior instance of the endpoint op as the parent producer so
+      // the body references a real sibling entity instead of a seeded fake
+      // (which the server rejects — 403/404, "folder not found"). The chain
+      // becomes createFolder(parent, at root) → createFolder(child,
+      // parentFolderKey=parent). `generateScenariosForEndpoint` gates the
+      // self-instance behind `allowEndpointAsProducer` (set by
+      // tryProducerChainVariant) and caps the repeat at one via cycle
+      // detection; the #416 prereq-scope guard keeps the warm-up producer from
+      // itself carrying `parentFolderKey`. The self-referential REQUIRED case
+      // (the path-param target entity, e.g. updateFolder) is already skipped
+      // by the requires.required guard above.
+      const endpointIsSoleProducer =
+        externalCandidates.length === 0 &&
+        (authoritative.includes(endpointOpId) || inclusive.includes(endpointOpId));
+      const producerCandidates = endpointIsSoleProducer ? [endpointOpId] : externalCandidates;
 
       // #162 PR 4 (suite-partition cut): Try to build a producer-chain
       // variant first (the canonical "warm-up + search + final" pattern

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -609,7 +609,28 @@ export function generateScenariosForEndpoint(
         return !!node && hasSatisfiedRequiredInputs(node, state.produced);
       });
     };
-    const targetSemantic = remaining.find(isActionableTarget) ?? remaining[0];
+    // #388 follow-up: when NO target is immediately actionable, prefer one
+    // whose authoritative producer's defer will make PROGRESS — i.e. it has a
+    // missing required input that is NOT already in `needed`, so
+    // `deferForMissingPrereqs` front-loads that new prereq (rather than
+    // skipping because "every missing prereq is already in needed"). Without
+    // this, a deep diamond dead-ends: e.g. updateFile's folderKey variant needs
+    // {FileKey, FileRevision, ProjectKey, FolderKey}; from the initial state
+    // none is actionable, so remaining[0] (FileKey→createFile) is targeted, but
+    // its only missing prereq (ProjectKey) is in `needed` → skipped without
+    // enqueue, and ProjectKey→createProject (whose defer would front-load the
+    // NOT-in-needed WorkspaceKey and unblock everything) is never targeted.
+    const canDeferProgress = (st: string): boolean => {
+      const candidates = graph.producersByType[st] ?? [];
+      return candidates.some((opId) => {
+        const node = graph.operations[opId];
+        if (!node || node.providerMap?.[st] !== true) return false;
+        const missing = node.requires.required.filter((s) => !state.produced.has(s));
+        return missing.length > 0 && missing.some((s) => !state.needed.has(s));
+      });
+    };
+    const targetSemantic =
+      remaining.find(isActionableTarget) ?? remaining.find(canDeferProgress) ?? remaining[0];
 
     // #305 Phase 3 — `runtimeEmission` semantics declare a discovery
     // operation (ABox `discoveredVia.operationId`) that surfaces the

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -109,6 +109,30 @@ export function generateScenariosForEndpoint(
   const required = [...endpoint.requires.required];
   const optional = [...endpoint.requires.optional];
 
+  // #415: a REQUIRED request-body field carrying a semantic type that has a
+  // producer must be CHAINED (extracted from the producer) rather than seeded.
+  // Example: updateFile's `revision` (FileRevision) — the file's current
+  // optimistic-lock revision, produced by createFile; seeding a placeholder
+  // fails ("Cannot coerce String to Integer" / stale revision). Promote such
+  // semantics into the required set so the BFS chains a producer and the body
+  // binds the extracted value. Guarded on `required` + a live producer that is
+  // NOT this endpoint itself — optional body semantics (variant leaves),
+  // producer-less client-minted fields, and identifiers the endpoint MINTS
+  // (e.g. createTenant supplies AND returns its own TenantId; promoting it would
+  // make the op chain a producer for its own output) are all untouched.
+  // Already-required semantics dedup below.
+  for (const rb of endpoint.requestBodySemantics ?? []) {
+    const producers = graph.producersByType[rb.semantic];
+    if (
+      rb.required &&
+      producers?.length &&
+      !producers.includes(endpointOpId) &&
+      !required.includes(rb.semantic)
+    ) {
+      required.push(rb.semantic);
+    }
+  }
+
   // Domain requirements flattening (for initial endpoint) - treat all domainRequiresAll as required states for ranking only (not gating existing logic yet)
   const domainRequiredStates = endpoint.domainRequiresAll ? [...endpoint.domainRequiresAll] : [];
   const domainDisjunctions = endpoint.domainDisjunctions ? [...endpoint.domainDisjunctions] : [];

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -1202,3 +1202,51 @@ describe('planner contracts: self-referential optional leaf is skipped (#updateF
     expect(leafSemantics).toContain('SiblingKey');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Required request-body semantic is chained from its producer (#415).
+//
+// A REQUIRED request-body field carrying a semantic type with a producer must
+// be chained (extracted from the producer) rather than seeded — e.g.
+// updateFile's optimistic-lock `revision` (FileRevision) produced by createFile.
+// The endpoint MUST NOT chain a producer for a semantic it mints itself (e.g.
+// createTenant supplies + returns its own client-minted TenantId) — that would
+// make it depend on its own output.
+// ---------------------------------------------------------------------------
+const fixtureRequiredBodySemanticChained: OperationGraph = makeGraph([
+  makeOp('createThing', { produces: ['ThingKey'], providerMap: { ThingKey: true } }),
+  makeOp('readThingRevision', {
+    produces: ['ThingRevision'],
+    providerMap: { ThingRevision: true },
+  }),
+  makeOp('updateThing', {
+    required: ['ThingKey'],
+    requestBodySemantics: [{ semantic: 'ThingRevision', fieldPath: 'revision', required: true }],
+  }),
+]);
+
+const fixtureSelfMintedBodySemantic: OperationGraph = makeGraph([
+  makeOp('createTenantLike', {
+    produces: ['TenantIdLike'],
+    providerMap: { TenantIdLike: true },
+    requestBodySemantics: [{ semantic: 'TenantIdLike', fieldPath: 'tenantId', required: true }],
+  }),
+]);
+
+describe('planner contracts: required request-body semantic chained from producer (#415)', () => {
+  it('promotes a required body semantic (with an external producer) into the chain', () => {
+    const scenario = plan(fixtureRequiredBodySemanticChained, 'updateThing').scenarios[0];
+    const ops = opIdsOf(scenario);
+    // The producer of the required body semantic (ThingRevision) is chained —
+    // NOT just the path-key producer (createThing).
+    expect(ops).toContain('readThingRevision');
+    expect(ops).toContain('createThing');
+  });
+
+  it('does NOT chain a producer for a body semantic the endpoint mints itself', () => {
+    const coll = plan(fixtureSelfMintedBodySemantic, 'createTenantLike');
+    // Satisfiable as a single-op scenario — no attempt to source its own output.
+    expect(coll.unsatisfied).toBe(false);
+    expect(opIdsOf(coll.scenarios[0])).toEqual(['createTenantLike']);
+  });
+});

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -231,6 +231,61 @@ const fixtureTransitivePrereq: OperationGraph = makeGraph([
   }),
 ]);
 
+// ---------------------------------------------------------------------------
+// Fixture F2: deep diamond — target selection must prefer a producer whose
+// defer makes progress (#388 follow-up, updateFile.variant-2)
+// ---------------------------------------------------------------------------
+//
+// Endpoint requires [A, B] (A is remaining[0]). Both siblings are blocked:
+//   - produceA requires B — but B is already in `needed` (endpoint requires
+//     it), so `deferForMissingPrereqs` would skip produceA WITHOUT enqueuing
+//     anything (every missing prereq already tracked) → no progress.
+//   - produceB requires C — C is NOT in `needed`, so deferring produceB
+//     front-loads produceC → progress.
+// If target selection always falls back to remaining[0] (=A), the state
+// drains without ever front-loading C, and B/A are seeded with fakes. The
+// planner must instead target B (whose defer progresses), yielding the full
+// transitive chain [produceC, produceB, produceA, endpoint]. This mirrors
+// updateFile's folderKey variant: {FileKey, ProjectKey, FolderKey} are all in
+// `needed`, createFile/createFolder defer without progress (need ProjectKey ∈
+// needed), only createProject's defer front-loads WorkspaceKey.
+const fixtureDeepDiamond: OperationGraph = makeGraph([
+  makeOp('produceC', {
+    produces: ['C'],
+    providerMap: { C: true },
+  }),
+  makeOp('produceB', {
+    produces: ['B'],
+    required: ['C'],
+    providerMap: { B: true },
+  }),
+  makeOp('produceA', {
+    produces: ['A'],
+    required: ['B'],
+    providerMap: { A: true },
+  }),
+  makeOp('endpointRequiringAB', {
+    required: ['A', 'B'],
+  }),
+]);
+
+describe('planner contracts: deep-diamond target selection (#388 follow-up)', () => {
+  it('assembles the full transitive chain rather than draining to fake seeds', () => {
+    const collection = plan(fixtureDeepDiamond, 'endpointRequiringAB');
+    expect(collection.unsatisfied).not.toBe(true);
+    expect(collection.scenarios.length).toBeGreaterThan(0);
+    const ops = opIdsOf(collection.scenarios[0]);
+    // Every prereq producer present, none dropped/seeded.
+    expect(ops).toContain('produceC');
+    expect(ops).toContain('produceB');
+    expect(ops).toContain('produceA');
+    // Ordering: each producer after its prereq producer.
+    expect(ops.indexOf('produceC')).toBeLessThan(ops.indexOf('produceB'));
+    expect(ops.indexOf('produceB')).toBeLessThan(ops.indexOf('produceA'));
+    expect(ops[ops.length - 1]).toBe('endpointRequiringAB');
+  });
+});
+
 describe('planner contracts: provider preference', () => {
   it('first scenario uses the authoritative provider (#34)', () => {
     // The planner explores both authoritative and incidental producers

--- a/tests/fixtures/planner/planner-contracts.test.ts
+++ b/tests/fixtures/planner/planner-contracts.test.ts
@@ -510,6 +510,60 @@ describe('planner contracts: optional sub-shape variants (#37)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Fixture H2: self-referential OPTIONAL leaf chains a distinct instance (#416)
+// ---------------------------------------------------------------------------
+//
+// `createFolder` produces `FolderKey` authoritatively AND has an optional
+// `parentFolderKey` (also a `FolderKey`). It is the ONLY producer of
+// `FolderKey`. Populating the optional leaf therefore needs a DISTINCT prior
+// `createFolder` instance to mint a real parent — otherwise the variant seeds
+// a fake key the server rejects (403/404). The endpoint is NOT a required
+// consumer of `FolderKey` (that's the path-param case, skipped elsewhere), so
+// the self-instance is legal. Expected chain:
+//   [createWorkspace, createProject, createFolder (parent), createFolder (child)]
+const fixtureSelfRefOptionalLeaf: OperationGraph = makeGraph([
+  makeOp('createWorkspace', {
+    produces: ['WorkspaceKey'],
+    providerMap: { WorkspaceKey: true },
+  }),
+  makeOp('createProject', {
+    required: ['WorkspaceKey'],
+    produces: ['ProjectKey'],
+    providerMap: { ProjectKey: true },
+  }),
+  makeOp('createFolder', {
+    required: ['ProjectKey'],
+    optional: ['FolderKey'],
+    produces: ['FolderKey'],
+    providerMap: { FolderKey: true },
+    optionalSubShapes: [
+      {
+        rootPath: '',
+        leaves: [{ fieldPath: 'parentFolderKey', semantic: 'FolderKey' }],
+      },
+    ],
+  }),
+]);
+
+describe('planner contracts: self-referential optional leaf (#416)', () => {
+  it('chains a distinct endpoint instance as the parent producer, not a seed', () => {
+    const variants = generateOptionalSubShapeVariants(fixtureSelfRefOptionalLeaf, 'createFolder', {
+      maxVariantsPerEndpoint: 10,
+    });
+    expect(variants.scenarios.length).toBeGreaterThan(0);
+    const variant = variants.scenarios[0];
+    const ops = opIdsOf(variant);
+    // Two createFolder instances: warm-up parent (at root) + endpoint child.
+    expect(ops.filter((o) => o === 'createFolder')).toHaveLength(2);
+    expect(ops).toEqual(['createWorkspace', 'createProject', 'createFolder', 'createFolder']);
+    // The leaf binding is CHAINED (__PENDING__, resolved from the warm-up's
+    // response extract), NOT a seeded fake literal.
+    expect(variant.bindings?.folderKeyVar).toBe('__PENDING__');
+    expect(variant.populatesSubShape?.leafPaths).toEqual(['parentFolderKey']);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Fixture I: variant planner ignores producers whose only response leaf
 // is in a 4xx/5xx response (#37)
 // ---------------------------------------------------------------------------

--- a/tests/fixtures/planner/variant-leaf-prereq-scope.test.ts
+++ b/tests/fixtures/planner/variant-leaf-prereq-scope.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Body-synthesis contract (#416) — a sub-shape variant exercises its leaf
+ * ONLY on the endpoint under test, never on a prerequisite step.
+ *
+ * `mergePopulatesSubShapeIntoFinalBody` injects the exercised leaf into the
+ * final (endpoint) step. A prerequisite step that happens to expose an
+ * OPTIONAL field of the same leaf must NOT opportunistically fill it from the
+ * variant's binding: that binding is `__PENDING__` (or resolved only by a
+ * later producer step), so the prerequisite would send a not-yet-created key
+ * and 4xx.
+ *
+ * Reproduces updateFile's folderKey variant: the chain runs
+ * createFile → createFolder → updateFile, and `createFile` also has an
+ * optional `folderKey`. Before the fix, `createFile`'s body carried
+ * `${folderKeyVar}` (seeded, folder not yet created) → 403.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  buildRequestBodyFromCanonical,
+  type CanonicalShape,
+} from '../../../path-analyser/src/index.ts';
+import type { EndpointScenario, OperationGraph } from '../../../path-analyser/src/types.ts';
+
+// createFile-like body: required `name`, optional `folderKey`.
+const canonical: Record<string, CanonicalShape> = {
+  createFile: {
+    requestByMediaType: {
+      'application/json': [
+        { path: 'name', type: 'string', required: true },
+        { path: 'folderKey', type: 'string', required: false },
+      ],
+    },
+  },
+};
+
+const graph: OperationGraph = {
+  operations: {
+    createFile: {
+      operationId: 'createFile',
+      method: 'POST',
+      path: '/files',
+      requires: { required: [], optional: [] },
+      produces: [],
+    },
+  },
+  producersByType: {},
+  producersByState: {},
+  responseProducersByType: {},
+};
+
+function variantScenario(): EndpointScenario {
+  return {
+    id: 'variant-2',
+    operations: [],
+    producedSemanticTypes: [],
+    satisfiedSemanticTypes: [],
+    // The variant leaf binding exists in the scenario (installed for the
+    // endpoint step) — this is exactly what used to leak into the prereq.
+    bindings: { folderKeyVar: '__PENDING__' },
+    populatesSubShape: {
+      rootPath: '',
+      leafPaths: ['folderKey'],
+      leafSemantics: ['FolderKey'],
+    },
+  };
+}
+
+describe('variant leaf-population is endpoint-scoped (#416)', () => {
+  it('does NOT fill the exercised leaf into a prerequisite body', () => {
+    const plan = buildRequestBodyFromCanonical(
+      'createFile',
+      variantScenario(),
+      graph,
+      canonical,
+      {},
+      /* isEndpoint */ false,
+    );
+    expect(plan?.kind).toBe('json');
+    const template = plan?.kind === 'json' ? plan.template : {};
+    expect(template).toHaveProperty('name'); // required field still synthesised
+    expect(template).not.toHaveProperty('folderKey'); // leaf must not leak into prereq
+  });
+
+  it('still fills the optional leaf when the step IS the endpoint', () => {
+    // Guard is scoped to prerequisites: the endpoint may opportunistically
+    // carry the leaf (redundant with mergePopulatesSubShapeIntoFinalBody).
+    const plan = buildRequestBodyFromCanonical(
+      'createFile',
+      variantScenario(),
+      graph,
+      canonical,
+      {},
+      /* isEndpoint */ true,
+    );
+    const template = plan?.kind === 'json' ? plan.template : {};
+    expect(template).toHaveProperty('folderKey');
+  });
+});


### PR DESCRIPTION
## Why

Four planner fixes were pushed to the `chore/run-hub-catalog-asset-fixture` branch **after** PR #414 had already squash-merged (merge @ 12:08; these commits 13:07–14:03). They never reached `main` — confirmed absent (`canDeferProgress`, `variantLeafNames`, `endpointIsSoleProducer`). This PR cherry-picks them onto current `main`.

## Recovered commits

- **#415** — `feat(planner): chain required request-body semantics from their producer` (updateFile revision optimistic-lock threading).
- `fix(planner): prefer defer-progressing target in deep diamonds` — updateFile.variant-2 deep-diamond chain assembly.
- **#416** — `fix(planner): scope sub-shape variant leaf to the endpoint body` — stops a variant leaf leaking into a prerequisite body.
- `fix(planner): chain a distinct instance for self-referential optional leaf` — createFolder.variant-1 (nested folder) chains a real parent instead of a fake seed.

Each carries its Layer-2 planner-contract fixture (red without the fix, green with).

## Validation

- OCA regression: **819 passing** (recovered fixtures included), typecheck clean, lint clean.
- Live Hub (spec regenerated from camunda-hub#25146): `updateFile.variant-2` and `createFolder.variant-1` now **pass**. Full positive suite: **33 passed / 9 failed**, up from 27/11 — the 9 remaining are all upstream-blocked (5 version #25801, 3 cluster feature-flag, 1 catalog #25576), none generator-side.

## Context

Independent of #420 (Workspace/Project entity lifecycles). Together they bring the positive Hub suite to its generator-clean ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)