### PR TITLE
fix(planner): bind required nested filter.<key> to its produced var (#408)

### DIFF
--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1653,8 +1653,12 @@ export function buildRequestBodyFromCanonical(
       // runtime), while an optional filter stays unbound (preserving #168). The
       // feature-suite scenario object doesn't carry `producedSemanticTypes`, so
       // the producer index — not the scenario's produced set — is the reliable
-      // signal here.
-      if (!requiredBodyPaths.has(fieldPath)) continue;
+      // signal here. Normalise the trailing `[]` off the semantic fieldPath to
+      // match `requiredBodyPaths` (built from canonical node paths the same way)
+      // so a required ARRAY filter field (`filter.tags[]`) can match too; the
+      // original `fieldPath` (with `[]`) is still passed to setLeafPlaceholder,
+      // which handles the array segment.
+      if (!requiredBodyPaths.has(fieldPath.replace(/\[\]$/, ''))) continue;
       const hasProducer =
         !!graph.producersByType[entry.semantic]?.length ||
         !!graph.establishersByType?.[entry.semantic]?.length;

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1630,6 +1630,40 @@ export function buildRequestBodyFromCanonical(
         scenario.bindings.jobTypeVar = nonExistentType;
       }
     }
+    // #408 / #168 — bind a REQUIRED nested `filter.*` scope field to its
+    // produced semantic's var. The `semanticFallback` pass above deliberately
+    // skips `filter.*` paths (line ~1327), and a required nested filter scalar
+    // is otherwise materialised by `synthesizeObjectFromPrefix`, which has no
+    // binding context and emits the literal `'placeholder'`. That leaves a
+    // scoped search unscoped even when the chain produced the key — e.g.
+    // `searchVersions` chains createFile (→ fileKeyVar) but its body was
+    // `{ filter: { fileKey: 'placeholder' } }`. Rewrite the dotted body path to
+    // the produced `${…Var}` instead. Gated to REQUIRED filter fields whose
+    // semantic has a graph producer/establisher (so the planner chained it and
+    // the var resolves at runtime) — optional filters stay unbound (#168).
+    const requiredBodyPaths = new Set(
+      nodes.filter((n) => n.required).map((n) => n.path.replace(/\[\]$/, '')),
+    );
+    for (const entry of graph.operations[opId]?.requestBodySemantics ?? []) {
+      const fieldPath = entry.fieldPath;
+      if (!(fieldPath.startsWith('filter.') || fieldPath.startsWith('filter['))) continue;
+      // Gate on REQUIRED filter fields whose semantic has a graph
+      // producer/establisher: a required field forces the planner to chain that
+      // producer (so the `${…Var}` is extracted upstream and resolves at
+      // runtime), while an optional filter stays unbound (preserving #168). The
+      // feature-suite scenario object doesn't carry `producedSemanticTypes`, so
+      // the producer index — not the scenario's produced set — is the reliable
+      // signal here.
+      if (!requiredBodyPaths.has(fieldPath)) continue;
+      const hasProducer =
+        !!graph.producersByType[entry.semantic]?.length ||
+        !!graph.establishersByType?.[entry.semantic]?.length;
+      if (!hasProducer) continue;
+      const varName = `${camelCase(entry.semantic)}Var`;
+      scenario.bindings ||= {};
+      if (!scenario.bindings[varName]) scenario.bindings[varName] = PENDING_BINDING;
+      setLeafPlaceholder(template, fieldPath, `${'${'}${varName}}`);
+    }
     // Removed prior absolute guard (folded into unified omission pass above).
     return { kind: 'json' as const, template };
   }

