### PR TITLE
feat(camunda-hub): model restore-after-soft-delete lifecycle (#426)

### DIFF
--- a/configs/camunda-hub/ontology/entity-kinds.json
+++ b/configs/camunda-hub/ontology/entity-kinds.json
@@ -39,7 +39,8 @@
       "establishedBy": "createFile",
       "observableVia": "getFile",
       "revokedBy": "deleteFile",
-      "description": "A file entity, identified by its server-minted fileKey. Established via createFile (POST /files), observed via getFile, revoked via deleteFile."
+      "restorableVia": "restoreFile",
+      "description": "A file entity, identified by its server-minted fileKey. Established via createFile (POST /files), observed via getFile, revoked via deleteFile (a soft-delete). restoreFile (POST /files/{fileKey}/restoration) restores a soft-deleted file — the RestoreLifecycle template (#426) drives create → soft-delete → restore so restore is exercised against a recently-deleted file rather than a live one (which 404s)."
     },
     {
       "@type": "EntityKind",

--- a/configs/camunda-hub/ontology/scenario-templates.json
+++ b/configs/camunda-hub/ontology/scenario-templates.json
@@ -75,6 +75,21 @@
         { "kind": "Invoke", "op": "transition" },
         { "kind": "Observe", "op": "fetcher", "expect": "stateEquals" }
       ]
+    },
+    {
+      "@type": "ScenarioTemplate",
+      "name": "RestoreLifecycle",
+      "appliesTo": { "kind": "Entity" },
+      "description": "#426 — for every shape: 'entity' kind whose delete is a soft-delete with a restore op (declared via `restorableVia`, e.g. File → restoreFile), drive the instance through the full soft-delete/restore transition: (1) establish the prerequisite chain and create the instance (establishedBy), (2) observe it is present (observableVia, status 200), (3) soft-delete it (revokedBy), (4) observe it is absent (observableVia, status 404), (5) restore it (restorableVia), (6) observe it is present again (observableVia, status 200). This exercises restore against an instance that is actually in the recently-deleted state — the plain requires-chain (restorableVia requires the entity, so it chains a create) would invoke restore on a live instance and get 404. Entity kinds without `restorableVia` are skipped (restore is opt-in per kind). Reuses EntityLifecycle's status-only observe assertion; consumes establishedBy/observableVia/revokedBy/restorableVia so restore is removed from the plain feature suite.",
+      "steps": [
+        { "kind": "PrereqChain", "for": "establishedBy" },
+        { "kind": "Invoke", "op": "establishedBy" },
+        { "kind": "Observe", "op": "observableVia", "expect": "present" },
+        { "kind": "Invoke", "op": "revokedBy" },
+        { "kind": "Observe", "op": "observableVia", "expect": "absent" },
+        { "kind": "Invoke", "op": "restorableVia" },
+        { "kind": "Observe", "op": "observableVia", "expect": "present" }
+      ]
     }
   ]
 }

