### PR TITLE
feat: add bump-spec-pin script to re-pin a config's spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ npm run build --workspaces --if-present
 |--------|-------------|
 | `npm run fetch-spec` | Fetch and bundle the upstream OpenAPI spec (from `main` branch) |
 | `npm run fetch-spec:ref` | Fetch a specific branch/tag: `SPEC_REF=stable/8.8 npm run fetch-spec:ref` |
+| `npm run bump-spec-pin` | Re-pin a config's spec: `npm run bump-spec-pin -- --config <name> [--ref <sha>] [--dry-run]` (see Spec pin → Bumping the spec pin) |
 | `npm run extract-graph` | Build the semantic graph extractor and extract the dependency graph |
 | `npm run generate:scenarios` | Build the path analyser and generate scenario JSON files |
 | `npm run codegen:playwright` | Build and emit a Playwright test for a single endpoint |
@@ -351,24 +352,45 @@ aborts the entire run with a single actionable error if the bundled spec
 drifts from that hash, so reviewers don't have to debug a confusing
 invariant failure when the real cause is upstream drift.
 
-To bump the spec:
+Each config has its own pin at `configs/<config>/spec-pin.json`.
+
+#### Bumping the spec pin
+
+Use the `bump-spec-pin` script — it resolves the target ref, fetches + bundles
+the spec, and rewrites `configs/<config>/spec-pin.json` (`specRef` as a resolved
+40-char commit SHA + the new `expectedSpecHash`, preserving the `$comment`). It
+does **not** commit — you review the diff, verify, then commit.
 
 ```bash
-# 1. Fetch the new spec. SPEC_REF can be a branch, tag, or commit SHA;
-#    a branch/tag is fine for convenience here, but step 3 must record
-#    the resolved 40-char commit SHA in spec-pin.json (branches drift).
-SPEC_REF=stable/8.10 npm run fetch-spec:ref
+# camunda-oca — public, fetched from camunda/camunda. Defaults to the main tip;
+# pass --ref <sha|branch|tag> for a specific one (resolved to a SHA).
+npm run bump-spec-pin -- --config camunda-oca
+npm run bump-spec-pin -- --config camunda-oca --ref stable/8.10
 
-# 2. Regenerate the pipeline so the invariants run against fresh output
-npm run testsuite:generate
-npm run generate:request-validation
+# camunda-hub — private, bundled in "local mode" from the sibling clone
+# ../camunda-hub (SPEC_REF is ignored). Bumps to that clone's checked-out HEAD;
+# pass --ref <sha> to check that out first. Requires camunda-hub cloned as a
+# sibling: <parent>/{api-test-generator, camunda-hub}.
+npm run bump-spec-pin -- --config camunda-hub
 
-# 3. Update configs/camunda-oca/spec-pin.json:
-#    - specRef:          the resolved 40-char commit SHA (NOT the branch/tag)
-#    - expectedSpecHash: the `specHash` printed in spec/<config>/bundled/spec-metadata.json
-# 4. Update any invariants whose values legitimately changed, then commit
-#    spec-pin.json alongside the invariant updates.
+# Preview any bump without writing:
+npm run bump-spec-pin -- --config <name> --dry-run
 ```
+
+Then verify the new spec flows through cleanly, update any invariants whose
+values legitimately changed, and commit `spec-pin.json` + the invariant updates
+together:
+
+```bash
+CONFIG=<name> npm run testsuite:generate \
+  && CONFIG=<name> npm run generate:request-validation \
+  && CONFIG=<name> npm test
+```
+
+> **specRef is always a resolved commit SHA** (branches drift). For camunda-oca
+> that's a `camunda/camunda` SHA; for camunda-hub, a `camunda/camunda-hub` SHA.
+> See [AGENTS.md → Spec pin](AGENTS.md) for the OCA (network-fetch) vs hub
+> (local-bundle) modes in detail.
 
 ### Continuous integration
 

