### PR TITLE
feat(camunda-hub): WorkspaceMemberMembership edge lifecycle (#25264 item 3)

### DIFF
--- a/configs/camunda-hub/ontology/edges.json
+++ b/configs/camunda-hub/ontology/edges.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://camunda.github.io/api-test-generator/ns/v1/edge.schema.json",
+  "@context": "https://camunda.github.io/api-test-generator/ns/v1/context.jsonld",
+  "version": 1,
+  "edges": [
+    {
+      "@type": "Edge",
+      "name": "WorkspaceMemberMembership",
+      "endpoints": {
+        "from": "Workspace",
+        "to": "Member"
+      },
+      "identifiedBy": ["WorkspaceKey", "MemberEmail"],
+      "establishedBy": "addMember",
+      "revokedBy": "removeMember",
+      "observableVia": "searchMembers",
+      "description": "Membership edge between a Workspace and a Member, identified by the (workspaceKey, email) tuple. Established by addMember, observable via searchMembers (the workspace-scoped member search), revoked by removeMember."
+    }
+  ]
+}

--- a/configs/camunda-hub/ontology/entity-kinds.json
+++ b/configs/camunda-hub/ontology/entity-kinds.json
@@ -6,6 +6,13 @@
   "kinds": [
     {
       "@type": "EntityKind",
+      "name": "Member",
+      "shape": "external-entity",
+      "identifiers": ["MemberEmail"],
+      "description": "A workspace member, identified by a client-supplied email address (MemberEmail, x-semantic-client-minted). Minted outside this API — the member's user account exists in the IdP; the API only references the email to grant/revoke workspace membership. Never created, fetched, or deleted as a standalone entity; participates only in the WorkspaceMemberMembership edge (addMember / searchMembers / removeMember)."
+    },
+    {
+      "@type": "EntityKind",
       "name": "Workspace",
       "shape": "entity",
       "identifiers": ["WorkspaceKey"],

--- a/configs/camunda-hub/spec-pin.json
+++ b/configs/camunda-hub/spec-pin.json
@@ -1,5 +1,5 @@
 {
   "$comment": "Spec pin for the camunda-hub config. Mirrors the camunda-oca contract: specRef MUST be a 40-char commit SHA on camunda/camunda-hub, expectedSpecHash is the specHash printed in spec/camunda-hub/bundled/spec-metadata.json after bundling. The hub spec lives at restapi/public-api/src/main/resources/openapi/v2/ inside camunda/camunda-hub (private repo).",
-  "specRef": "fcbd0b94d8bff5ccbf208124a1b6f47d6982f49f",
-  "expectedSpecHash": "sha256:c7fd8b89853c1308069cbbea24c10385a6f9d7eaee08f398f727f70b07c5e76f"
+  "specRef": "35c76d6994ce8f87342f28d791525937cf8e4125",
+  "expectedSpecHash": "sha256:701f889bcdec0475e1d331c44b89f10d14aed9a8d05efc95ca9df3d5bec1879a"
 }

--- a/path-analyser/src/ontology/observeArrayPath.ts
+++ b/path-analyser/src/ontology/observeArrayPath.ts
@@ -56,27 +56,51 @@ export function findMembershipArrayPath(
     | { responseSemanticTypes?: Record<string, { semanticType: string; fieldPath: string }[]> }
     | undefined,
   identifiedBy: readonly string[],
+  // Membership identifier(s) to prefer — typically the edge's `to`-endpoint
+  // identifier (the entity added to the container). When the observation
+  // response echoes more than one identifiedBy semantic array-nested (e.g.
+  // Hub's searchMembers items carry both `workspaceKey` and `email`), without
+  // this the helper matches the FIRST in iteration order and could assert on
+  // the container key rather than the member. Empty preserves the prior
+  // iteration-order behaviour (e.g. OCA RoleUserMembership → username).
+  preferred: readonly string[] = [],
 ): MembershipArrayPath | null {
   if (!op) return null;
   const responses = op.responseSemanticTypes?.['200'] ?? [];
   const identifiedSet = new Set(identifiedBy);
-  for (const entry of responses) {
-    if (!identifiedSet.has(entry.semanticType)) continue;
-    if (!entry.fieldPath.includes('[]')) continue;
+
+  const toLocator = (entry: {
+    semanticType: string;
+    fieldPath: string;
+  }): MembershipArrayPath | null => {
+    if (!entry.fieldPath.includes('[]')) return null;
     const idx = entry.fieldPath.indexOf('[]');
     const before = entry.fieldPath.slice(0, idx);
     const after = entry.fieldPath.slice(idx + 2);
     // Strip a leading '.' from the post-`[]` remainder so a path like
     // `items[].username` yields elementField='username' not '.username'.
     const elementField = after.startsWith('.') ? after.slice(1) : after;
-    if (!elementField) continue;
+    if (!elementField) return null;
     const arrayPath = before.split('.').filter((s) => s.length > 0);
-    if (arrayPath.length === 0) continue;
-    return {
-      arrayPath,
-      elementField,
-      membershipSemanticType: entry.semanticType,
-    };
+    if (arrayPath.length === 0) return null;
+    return { arrayPath, elementField, membershipSemanticType: entry.semanticType };
+  };
+
+  // Pass 1: prefer the `to`-endpoint membership identifier(s).
+  const preferredSet = new Set(preferred);
+  if (preferredSet.size > 0) {
+    for (const entry of responses) {
+      if (!preferredSet.has(entry.semanticType)) continue;
+      if (!identifiedSet.has(entry.semanticType)) continue;
+      const loc = toLocator(entry);
+      if (loc) return loc;
+    }
+  }
+  // Pass 2: any identifiedBy semantic, in iteration order (legacy behaviour).
+  for (const entry of responses) {
+    if (!identifiedSet.has(entry.semanticType)) continue;
+    const loc = toLocator(entry);
+    if (loc) return loc;
   }
   return null;
 }

--- a/path-analyser/src/scenarioTemplateInstantiator.ts
+++ b/path-analyser/src/scenarioTemplateInstantiator.ts
@@ -56,6 +56,10 @@ import type {
  * without consulting the scenario binding table at every site.
  */
 
+function isPlainRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
 function camelCase(name: string): string {
   return name.length > 0 ? name.charAt(0).toLowerCase() + name.slice(1) : name;
 }
@@ -93,6 +97,7 @@ function compileEdgeLifecycle(
   edge: Edge,
   graph: OperationGraph,
   canonical: CanonicalScenarioMap,
+  entityKinds: EntityKindsAbox | null,
 ): { scenario: TemplateScenario } | { error: string } {
   const establishScenario = canonical.get(edge.establishedBy);
   const revokeScenario = canonical.get(edge.revokedBy);
@@ -156,34 +161,59 @@ function compileEdgeLifecycle(
   // identifiedBy entries are present, not that the table is
   // minimal — keeping it inclusive matches the EndpointScenario
   // contract.
+  // Binding names for the edge's identifiers follow the request-body / URL
+  // emitter convention — keyed on the establisher's FIELD/PARAM `name`, NOT the
+  // semantic type. For most identifiers `camelCase(name) === camelCase(semantic)`
+  // so `bindingNameFor` agrees, but where they diverge the field name wins:
+  // Hub's `email` body field carries semantic `MemberEmail`, so the request-body
+  // builder seeds `emailVar` (not `memberEmailVar`). Every step and the binding
+  // table must use the field-derived name to stay consistent with the canonical
+  // establish scenario, else the emitter can't resolve the membership semantic
+  // back to a binding. Derived from the establisher's `establishes.identifiedBy`
+  // (name + semanticType per identifier).
+  const establishOp = graph.operations[edge.establishedBy];
+  const bindingNameBySemantic = new Map<string, string>();
+  const semanticByBindingName = new Map<string, string>();
+  for (const id of establishOp?.establishes?.identifiedBy ?? []) {
+    const bindName = `${camelCase(id.name)}Var`;
+    bindingNameBySemantic.set(id.semanticType, bindName);
+    semanticByBindingName.set(bindName, id.semanticType);
+  }
+  const bindingNameForEdge = (semantic: string): string =>
+    bindingNameBySemantic.get(semantic) ?? bindingNameFor(semantic);
+
   const bindings: Record<string, string> = {};
   const aggregateBindingNames = new Set<string>([
     ...Object.keys(establishScenario.bindings ?? {}),
     ...(establishScenario.seedBindings ?? []),
   ]);
   for (const bindName of aggregateBindingNames) {
-    // Recover the semantic type by stripping the trailing 'Var' and
-    // upper-casing the first letter. This matches the inverse of
-    // `bindingNameFor`. A binding name that doesn't end in 'Var'
-    // (none exist today) would be passed through as-is so the
-    // emitter still sees a stable round-trip key.
-    const sem = bindName.endsWith('Var')
-      ? bindName.slice(0, -3).charAt(0).toUpperCase() + bindName.slice(0, -3).slice(1)
-      : bindName;
+    // Prefer the establisher's authoritative semantic for any field-derived
+    // identifier binding (so `emailVar → MemberEmail`, not the lossy `Email`
+    // the reverse-engineering below would produce). Otherwise recover the
+    // semantic by stripping the trailing 'Var' and upper-casing — the inverse
+    // of `bindingNameFor` — for seeded extras (e.g. `roleVar → Role`) with no
+    // identifiedBy entry. A binding name that doesn't end in 'Var' (none exist
+    // today) is passed through so the emitter still sees a stable key.
+    const sem =
+      semanticByBindingName.get(bindName) ??
+      (bindName.endsWith('Var')
+        ? bindName.slice(0, -3).charAt(0).toUpperCase() + bindName.slice(0, -3).slice(1)
+        : bindName);
     bindings[sem] = bindName;
   }
 
   // Helper: map an op's required semantics to {semanticType: bindingName}.
-  // Used by Invoke and Observe alike. We consult the graph for the
-  // op's `requires.required`; the bindingName follows the camelCase
-  // convention so callers don't need to inspect the canonical scenario
-  // bindings (the union table built above is the source of truth at
-  // emit time; this map is the per-step view onto it).
+  // Used by Invoke and Observe alike. We consult the graph for the op's
+  // `requires.required`; the bindingName follows the establisher's field-derived
+  // convention (`bindingNameForEdge`) so callers don't need to inspect the
+  // canonical scenario bindings (the union table built above is the source of
+  // truth at emit time; this map is the per-step view onto it).
   const inputsFor = (opId: string): Record<string, string> => {
     const op = graph.operations[opId];
     const result: Record<string, string> = {};
     for (const sem of op?.requires.required ?? []) {
-      result[sem] = bindingNameFor(sem);
+      result[sem] = bindingNameForEdge(sem);
     }
     return result;
   };
@@ -208,28 +238,74 @@ function compileEdgeLifecycle(
   // to keep the instantiator drop-in for future configs whose
   // edges might not yet satisfy the precondition.
   const observeOp = graph.operations[edge.observableVia];
-  const locator = findMembershipArrayPath(observeOp, edge.identifiedBy);
+  // Prefer the `to`-endpoint identifier as the membership key — the entity
+  // added to the container. When the observe response also echoes the
+  // container/`from` key (e.g. Hub's searchMembers items carry workspaceKey AND
+  // email), this asserts membership on the member (email), not the container.
+  const toKind = entityKinds?.kinds.find((k) => k.name === edge.endpoints.to);
+  const locator = findMembershipArrayPath(observeOp, edge.identifiedBy, toKind?.identifiers ?? []);
   if (!locator) {
     return {
       error: `${template.name} × ${edge.name}: findMembershipArrayPath returned null for observableVia='${edge.observableVia}'; an edge with no array-nested identifiedBy semantic on its observation op cannot be observed via present/absent membership`,
     };
   }
 
-  // Observe `inputs` are the SCOPING identifiers — identifiedBy
-  // members the op consumes (path or filter params), minus the
-  // membership identifier (which is asserted on the response, not
-  // submitted). The scoping inputs come from the union
-  // `identifiedBy ∩ op.requires.required`; the membership
-  // identifier is whatever locator.membershipSemanticType says.
+  // Observe `inputs` are the SCOPING identifiers — identifiedBy members the op
+  // consumes to scope the search, minus the membership identifier (asserted on
+  // the response, not submitted). They arrive two ways:
+  //   - as path/query params (`op.requires.required`) — the URL/inputs carry them;
+  //   - as filter BODY fields (`op.requestBodySemantics`, fieldPath `filter.*`) —
+  //     e.g. searchMembers scopes by `filter.workspaceKey`. These are NOT in
+  //     `requires.required`, and `buildRequestBodyFromCanonical` leaves filter
+  //     fields as a placeholder (#168), so they are bound into the observe body
+  //     directly below (`scopingFilterBindings`).
   const observeRequired = new Set(observeOp?.requires.required ?? []);
+  const filterFieldBySemantic = new Map<string, string>();
+  for (const entry of observeOp?.requestBodySemantics ?? []) {
+    if (entry.fieldPath.startsWith('filter.') && !entry.fieldPath.slice(7).includes('.')) {
+      filterFieldBySemantic.set(entry.semantic, entry.fieldPath.slice('filter.'.length));
+    }
+  }
   const observeInputs: Record<string, string> = {};
+  const scopingFilterBindings: { field: string; varName: string }[] = [];
   for (const sem of edge.identifiedBy) {
     if (sem === locator.membershipSemanticType) continue;
-    if (!observeRequired.has(sem)) continue;
-    observeInputs[sem] = bindingNameFor(sem);
+    const varName = bindingNameForEdge(sem);
+    const filterField = filterFieldBySemantic.get(sem);
+    // Check the filter-body case FIRST: a required filter field is also promoted
+    // into `requires.required` by the graph loader, so testing `observeRequired`
+    // first would wrongly treat it as a path/query param and skip binding the
+    // filter value.
+    if (filterField !== undefined) {
+      observeInputs[sem] = varName;
+      scopingFilterBindings.push({ field: filterField, varName });
+    } else if (observeRequired.has(sem)) {
+      observeInputs[sem] = varName;
+    }
   }
 
   const lastOf = (plan: RequestStep[]): RequestStep => plan[plan.length - 1];
+
+  // The observe search's scoping filter fields (e.g. filter.workspaceKey) are
+  // left as placeholders by the canonical request-body builder (#168 defers
+  // filter-path binding). Bind them here to the scoping identifiers' vars so
+  // the search is actually scoped to the container under test. Clone the
+  // canonical step so the shared searchMembers scenario (its feature spec) is
+  // untouched.
+  const observeStepPlan: RequestStep = (() => {
+    const base = lastOf(observePlan);
+    if (scopingFilterBindings.length === 0) return base;
+    const cloned: RequestStep = structuredClone(base);
+    const body = isPlainRecord(cloned.bodyTemplate) ? cloned.bodyTemplate : {};
+    const filter = isPlainRecord(body.filter) ? body.filter : {};
+    for (const { field, varName } of scopingFilterBindings) {
+      filter[field] = `\${${varName}}`;
+    }
+    body.filter = filter;
+    cloned.bodyTemplate = body;
+    cloned.bodyKind = 'json';
+    return cloned;
+  })();
 
   // Aggregate the set of operationIds across all five steps whose source
   // OperationSpec carries `eventuallyConsistent: true`. Threaded onto the
@@ -271,7 +347,7 @@ function compileEdgeLifecycle(
       kind: 'observe',
       operationId: edge.observableVia,
       inputs: observeInputs,
-      requestPlan: lastOf(observePlan),
+      requestPlan: observeStepPlan,
       assertion: {
         kind: 'membership',
         expect: 'present',
@@ -291,7 +367,7 @@ function compileEdgeLifecycle(
       kind: 'observe',
       operationId: edge.observableVia,
       inputs: observeInputs,
-      requestPlan: lastOf(observePlan),
+      requestPlan: observeStepPlan,
       assertion: {
         kind: 'membership',
         expect: 'absent',
@@ -1011,7 +1087,7 @@ export function instantiateAllTemplates(
         );
       }
       for (const edge of edges.edges) {
-        const compiled = compileEdgeLifecycle(tpl, edge, graph, canonical);
+        const compiled = compileEdgeLifecycle(tpl, edge, graph, canonical, entityKinds);
         if ('error' in compiled) {
           errors.push(compiled.error);
           continue;

--- a/tests/fixtures/planner/observe-array-path-preference.test.ts
+++ b/tests/fixtures/planner/observe-array-path-preference.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { findMembershipArrayPath } from '../../../path-analyser/src/ontology/observeArrayPath.ts';
+
+/**
+ * Layer-2 fixture for the membership-edge observe locator (#421).
+ *
+ * When a search response echoes MORE than one `identifiedBy` semantic
+ * array-nested — e.g. Hub's `searchMembers` items carry both `workspaceKey`
+ * (the container) and `email` (the member) — the observe assertion must key on
+ * the member, not the container. `findMembershipArrayPath`'s `preferred`
+ * argument (the edge's `to`-endpoint identifiers) drives that choice; without
+ * it the helper matches the first in iteration order.
+ */
+function op(entries: { semanticType: string; fieldPath: string }[]) {
+  return { responseSemanticTypes: { '200': entries } };
+}
+
+// searchMembers-shaped response: container key first, member key second.
+const membersOp = op([
+  { semanticType: 'WorkspaceKey', fieldPath: 'items[].workspaceKey' },
+  { semanticType: 'MemberEmail', fieldPath: 'items[].email' },
+]);
+const identifiedBy = ['WorkspaceKey', 'MemberEmail'];
+
+describe('findMembershipArrayPath — preferred (to-endpoint) identifier (#421)', () => {
+  it('picks the preferred (member) identifier over the container key', () => {
+    const loc = findMembershipArrayPath(membersOp, identifiedBy, ['MemberEmail']);
+    expect(loc?.membershipSemanticType).toBe('MemberEmail');
+    expect(loc?.arrayPath).toEqual(['items']);
+    expect(loc?.elementField).toBe('email');
+  });
+
+  it('falls back to iteration order when no preferred is given (legacy behaviour)', () => {
+    const loc = findMembershipArrayPath(membersOp, identifiedBy);
+    expect(loc?.membershipSemanticType).toBe('WorkspaceKey');
+  });
+
+  it('falls back to Pass 2 when the preferred semantic is not array-nested', () => {
+    // preferred names a semantic that only appears as a scalar (not `[]`), so
+    // Pass 1 finds nothing and Pass 2 returns the first array-nested match.
+    const loc = findMembershipArrayPath(membersOp, identifiedBy, ['ProjectKey']);
+    expect(loc?.membershipSemanticType).toBe('WorkspaceKey');
+  });
+
+  it('ignores a preferred semantic that is not in identifiedBy', () => {
+    const loc = findMembershipArrayPath(membersOp, ['MemberEmail'], ['WorkspaceKey']);
+    // WorkspaceKey is preferred but not in identifiedBy → Pass 1 skips it,
+    // Pass 2 returns the only identifiedBy match (email).
+    expect(loc?.membershipSemanticType).toBe('MemberEmail');
+  });
+});


### PR DESCRIPTION
Ships **Part 3 (edge lifecycle)** of the Hub API test coverage plan (#25264) — the `WorkspaceMemberMembership` edge — plus the two generator fixes it required, and re-pins the Hub spec to merged `main`. Closes the generator side of #421.

## ABox
- `Member` external-entity kind (client-minted `MemberEmail`).
- `configs/camunda-hub/ontology/edges.json`: `WorkspaceMemberMembership` (`from=Workspace`, `to=Member`, `identifiedBy [WorkspaceKey, MemberEmail]`; `addMember` / `searchMembers` / `removeMember`).

## Generator fixes
1. **Observe asserts on the member, not the container.** `searchMembers` items carry both `workspaceKey` and `email`; `findMembershipArrayPath` gained a `preferred` arg (the edge's `to`-endpoint identifiers), so it keys the membership assertion on `email` rather than the first-in-iteration `workspaceKey`.
2. **Field-derived binding names.** Edge identifier bindings come from the establisher's `establishes.identifiedBy` field names (so `MemberEmail → emailVar`, matching the request-body builder), not `memberEmailVar`.
3. **Filter-scoped observe binding (#168, targeted).** `searchMembers` scopes by `filter.workspaceKey` — a filter-body field the canonical builder leaves as a placeholder. The edge compiler now binds the scoping identifier into the observe body from its var. Checked before `requires.required`, since the loader promotes required filter semantics into `requires.required`.

## Spec re-pin to merged main
camunda/camunda-hub#25146 (public-api semantic annotations) is merged, so the Hub config no longer needs the feature-branch ancestor. `configs/camunda-hub/spec-pin.json` moves from `fcbd0b9` to `main` HEAD `35c76d6` (the #25146 merge commit), which carries the complete `x-semantic-*` annotation set. Bundling from main yields 41 operations; `expectedSpecHash` updated to match. Generated tests + bundle are gitignored, so the only tracked change is the pin.

## Verification
- **`WorkspaceMemberMembership` lifecycle passes live** (establish → observe present → revoke → observe absent) against `camunda/hub:SNAPSHOT`, run via `scripts/e2e/run-hub.sh`.
- **Full suites against a live Hub** (main-based generation): **positive 32 / 7**, **negative 320 / 27**. Every failure maps to a pre-existing tracked hub issue — #25801 (versions), #25576 (catalog), #426 (`restoreFile`), #427 (wrong-type `*Key` → 403). None introduced by this PR.
- **`addMember` requires an existing Hub user.** It resolves `email → org/IAM member` (`ProjectInvitationService.getOrCreateUserFromIam`); an unknown email → `400 UserNotFoundException` (confirmed live: `camunda@example.com` → 200, synthetic/unsynced email → 400). This is a test-data requirement, already wired: `run-hub.sh` defaults `POS_FIXTURE_MEMBER_EMAIL=camunda@example.com` (mirrors `POS_FIXTURE_FILE_CONTENT` for `createFile`). No generator/spec change needed.
- **OCA unaffected**: 826 tests pass (RoleUserMembership invariants intact) — the `preferred` arg defaults to `[]` (legacy iteration order) and the filter binding is a no-op for path-scoped observes. Regression gate (spec-pin) passes on the new pin. tsc + lint clean.
- Adds a Layer-2 test for the preferred-locator behaviour.

## Follow-up
`#421` can close once this merges. The membership edge is the only edge in the Hub spec, so Part 3 is complete. The positive nightly is now unblocked (#25146 landed) as a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