--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -162,6 +162,14 @@ function renderLifecycleSuite(
 ): string {
   const scenario = file.scenario;
   const steps = scenario.steps;
+  // #426 — RestoreLifecycle is a 7-step Entity-subject template
+  // (create → present → soft-delete → absent → restore → present). It
+  // shares the statusOnly observe assertion and the per-step helpers with
+  // EntityLifecycle but has its own step sequence, so it renders through a
+  // dedicated path rather than the fixed 5-step lifecycle below.
+  if (file.templateName === 'RestoreLifecycle') {
+    return renderRestoreLifecycleSuite(file, globalContextSeeds, clientMintedFixtures);
+  }
   // Validate template shape before emit. The L3 invariants already
   // guarantee this on `npm test`, but the emitter is its own entry point
   // (materializer CLI, future per-suite invocations) and must not produce
@@ -359,6 +367,178 @@ function renderLifecycleSuite(
   // (7) observe absent
   lines.push('');
   appendObserveStep(lines, observeAbsent, scenario.bindings, stepIdx, 'observe (absent)', ecOps);
+
+  lines.push('  });');
+  lines.push('});');
+  lines.push('');
+  return lines.join('\n');
+}
+
+/**
+ * #426 — RestoreLifecycle suite emitter.
+ *
+ * Renders the 7-step soft-delete-restore lifecycle:
+ *   prereqChain → invoke(create) → observe(present, 200)
+ *     → invoke(soft-delete) → observe(absent, 404)
+ *     → invoke(restore) → observe(present, 200)
+ *
+ * Reuses the same per-step helpers and import-detection logic as
+ * `renderLifecycleSuite`; only the step sequence and the test title differ.
+ */
+function renderRestoreLifecycleSuite(
+  file: TemplateScenarioFile,
+  globalContextSeeds: readonly TemplateGlobalContextSeed[],
+  clientMintedFixtures?: Readonly<Record<string, string>>,
+): string {
+  const scenario = file.scenario;
+  const steps = scenario.steps;
+  if (steps.length !== 7) {
+    throw new Error(
+      `RestoreLifecycle template ${file.subjectName} must have exactly 7 steps; got ${steps.length}.`,
+    );
+  }
+  const [prereq, establish, observePresent1, revoke, observeAbsent, restore, observePresent2] =
+    steps;
+  if (prereq.kind !== 'prereqChain') {
+    throw new Error(`Step 0 of ${file.subjectName} must be a prereqChain step.`);
+  }
+  if (establish.kind !== 'invoke') {
+    throw new Error(`Step 1 of ${file.subjectName} must be an invoke step (create).`);
+  }
+  if (revoke.kind !== 'invoke') {
+    throw new Error(`Step 3 of ${file.subjectName} must be an invoke step (soft-delete).`);
+  }
+  if (restore.kind !== 'invoke') {
+    throw new Error(`Step 5 of ${file.subjectName} must be an invoke step (restore).`);
+  }
+  for (const [i, s] of [
+    [2, observePresent1],
+    [6, observePresent2],
+  ] as const) {
+    if (
+      s.kind !== 'observe' ||
+      s.assertion.kind !== 'statusOnly' ||
+      s.assertion.expect !== 'present'
+    ) {
+      throw new Error(`Step ${i} of ${file.subjectName} must be a present-observe step.`);
+    }
+  }
+  if (
+    observeAbsent.kind !== 'observe' ||
+    observeAbsent.assertion.kind !== 'statusOnly' ||
+    observeAbsent.assertion.expect !== 'absent'
+  ) {
+    throw new Error(`Step 4 of ${file.subjectName} must be an absent-observe step.`);
+  }
+  // Narrow the present-observe steps for the render calls below.
+  if (observePresent1.kind !== 'observe' || observePresent2.kind !== 'observe') {
+    throw new Error(`RestoreLifecycle ${file.subjectName}: present steps must be observe steps.`);
+  }
+
+  const allRequestSteps: RequestStep[] = [
+    ...prereq.requestPlan,
+    establish.requestPlan,
+    observePresent1.requestPlan,
+    revoke.requestPlan,
+    observeAbsent.requestPlan,
+    restore.requestPlan,
+    observePresent2.requestPlan,
+  ];
+  const ecOps = new Set<string>(scenario.eventuallyConsistentOps ?? []);
+  const observeOpIds = [
+    observePresent1.operationId,
+    observeAbsent.operationId,
+    observePresent2.operationId,
+  ];
+  const needsExtractInto = allRequestSteps.some((rp) => (rp.extract?.length ?? 0) > 0);
+  const needsAwaitEventually =
+    allRequestSteps.some((rp) => (rp.eventualWaitsAfter?.length ?? 0) > 0) ||
+    allRequestSteps.some((rp) => stepNeedsAwaitForOp(rp, ecOps)) ||
+    observeOpIds.some((opId) => ecOps.has(opId));
+  const needsResolveFixture = allRequestSteps.some(
+    (rp) => rp.bodyKind === 'multipart' && !!rp.multipartTemplate,
+  );
+
+  const lines: string[] = [];
+  lines.push("import { expect, test } from '@playwright/test';");
+  lines.push("import { authHeaders, buildBaseUrl } from '../../support/env';");
+  const seedingImports = ['initSpecSalt', 'seedBinding'];
+  if (needsExtractInto) seedingImports.push('extractInto');
+  lines.push(`import { ${seedingImports.join(', ')} } from '../../support/seeding';`);
+  if (needsAwaitEventually) {
+    lines.push("import { awaitEventually } from '../../support/await-eventually';");
+  }
+  if (needsResolveFixture) {
+    lines.push("import { resolveFixture } from '../../support/fixtures';");
+  }
+  lines.push('');
+  lines.push(`initSpecSalt('${file.subjectName}.restore-lifecycle');`);
+  lines.push('');
+  lines.push(`test.describe('${file.subjectName} restore lifecycle', () => {`);
+  lines.push(
+    `  test('establish ${file.subjectName}, soft-delete, restore, observe present', async ({ request }) => {`,
+  );
+  lines.push('    const baseUrl = buildBaseUrl();');
+  lines.push('    const ctx: Record<string, unknown> = {};');
+  lines.push(
+    ...emitCtxSeeding({
+      indent: '    ',
+      bindings: prereq.bindings,
+      seedBindings: prereq.seedBindings,
+      globalContextSeeds,
+      uniqueBindings: computeUniqueBindings(allRequestSteps),
+      fixtureEnvByBinding: clientMintedFixtures,
+    }),
+  );
+
+  let stepIdx = 0;
+  for (const rp of prereq.requestPlan) {
+    lines.push('');
+    appendInlineRequestStep(lines, rp, stepIdx, `prereq: ${rp.operationId}`, ecOps);
+    stepIdx++;
+  }
+  lines.push('');
+  appendInlineRequestStep(
+    lines,
+    establish.requestPlan,
+    stepIdx,
+    `invoke (establish): ${establish.operationId}`,
+    ecOps,
+  );
+  stepIdx++;
+  lines.push('');
+  appendObserveStep(lines, observePresent1, scenario.bindings, stepIdx, 'observe (present)', ecOps);
+  stepIdx++;
+  lines.push('');
+  appendInlineRequestStep(
+    lines,
+    revoke.requestPlan,
+    stepIdx,
+    `invoke (soft-delete): ${revoke.operationId}`,
+    ecOps,
+  );
+  stepIdx++;
+  lines.push('');
+  appendObserveStep(lines, observeAbsent, scenario.bindings, stepIdx, 'observe (absent)', ecOps);
+  stepIdx++;
+  lines.push('');
+  appendInlineRequestStep(
+    lines,
+    restore.requestPlan,
+    stepIdx,
+    `invoke (restore): ${restore.operationId}`,
+    ecOps,
+  );
+  stepIdx++;
+  lines.push('');
+  appendObserveStep(
+    lines,
+    observePresent2,
+    scenario.bindings,
+    stepIdx,
+    'observe (present, restored)',
+    ecOps,
+  );
 
   lines.push('  });');
   lines.push('});');

--- a/ontology/vocabulary/entity-kinds.schema.json
+++ b/ontology/vocabulary/entity-kinds.schema.json
@@ -92,6 +92,11 @@
           "minLength": 1,
           "description": "#280 — operationId of the canonical delete operation for this entity kind (e.g. `deleteUser` for `User`). Conventionally a `DELETE` returning 204. Required on `shape: \"entity\"`; forbidden on `shape: \"external-entity\"` and `shape: \"runtime-entity\"`. ProcessInstance (cancel/delete divergence) is intentionally excluded here — see follow-up #281."
         },
+        "restorableVia": {
+          "type": "string",
+          "minLength": 1,
+          "description": "#426 — operationId of the operation that restores a soft-deleted instance of this entity kind (e.g. `restoreFile` for `File`, `POST /files/{fileKey}/restoration`). When present, the `RestoreLifecycle` template emits a create → observe-present → soft-delete (`revokedBy`) → observe-absent → restore → observe-present scenario, so the restore is exercised against an instance that is actually in the recently-deleted state (a plain requires-chain would invoke restore on a live instance and get 404). OPTIONAL on `shape: \"entity\"` (only kinds whose delete is a soft-delete with a restore op carry it); forbidden on every other shape. Not part of the `entity` all-or-nothing triple — an entity without a restore op simply omits it."
+        },
         "mutators": {
           "type": "array",
           "minItems": 1,
@@ -193,6 +198,11 @@
                 },
                 {
                   "required": [
+                    "restorableVia"
+                  ]
+                },
+                {
+                  "required": [
                     "mutators"
                   ]
                 },
@@ -255,6 +265,11 @@
                   "required": [
                     "revokedBy"
                   ]
+                },
+                {
+                  "required": [
+                    "restorableVia"
+                  ]
                 }
               ]
             }