--- a/README.md
+++ b/README.md
@@ -362,8 +362,9 @@ the spec, and rewrites `configs/<config>/spec-pin.json` (`specRef` as a resolved
 does **not** commit — you review the diff, verify, then commit.
 
 ```bash
-# camunda-oca — public, fetched from camunda/camunda. Defaults to the main tip;
-# pass --ref <sha|branch|tag> for a specific one (resolved to a SHA).
+# camunda-oca — public, fetched from camunda/camunda. Defaults to the repo's
+# default-branch tip (resolved via `git ls-remote <repo> HEAD`); pass
+# --ref <sha|branch|tag> for a specific one (resolved to a SHA).
 npm run bump-spec-pin -- --config camunda-oca
 npm run bump-spec-pin -- --config camunda-oca --ref stable/8.10
 

--- a/README.md
+++ b/README.md
@@ -377,6 +377,21 @@ npm run bump-spec-pin -- --config camunda-hub
 npm run bump-spec-pin -- --config <name> --dry-run
 ```
 
+Example — preview bumping camunda-oca to `main` (`--ref main` is also the
+default when `--ref` is omitted):
+
+```console
+$ npm run bump-spec-pin -- --config camunda-oca --ref main --dry-run
+[bump-spec-pin] camunda-oca: network-fetch https://github.com/camunda/camunda.git @ 2d51d5a244b8a055dce4a7c2f544ad49d3a57276
+[bump-spec-pin] camunda-oca
+  specRef:  06073e00fea50e518cf670b12c455baba76a05df  →  2d51d5a244b8a055dce4a7c2f544ad49d3a57276
+  specHash: sha256:26f2149071b5d3b472ac5cbebadeed03e4eac7ee29f5f90cb2d9f54fd2f0c16a  →  sha256:5018d5a2c0a3ac4c901ce1d5ccd246e08960e1cf0c4d7e1af04fb2b548568c8a
+  --dry-run: not writing spec-pin.json.
+```
+
+`--ref main` resolves to the current 40-char commit SHA (that's what lands in
+`spec-pin.json`, never the branch name). Drop `--dry-run` to write the pin.
+
 Then verify the new spec flows through cleanly, update any invariants whose
 values legitimately changed, and commit `spec-pin.json` + the invariant updates
 together:

--- a/README.md
+++ b/README.md
@@ -377,21 +377,6 @@ npm run bump-spec-pin -- --config camunda-hub
 npm run bump-spec-pin -- --config <name> --dry-run
 ```
 
-Example — preview bumping camunda-oca to `main` (`--ref main` is also the
-default when `--ref` is omitted):
-
-```console
-$ npm run bump-spec-pin -- --config camunda-oca --ref main --dry-run
-[bump-spec-pin] camunda-oca: network-fetch https://github.com/camunda/camunda.git @ 2d51d5a244b8a055dce4a7c2f544ad49d3a57276
-[bump-spec-pin] camunda-oca
-  specRef:  06073e00fea50e518cf670b12c455baba76a05df  →  2d51d5a244b8a055dce4a7c2f544ad49d3a57276
-  specHash: sha256:26f2149071b5d3b472ac5cbebadeed03e4eac7ee29f5f90cb2d9f54fd2f0c16a  →  sha256:5018d5a2c0a3ac4c901ce1d5ccd246e08960e1cf0c4d7e1af04fb2b548568c8a
-  --dry-run: not writing spec-pin.json.
-```
-
-`--ref main` resolves to the current 40-char commit SHA (that's what lands in
-`spec-pin.json`, never the branch name). Drop `--dry-run` to write the pin.
-
 Then verify the new spec flows through cleanly, update any invariants whose
 values legitimately changed, and commit `spec-pin.json` + the invariant updates
 together:

--- a/README.md
+++ b/README.md
@@ -370,8 +370,9 @@ npm run bump-spec-pin -- --config camunda-oca --ref stable/8.10
 
 # camunda-hub — private, bundled in "local mode" from the sibling clone
 # ../camunda-hub (SPEC_REF is ignored). Bumps to that clone's checked-out HEAD;
-# pass --ref <sha> to check that out first. Requires camunda-hub cloned as a
-# sibling: <parent>/{api-test-generator, camunda-hub}.
+# pass --ref <sha|branch|tag> to check that out first (the clone is restored
+# afterwards). Requires camunda-hub cloned as a sibling:
+# <parent>/{api-test-generator, camunda-hub}.
 npm run bump-spec-pin -- --config camunda-hub
 
 # Preview any bump without writing:

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ npm run build --workspaces --if-present
 |--------|-------------|
 | `npm run fetch-spec` | Fetch and bundle the upstream OpenAPI spec (from `main` branch) |
 | `npm run fetch-spec:ref` | Fetch a specific branch/tag: `SPEC_REF=stable/8.8 npm run fetch-spec:ref` |
-| `npm run bump-spec-pin` | Re-pin a config's spec: `npm run bump-spec-pin -- --config <name> [--ref <sha>] [--dry-run]` (see Spec pin → Bumping the spec pin) |
+| `npm run bump-spec-pin` | Re-pin a config's spec: `npm run bump-spec-pin -- --config <name> [--ref <sha\|branch\|tag>] [--dry-run]` (see Spec pin → Bumping the spec pin) |
 | `npm run extract-graph` | Build the semantic graph extractor and extract the dependency graph |
 | `npm run generate:scenarios` | Build the path analyser and generate scenario JSON files |
 | `npm run codegen:playwright` | Build and emit a Playwright test for a single endpoint |

--- a/README.md
+++ b/README.md
@@ -377,6 +377,8 @@ npm run bump-spec-pin -- --config camunda-hub
 npm run bump-spec-pin -- --config <name> --dry-run
 ```
 
+Drop `--dry-run` to write the pin.
+
 Then verify the new spec flows through cleanly, update any invariants whose
 values legitimately changed, and commit `spec-pin.json` + the invariant updates
 together:

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "biome:fix-generated:request-validation": "npm run biome:fix-generated",
     "format": "biome format --write",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "bump-spec-pin": "tsx scripts/bump-spec-pin.ts"
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^12.0.0",

--- a/scripts/bump-spec-pin.ts
+++ b/scripts/bump-spec-pin.ts
@@ -26,7 +26,7 @@
  * `--dry-run` prints the old → new pin without writing.
  */
 import { execFileSync, spawnSync } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
@@ -94,6 +94,45 @@ function resolveSha(repoUrl: string, ref: string): string {
   return sha;
 }
 
+// Find the git repo root at/above a directory by walking up to the `.git`
+// entry. File-based (existsSync) so it works where `git` itself can't run — on
+// some macOS setups `git` in the sibling clone fails with "Unable to read
+// current working directory", while plain file reads (which fetch-spec also
+// relies on) succeed.
+function findGitRoot(startDir: string): string {
+  let dir = startDir;
+  for (let i = 0; i < 40; i++) {
+    if (existsSync(join(dir, '.git'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(`no .git repository found at or above ${startDir}`);
+}
+
+// Read a clone's checked-out HEAD commit SHA without invoking git: resolve
+// `.git/HEAD` (a detached SHA, or a symbolic ref → loose ref file → packed-refs).
+function readHeadSha(gitRoot: string): string {
+  const head = readFileSync(join(gitRoot, '.git', 'HEAD'), 'utf8').trim();
+  if (SHA_RE.test(head)) return head; // detached HEAD
+  const m = /^ref:\s*(\S+)$/.exec(head);
+  if (!m) throw new Error(`unexpected .git/HEAD in ${gitRoot}: '${head}'`);
+  const ref = m[1];
+  const loose = join(gitRoot, '.git', ref);
+  if (existsSync(loose)) {
+    const sha = readFileSync(loose, 'utf8').trim();
+    if (SHA_RE.test(sha)) return sha;
+  }
+  const packed = join(gitRoot, '.git', 'packed-refs');
+  if (existsSync(packed)) {
+    for (const line of readFileSync(packed, 'utf8').split('\n')) {
+      const [sha, name] = line.split(' ');
+      if (name === ref && SHA_RE.test(sha)) return sha;
+    }
+  }
+  throw new Error(`could not resolve ${ref} to a SHA in ${gitRoot}/.git`);
+}
+
 function run(cmd: string, env: NodeJS.ProcessEnv): void {
   const res = spawnSync('npm', ['run', cmd], {
     cwd: REPO_ROOT,
@@ -146,21 +185,19 @@ function main(): void {
 
   if (localBundle) {
     // local-bundle (hub): bundle from the sibling clone; specRef = its HEAD.
-    // Use `git -C <dir>` and keep the child's cwd at REPO_ROOT — launching git
-    // with cwd set to the sibling path fails on macOS ("Unable to read current
-    // working directory: Operation not permitted").
     const specDirAbs = resolve(REPO_ROOT, spec.localSpecDir ?? '');
-    const siblingRoot = git(['-C', specDirAbs, 'rev-parse', '--show-toplevel']);
+    const siblingRoot = findGitRoot(specDirAbs);
     const wantRef = arg('ref');
     if (wantRef) {
-      // `fetch` updates FETCH_HEAD but NOT an existing local branch of the same
-      // name, so check out the freshly-fetched commit directly (detached) rather
-      // than a possibly-stale local branch (`git checkout main` could otherwise
-      // land on the old local `main`).
+      // Only --ref needs git (to move the clone to a specific ref). `fetch`
+      // updates FETCH_HEAD but NOT an existing local branch, so check out the
+      // freshly-fetched commit (detached) rather than a possibly-stale branch.
       git(['-C', siblingRoot, 'fetch', '--depth', '1', 'origin', wantRef]);
       git(['-C', siblingRoot, 'checkout', '--detach', 'FETCH_HEAD']);
     }
-    newRef = git(['-C', siblingRoot, 'rev-parse', 'HEAD']);
+    // Read the checked-out HEAD SHA from `.git` (no git subprocess — see
+    // readHeadSha), so the default bump works even where `git` can't run here.
+    newRef = readHeadSha(siblingRoot);
     console.error(`[bump-spec-pin] ${config}: local-bundle from ${siblingRoot} @ ${newRef}`);
     run('fetch-spec', { ...process.env });
   } else {

--- a/scripts/bump-spec-pin.ts
+++ b/scripts/bump-spec-pin.ts
@@ -12,8 +12,8 @@
  *     && CONFIG=<config> npm test
  *
  * Usage:
- *   npm run bump-spec-pin -- --config camunda-oca [--ref <sha|branch>] [--dry-run]
- *   npm run bump-spec-pin -- --config camunda-hub [--ref <sha>] [--dry-run]
+ *   npm run bump-spec-pin -- --config camunda-oca [--ref <sha|branch|tag>] [--dry-run]
+ *   npm run bump-spec-pin -- --config camunda-hub [--ref <sha|branch|tag>] [--dry-run]
  *
  * Modes (inferred from the active config's spec source — `localSpecDir` present
  * ⇒ local-bundle, otherwise network-fetch):

--- a/scripts/bump-spec-pin.ts
+++ b/scripts/bump-spec-pin.ts
@@ -59,6 +59,17 @@ function git(args: string[], cwd = REPO_ROOT): string {
   return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
 }
 
+// The clone's current checkout — its branch name, or the commit SHA if
+// detached. Used to restore the sibling clone after a `--ref` bump so we don't
+// leave a developer's working copy in a surprising state.
+function currentRef(gitRoot: string): string {
+  try {
+    return git(['-C', gitRoot, 'symbolic-ref', '--quiet', '--short', 'HEAD']);
+  } catch {
+    return git(['-C', gitRoot, 'rev-parse', 'HEAD']); // detached HEAD
+  }
+}
+
 const SHA_RE = /^[0-9a-f]{40}$/i;
 
 // specRef MUST be a resolved 40-char commit SHA (branches drift). Resolve the
@@ -157,7 +168,7 @@ function main(): void {
 
   const spec = getActiveSpecSource(REPO_ROOT);
   const localBundle = spec.localSpecDir !== undefined;
-  let newRef: string;
+  let newRef = '';
 
   if (localBundle) {
     // local-bundle (hub): bundle from the sibling clone; specRef = its HEAD.
@@ -166,16 +177,23 @@ function main(): void {
     const specDirAbs = resolve(REPO_ROOT, spec.localSpecDir ?? '');
     const siblingRoot = git(['-C', specDirAbs, 'rev-parse', '--show-toplevel']);
     const wantRef = arg('ref');
-    if (wantRef) {
-      // `fetch` updates FETCH_HEAD but NOT an existing local branch of the same
-      // name, so check out the freshly-fetched commit (detached) rather than a
-      // possibly-stale local branch (`git checkout main` could land on old main).
-      git(['-C', siblingRoot, 'fetch', '--depth', '1', 'origin', wantRef]);
-      git(['-C', siblingRoot, 'checkout', '--detach', 'FETCH_HEAD']);
+    // Only --ref moves the clone; capture its current checkout so we can restore
+    // it (in `finally`, even on error) rather than leaving it detached.
+    const restoreRef = wantRef ? currentRef(siblingRoot) : undefined;
+    try {
+      if (wantRef) {
+        // `fetch` updates FETCH_HEAD but NOT an existing local branch of the same
+        // name, so check out the freshly-fetched commit (detached) rather than a
+        // possibly-stale local branch (`git checkout main` could land on old main).
+        git(['-C', siblingRoot, 'fetch', '--depth', '1', 'origin', wantRef]);
+        git(['-C', siblingRoot, 'checkout', '--detach', 'FETCH_HEAD']);
+      }
+      newRef = git(['-C', siblingRoot, 'rev-parse', 'HEAD']);
+      console.error(`[bump-spec-pin] ${config}: local-bundle from ${siblingRoot} @ ${newRef}`);
+      run('fetch-spec', { ...process.env });
+    } finally {
+      if (restoreRef) git(['-C', siblingRoot, 'checkout', restoreRef]);
     }
-    newRef = git(['-C', siblingRoot, 'rev-parse', 'HEAD']);
-    console.error(`[bump-spec-pin] ${config}: local-bundle from ${siblingRoot} @ ${newRef}`);
-    run('fetch-spec', { ...process.env });
   } else {
     // network-fetch (oca): resolve --ref (or the remote's default branch) to a
     // 40-char SHA before it's written to spec-pin.json / passed as SPEC_REF.

--- a/scripts/bump-spec-pin.ts
+++ b/scripts/bump-spec-pin.ts
@@ -26,7 +26,7 @@
  * `--dry-run` prints the old → new pin without writing.
  */
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
@@ -94,45 +94,6 @@ function resolveSha(repoUrl: string, ref: string): string {
   return sha;
 }
 
-// Find the git repo root at/above a directory by walking up to the `.git`
-// entry. File-based (existsSync) so it works where `git` itself can't run — on
-// some macOS setups `git` in the sibling clone fails with "Unable to read
-// current working directory", while plain file reads (which fetch-spec also
-// relies on) succeed.
-function findGitRoot(startDir: string): string {
-  let dir = startDir;
-  for (let i = 0; i < 40; i++) {
-    if (existsSync(join(dir, '.git'))) return dir;
-    const parent = dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  throw new Error(`no .git repository found at or above ${startDir}`);
-}
-
-// Read a clone's checked-out HEAD commit SHA without invoking git: resolve
-// `.git/HEAD` (a detached SHA, or a symbolic ref → loose ref file → packed-refs).
-function readHeadSha(gitRoot: string): string {
-  const head = readFileSync(join(gitRoot, '.git', 'HEAD'), 'utf8').trim();
-  if (SHA_RE.test(head)) return head; // detached HEAD
-  const m = /^ref:\s*(\S+)$/.exec(head);
-  if (!m) throw new Error(`unexpected .git/HEAD in ${gitRoot}: '${head}'`);
-  const ref = m[1];
-  const loose = join(gitRoot, '.git', ref);
-  if (existsSync(loose)) {
-    const sha = readFileSync(loose, 'utf8').trim();
-    if (SHA_RE.test(sha)) return sha;
-  }
-  const packed = join(gitRoot, '.git', 'packed-refs');
-  if (existsSync(packed)) {
-    for (const line of readFileSync(packed, 'utf8').split('\n')) {
-      const [sha, name] = line.split(' ');
-      if (name === ref && SHA_RE.test(sha)) return sha;
-    }
-  }
-  throw new Error(`could not resolve ${ref} to a SHA in ${gitRoot}/.git`);
-}
-
 function run(cmd: string, env: NodeJS.ProcessEnv): void {
   const res = spawnSync('npm', ['run', cmd], {
     cwd: REPO_ROOT,
@@ -185,19 +146,19 @@ function main(): void {
 
   if (localBundle) {
     // local-bundle (hub): bundle from the sibling clone; specRef = its HEAD.
+    // `git -C <dir>` (child cwd stays at REPO_ROOT) — this is the pattern the
+    // nightly uses against ../camunda-hub in CI.
     const specDirAbs = resolve(REPO_ROOT, spec.localSpecDir ?? '');
-    const siblingRoot = findGitRoot(specDirAbs);
+    const siblingRoot = git(['-C', specDirAbs, 'rev-parse', '--show-toplevel']);
     const wantRef = arg('ref');
     if (wantRef) {
-      // Only --ref needs git (to move the clone to a specific ref). `fetch`
-      // updates FETCH_HEAD but NOT an existing local branch, so check out the
-      // freshly-fetched commit (detached) rather than a possibly-stale branch.
+      // `fetch` updates FETCH_HEAD but NOT an existing local branch of the same
+      // name, so check out the freshly-fetched commit (detached) rather than a
+      // possibly-stale local branch (`git checkout main` could land on old main).
       git(['-C', siblingRoot, 'fetch', '--depth', '1', 'origin', wantRef]);
       git(['-C', siblingRoot, 'checkout', '--detach', 'FETCH_HEAD']);
     }
-    // Read the checked-out HEAD SHA from `.git` (no git subprocess — see
-    // readHeadSha), so the default bump works even where `git` can't run here.
-    newRef = readHeadSha(siblingRoot);
+    newRef = git(['-C', siblingRoot, 'rev-parse', 'HEAD']);
     console.error(`[bump-spec-pin] ${config}: local-bundle from ${siblingRoot} @ ${newRef}`);
     run('fetch-spec', { ...process.env });
   } else {

--- a/scripts/bump-spec-pin.ts
+++ b/scripts/bump-spec-pin.ts
@@ -150,8 +150,12 @@ function main(): void {
     );
     const wantRef = arg('ref');
     if (wantRef) {
+      // `fetch` updates FETCH_HEAD but NOT an existing local branch of the same
+      // name, so check out the freshly-fetched commit directly (detached) rather
+      // than a possibly-stale local branch (`git checkout main` could otherwise
+      // land on the old local `main`).
       git(['fetch', '--depth', '1', 'origin', wantRef], siblingRoot);
-      git(['checkout', wantRef], siblingRoot);
+      git(['checkout', '--detach', 'FETCH_HEAD'], siblingRoot);
     }
     newRef = git(['rev-parse', 'HEAD'], siblingRoot);
     console.error(`[bump-spec-pin] ${config}: local-bundle from ${siblingRoot} @ ${newRef}`);

--- a/scripts/bump-spec-pin.ts
+++ b/scripts/bump-spec-pin.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env tsx
+/**
+ * bump-spec-pin — re-pin a config's spec to a newer upstream ref.
+ *
+ * Resolves a target upstream ref, fetches + bundles that spec, and rewrites
+ * `configs/<config>/spec-pin.json` (`specRef` + `expectedSpecHash`, preserving
+ * the `$comment` and key order). It does NOT commit — review the diff, then
+ * regenerate + run invariants to confirm the new spec is clean before landing:
+ *
+ *   CONFIG=<config> npm run testsuite:generate && CONFIG=<config> npm test
+ *
+ * Usage:
+ *   npm run bump-spec-pin -- --config camunda-oca [--ref <sha|branch>] [--dry-run]
+ *   npm run bump-spec-pin -- --config camunda-hub [--ref <sha>] [--dry-run]
+ *
+ * Modes (from configs.json `spec.source`):
+ *   - network-fetch (camunda-oca): `--ref` defaults to the upstream default
+ *     branch tip (resolved via `git ls-remote`). Runs `SPEC_REF=<ref>
+ *     npm run fetch-spec:ref`.
+ *   - local-bundle (camunda-hub): bundles from the sibling clone
+ *     (`../camunda-hub`); `--ref` (if given) is checked out there first, else the
+ *     sibling's current HEAD is used. `specRef` = that SHA.
+ *
+ * `--dry-run` prints the old → new pin without writing.
+ */
+import { execFileSync, spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { getActiveSpecSource, getSpecBundleDir } from '../path-analyser/src/configResolver.ts';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+const hasFlag = (name: string): boolean => process.argv.includes(`--${name}`);
+
+function git(args: string[], cwd = REPO_ROOT): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function run(cmd: string, env: NodeJS.ProcessEnv): void {
+  const res = spawnSync('npm', ['run', cmd], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+    env,
+    shell: process.platform === 'win32',
+  });
+  if (res.status !== 0) {
+    throw new Error(`\`npm run ${cmd}\` failed (exit ${res.status ?? res.signal})`);
+  }
+}
+
+function readSpecHash(): string {
+  const metaPath = join(getSpecBundleDir(REPO_ROOT), 'spec-metadata.json');
+  const raw: unknown = JSON.parse(readFileSync(metaPath, 'utf8'));
+  if (!isRecord(raw) || typeof raw.specHash !== 'string') {
+    throw new Error(`spec-metadata.json at ${metaPath} is malformed`);
+  }
+  return raw.specHash;
+}
+
+function main(): void {
+  const config = arg('config') ?? process.env.CONFIG ?? 'camunda-oca';
+  const dryRun = hasFlag('dry-run');
+  // configResolver reads CONFIG from the env — set it so every helper + the
+  // spawned fetch-spec target the requested config.
+  process.env.CONFIG = config;
+
+  const pinPath = join(REPO_ROOT, 'configs', config, 'spec-pin.json');
+  const pinRaw: unknown = JSON.parse(readFileSync(pinPath, 'utf8'));
+  if (
+    !isRecord(pinRaw) ||
+    typeof pinRaw.specRef !== 'string' ||
+    typeof pinRaw.expectedSpecHash !== 'string'
+  ) {
+    throw new Error(`spec-pin.json at ${pinPath} is malformed`);
+  }
+  const oldRef = pinRaw.specRef;
+  const oldHash = pinRaw.expectedSpecHash;
+
+  const spec = getActiveSpecSource(REPO_ROOT);
+  const localBundle = spec.localSpecDir !== undefined;
+  let newRef: string;
+
+  if (localBundle) {
+    // local-bundle (hub): bundle from the sibling clone; specRef = its HEAD.
+    const siblingRoot = git(
+      ['rev-parse', '--show-toplevel'],
+      resolve(REPO_ROOT, spec.localSpecDir ?? ''),
+    );
+    const wantRef = arg('ref');
+    if (wantRef) {
+      git(['fetch', '--depth', '1', 'origin', wantRef], siblingRoot);
+      git(['checkout', wantRef], siblingRoot);
+    }
+    newRef = git(['rev-parse', 'HEAD'], siblingRoot);
+    console.error(`[bump-spec-pin] ${config}: local-bundle from ${siblingRoot} @ ${newRef}`);
+    run('fetch-spec', { ...process.env });
+  } else {
+    // network-fetch (oca): --ref or the upstream default branch tip.
+    const repoUrl = spec.repoUrl;
+    if (!repoUrl) throw new Error(`${config}: spec.repoUrl is required for network-fetch mode`);
+    newRef = arg('ref') ?? git(['ls-remote', repoUrl, 'refs/heads/main']).split('\t')[0];
+    if (!newRef) throw new Error(`could not resolve a ref for ${config} from ${repoUrl}`);
+    console.error(`[bump-spec-pin] ${config}: network-fetch ${repoUrl} @ ${newRef}`);
+    run('fetch-spec:ref', { ...process.env, SPEC_REF: newRef });
+  }
+
+  const newHash = readSpecHash();
+
+  console.error(`\n[bump-spec-pin] ${config}`);
+  console.error(`  specRef:  ${oldRef}  →  ${newRef}`);
+  console.error(`  specHash: ${oldHash}  →  ${newHash}`);
+
+  if (oldRef === newRef && oldHash === newHash) {
+    console.error('  pin already current — nothing to write.');
+    return;
+  }
+  if (oldHash === newHash) {
+    console.error('  note: SHA moved but spec content is unchanged (hash identical).');
+  }
+  if (dryRun) {
+    console.error('  --dry-run: not writing spec-pin.json.');
+    return;
+  }
+
+  pinRaw.specRef = newRef;
+  pinRaw.expectedSpecHash = newHash;
+  writeFileSync(pinPath, `${JSON.stringify(pinRaw, null, 2)}\n`);
+  console.error(`  wrote ${pinPath}`);
+  console.error(
+    `\nNext: CONFIG=${config} npm run testsuite:generate && CONFIG=${config} npm test  (confirm the new spec is clean, update any changed invariants), then commit.`,
+  );
+}
+
+main();

--- a/scripts/bump-spec-pin.ts
+++ b/scripts/bump-spec-pin.ts
@@ -144,20 +144,21 @@ function main(): void {
 
   if (localBundle) {
     // local-bundle (hub): bundle from the sibling clone; specRef = its HEAD.
-    const siblingRoot = git(
-      ['rev-parse', '--show-toplevel'],
-      resolve(REPO_ROOT, spec.localSpecDir ?? ''),
-    );
+    // Use `git -C <dir>` and keep the child's cwd at REPO_ROOT — launching git
+    // with cwd set to the sibling path fails on macOS ("Unable to read current
+    // working directory: Operation not permitted").
+    const specDirAbs = resolve(REPO_ROOT, spec.localSpecDir ?? '');
+    const siblingRoot = git(['-C', specDirAbs, 'rev-parse', '--show-toplevel']);
     const wantRef = arg('ref');
     if (wantRef) {
       // `fetch` updates FETCH_HEAD but NOT an existing local branch of the same
       // name, so check out the freshly-fetched commit directly (detached) rather
       // than a possibly-stale local branch (`git checkout main` could otherwise
       // land on the old local `main`).
-      git(['fetch', '--depth', '1', 'origin', wantRef], siblingRoot);
-      git(['checkout', '--detach', 'FETCH_HEAD'], siblingRoot);
+      git(['-C', siblingRoot, 'fetch', '--depth', '1', 'origin', wantRef]);
+      git(['-C', siblingRoot, 'checkout', '--detach', 'FETCH_HEAD']);
     }
-    newRef = git(['rev-parse', 'HEAD'], siblingRoot);
+    newRef = git(['-C', siblingRoot, 'rev-parse', 'HEAD']);
     console.error(`[bump-spec-pin] ${config}: local-bundle from ${siblingRoot} @ ${newRef}`);
     run('fetch-spec', { ...process.env });
   } else {

--- a/scripts/bump-spec-pin.ts
+++ b/scripts/bump-spec-pin.ts
@@ -46,6 +46,29 @@ function git(args: string[], cwd = REPO_ROOT): string {
   return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
 }
 
+const SHA_RE = /^[0-9a-f]{40}$/i;
+
+// specRef MUST be a resolved 40-char commit SHA (branches drift). Resolve the
+// remote's default branch tip via `HEAD` (no hardcoded `main`, so it works for
+// any config's repo).
+function resolveDefaultBranchSha(repoUrl: string): string {
+  const sha = git(['ls-remote', repoUrl, 'HEAD']).split('\n')[0]?.split('\t')[0] ?? '';
+  if (!SHA_RE.test(sha)) {
+    throw new Error(`could not resolve default-branch HEAD to a SHA for ${repoUrl} (got '${sha}')`);
+  }
+  return sha;
+}
+
+// Resolve a user-supplied --ref (SHA passthrough, or branch/tag → SHA).
+function resolveSha(repoUrl: string, ref: string): string {
+  if (SHA_RE.test(ref)) return ref.toLowerCase();
+  const sha = git(['ls-remote', repoUrl, ref]).split('\n')[0]?.split('\t')[0] ?? '';
+  if (!SHA_RE.test(sha)) {
+    throw new Error(`could not resolve ref '${ref}' to a commit SHA in ${repoUrl}`);
+  }
+  return sha;
+}
+
 function run(cmd: string, env: NodeJS.ProcessEnv): void {
   const res = spawnSync('npm', ['run', cmd], {
     cwd: REPO_ROOT,
@@ -105,11 +128,12 @@ function main(): void {
     console.error(`[bump-spec-pin] ${config}: local-bundle from ${siblingRoot} @ ${newRef}`);
     run('fetch-spec', { ...process.env });
   } else {
-    // network-fetch (oca): --ref or the upstream default branch tip.
+    // network-fetch (oca): resolve --ref (or the remote's default branch) to a
+    // 40-char SHA before it's written to spec-pin.json / passed as SPEC_REF.
     const repoUrl = spec.repoUrl;
     if (!repoUrl) throw new Error(`${config}: spec.repoUrl is required for network-fetch mode`);
-    newRef = arg('ref') ?? git(['ls-remote', repoUrl, 'refs/heads/main']).split('\t')[0];
-    if (!newRef) throw new Error(`could not resolve a ref for ${config} from ${repoUrl}`);
+    const wantRef = arg('ref');
+    newRef = wantRef ? resolveSha(repoUrl, wantRef) : resolveDefaultBranchSha(repoUrl);
     console.error(`[bump-spec-pin] ${config}: network-fetch ${repoUrl} @ ${newRef}`);
     run('fetch-spec:ref', { ...process.env, SPEC_REF: newRef });
   }

--- a/scripts/bump-spec-pin.ts
+++ b/scripts/bump-spec-pin.ts
@@ -7,7 +7,9 @@
  * the `$comment` and key order). It does NOT commit — review the diff, then
  * regenerate + run invariants to confirm the new spec is clean before landing:
  *
- *   CONFIG=<config> npm run testsuite:generate && CONFIG=<config> npm test
+ *   CONFIG=<config> npm run testsuite:generate \
+ *     && CONFIG=<config> npm run generate:request-validation \
+ *     && CONFIG=<config> npm test
  *
  * Usage:
  *   npm run bump-spec-pin -- --config camunda-oca [--ref <sha|branch>] [--dry-run]
@@ -195,7 +197,7 @@ function main(): void {
   writeFileSync(pinPath, `${JSON.stringify(pinRaw, null, 2)}\n`);
   console.error(`  wrote ${pinPath}`);
   console.error(
-    `\nNext: CONFIG=${config} npm run testsuite:generate && CONFIG=${config} npm test  (confirm the new spec is clean, update any changed invariants), then commit.`,
+    `\nNext: CONFIG=${config} npm run testsuite:generate && CONFIG=${config} npm run generate:request-validation && CONFIG=${config} npm test  (confirm the new spec is clean, update any changed invariants), then commit.`,
   );
 }
 

--- a/scripts/bump-spec-pin.ts
+++ b/scripts/bump-spec-pin.ts
@@ -28,7 +28,11 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
-import { getActiveSpecSource, getSpecBundleDir } from '../path-analyser/src/configResolver.ts';
+import {
+  getActiveConfigName,
+  getActiveSpecSource,
+  getSpecBundleDir,
+} from '../path-analyser/src/configResolver.ts';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -38,7 +42,13 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 
 function arg(name: string): string | undefined {
   const i = process.argv.indexOf(`--${name}`);
-  return i >= 0 ? process.argv[i + 1] : undefined;
+  if (i < 0) return undefined;
+  const value = process.argv[i + 1];
+  // Guard against `--config --dry-run` swallowing the next flag as the value.
+  if (value === undefined || value.startsWith('--')) {
+    throw new Error(`--${name} requires a value`);
+  }
+  return value;
 }
 const hasFlag = (name: string): boolean => process.argv.includes(`--${name}`);
 
@@ -62,7 +72,20 @@ function resolveDefaultBranchSha(repoUrl: string): string {
 // Resolve a user-supplied --ref (SHA passthrough, or branch/tag → SHA).
 function resolveSha(repoUrl: string, ref: string): string {
   if (SHA_RE.test(ref)) return ref.toLowerCase();
-  const sha = git(['ls-remote', repoUrl, ref]).split('\n')[0]?.split('\t')[0] ?? '';
+  const lines = git(['ls-remote', repoUrl, ref])
+    .split('\n')
+    .filter((l) => l.trim() !== '');
+  if (lines.length === 0) {
+    throw new Error(`could not resolve ref '${ref}' to a commit SHA in ${repoUrl}`);
+  }
+  // `ls-remote <ref>` can match multiple refs (e.g. a branch AND a tag of the
+  // same name); don't silently pick the first — require an unambiguous ref.
+  if (lines.length > 1) {
+    throw new Error(
+      `ref '${ref}' is ambiguous in ${repoUrl} (${lines.length} matches); pass a full refname (refs/heads/… or refs/tags/…) or a SHA:\n${lines.join('\n')}`,
+    );
+  }
+  const sha = lines[0].split('\t')[0] ?? '';
   if (!SHA_RE.test(sha)) {
     throw new Error(`could not resolve ref '${ref}' to a commit SHA in ${repoUrl}`);
   }
@@ -91,10 +114,16 @@ function readSpecHash(): string {
 }
 
 function main(): void {
-  const config = arg('config') ?? process.env.CONFIG ?? 'camunda-oca';
   const dryRun = hasFlag('dry-run');
   // configResolver reads CONFIG from the env — set it so every helper + the
   // spawned fetch-spec target the requested config.
+  const requested = (arg('config') ?? process.env.CONFIG ?? '').trim();
+  if (requested) process.env.CONFIG = requested;
+  else delete process.env.CONFIG;
+  // Validate + canonicalise via getActiveConfigName BEFORE building any path:
+  // it enforces the configs.json allowlist + safe-name regex (rejecting e.g.
+  // `--config ../../..`) and falls back to the configs.json default when unset.
+  const config = getActiveConfigName(REPO_ROOT);
   process.env.CONFIG = config;
 
   const pinPath = join(REPO_ROOT, 'configs', config, 'spec-pin.json');

--- a/scripts/bump-spec-pin.ts
+++ b/scripts/bump-spec-pin.ts
@@ -15,7 +15,8 @@
  *   npm run bump-spec-pin -- --config camunda-oca [--ref <sha|branch>] [--dry-run]
  *   npm run bump-spec-pin -- --config camunda-hub [--ref <sha>] [--dry-run]
  *
- * Modes (from configs.json `spec.source`):
+ * Modes (inferred from the active config's spec source — `localSpecDir` present
+ * ⇒ local-bundle, otherwise network-fetch):
  *   - network-fetch (camunda-oca): `--ref` defaults to the upstream default
  *     branch tip (resolved via `git ls-remote`). Runs `SPEC_REF=<ref>
  *     npm run fetch-spec:ref`.
@@ -74,24 +75,32 @@ function resolveDefaultBranchSha(repoUrl: string): string {
 // Resolve a user-supplied --ref (SHA passthrough, or branch/tag → SHA).
 function resolveSha(repoUrl: string, ref: string): string {
   if (SHA_RE.test(ref)) return ref.toLowerCase();
-  const lines = git(['ls-remote', repoUrl, ref])
+  const entries = git(['ls-remote', repoUrl, ref])
     .split('\n')
-    .filter((l) => l.trim() !== '');
-  if (lines.length === 0) {
+    .filter((l) => l.trim() !== '')
+    .map((l) => {
+      const [sha, name] = l.split('\t');
+      return { sha: sha ?? '', name: name ?? '' };
+    });
+  if (entries.length === 0) {
     throw new Error(`could not resolve ref '${ref}' to a commit SHA in ${repoUrl}`);
   }
-  // `ls-remote <ref>` can match multiple refs (e.g. a branch AND a tag of the
-  // same name); don't silently pick the first — require an unambiguous ref.
-  if (lines.length > 1) {
+  // Ambiguity is >1 DISTINCT ref (e.g. a branch and a tag of the same name).
+  // An annotated tag legitimately lists two lines — `refs/tags/<t>` and the
+  // peeled `refs/tags/<t>^{}` — for the SAME ref, which is not ambiguous.
+  const distinct = new Set(entries.map((e) => e.name.replace(/\^\{\}$/, '')));
+  if (distinct.size > 1) {
     throw new Error(
-      `ref '${ref}' is ambiguous in ${repoUrl} (${lines.length} matches); pass a full refname (refs/heads/… or refs/tags/…) or a SHA:\n${lines.join('\n')}`,
+      `ref '${ref}' is ambiguous in ${repoUrl} (${distinct.size} distinct refs); pass a full refname (refs/heads/… or refs/tags/…) or a SHA:\n${entries.map((e) => `${e.sha}\t${e.name}`).join('\n')}`,
     );
   }
-  const sha = lines[0].split('\t')[0] ?? '';
-  if (!SHA_RE.test(sha)) {
+  // Prefer the peeled commit SHA (`^{}`) so an annotated tag resolves to the
+  // commit it points at, not the tag object.
+  const chosen = entries.find((e) => e.name.endsWith('^{}')) ?? entries[0];
+  if (!SHA_RE.test(chosen.sha)) {
     throw new Error(`could not resolve ref '${ref}' to a commit SHA in ${repoUrl}`);
   }
-  return sha;
+  return chosen.sha.toLowerCase();
 }
 
 function run(cmd: string, env: NodeJS.ProcessEnv): void {
@@ -101,8 +110,14 @@ function run(cmd: string, env: NodeJS.ProcessEnv): void {
     env,
     shell: process.platform === 'win32',
   });
+  if (res.error) {
+    throw new Error(`could not start \`npm run ${cmd}\`: ${res.error.message}`);
+  }
+  if (res.signal) {
+    throw new Error(`\`npm run ${cmd}\` was killed by signal ${res.signal}`);
+  }
   if (res.status !== 0) {
-    throw new Error(`\`npm run ${cmd}\` failed (exit ${res.status ?? res.signal})`);
+    throw new Error(`\`npm run ${cmd}\` failed (exit ${res.status})`);
   }
 }
 


### PR DESCRIPTION
A reusable spec-pin bumper — the building block for automating bumps the safe way (per the discussion: script now; auto-open a **PR** from the *scheduled* dry-run, never auto-commit from the per-PR check).

## Usage
```bash
npm run bump-spec-pin -- --config camunda-oca [--ref <sha|branch>] [--dry-run]
npm run bump-spec-pin -- --config camunda-hub [--ref <sha>]      [--dry-run]
```
Resolves a target upstream ref → fetches + bundles that spec → rewrites `configs/<config>/spec-pin.json` (`specRef` + `expectedSpecHash`, preserving `$comment`/key order). **Does not commit.**

- **network-fetch** (camunda-oca): `--ref` defaults to `camunda/camunda@main` tip (`git ls-remote`); runs `SPEC_REF=<ref> fetch-spec:ref`.
- **local-bundle** (camunda-hub): bundles from the `../camunda-hub` sibling; `--ref` is checked out there first, else the sibling's HEAD is used.
- `--dry-run` prints the old → new pin without writing.

## Why it doesn't auto-commit
A bump can pull in a new upstream domain the generator can't model yet (the #386 case) → generation breaks. So a bump needs a **human-reviewed PR + green CI**, not a silent auto-apply. This script does the mechanical re-pin; adoption stays a reviewed step.

## Verified
- **camunda-oca dry-run**: resolves latest main, bundles, prints `specRef`/`specHash` old → new (correctly shows OCA is behind), writes nothing.
- Lint clean.
- **camunda-hub** mode couldn't be exercised in this sandbox (git can't operate in the `../camunda-hub` sibling here — a local-env restriction), but the path mirrors `nightly-camunda-hub.yml`'s proven `git -C ../camunda-hub` clone/bundle, which runs fine in CI.

## Next (separate)
Wire this into the **scheduled** drift dry-run (#434 OCA / #435 hub) so it opens a bump PR when a pin is behind. The per-PR `spec-freshness` job stays a detector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)