### PR TITLE
fix(request-validation): skip wrong-type body tests on authz-resolved key fields (#427)

### DIFF
--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -45,8 +45,9 @@ export interface EmitTemplateSuitesOptions {
   /**
    * Absolute path to a template's scenarios directory, i.e.
    * `generated/<config>/scenarios/templates/<TemplateName>/`
-   * (e.g. `EdgeLifecycle`, `EntityLifecycle`). Each `.json` underneath
-   * is read and rendered to one `<Subject>.lifecycle.spec.ts`.
+   * (e.g. `EdgeLifecycle`, `EntityLifecycle`, `RestoreLifecycle`). Each
+   * `.json` underneath is read and rendered to one
+   * `<Subject>.lifecycle.spec.ts`.
    */
   scenariosDir: string;
   /**
@@ -74,12 +75,16 @@ export interface EmitTemplateSuitesOptions {
 
 /**
  * Read every lifecycle template scenario JSON from `scenariosDir` and
- * write one Playwright suite per subject to `outDir`. Handles both
- * EdgeLifecycle (membership-search observe) and EntityLifecycle
- * (#280 — get-by-id status observe); dispatch is by
- * `TemplateScenarioFile.subjectKind` ('Edge' vs 'Entity').
+ * write one Playwright suite per subject to `outDir`. `renderLifecycleSuite`
+ * dispatches by template:
+ *   - **EdgeLifecycle** (membership-search observe) and **EntityLifecycle**
+ *     (#280 — get-by-id status observe) share the fixed 5-step shape below,
+ *     routed by `TemplateScenarioFile.subjectKind` ('Edge' vs 'Entity').
+ *   - **RestoreLifecycle** (#426) has its own 7-step shape and a dedicated
+ *     render path (`renderRestoreLifecycleSuite`), routed by `templateName`;
+ *     see that function for its step sequence.
  *
- * Suite shape (both templates share steps 1–4, differ on 5/7):
+ * The 5-step Edge/Entity shape (both share steps 1–4, differ on 5/7):
  *   1. universal-seed prologue (one `ctx.<binding> ??= seedBinding(...)`
  *      per configured GlobalContextSeed),
  *   2. one `seedBinding('<name>')` per `PrereqChainStep.seedBindings`

--- a/request-validation/scripts/generate.ts
+++ b/request-validation/scripts/generate.ts
@@ -214,6 +214,10 @@ async function main() {
           capPerOperation: opts.maxTypeMismatch,
           onlyOperations: opts.onlyOperations,
           maxPerField: 2,
+          // #427 — the resource-key fields (keys of resourceFixtures) are
+          // authz-resolved before body validation, so wrong-type mutations on
+          // them yield 403/500 not 400; skip them.
+          resourceKeyFields: new Set(Object.keys(rvConfig.resourceFixtures ?? {})),
         }),
       );
     }

--- a/request-validation/src/analysis/bodyTypeMismatch.ts
+++ b/request-validation/src/analysis/bodyTypeMismatch.ts
@@ -7,6 +7,23 @@ interface Opts {
   onlyOperations?: Set<string>;
   capPerOperation?: number;
   maxPerField?: number;
+  /**
+   * #427 — leaf names of body fields the server's authorization layer
+   * resolves *before* body type-validation (the resource-key fields, i.e.
+   * the keys of `resourceFixtures`: projectKey, folderKey, parentFolderKey,
+   * workspaceKey, …). A wrong-type value on one of these never reaches
+   * body validation: the @PreAuthorize gate resolves the malformed key
+   * first, so a scalar wrong-type (`123`, `true`) short-circuits to 403
+   * and a structural one (`{}`, `[]`) currently 500s (a Hub bug —
+   * unhandled non-scalar key). Neither is the expected 400, so emitting a
+   * body-type-mismatch on an authz-resolved key field is a guaranteed
+   * false-positive. Verified live 2026-07-03: a non-key string field with
+   * the same mutations correctly returns 400, confirming the bypass is
+   * specific to authz-resolved keys. Skipped here rather than
+   * re-expected-as-403 so the suite keeps asserting strict body-validation
+   * (400) everywhere it actually runs. Analogous to `unenforcedStringFormats`.
+   */
+  resourceKeyFields?: ReadonlySet<string>;
 }
 
 const TYPE_MISMATCH_TABLE: Record<string, unknown[]> = {
@@ -31,6 +48,10 @@ export function generateBodyTypeMismatch(ops: OperationModel[], opts: Opts): Val
     for (const f of fields) {
       const t = Array.isArray(f.type) ? f.type[0] : f.type;
       if (!t || !TYPE_MISMATCH_TABLE[t]) continue;
+      // #427 — skip authz-resolved resource-key fields: the server resolves
+      // them before body validation, so a wrong-type value yields 403/500,
+      // never the expected 400.
+      if (opts.resourceKeyFields?.has(f.path[f.path.length - 1])) continue;
       let perField = 0;
       for (const wrong of TYPE_MISMATCH_TABLE[t]) {
         if (opts.capPerOperation && produced >= opts.capPerOperation) break;

--- a/tests/request-validation/wrong-type-key-skip.test.ts
+++ b/tests/request-validation/wrong-type-key-skip.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { generateBodyTypeMismatch } from '../../request-validation/src/analysis/bodyTypeMismatch.js';
+import type { OperationModel } from '../../request-validation/src/model/types.js';
+
+/**
+ * #427 — body wrong-type mutations on authz-resolved resource-key fields
+ * (the keys of `resourceFixtures`, e.g. `projectKey`) must be skipped:
+ * the server resolves the key for authorization *before* body
+ * type-validation, so a wrong-type value never reaches the 400 path
+ * (scalar → 403, object/array → 500, a Hub bug). Verified live: the same
+ * mutation on a non-key string field correctly returns 400, so the skip
+ * is scoped to the declared resource-key fields — every other field still
+ * gets strict 400-expecting wrong-type coverage.
+ */
+describe('bodyTypeMismatch: skips authz-resolved resource-key fields (#427)', () => {
+  function updateFolderOp(): OperationModel {
+    return {
+      operationId: 'updateFolder',
+      method: 'PATCH',
+      path: '/folders/{folderKey}',
+      tags: [],
+      requestBodySchema: {
+        type: 'object',
+        required: ['name', 'projectKey', 'parentFolderKey'],
+        properties: {
+          name: { type: 'string' },
+          projectKey: { type: 'string' },
+          parentFolderKey: { type: 'string' },
+        },
+      },
+      requiredProps: ['name', 'projectKey', 'parentFolderKey'],
+      parameters: [{ name: 'folderKey', in: 'path', required: true, schema: { type: 'string' } }],
+    };
+  }
+
+  const targets = (scenarios: { target?: string }[]) => new Set(scenarios.map((s) => s.target));
+
+  it('emits wrong-type cases for key fields when no resourceKeyFields are configured', () => {
+    const out = generateBodyTypeMismatch([updateFolderOp()], { maxPerField: 2 });
+    const t = targets(out);
+    expect(t.has('projectKey')).toBe(true);
+    expect(t.has('parentFolderKey')).toBe(true);
+    expect(t.has('name')).toBe(true);
+  });
+
+  it('skips the authz-resolved key fields but keeps non-key fields when configured', () => {
+    const out = generateBodyTypeMismatch([updateFolderOp()], {
+      maxPerField: 2,
+      resourceKeyFields: new Set(['projectKey', 'parentFolderKey', 'folderKey', 'workspaceKey']),
+    });
+    const t = targets(out);
+    expect(t.has('projectKey')).toBe(false);
+    expect(t.has('parentFolderKey')).toBe(false);
+    // name is not a resource key → still exercised with strict 400 expectation.
+    expect(t.has('name')).toBe(true);
+    expect(out.find((s) => s.target === 'name')?.expectedStatus).toBe(400);
+  });
+});


### PR DESCRIPTION
Fixes **#427** — wrong-type body tests on resource-key fields expected `400` but got `403`/`500`.

## Root cause (empirically determined)
The issue proposed either (a) Jackson coercion or (b) hub validation-ordering. Live probing against `camunda/hub:SNAPSHOT` (2026-07-03) shows it's **(b)-flavored** and **disproves (a)**:

| body field | mutation | result |
|---|---|---|
| `name` (non-key string) | `123` / `{}` / `[]` | **400** ✓ (Jackson does *not* coerce) |
| `projectKey` (authz key) | `123`, `true` (scalar) | **403** |
| `projectKey` (authz key) | `{}`, `[]` (structural) | **500** ⚠️ |
| `projectKey` (authz key) | `"123"` (wrong *value*, right type) | **403** |

The authorization layer (`@PreAuthorize`) resolves the key **before** body type-validation, so a malformed key never reaches the 400 path. A non-key field with the *same* mutations correctly returns 400, confirming the bypass is specific to authz-resolved keys.

## Fix
Skip body wrong-type mutations on authz-resolved resource-key fields, keyed off the config's `resourceFixtures` field names (the declared resource keys — same single source of truth that already substitutes real keys into other tests' envelopes). Every non-key field keeps strict 400-expecting coverage. Analogous to `unenforcedStringFormats` / `enumCaseInsensitive`.

- `bodyTypeMismatch.ts`: new `resourceKeyFields` opt; skip fields whose leaf name is in it.
- `generate.ts`: pass `Object.keys(resourceFixtures)`.
- Unit test: key fields skipped, non-key fields kept (strict 400).

## Verification
- Live negative suite: **304 passed / 17 failed** (was 320 / 27) — the 10 #427 false-positives gone; remaining 17 are all #25801 version ops. Restores the negative nightly to a single known-issue class.
- 835 unit tests pass; tsc + lint clean.

## Follow-up (separate hub bug)
The **500 on object/array key values** (`{"projectKey":{}}` → 500) is a distinct Hub robustness bug — it should be `400`, like the non-key equivalent. To be filed upstream against camunda-hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