@@ -282,6 +297,11 @@
                 {
                   "required": [
                     "revokedBy"
+                  ]
+                },
+                {
+                  "required": [
+                    "restorableVia"
                   ]
                 },
                 {

--- a/path-analyser/src/ontology/entityKindsSchema.ts
+++ b/path-analyser/src/ontology/entityKindsSchema.ts
@@ -159,6 +159,12 @@ export const entityKindsSchema = {
           description:
             '#280 — operationId of the canonical delete operation for this entity kind (e.g. `deleteUser` for `User`). Conventionally a `DELETE` returning 204. Required on `shape: "entity"`; forbidden on `shape: "external-entity"` and `shape: "runtime-entity"`. ProcessInstance (cancel/delete divergence) is intentionally excluded here — see follow-up #281.',
         },
+        restorableVia: {
+          type: 'string',
+          minLength: 1,
+          description:
+            '#426 — operationId of the operation that restores a soft-deleted instance of this entity kind (e.g. `restoreFile` for `File`, `POST /files/{fileKey}/restoration`). When present, the `RestoreLifecycle` template emits a create → observe-present → soft-delete (`revokedBy`) → observe-absent → restore → observe-present scenario, so the restore is exercised against an instance that is actually in the recently-deleted state (a plain requires-chain would invoke restore on a live instance and get 404). OPTIONAL on `shape: "entity"` (only kinds whose delete is a soft-delete with a restore op carry it); forbidden on every other shape. Not part of the `entity` all-or-nothing triple — an entity without a restore op simply omits it.',
+        },
         mutators: {
           type: 'array',
           minItems: 1,
@@ -230,6 +236,7 @@ export const entityKindsSchema = {
                 { required: ['establishedBy'] },
                 { required: ['observableVia'] },
                 { required: ['revokedBy'] },
+                { required: ['restorableVia'] },
                 { required: ['mutators'] },
                 { required: ['transitions'] },
                 { required: ['stateField'] },
@@ -249,6 +256,7 @@ export const entityKindsSchema = {
                 { required: ['establishedBy'] },
                 { required: ['observableVia'] },
                 { required: ['revokedBy'] },
+                { required: ['restorableVia'] },
               ],
             },
           },
@@ -268,6 +276,7 @@ export const entityKindsSchema = {
               anyOf: [
                 { required: ['observableVia'] },
                 { required: ['revokedBy'] },
+                { required: ['restorableVia'] },
                 { required: ['mutators'] },
                 { required: ['transitions'] },
                 { required: ['stateField'] },

--- a/path-analyser/src/scenarioTemplateInstantiator.ts
+++ b/path-analyser/src/scenarioTemplateInstantiator.ts
@@ -582,6 +582,204 @@ function compileEntityLifecycle(
 }
 
 /**
+ * #426 — RestoreLifecycle compiler.
+ *
+ * A soft-delete restore op (e.g. `restoreFile`, `POST
+ * /files/{fileKey}/restoration`) only succeeds when its target instance
+ * is actually in the recently-deleted state. The plain requires-chain
+ * (`x-semantic-requires: File` → chain `createFile`) invokes restore on a
+ * *live* instance and gets 404. This template instead drives the instance
+ * through the full transition so restore is exercised meaningfully:
+ *
+ *   create → observe present (200) → soft-delete (`revokedBy`)
+ *     → observe absent (404) → restore (`restorableVia`) → observe present (200)
+ *
+ * Applies to `shape: "entity"` kinds that declare `restorableVia`; the
+ * dispatcher skips entity kinds without it (not every entity has a
+ * restore op). Structurally an extension of `compileEntityLifecycle`
+ * (same prereq/bindings/observe machinery), so it reuses the same helpers
+ * and the existing `statusOnly` observe assertion.
+ */
+function compileRestoreLifecycle(
+  template: ScenarioTemplate,
+  kind: EntityKind,
+  graph: OperationGraph,
+  canonical: CanonicalScenarioMap,
+): { scenario: TemplateScenario } | { error: string } {
+  if (kind.shape !== 'entity') {
+    return {
+      error: `${template.name} × ${kind.name}: appliesTo Entity templates only apply to shape: "entity" kinds, got shape: "${kind.shape}"`,
+    };
+  }
+  const establishOpId = kind.establishedBy;
+  const observeOpId = kind.observableVia;
+  const revokeOpId = kind.revokedBy;
+  const restoreOpId = kind.restorableVia;
+  if (
+    typeof establishOpId !== 'string' ||
+    typeof observeOpId !== 'string' ||
+    typeof revokeOpId !== 'string'
+  ) {
+    return {
+      error: `${template.name} × ${kind.name}: missing one of establishedBy/observableVia/revokedBy on shape: "entity" kind (schema bug?)`,
+    };
+  }
+  if (typeof restoreOpId !== 'string') {
+    // The dispatcher only compiles RestoreLifecycle for kinds that declare
+    // restorableVia, so reaching here means a schema/dispatch mismatch.
+    return {
+      error: `${template.name} × ${kind.name}: missing restorableVia on shape: "entity" kind (dispatch bug — RestoreLifecycle should only run on kinds that declare it)`,
+    };
+  }
+
+  const establishScenario = canonical.get(establishOpId);
+  const revokeScenario = canonical.get(revokeOpId);
+  const observeScenario = canonical.get(observeOpId);
+  const restoreScenario = canonical.get(restoreOpId);
+  if (!establishScenario)
+    return {
+      error: `${template.name} × ${kind.name}: no canonical scenario for establishedBy='${establishOpId}'`,
+    };
+  if (!revokeScenario)
+    return {
+      error: `${template.name} × ${kind.name}: no canonical scenario for revokedBy='${revokeOpId}'`,
+    };
+  if (!observeScenario)
+    return {
+      error: `${template.name} × ${kind.name}: no canonical scenario for observableVia='${observeOpId}'`,
+    };
+  if (!restoreScenario)
+    return {
+      error: `${template.name} × ${kind.name}: no canonical scenario for restorableVia='${restoreOpId}'`,
+    };
+
+  const establishPlan = establishScenario.requestPlan;
+  const revokePlan = revokeScenario.requestPlan;
+  const observePlan = observeScenario.requestPlan;
+  const restorePlan = restoreScenario.requestPlan;
+  if (!establishPlan?.length || !revokePlan?.length || !observePlan?.length || !restorePlan?.length)
+    return {
+      error: `${template.name} × ${kind.name}: one of the referenced scenarios is missing a requestPlan`,
+    };
+
+  const establishOps = establishScenario.operations;
+  if (establishOps.length !== establishPlan.length) {
+    return {
+      error: `${template.name} × ${kind.name}: establishedBy scenario operations.length (${establishOps.length}) ≠ requestPlan.length (${establishPlan.length}); duplicate invocation on an establisher is unsupported`,
+    };
+  }
+  const prereqOps: OperationRef[] = establishOps.slice(0, -1).map((o) => ({ ...o }));
+  const prereqPlan: RequestStep[] = establishPlan.slice(0, -1);
+
+  const bindings: Record<string, string> = {};
+  const aggregateBindingNames = new Set<string>([
+    ...Object.keys(establishScenario.bindings ?? {}),
+    ...(establishScenario.seedBindings ?? []),
+  ]);
+  for (const bindName of aggregateBindingNames) {
+    const sem = bindName.endsWith('Var')
+      ? bindName.slice(0, -3).charAt(0).toUpperCase() + bindName.slice(0, -3).slice(1)
+      : bindName;
+    bindings[sem] = bindName;
+  }
+
+  const inputsFor = (opId: string): Record<string, string> => {
+    const op = graph.operations[opId];
+    const result: Record<string, string> = {};
+    for (const sem of op?.requires.required ?? []) {
+      result[sem] = bindingNameFor(sem);
+    }
+    return result;
+  };
+  const producesFor = (opId: string): Record<string, string> => {
+    const op = graph.operations[opId];
+    const result: Record<string, string> = {};
+    for (const leaf of op?.responseSemanticLeaves ?? []) {
+      if (!leaf.provider) continue;
+      result[leaf.semantic] = bindingNameFor(leaf.semantic);
+    }
+    return result;
+  };
+
+  const observeInputs = inputsFor(observeOpId);
+  const lastOf = (plan: RequestStep[]): RequestStep => plan[plan.length - 1];
+
+  const allOpIds = new Set<string>([
+    ...prereqOps.map((o) => o.operationId),
+    establishOpId,
+    observeOpId,
+    revokeOpId,
+    restoreOpId,
+  ]);
+  const eventuallyConsistentOps: string[] = [];
+  for (const opId of allOpIds) {
+    const op = graph.operations[opId];
+    if (op?.eventuallyConsistent) eventuallyConsistentOps.push(opId);
+  }
+  eventuallyConsistentOps.sort();
+
+  const observePresent = (): TemplateStep => ({
+    kind: 'observe',
+    operationId: observeOpId,
+    inputs: observeInputs,
+    requestPlan: lastOf(observePlan),
+    assertion: { kind: 'statusOnly', expect: 'present', expectedStatus: 200 },
+  });
+
+  const steps: TemplateStep[] = [
+    {
+      kind: 'prereqChain',
+      targetOperationId: establishOpId,
+      operations: prereqOps,
+      bindings: { ...(establishScenario.bindings ?? {}) },
+      seedBindings: [...(establishScenario.seedBindings ?? [])],
+      requestPlan: prereqPlan,
+    },
+    {
+      kind: 'invoke',
+      operationId: establishOpId,
+      inputs: inputsFor(establishOpId),
+      produces: producesFor(establishOpId),
+      requestPlan: lastOf(establishPlan),
+    },
+    observePresent(),
+    {
+      kind: 'invoke',
+      operationId: revokeOpId,
+      inputs: inputsFor(revokeOpId),
+      produces: producesFor(revokeOpId),
+      requestPlan: lastOf(revokePlan),
+    },
+    {
+      kind: 'observe',
+      operationId: observeOpId,
+      inputs: observeInputs,
+      requestPlan: lastOf(observePlan),
+      assertion: { kind: 'statusOnly', expect: 'absent', expectedStatus: 404 },
+    },
+    {
+      kind: 'invoke',
+      operationId: restoreOpId,
+      inputs: inputsFor(restoreOpId),
+      produces: producesFor(restoreOpId),
+      requestPlan: lastOf(restorePlan),
+    },
+    observePresent(),
+  ];
+
+  return {
+    scenario: {
+      templateName: template.name,
+      subjectName: kind.name,
+      subjectKind: 'Entity',
+      steps,
+      bindings,
+      eventuallyConsistentOps,
+    },
+  };
+}
+
+/**
  * #305 Phase 4 — Produce one {@link TemplateScenario} per
  * (runtime-entity × mutator) pair. Parallel to
  * {@link compileEntityLifecycle}, but tailored for runtime-emitted
@@ -1102,11 +1300,17 @@ export function instantiateAllTemplates(
       continue;
     }
     if (tpl.appliesTo.kind === 'Entity') {
-      if (tpl.name !== 'EntityLifecycle') {
+      // Two Entity-scoped compilers ship today: EntityLifecycle (#280,
+      // create/observe/delete) and RestoreLifecycle (#426,
+      // create/delete/restore). Refuse-by-default for any other name so an
+      // unrecognised entry fails loudly rather than silently re-running the
+      // wrong compiler.
+      if (tpl.name !== 'EntityLifecycle' && tpl.name !== 'RestoreLifecycle') {
         throw new Error(
           `No compiler registered for scenario template '${tpl.name}'. ` +
-            `#280 only ships the EntityLifecycle compiler; additional ` +
-            `Entity-scoped templates need their own dispatch in instantiateAllTemplates.`,
+            `Entity-scoped templates currently shipped: EntityLifecycle (#280), ` +
+            `RestoreLifecycle (#426). Additional templates need their own ` +
+            `dispatch in instantiateAllTemplates.`,
         );
       }
       if (entityKinds === null) continue;
@@ -1117,7 +1321,15 @@ export function instantiateAllTemplates(
         // here (not an error) because the template applies to the
         // whole ABox and the schema already classified them out.
         if (kind.shape !== 'entity') continue;
-        const compiled = compileEntityLifecycle(tpl, kind, graph, canonical);
+        // RestoreLifecycle only applies to entity kinds whose delete is a
+        // soft-delete with a restore op (declared via restorableVia). Silent
+        // skip for the rest — the template applies to the whole ABox but the
+        // restore transition is opt-in per kind, not a schema error.
+        if (tpl.name === 'RestoreLifecycle' && typeof kind.restorableVia !== 'string') continue;
+        const compiled =
+          tpl.name === 'RestoreLifecycle'
+            ? compileRestoreLifecycle(tpl, kind, graph, canonical)
+            : compileEntityLifecycle(tpl, kind, graph, canonical);
         if ('error' in compiled) {
           errors.push(compiled.error);
           continue;

--- a/tests/fixtures/loader/entity-kinds-abox-loader.test.ts
+++ b/tests/fixtures/loader/entity-kinds-abox-loader.test.ts
@@ -123,6 +123,46 @@ describe('loadEntityKindsAbox: documented branches', () => {
     expect(abox?.kinds).toHaveLength(1);
     expect(abox?.kinds[0]?.name).toBe('Role');
   });
+
+  it('accepts an optional restorableVia on a shape: "entity" kind (#426)', () => {
+    writeAbox(
+      JSON.stringify({
+        version: 1,
+        kinds: [
+          {
+            name: 'File',
+            shape: 'entity',
+            identifiers: ['FileKey'],
+            establishedBy: 'createFile',
+            observableVia: 'getFile',
+            revokedBy: 'deleteFile',
+            restorableVia: 'restoreFile',
+            description: 'A file with a soft-delete/restore transition.',
+          },
+        ],
+      }),
+    );
+    const abox = loadEntityKindsAbox(workdir);
+    expect(abox?.kinds[0]?.restorableVia).toBe('restoreFile');
+  });
+
+  it('rejects restorableVia on a non-entity shape (#426 — restore is entity-only)', () => {
+    writeAbox(
+      JSON.stringify({
+        version: 1,
+        kinds: [
+          {
+            name: 'Member',
+            shape: 'external-entity',
+            identifiers: ['MemberEmail'],
+            restorableVia: 'restoreMember',
+            description: 'External entity may not declare restorableVia.',
+          },
+        ],
+      }),
+    );
+    expect(() => loadEntityKindsAbox(workdir)).toThrow(/failed TBox validation/);
+  });
 });
 
 describe('loadExternalEntityIdentifiers: ABox-derived externalBoundary set', () => {

--- a/tests/fixtures/planner/restore-lifecycle.test.ts
+++ b/tests/fixtures/planner/restore-lifecycle.test.ts
@@ -63,7 +63,9 @@ describe('RestoreLifecycle compiler — Layer 2 contract', () => {
         method: 'POST',
         path: '/things',
         requires: { required: [], optional: [] },
-        responseSemanticLeaves: [{ semantic: 'ThingKey', path: 'thingKey', provider: true }],
+        responseSemanticLeaves: [
+          { semantic: 'ThingKey', fieldPath: 'thingKey', status: '200', provider: true },
+        ],
       }),
       getThing: makeOp('getThing', {
         method: 'GET',
@@ -86,7 +88,10 @@ describe('RestoreLifecycle compiler — Layer 2 contract', () => {
   };
 
   const canonical = new Map<string, EndpointScenario>([
-    ['createThing', makeScenario('createThing', [makeStep('createThing', { path: '/things' })])],
+    [
+      'createThing',
+      makeScenario('createThing', [makeStep('createThing', { pathTemplate: '/things' })]),
+    ],
     [
       'getThing',
       makeScenario('getThing', [

--- a/tests/fixtures/planner/restore-lifecycle.test.ts
+++ b/tests/fixtures/planner/restore-lifecycle.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+import { instantiateAllTemplates } from '../../../path-analyser/src/scenarioTemplateInstantiator.ts';
+import type {
+  EndpointScenario,
+  OperationGraph,
+  OperationNode,
+  RequestStep,
+} from '../../../path-analyser/src/types.ts';
+
+/**
+ * #426 — Layer-2 fixtures for the `RestoreLifecycle` compiler. Each `it`
+ * is one chain statement about how a `shape: "entity"` ABox row that
+ * declares `restorableVia` flows through `instantiateAllTemplates`.
+ *
+ * The fixture hand-builds a minimal `OperationGraph` (create / get /
+ * delete / restore) and a canonical map (one EndpointScenario per op),
+ * then asserts on the emitted TemplateScenario's 7-step shape and the
+ * status-only present/absent/present assertions that drive the
+ * create → soft-delete → restore lifecycle.
+ */
+
+function makeOp(operationId: string, opts: Partial<OperationNode>): OperationNode {
+  return {
+    operationId,
+    method: 'POST',
+    path: `/${operationId}`,
+    requires: { required: [], optional: [] },
+    produces: [],
+    ...opts,
+  };
+}
+
+function makeStep(operationId: string, opts: Partial<RequestStep>): RequestStep {
+  return {
+    operationId,
+    method: 'POST',
+    pathTemplate: `/${operationId}`,
+    expect: { status: 200 },
+    ...opts,
+  };
+}
+
+function makeScenario(operationId: string, plan: RequestStep[]): EndpointScenario {
+  return {
+    id: `s:${operationId}`,
+    operations: plan.map((s) => ({
+      operationId: s.operationId,
+      method: s.method,
+      path: s.pathTemplate,
+    })),
+    producedSemanticTypes: [],
+    satisfiedSemanticTypes: [],
+    requestPlan: plan,
+    bindings: {},
+    seedBindings: [],
+  };
+}
+
+describe('RestoreLifecycle compiler — Layer 2 contract', () => {
+  const graph: OperationGraph = {
+    operations: {
+      createThing: makeOp('createThing', {
+        method: 'POST',
+        path: '/things',
+        requires: { required: [], optional: [] },
+        responseSemanticLeaves: [{ semantic: 'ThingKey', path: 'thingKey', provider: true }],
+      }),
+      getThing: makeOp('getThing', {
+        method: 'GET',
+        path: '/things/{thingKey}',
+        requires: { required: ['ThingKey'], optional: [] },
+      }),
+      deleteThing: makeOp('deleteThing', {
+        method: 'DELETE',
+        path: '/things/{thingKey}',
+        requires: { required: ['ThingKey'], optional: [] },
+      }),
+      restoreThing: makeOp('restoreThing', {
+        method: 'POST',
+        path: '/things/{thingKey}/restoration',
+        requires: { required: ['ThingKey'], optional: [] },
+      }),
+    },
+    producersByType: {},
+    establishersByType: {},
+  };
+
+  const canonical = new Map<string, EndpointScenario>([
+    ['createThing', makeScenario('createThing', [makeStep('createThing', { path: '/things' })])],
+    [
+      'getThing',
+      makeScenario('getThing', [
+        makeStep('getThing', { method: 'GET', pathTemplate: '/things/{thingKey}' }),
+      ]),
+    ],
+    [
+      'deleteThing',
+      makeScenario('deleteThing', [
+        makeStep('deleteThing', {
+          method: 'DELETE',
+          pathTemplate: '/things/{thingKey}',
+          expect: { status: 204 },
+        }),
+      ]),
+    ],
+    [
+      'restoreThing',
+      makeScenario('restoreThing', [
+        makeStep('restoreThing', {
+          method: 'POST',
+          pathTemplate: '/things/{thingKey}/restoration',
+        }),
+      ]),
+    ],
+  ]);
+
+  const templates = {
+    version: 1,
+    templates: [
+      {
+        '@type': 'ScenarioTemplate' as const,
+        name: 'RestoreLifecycle',
+        appliesTo: { kind: 'Entity' as const },
+        description: 'test',
+        steps: [],
+      },
+    ],
+  };
+
+  const restorableKind = {
+    '@type': 'EntityKind' as const,
+    name: 'Thing',
+    shape: 'entity' as const,
+    identifiers: ['ThingKey'],
+    establishedBy: 'createThing',
+    observableVia: 'getThing',
+    revokedBy: 'deleteThing',
+    restorableVia: 'restoreThing',
+    description: 'test',
+  };
+  // A second entity kind with NO restorableVia — RestoreLifecycle must skip it.
+  const nonRestorableKind = {
+    '@type': 'EntityKind' as const,
+    name: 'Widget',
+    shape: 'entity' as const,
+    identifiers: ['WidgetKey'],
+    establishedBy: 'createThing',
+    observableVia: 'getThing',
+    revokedBy: 'deleteThing',
+    description: 'test',
+  };
+  const entityKinds = { version: 1, kinds: [restorableKind, nonRestorableKind] };
+  const edges = { version: 1, edges: [] };
+
+  const result = instantiateAllTemplates(graph, templates, edges, canonical, entityKinds);
+
+  it('emits exactly one scenario — only for the kind that declares restorableVia', () => {
+    expect(result).toHaveLength(1);
+    expect(result[0].subjectKind).toBe('Entity');
+    expect(result[0].subjectName).toBe('Thing');
+    expect(result[0].templateName).toBe('RestoreLifecycle');
+  });
+
+  it('emits the 7-step shape (prereq → create → present → delete → absent → restore → present)', () => {
+    const steps = result[0].scenario.steps;
+    expect(steps.map((s) => s.kind)).toEqual([
+      'prereqChain',
+      'invoke',
+      'observe',
+      'invoke',
+      'observe',
+      'invoke',
+      'observe',
+    ]);
+  });
+
+  it('targets create / delete / restore on the three invoke steps', () => {
+    const steps = result[0].scenario.steps;
+    const invokes = steps.filter((s) => s.kind === 'invoke').map((s) => s.operationId);
+    expect(invokes).toEqual(['createThing', 'deleteThing', 'restoreThing']);
+  });
+
+  it('asserts present(200) → absent(404) → present(200) via status-only observes on the fetcher', () => {
+    const observes = result[0].scenario.steps.filter((s) => s.kind === 'observe');
+    expect(observes).toHaveLength(3);
+    for (const o of observes) {
+      if (o.kind !== 'observe' || o.assertion.kind !== 'statusOnly') {
+        throw new Error('expected statusOnly observe');
+      }
+      expect(o.operationId).toBe('getThing');
+    }
+    const expectations = observes.map((o) =>
+      o.kind === 'observe' && o.assertion.kind === 'statusOnly'
+        ? [o.assertion.expect, o.assertion.expectedStatus]
+        : null,
+    );
+    expect(expectations).toEqual([
+      ['present', 200],
+      ['absent', 404],
+      ['present', 200],
+    ]);
+  });
+
+  it('throws (loud failure) when the restore op has no canonical scenario', () => {
+    const badCanonical = new Map(canonical);
+    badCanonical.delete('restoreThing');
+    expect(() =>
+      instantiateAllTemplates(graph, templates, edges, badCanonical, entityKinds),
+    ).toThrow(/no canonical scenario for restorableVia='restoreThing'/);
+  });
+});


### PR DESCRIPTION
Models the **restore-after-soft-delete lifecycle** (#25264 coverage) so `restoreFile` is exercised meaningfully. Closes #426.

## Problem
`restoreFile` (`POST /files/{fileKey}/restoration`) restores a **soft-deleted** file. The plain requires-chain (`restoreFile` requires `File` → chain `createFile`) invoked it on a **live** file, which the Hub rejects with 404 — so `restoreFile` was a standing positive-suite failure.

## Fix — `RestoreLifecycle` scenario-template
A 7-step lifecycle that drives the instance through the actual transition (all statuses confirmed live against `camunda/hub:SNAPSHOT`):

```
prereq → create[200] → observe present[200] → soft-delete (revokedBy)[204]
       → observe absent[404] → restore (restorableVia)[200] → observe present[200]
```

- **TBox** (`entityKindsSchema.ts`): optional `restorableVia` on `shape:"entity"` kinds — forbidden on the other three shapes, and **not** part of the entity all-or-nothing triple (restore is opt-in per kind, so Workspace/Project without a restore op are unaffected). Regenerated `entity-kinds.schema.json`.
- **Instantiator** (`scenarioTemplateInstantiator.ts`): `compileRestoreLifecycle` + dispatch under `appliesTo: Entity`. Entity kinds without `restorableVia` are skipped silently (not an error).
- **Emitter** (`templateEmitter.ts`): `renderRestoreLifecycleSuite`, routed on `templateName`, reusing EntityLifecycle's `statusOnly` observe assertion and the shared per-step helpers.
- **ABox** (hub): `File` declares `restorableVia: "restoreFile"`; `RestoreLifecycle` added to `scenario-templates.json`. `restoreFile` is now consumed by the template and dropped from the plain feature suite.

## Verification
- **File restore lifecycle passes live** (create 200 → present 200 → soft-delete 204 → absent 404 → restore 200 → present 200).
- **Positive suite 33 / 6** (was 32 / 7): `restoreFile` no longer fails; the 6 remaining are all tracked hub gaps — 5 version ops (#25801) + `deleteCatalogAsset` (#25576).
- **833 unit tests pass** (+7: `compileRestoreLifecycle` contract in `restore-lifecycle.test.ts` + schema accept/reject in the entity-kinds loader test). tsc + lint clean.
- **OCA unaffected**: it ships no `restorableVia`, so `RestoreLifecycle` instantiates nothing there — generalizes to `restoreFolder`/`restoreProject` if/when those are modelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