--- a/tests/fixtures/planner/filter-scope-binding.test.ts
+++ b/tests/fixtures/planner/filter-scope-binding.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Nested filter-scope binding (#408 / #168).
+ *
+ * A search op with a REQUIRED nested `filter.<key>` scope field whose semantic
+ * has a graph producer must bind that field to the produced `${…Var}`, not the
+ * synthesised `'placeholder'`. Reproduces camunda-hub `searchVersions`, whose
+ * body used to be `{ filter: { fileKey: 'placeholder' } }` even though the
+ * chain created a file and extracted `fileKeyVar` — leaving the version search
+ * unscoped. `buildRequestBodyFromCanonical` otherwise fills required nested
+ * fields via `synthesizeObjectFromPrefix`, which has no binding context.
+ *
+ * The bind is gated to REQUIRED filter fields with a producer (an optional
+ * filter stays unbound — the deferred #168 behaviour) so it can't reference a
+ * var the chain never produces.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  buildRequestBodyFromCanonical,
+  type CanonicalShape,
+} from '../../../path-analyser/src/index.ts';
+import type { EndpointScenario, OperationGraph } from '../../../path-analyser/src/types.ts';
+
+// searchVersions-like body: a `filter` object with a nested `filter.fileKey`
+// (semantic FileKey). The nested field's `required` flag is the gate the fix
+// reads (a required scope field binds; an optional one stays unbound, #168).
+function makeCanonical(fileKeyRequired: boolean): Record<string, CanonicalShape> {
+  return {
+    searchVersions: {
+      requestByMediaType: {
+        'application/json': [
+          { path: 'filter', type: 'object', required: true },
+          { path: 'filter.fileKey', type: 'string', required: fileKeyRequired },
+        ],
+      },
+    },
+  };
+}
+
+function makeGraph(fileKeyProducer: boolean): OperationGraph {
+  return {
+    operations: {
+      searchVersions: {
+        operationId: 'searchVersions',
+        method: 'POST',
+        path: '/versions/search',
+        requires: { required: [], optional: [] },
+        produces: [],
+        requestBodySemantics: [
+          { semantic: 'FileKey', fieldPath: 'filter.fileKey', required: true },
+        ],
+      },
+    },
+    producersByType: fileKeyProducer ? { FileKey: ['createFile'] } : {},
+    producersByState: {},
+    responseProducersByType: {},
+  };
+}
+
+function scenario(): EndpointScenario {
+  return {
+    id: 'feature-1',
+    operations: [],
+    producedSemanticTypes: [], // feature scenarios don't carry this — must not gate on it
+    satisfiedSemanticTypes: [],
+  };
+}
+
+function fileKeyValue(opts: { producer: boolean; required: boolean }): unknown {
+  const plan = buildRequestBodyFromCanonical(
+    'searchVersions',
+    scenario(),
+    makeGraph(opts.producer),
+    makeCanonical(opts.required),
+    {},
+    /* isEndpoint */ true,
+  );
+  const template = plan?.kind === 'json' ? plan.template : {};
+  const filter = template.filter;
+  return isRecord(filter) ? filter.fileKey : undefined;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+describe('nested filter-scope binding (#408 / #168)', () => {
+  it('binds a required filter.<key> to its produced var (not placeholder)', () => {
+    expect(fileKeyValue({ producer: true, required: true })).toBe('${fileKeyVar}');
+  });
+
+  it('leaves the field synthesised when the semantic has no producer', () => {
+    // No producer → binding it would reference a var the chain never extracts.
+    expect(fileKeyValue({ producer: false, required: true })).toBe('placeholder');
+  });
+
+  it('leaves an OPTIONAL filter field unbound (preserves #168)', () => {
+    // Optional filters are not force-scoped; only required scope fields bind.
+    expect(fileKeyValue({ producer: true, required: false })).not.toBe('${fileKeyVar}');
+  });
+});

--- a/tests/fixtures/planner/filter-scope-binding.test.ts
+++ b/tests/fixtures/planner/filter-scope-binding.test.ts
@@ -97,4 +97,46 @@ describe('nested filter-scope binding (#408 / #168)', () => {
     // Optional filters are not force-scoped; only required scope fields bind.
     expect(fileKeyValue({ producer: true, required: false })).not.toBe('${fileKeyVar}');
   });
+
+  it('binds a required ARRAY filter field (filter.tags[]) despite the [] suffix', () => {
+    // requiredBodyPaths strips the trailing `[]` from the canonical node; the
+    // membership check must normalise the semantic fieldPath the same way so an
+    // array filter field still matches (else the [] mismatch skips the bind).
+    const canonical: Record<string, CanonicalShape> = {
+      searchThings: {
+        requestByMediaType: {
+          'application/json': [
+            { path: 'filter', type: 'object', required: true },
+            { path: 'filter.tags[]', type: 'string', required: true },
+          ],
+        },
+      },
+    };
+    const graph: OperationGraph = {
+      operations: {
+        searchThings: {
+          operationId: 'searchThings',
+          method: 'POST',
+          path: '/things/search',
+          requires: { required: [], optional: [] },
+          produces: [],
+          requestBodySemantics: [{ semantic: 'Tag', fieldPath: 'filter.tags[]', required: true }],
+        },
+      },
+      producersByType: { Tag: ['createTag'] },
+      producersByState: {},
+      responseProducersByType: {},
+    };
+    const plan = buildRequestBodyFromCanonical(
+      'searchThings',
+      scenario(),
+      graph,
+      canonical,
+      {},
+      /* isEndpoint */ true,
+    );
+    const template = plan?.kind === 'json' ? plan.template : {};
+    const filter = template.filter;
+    expect(isRecord(filter) ? filter.tags : undefined).toEqual(['${tagVar}']);
+  });
 });


