### PR TITLE
test(camunda-hub): add Layer-3 regression invariants (#128)

### DIFF
--- a/configs/camunda-hub/regression-invariants.test.ts
+++ b/configs/camunda-hub/regression-invariants.test.ts
@@ -1,0 +1,146 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  getActiveConfigName,
+  getPlaywrightSuiteDir,
+  getSpecBundleDir,
+} from '../../path-analyser/src/configResolver.js';
+
+/**
+ * Bundled-spec invariants — Layer 3, camunda-hub config (#128).
+ *
+ * The camunda-hub counterpart of configs/camunda-oca/regression-invariants.test.ts:
+ * each `it` is a single named regression statement of the form "X must hold for
+ * the hub bundled-spec output". These lock in behaviours already proven correct
+ * against a live hub (see #408 verification) so a generator regression surfaces
+ * as one named failure rather than a red nightly.
+ *
+ * Per-config guard (#128): this file lives under configs/camunda-hub/ and only
+ * runs when the active CONFIG is camunda-hub. `describe.skipIf` collects the
+ * file but skips the suite for any other config, so the default `npm test`
+ * (camunda-oca) no-ops here and a camunda-hub CI leg runs it against the
+ * regenerated hub output.
+ *
+ * Prerequisites: the hub pipeline must have been generated for the pinned spec:
+ *   CONFIG=camunda-hub npm run fetch-spec && CONFIG=camunda-hub npm run testsuite:generate
+ * The spec-pin gate (tests/regression/spec-pin.setup.ts) aborts on drift from
+ * configs/camunda-hub/spec-pin.json before these assertions load.
+ */
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const CONFIG_NAME = 'camunda-hub';
+const ACTIVE_CONFIG = getActiveConfigName(REPO_ROOT);
+const describeForThisConfig = describe.skipIf(ACTIVE_CONFIG !== CONFIG_NAME);
+
+const SUITE_DIR = getPlaywrightSuiteDir(REPO_ROOT);
+const BUNDLED_SPEC_PATH = join(getSpecBundleDir(REPO_ROOT), 'rest-api.bundle.json');
+const COVERAGE_PATH = join(SUITE_DIR, 'coverage.json');
+
+const HTTP_METHODS = new Set(['get', 'put', 'post', 'delete', 'patch', 'options', 'head', 'trace']);
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function bundleOperationIds(): Set<string> {
+  const raw: unknown = JSON.parse(readFileSync(BUNDLED_SPEC_PATH, 'utf8'));
+  const ids = new Set<string>();
+  if (!isRecord(raw) || !isRecord(raw.paths)) return ids;
+  for (const item of Object.values(raw.paths)) {
+    if (!isRecord(item)) continue;
+    for (const [method, op] of Object.entries(item)) {
+      if (!HTTP_METHODS.has(method.toLowerCase())) continue;
+      if (isRecord(op) && typeof op.operationId === 'string') ids.add(op.operationId);
+    }
+  }
+  return ids;
+}
+
+function readGeneratedSpec(relPath: string): string {
+  return readFileSync(join(SUITE_DIR, relPath), 'utf8');
+}
+
+function explicitlySuppressedOpIds(): string[] {
+  const raw: unknown = JSON.parse(readFileSync(COVERAGE_PATH, 'utf8'));
+  if (isRecord(raw) && Array.isArray(raw.explicitlySuppressedOpIds)) {
+    return raw.explicitlySuppressedOpIds.filter((x): x is string => typeof x === 'string');
+  }
+  return [];
+}
+
+const ENTITY_LIFECYCLE = 'templates/EntityLifecycle';
+const EDGE_LIFECYCLE = 'templates/EdgeLifecycle';
+
+describeForThisConfig('camunda-hub bundled-spec invariants (#128)', () => {
+  // --- Surface: the modelled hub API is present in the bundle ---------------
+  it('the bundle exposes the workspace/project/file/folder create operations', () => {
+    const ids = bundleOperationIds();
+    for (const op of ['createWorkspace', 'createProject', 'createFile', 'createFolder']) {
+      expect(ids.has(op), `${op} missing from bundled hub spec`).toBe(true);
+    }
+  });
+
+  it('the bundle exposes the workspace-member edge operations', () => {
+    const ids = bundleOperationIds();
+    for (const op of ['addMember', 'removeMember', 'searchMembers']) {
+      expect(ids.has(op), `${op} missing from bundled hub spec`).toBe(true);
+    }
+  });
+
+  // --- Lifecycle generation --------------------------------------------------
+  it('generates an entity lifecycle spec for each container entity', () => {
+    for (const entity of ['Workspace', 'Project', 'Folder', 'File']) {
+      const path = join(SUITE_DIR, ENTITY_LIFECYCLE, `${entity}.lifecycle.spec.ts`);
+      expect(existsSync(path), `${entity}.lifecycle.spec.ts not generated`).toBe(true);
+    }
+  });
+
+  it('generates the WorkspaceMemberMembership edge lifecycle spec', () => {
+    const path = join(SUITE_DIR, EDGE_LIFECYCLE, 'WorkspaceMemberMembership.lifecycle.spec.ts');
+    expect(existsSync(path)).toBe(true);
+  });
+
+  // --- Server-minted-key chaining (#408 Gap 1) -------------------------------
+  it('File lifecycle chains createWorkspace → createProject → createFile (no search-discovery for keys)', () => {
+    const spec = readGeneratedSpec(`${ENTITY_LIFECYCLE}/File.lifecycle.spec.ts`);
+    expect(spec).toContain('createWorkspace');
+    expect(spec).toContain('createProject');
+    expect(spec).toContain('createFile');
+    // The parent projectKey comes from the create-chain, never sourced by
+    // searching for a pre-existing project (fragile, `items[0]` may be undefined).
+    expect(spec).not.toContain('searchProjects');
+  });
+
+  // --- Edge scope-key chaining (#408 Gap 2) ----------------------------------
+  it('the edge lifecycle chains createWorkspace and uses the extracted workspaceKey in addMember', () => {
+    const spec = readGeneratedSpec(`${EDGE_LIFECYCLE}/WorkspaceMemberMembership.lifecycle.spec.ts`);
+    expect(spec).toContain('createWorkspace');
+    // addMember's path scope key is the extracted var, not a fresh seed.
+    expect(spec).toContain('workspaceKeyVar');
+    expect(spec).toMatch(/\/workspaces\/\$\{ctx\.workspaceKeyVar/);
+  });
+
+  // --- Nested filter-scope binding (#408 Gap 3) ------------------------------
+  it('searchVersions scopes its filter to the produced fileKey, not a placeholder', () => {
+    const spec = readGeneratedSpec('searchVersions.feature.spec.ts');
+    expect(spec).toContain('fileKey: ctx.fileKeyVar');
+    expect(spec).not.toMatch(/fileKey:\s*'placeholder'/);
+  });
+
+  // --- Suppression contract (upstream-blocked ops stay out of the suite) -----
+  it('version + catalog blockers are explicitly suppressed from the positive suite', () => {
+    const suppressed = new Set(explicitlySuppressedOpIds());
+    // Blocked on camunda-hub#25801 (versions) and #25576 (catalog).
+    for (const op of [
+      'createVersion',
+      'getVersion',
+      'updateVersion',
+      'deleteVersion',
+      'restoreVersion',
+      'deleteCatalogAsset',
+    ]) {
+      expect(suppressed.has(op), `${op} should be explicitly suppressed`).toBe(true);
+    }
+  });
+});

--- a/configs/camunda-hub/regression-invariants.test.ts
+++ b/configs/camunda-hub/regression-invariants.test.ts
@@ -48,26 +48,42 @@ function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
+// Mirror the OCA file's actionable-missing-output pattern: fail with a clear
+// "not generated — run this" message instead of a low-signal ENOENT, so a
+// suite that hasn't been generated (the common local-repro slip) is obvious.
+const GEN_HINT =
+  "check out the pinned specRef in ../camunda-hub, then run 'CONFIG=camunda-hub npm run fetch-spec && CONFIG=camunda-hub npm run testsuite:generate'";
+function readRequired(path: string): string {
+  if (!existsSync(path)) {
+    throw new Error(`Hub pipeline output not found at ${path}. To reproduce: ${GEN_HINT}.`);
+  }
+  return readFileSync(path, 'utf8');
+}
+
+let _bundleOpIdsCache: Set<string> | undefined;
 function bundleOperationIds(): Set<string> {
-  const raw: unknown = JSON.parse(readFileSync(BUNDLED_SPEC_PATH, 'utf8'));
+  if (_bundleOpIdsCache) return _bundleOpIdsCache;
+  const raw: unknown = JSON.parse(readRequired(BUNDLED_SPEC_PATH));
   const ids = new Set<string>();
-  if (!isRecord(raw) || !isRecord(raw.paths)) return ids;
-  for (const item of Object.values(raw.paths)) {
-    if (!isRecord(item)) continue;
-    for (const [method, op] of Object.entries(item)) {
-      if (!HTTP_METHODS.has(method.toLowerCase())) continue;
-      if (isRecord(op) && typeof op.operationId === 'string') ids.add(op.operationId);
+  if (isRecord(raw) && isRecord(raw.paths)) {
+    for (const item of Object.values(raw.paths)) {
+      if (!isRecord(item)) continue;
+      for (const [method, op] of Object.entries(item)) {
+        if (!HTTP_METHODS.has(method.toLowerCase())) continue;
+        if (isRecord(op) && typeof op.operationId === 'string') ids.add(op.operationId);
+      }
     }
   }
+  _bundleOpIdsCache = ids;
   return ids;
 }
 
 function readGeneratedSpec(relPath: string): string {
-  return readFileSync(join(SUITE_DIR, relPath), 'utf8');
+  return readRequired(join(SUITE_DIR, relPath));
 }
 
 function explicitlySuppressedOpIds(): string[] {
-  const raw: unknown = JSON.parse(readFileSync(COVERAGE_PATH, 'utf8'));
+  const raw: unknown = JSON.parse(readRequired(COVERAGE_PATH));
   if (isRecord(raw) && Array.isArray(raw.explicitlySuppressedOpIds)) {
     return raw.explicitlySuppressedOpIds.filter((x): x is string => typeof x === 'string');
   }

--- a/configs/camunda-hub/regression-invariants.test.ts
+++ b/configs/camunda-hub/regression-invariants.test.ts
@@ -22,10 +22,15 @@ import {
  * (camunda-oca) no-ops here and a camunda-hub CI leg runs it against the
  * regenerated hub output.
  *
- * Prerequisites: the hub pipeline must have been generated for the pinned spec:
- *   CONFIG=camunda-hub npm run fetch-spec && CONFIG=camunda-hub npm run testsuite:generate
- * The spec-pin gate (tests/regression/spec-pin.setup.ts) aborts on drift from
- * configs/camunda-hub/spec-pin.json before these assertions load.
+ * Prerequisites: the hub pipeline must have been generated for the PINNED spec.
+ * Hub bundles in local mode from the ../camunda-hub sibling clone (SPEC_REF is
+ * ignored — fetch-spec bundles whatever ref that clone has checked out), so
+ * check out the pin *there* first, then bundle + generate:
+ *   git -C ../camunda-hub checkout <specRef from configs/camunda-hub/spec-pin.json>
+ *   CONFIG=camunda-hub npm run fetch-spec
+ *   CONFIG=camunda-hub npm run testsuite:generate
+ * The spec-pin gate (tests/regression/spec-pin.setup.ts) then aborts on drift
+ * from configs/camunda-hub/spec-pin.json before these assertions load.
  */
 
 const REPO_ROOT = join(import.meta.dirname, '..', '..');


### PR DESCRIPTION
Part of #128 (config-driven generation). Delivers the outstanding **"equivalent Layer-3 invariants are defined for Hub"** acceptance item — hub had no `regression-invariants.test.ts` (OCA does), which also blocks a hub CI matrix leg from having anything to run.

## What
`configs/camunda-hub/regression-invariants.test.ts` — the hub counterpart of the OCA invariants, `describe.skipIf`-guarded to the active `CONFIG` (same mechanism as OCA). The default `npm test` (camunda-oca) collects-but-skips it; a `CONFIG=camunda-hub` run executes it against the regenerated hub output, after the per-config `spec-pin.setup.ts` drift gate.

Eight named invariants, each locking in behaviour already proven against a live hub (the #408 verification run):
- **Surface** — bundle exposes `createWorkspace/createProject/createFile/createFolder` + `addMember/removeMember/searchMembers`.
- **Lifecycle generation** — entity specs (Workspace/Project/Folder/File) + the `WorkspaceMemberMembership` edge spec are emitted.
- **#408 create-chain guards** — File lifecycle chains `createWorkspace → createProject → createFile` (no `searchProjects` key-sourcing); the edge chains `createWorkspace` and uses the extracted `workspaceKey` in `addMember`.
- **#408 filter-binding guard** — `searchVersions` scopes `filter.fileKey` to `ctx.fileKeyVar`, not `'placeholder'`.
- **Suppression contract** — the version + catalog blockers (camunda-hub#25801 / #25576) stay explicitly suppressed.

## Verification
- `CONFIG=camunda-hub`: **8/8 pass** against generated hub output.
- Default `npm test` (camunda-oca): **846 passed**, hub file skipped — zero regression.
- Lint clean.

## Remaining for #128
The last core deliverable is the **CI matrix leg** that runs the hub config in PR CI (generate + these invariants). That needs the private `camunda-hub` clone auth in `ci.yml` (the qa-processes/Vault pattern the nightly already uses) — tracked as the follow-up. This PR unblocks it by giving the hub leg invariants to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)