### PR TITLE
docs(agents): document camunda-hub local-bundle spec-pin mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@ npm workspaces monorepo. Node `>=22`.
 | `configs/camunda-oca/spec-pin.json` | Pinned upstream `specRef` + `expectedSpecHash` for the camunda-oca config |
 | `configs/camunda-oca/{domain-semantics,filter-providers,request-defaults}.json` | Domain rules, value providers, and request-body defaults for camunda-oca |
 | `configs/camunda-oca/fixtures/` | Deployment-artifact fixture registry + BPMN/DMN/Form files for camunda-oca (#221 / Lift 11) |
+| `configs/camunda-hub/spec-pin.json` | Pinned `specRef` (a `camunda/camunda-hub` SHA) + `expectedSpecHash` for camunda-hub. **Local-bundle mode — see Spec pin.** |
+| `configs/camunda-hub/positive-suppress.json` | Per-op positive-suite suppressions for camunda-hub (upstream-blocked / opt-in ops), each with an optional `knownIssue { summary, url }` surfaced in the nightly |
 | `configs.json` | Index of named configs (default + per-config metadata) |
 | `spec/<config>/bundled/` | Gitignored bundled-spec output (partitioned by active CONFIG) |
 | `generated/<config>/` | Gitignored generator output (graph, scenarios, playwright suite, request-validation) |
@@ -141,6 +143,34 @@ To bump:
      and never this repo's own SHA — see the callout above)
    - `expectedSpecHash`: the `specHash` printed in `spec/<config>/bundled/spec-metadata.json`
 5. Update any invariants whose values legitimately changed; commit together.
+
+The procedure above (and the `git ls-remote camunda/camunda` callout) is
+**network-fetch mode**, used by `camunda-oca`. `camunda-hub` differs:
+
+### camunda-hub: local-bundle mode
+
+Hub's spec lives at `restapi/public-api/src/main/resources/openapi/v2/` inside
+the **private** `camunda/camunda-hub` repo — a non-default path the bundler's
+network-fetch CLI can't target. So `fetch-spec` bundles from a **sibling clone**
+(`../camunda-hub`) instead, and **`SPEC_REF` is ignored** — it bundles whatever
+ref that clone currently has checked out. Implications:
+
+- `configs/camunda-hub/spec-pin.json`'s `specRef` is a SHA on
+  **`camunda/camunda-hub`** (not `camunda/camunda`), so the `git ls-remote
+  camunda/camunda` check above does **not** apply.
+- To reproduce a hub invariant failure or bump the pin, check the ref out **in
+  the sibling clone first**, then bundle + generate:
+  ```bash
+  git -C ../camunda-hub checkout <specRef>   # or latest main to bump
+  CONFIG=camunda-hub npm run fetch-spec       # NOT fetch-spec:ref — SPEC_REF is ignored here
+  CONFIG=camunda-hub npm run testsuite:generate && CONFIG=camunda-hub npm run generate:request-validation
+  ```
+  Then update `configs/camunda-hub/spec-pin.json` (`specRef` = the checked-out
+  `camunda/camunda-hub` SHA, `expectedSpecHash` = the `specHash` in
+  `spec/camunda-hub/bundled/spec-metadata.json`), as in steps 4–5 above.
+- The nightly (`.github/workflows/nightly-camunda-hub.yml`) runs hub **unpinned**
+  (clones `camunda-hub@main`, bundles latest) — the pin governs only the
+  Layer-3 invariants in `configs/camunda-hub/regression-invariants.test.ts`.
 
 ## Code style & lint (Biome)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,7 +260,7 @@ fixtures and named invariants point directly at the broken property.
 |---|---|---|
 | 1 — extractor constructs | `tests/fixtures/extractor/extractor-constructs.test.ts` | One OpenAPI construct → one extractor property (`required`, `provider`, `fieldPath`, …) |
 | 2 — planner contracts | `tests/fixtures/planner/planner-contracts.test.ts` | Hand-built minimal `OperationGraph` → chain-shape assertion on `generateScenariosForEndpoint` |
-| 3 — bundled-spec invariants | `configs/<config>/regression-invariants.test.ts` (e.g. `configs/camunda-oca/regression-invariants.test.ts`) | Per-config (#128 PR 3) named, human-readable invariants over real pipeline output (requires `npm run pipeline` first). Each file `describe.skipIf`-guards itself to its own CONFIG so the CI matrix only runs the active config's invariants. |
+| 3 — bundled-spec invariants | `configs/<config>/regression-invariants.test.ts` (e.g. `configs/camunda-oca/regression-invariants.test.ts`) | Per-config (#128 PR 3) named, human-readable invariants over real pipeline output (requires `npm run pipeline` first). Each file `describe.skipIf`-guards itself to its own CONFIG, so a run only executes the active config's invariants — the default (`camunda-oca`) run skips hub's, and a future per-config CI leg (#128, still pending) would run only its own. |
 
 `tests/regression/standalone-suite-imports.test.ts` and the suites under
 `tests/codegen/` and `tests/request-validation/` cover emitter and
@@ -410,8 +410,9 @@ fix: address review comments — …
 
 ## Continuous integration
 
-Single workflow: [.github/workflows/ci.yml](.github/workflows/ci.yml). Runs
-on every PR to `main` and every push to `main`.
+PR/branch workflow: [.github/workflows/ci.yml](.github/workflows/ci.yml). Runs
+on every PR to `main` and every push to `main`. **It exercises `camunda-oca`
+only** — steps 2 and 5 below are OCA-specific.
 
 Steps (in order — match these locally before pushing):
 
@@ -424,6 +425,14 @@ Steps (in order — match these locally before pushing):
 7. `npm test`
 
 On failure, the `pipeline-outputs` artifact is uploaded for inspection.
+
+**`camunda-hub` is not in PR CI yet.** It runs via a separate scheduled
+workflow, [.github/workflows/nightly-camunda-hub.yml](.github/workflows/nightly-camunda-hub.yml),
+which clones `camunda-hub@main` (unpinned), generates, and runs the positive +
+negative suites against a live Hub. The per-config PR-CI matrix leg envisaged in
+#128 (fetch the pinned hub spec → generate → run
+`configs/camunda-hub/regression-invariants.test.ts`) is still pending; it needs
+the private `camunda-hub` clone auth wired into `ci.yml`.
 
 ## Pre-push checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,10 @@ env var; default `camunda-oca`). A vitest `globalSetup`
 (`tests/regression/spec-pin.setup.ts`) aborts the entire run if the bundled
 spec content drifts.
 
+> **This callout applies to `camunda-oca` (network-fetch mode). `camunda-hub`
+> pins to `camunda/camunda-hub` in local-bundle mode — see the subsection below,
+> where `git ls-remote camunda/camunda` does NOT apply.**
+>
 > **`specRef` is a commit SHA on the upstream `camunda/camunda` repo — NOT
 > on this repo (`camunda/api-test-generator`).** `camunda-schema-bundler`
 > shallow-clones `camunda/camunda` and runs `git fetch --depth 1 origin


### PR DESCRIPTION
AGENTS.md's Spec-pin section described only camunda-oca's **network-fetch** mode (specRef = `camunda/camunda` SHA, the `git ls-remote` check, `SPEC_REF=<sha> npm run fetch-spec:ref`). Hub works differently, and now that hub has its own Layer-3 invariants (`configs/camunda-hub/regression-invariants.test.ts`, #438) gated on the hub pin, an agent reproducing a hub invariant failure would follow the wrong procedure — the exact confusion flagged in #438 review.

## Changes
- New **"camunda-hub: local-bundle mode"** subsection under Spec pin: hub's `specRef` is a `camunda/camunda-hub` SHA (private repo), `fetch-spec` bundles from the `../camunda-hub` sibling clone at whatever ref is checked out (**`SPEC_REF` ignored**), so check the pin out **in the sibling first**; the nightly runs unpinned (pin governs only the invariants).
- Layout table now lists `configs/camunda-hub/{spec-pin,positive-suppress}.json`.

Docs-only; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)