### PR TITLE
chore(camunda-oca): bump spec pin to latest upstream (2d51d5a2)

### DIFF
--- a/configs/camunda-oca/spec-pin.json
+++ b/configs/camunda-oca/spec-pin.json
@@ -1,5 +1,5 @@
 {
   "$comment": "Spec pin for the bundled-spec invariants regression layer. The invariants in configs/camunda-oca/regression-invariants.test.ts assert named properties of the upstream spec content fingerprinted by `expectedSpecHash`. `specRef` MUST be a full 40-char commit SHA on camunda/camunda (not a branch like `main`) so the baseline does not drift on every upstream merge. CI fetches the spec at `specRef` (requires camunda-schema-bundler >= 2.1.0 for SHA support) and aborts early via tests/regression/spec-pin.setup.ts if its hash drifts, so reviewers see a clear 'spec changed upstream — re-pin' signal instead of confusing invariant failures. To bump: pick a newer SHA, run `SPEC_REF=<sha> npm run fetch-spec:ref`, regenerate the pipeline, update any invariants whose values legitimately changed, then update both fields below in the same PR.",
-  "specRef": "06073e00fea50e518cf670b12c455baba76a05df",
-  "expectedSpecHash": "sha256:26f2149071b5d3b472ac5cbebadeed03e4eac7ee29f5f90cb2d9f54fd2f0c16a"
+  "specRef": "2d51d5a244b8a055dce4a7c2f544ad49d3a57276",
+  "expectedSpecHash": "sha256:5018d5a2c0a3ac4c901ce1d5ccd246e08960e1cf0c4d7e1af04fb2b548568c8a"
 }


### PR DESCRIPTION
Bumps the camunda-oca spec pin from `06073e00` → `2d51d5a244b8a055dce4a7c2f544ad49d3a57276` (latest `camunda/camunda@main`), adopting the upstream spec changes the pin was behind on.

## How
`npm run bump-spec-pin -- --config camunda-oca` — the first real use of the new bumper (#445). It resolved main to the SHA, re-bundled, and rewrote `spec-pin.json` (specRef + expectedSpecHash).

## Verification
- Regenerated the pipeline (`testsuite:generate` + `generate:request-validation`) against the new spec.
- **Full suite green: 850 passed / 12 skipped** (up from 846 — the new upstream operations add scenarios).
- **No invariant changes needed** — the Layer-3 invariants pass unchanged against the new content.

## Why
The pin was behind upstream, so the advisory `spec-freshness` check was red on every PR. This adopts the verified-clean upstream state and clears that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)