### PR DESCRIPTION
Addresses #408 (hub server-minted-key handling in the positive-suite planner).

## TL;DR — 2 of the 3 gaps were already fixed on `main`; this fixes the third
I generated the hub suite and inspected the actual output before touching code. Two of #408's gaps no longer reproduce:

- **Gap 1 (search-vs-create):** every entity lifecycle (Project/Folder/File/Version-restore) *and* the base-planner scenarios (`createFile.variant`, `updateFile.feature`) chain `createWorkspace → createProject → create*` and extract real keys. No `searchProjects` key-sourcing anywhere.
- **Gap 2 (edge scope key seeded):** the `WorkspaceMemberMembership` lifecycle chains `createWorkspace` and uses `ctx.workspaceKeyVar` in `addMember`'s URL. No seeded key, no 404.

## The real residual — Gap 3 (nested filter binding)
`searchVersions` correctly chained `createFile` (extracting `fileKeyVar`) but its body was:
```js
filter: { fileKey: 'placeholder' }   // ← unscoped
```
`buildRequestBodyFromCanonical` fills a required nested filter scalar via `synthesizeObjectFromPrefix`, which has no binding context and emits `'placeholder'` (the deferred #168 behaviour). 

**Fix:** a post-pass rewrites a **required** `filter.<key>` whose semantic has a graph producer/establisher to the produced `${…Var}` (reusing the existing dotted-path writer `setLeafPlaceholder`). Now `searchVersions` emits `filter: { fileKey: ctx.fileKeyVar }`.

### Why this gate
- **Required + has-producer:** a required filter field forces the planner to chain that producer, so the `${…Var}` is extracted upstream and resolves at runtime. Optional filters stay unbound → preserves #168.
- Uses the **producer index**, not `scenario.producedSemanticTypes` — the feature-suite scenario object doesn't populate the latter (that was a false start; see the two-scenario trace).

### Edge workaround kept (not retired)
`compileEdgeLifecycle`'s filter re-bind covers the edge observe's **optional** scoping filter (`searchMembers.filter.workspaceKey`) — complementary to this **required**-field fix, not redundant. Removing it would unscope the edge search.

## Verification
- New regression test `tests/fixtures/planner/filter-scope-binding.test.ts` (binds required+producer; leaves no-producer and optional cases alone). 3/3.
- Full suite **845 passed / 4 skipped** — **zero change to OCA output** (the shared body-builder change is contained to required filter fields with a chained producer).
- Generated hub output: `searchVersions` now scoped; no `placeholder` in any hub filter.

Runtime proof (scoped search returns 200) is covered by the positive nightly, which already runs these lifecycles against a live hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)