### PR TITLE
feat(nightly-hub): Slack heads-up for upstream op-surface drift (#435)

### DIFF
--- a/.github/workflows/nightly-camunda-hub.yml
+++ b/.github/workflows/nightly-camunda-hub.yml
@@ -238,10 +238,15 @@ jobs:
             echo "No pinned ref or clone token — skipping drift heads-up."; exit 0
           fi
           # 2. Pinned op surface — fetch + check out the pin in the sibling, re-bundle.
+          # Check fetch/checkout explicitly: under `set -u` (no -e) a failed fetch
+          # would leave the sibling at latest, so "pinned" ops would equal latest
+          # and the diff would silently show no drift (false negative).
           dest="${GITHUB_WORKSPACE}/../camunda-hub"
-          git -C "$dest" -c "url.https://x-access-token:${HUB_TOKEN}@github.com/.insteadOf=https://github.com/" \
-            fetch --depth 1 origin "$pinned"
-          git -C "$dest" checkout -q --detach FETCH_HEAD
+          if ! git -C "$dest" -c "url.https://x-access-token:${HUB_TOKEN}@github.com/.insteadOf=https://github.com/" \
+                 fetch --depth 1 origin "$pinned" \
+             || ! git -C "$dest" checkout -q --detach FETCH_HEAD; then
+            echo "Could not check out the pinned ref — skipping drift heads-up."; exit 0
+          fi
           if ! CONFIG=camunda-hub npm run fetch-spec >/dev/null \
              || ! CONFIG=camunda-hub npm run -s spec-operations > /tmp/hub-pinned-ops.txt; then
             echo "Could not bundle the pinned ref — skipping drift heads-up."; exit 0
@@ -560,7 +565,7 @@ jobs:
       # (#435). Only posts when the surface actually drifted — a fresh pin is
       # silent. Derived by the "Hub op-surface drift vs pinned baseline" step.
       - name: Notify Slack (positive — upstream op-surface drift)
-        if: ${{ always() && steps.slack-secrets.outputs.SLACK_BOT_TOKEN != '' && steps.slack-positive.outputs.ts != '' && (steps.op-drift.outputs.n_added != '0' || steps.op-drift.outputs.n_removed != '0') }}
+        if: ${{ always() && steps.slack-secrets.outputs.SLACK_BOT_TOKEN != '' && steps.slack-positive.outputs.ts != '' && steps.op-drift.outputs.pinned_short != '' && (steps.op-drift.outputs.n_added != '0' || steps.op-drift.outputs.n_removed != '0') }}
         uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage

--- a/.github/workflows/nightly-camunda-hub.yml
+++ b/.github/workflows/nightly-camunda-hub.yml
@@ -204,6 +204,65 @@ jobs:
           path: test-results/e2e-camunda-hub/
           retention-days: 14
 
+      # --- Operation-surface drift heads-up (#435) -----------------------------
+      # The nightly runs UNPINNED (latest camunda-hub@main), so a new/renamed
+      # upstream domain currently only shows up as a red run. Surface *which*
+      # operationIds appeared/disappeared vs the recorded pin
+      # (configs/camunda-hub/spec-pin.json) as a threaded Slack reply, so the
+      # channel sees the new surface explicitly. The canonical, richer signal is
+      # still the spec-bump-check tracking issue (#434) — this is the same info
+      # delivered to the nightly's audience, reusing `spec-operations`.
+      #
+      # Runs POST-run + continue-on-error: it re-checks out the pinned ref in the
+      # sibling and re-bundles (mutating spec/camunda-hub/bundled), which is only
+      # safe once the suites — which need the latest bundle — have finished. The
+      # bundle currently on disk is latest (generate never re-bundles), so we read
+      # latest first, then swap to pinned. Only emits drift when the surfaces
+      # actually differ, so a fresh pin posts nothing (no noise).
+      - name: Hub op-surface drift vs pinned baseline
+        id: op-drift
+        if: always()
+        continue-on-error: true
+        env:
+          HUB_TOKEN: ${{ steps.hub-token.outputs.token }}
+        run: |
+          set -uo pipefail
+          # 1. Latest op surface — the bundle on disk is still latest.
+          if ! CONFIG=camunda-hub npm run -s spec-operations > /tmp/hub-latest-ops.txt; then
+            echo "Could not read the latest op surface — skipping drift heads-up."; exit 0
+          fi
+          pinned="$(node -e "console.log(JSON.parse(require('fs').readFileSync('configs/camunda-hub/spec-pin.json','utf8')).specRef)")"
+          if [ -z "$pinned" ] || [ -z "${HUB_TOKEN:-}" ]; then
+            echo "No pinned ref or clone token — skipping drift heads-up."; exit 0
+          fi
+          # 2. Pinned op surface — fetch + check out the pin in the sibling, re-bundle.
+          dest="${GITHUB_WORKSPACE}/../camunda-hub"
+          git -C "$dest" -c "url.https://x-access-token:${HUB_TOKEN}@github.com/.insteadOf=https://github.com/" \
+            fetch --depth 1 origin "$pinned"
+          git -C "$dest" checkout -q --detach FETCH_HEAD
+          if ! CONFIG=camunda-hub npm run fetch-spec >/dev/null \
+             || ! CONFIG=camunda-hub npm run -s spec-operations > /tmp/hub-pinned-ops.txt; then
+            echo "Could not bundle the pinned ref — skipping drift heads-up."; exit 0
+          fi
+          # 3. Diff (LC_ALL=C so comm's byte order matches the re-sorted inputs).
+          LC_ALL=C sort -o /tmp/hub-latest-ops.txt /tmp/hub-latest-ops.txt
+          LC_ALL=C sort -o /tmp/hub-pinned-ops.txt /tmp/hub-pinned-ops.txt
+          added="$(LC_ALL=C comm -13 /tmp/hub-pinned-ops.txt /tmp/hub-latest-ops.txt || true)"
+          removed="$(LC_ALL=C comm -23 /tmp/hub-pinned-ops.txt /tmp/hub-latest-ops.txt || true)"
+          n_added="$(printf '%s' "$added" | grep -c . || true)"
+          n_removed="$(printf '%s' "$removed" | grep -c . || true)"
+          echo "Op-surface vs pin ${pinned:0:12}: +${n_added} / -${n_removed}"
+          # operationIds are camelCase identifiers (no JSON-sensitive chars), so a
+          # comma-join is safe to interpolate into the Slack payload. Cap at 30.
+          csv() { printf '%s' "$1" | grep -E '.' | head -30 | paste -sd, - | sed 's/,/, /g' || true; }
+          {
+            echo "n_added=${n_added}"
+            echo "n_removed=${n_removed}"
+            echo "pinned_short=${pinned:0:12}"
+            echo "added_csv=$(csv "$added")"
+            echo "removed_csv=$(csv "$removed")"
+          } >> "$GITHUB_OUTPUT"
+
       # --- 7. Results summary --------------------------------------------------
       # Write per-profile Playwright pass/fail (from the JSON reporter stats) to
       # the GitHub Actions run summary. The Playwright HTML report (in the artifact)
@@ -473,6 +532,22 @@ jobs:
               "channel": "${{ env.SLACK_CHANNEL }}",
               "thread_ts": "${{ steps.slack-positive.outputs.ts }}",
               "text": "ℹ️ Some operations are skipped in the positive suite due to known issues:\n${{ steps.known-issues.outputs.positive_known_issues }}"
+            }
+
+      # Threaded reply: which operations appeared/disappeared upstream vs the pin
+      # (#435). Only posts when the surface actually drifted — a fresh pin is
+      # silent. Derived by the "Hub op-surface drift vs pinned baseline" step.
+      - name: Notify Slack (positive — upstream op-surface drift)
+        if: ${{ always() && steps.slack-secrets.outputs.SLACK_BOT_TOKEN != '' && steps.slack-positive.outputs.ts != '' && (steps.op-drift.outputs.n_added != '0' || steps.op-drift.outputs.n_removed != '0') }}
+        uses: slackapi/slack-github-action@v2
+        with:
+          method: chat.postMessage
+          token: ${{ steps.slack-secrets.outputs.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ env.SLACK_CHANNEL }}",
+              "thread_ts": "${{ steps.slack-positive.outputs.ts }}",
+              "text": "🔎 *Upstream op-surface drift* vs the pinned baseline (`${{ steps.op-drift.outputs.pinned_short }}`):\n🆕 added (${{ steps.op-drift.outputs.n_added }}): ${{ steps.op-drift.outputs.added_csv }}\n🗑️ removed (${{ steps.op-drift.outputs.n_removed }}): ${{ steps.op-drift.outputs.removed_csv }}\nℹ️ Canonical heads-up: the `Spec-bump check: camunda-hub drifted from the pin` tracking issue."
             }
 
       - name: Notify Slack (negative suite)

--- a/.github/workflows/nightly-camunda-hub.yml
+++ b/.github/workflows/nightly-camunda-hub.yml
@@ -229,14 +229,21 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
+          # Seed every output up front so the "skip" exits below leave
+          # well-defined values. Downstream the Slack step compares against '0'
+          # and '' — an unset output reads as '' (and '' != '0' is true), which
+          # would otherwise fire a blank drift message. Real values are appended
+          # at the end (last write wins). skip() logs + exits cleanly.
+          {
+            echo "n_added=0"; echo "n_removed=0"; echo "pinned_short="
+            echo "added_csv="; echo "removed_csv="; echo "link_md="
+          } >> "$GITHUB_OUTPUT"
+          skip() { echo "$1 — skipping drift heads-up."; exit 0; }
           # 1. Latest op surface — the bundle on disk is still latest.
-          if ! CONFIG=camunda-hub npm run -s spec-operations > /tmp/hub-latest-ops.txt; then
-            echo "Could not read the latest op surface — skipping drift heads-up."; exit 0
-          fi
+          CONFIG=camunda-hub npm run -s spec-operations > /tmp/hub-latest-ops.txt \
+            || skip "Could not read the latest op surface"
           pinned="$(node -e "console.log(JSON.parse(require('fs').readFileSync('configs/camunda-hub/spec-pin.json','utf8')).specRef)")"
-          if [ -z "$pinned" ] || [ -z "${HUB_TOKEN:-}" ]; then
-            echo "No pinned ref or clone token — skipping drift heads-up."; exit 0
-          fi
+          if [ -z "$pinned" ] || [ -z "${HUB_TOKEN:-}" ]; then skip "No pinned ref or clone token"; fi
           # 2. Pinned op surface — fetch + check out the pin in the sibling, re-bundle.
           # Check fetch/checkout explicitly: under `set -u` (no -e) a failed fetch
           # would leave the sibling at latest, so "pinned" ops would equal latest
@@ -245,11 +252,11 @@ jobs:
           if ! git -C "$dest" -c "url.https://x-access-token:${HUB_TOKEN}@github.com/.insteadOf=https://github.com/" \
                  fetch --depth 1 origin "$pinned" \
              || ! git -C "$dest" checkout -q --detach FETCH_HEAD; then
-            echo "Could not check out the pinned ref — skipping drift heads-up."; exit 0
+            skip "Could not check out the pinned ref"
           fi
           if ! CONFIG=camunda-hub npm run fetch-spec >/dev/null \
              || ! CONFIG=camunda-hub npm run -s spec-operations > /tmp/hub-pinned-ops.txt; then
-            echo "Could not bundle the pinned ref — skipping drift heads-up."; exit 0
+            skip "Could not bundle the pinned ref"
           fi
           # 3. Diff (LC_ALL=C so comm's byte order matches the re-sorted inputs).
           LC_ALL=C sort -o /tmp/hub-latest-ops.txt /tmp/hub-latest-ops.txt

--- a/.github/workflows/nightly-camunda-hub.yml
+++ b/.github/workflows/nightly-camunda-hub.yml
@@ -268,7 +268,14 @@ jobs:
           echo "Op-surface vs pin ${pinned:0:12}: +${n_added} / -${n_removed}"
           # operationIds are camelCase identifiers (no JSON-sensitive chars), so a
           # comma-join is safe to interpolate into the Slack payload. Cap at 30.
-          csv() { printf '%s' "$1" | grep -E '.' | head -30 | paste -sd, - | sed 's/,/, /g' || true; }
+          # Comma-join the first 30 ids; append "… (+N more)" when the count
+          # ($2) exceeds the cap so a big drift isn't silently truncated.
+          csv() {
+            local out
+            out="$(printf '%s' "$1" | grep -E '.' | head -30 | paste -sd, - | sed 's/,/, /g' || true)"
+            if [ "${2:-0}" -gt 30 ]; then out="${out}, … (+$(( $2 - 30 )) more)"; fi
+            printf '%s' "$out"
+          }
           # Link to the actionable artifact spec-bump-check routes this drift to:
           # a bump PR (clean drift) or the tracking issue (broken drift). Prefer
           # the PR; fall back to the issue; else a plain note (spec-bump-check
@@ -292,8 +299,8 @@ jobs:
             echo "n_added=${n_added}"
             echo "n_removed=${n_removed}"
             echo "pinned_short=${pinned:0:12}"
-            echo "added_csv=$(csv "$added")"
-            echo "removed_csv=$(csv "$removed")"
+            echo "added_csv=$(csv "$added" "$n_added")"
+            echo "removed_csv=$(csv "$removed" "$n_removed")"
             echo "link_md=${link_md}"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/nightly-camunda-hub.yml
+++ b/.github/workflows/nightly-camunda-hub.yml
@@ -225,6 +225,8 @@ jobs:
         continue-on-error: true
         env:
           HUB_TOKEN: ${{ steps.hub-token.outputs.token }}
+          # For the PR/issue lookup below (read-only; repo is public).
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
           # 1. Latest op surface — the bundle on disk is still latest.
@@ -255,12 +257,32 @@ jobs:
           # operationIds are camelCase identifiers (no JSON-sensitive chars), so a
           # comma-join is safe to interpolate into the Slack payload. Cap at 30.
           csv() { printf '%s' "$1" | grep -E '.' | head -30 | paste -sd, - | sed 's/,/, /g' || true; }
+          # Link to the actionable artifact spec-bump-check routes this drift to:
+          # a bump PR (clean drift) or the tracking issue (broken drift). Prefer
+          # the PR; fall back to the issue; else a plain note (spec-bump-check
+          # runs daily and may not have filed yet). Only looked up when drifted.
+          link_md=""
+          if [ "$n_added" != "0" ] || [ "$n_removed" != "0" ]; then
+            issue_title='Spec-bump check: camunda-hub drifted from the pin'
+            pr_url="$(gh pr list --head chore/spec-bump-camunda-hub --state open --json url --jq '.[0].url // empty' 2>/dev/null || true)"
+            pr_num="$(gh pr list --head chore/spec-bump-camunda-hub --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+            issue_url="$(gh issue list --state open --search "in:title \"${issue_title}\"" --json number,title,url --jq "[.[] | select(.title == \"${issue_title}\")] | .[0].url // empty" 2>/dev/null || true)"
+            issue_num="$(gh issue list --state open --search "in:title \"${issue_title}\"" --json number,title --jq "[.[] | select(.title == \"${issue_title}\")] | .[0].number // empty" 2>/dev/null || true)"
+            if [ -n "$pr_url" ]; then
+              link_md="➡️ Adopt via <${pr_url}|bump PR #${pr_num}>"
+            elif [ -n "$issue_url" ]; then
+              link_md="📋 Blocked — see <${issue_url}|tracking issue #${issue_num}>"
+            else
+              link_md="ℹ️ Canonical heads-up: the \`${issue_title}\` tracking issue (spec-bump-check may not have filed it yet — it runs daily 06:00 UTC)."
+            fi
+          fi
           {
             echo "n_added=${n_added}"
             echo "n_removed=${n_removed}"
             echo "pinned_short=${pinned:0:12}"
             echo "added_csv=$(csv "$added")"
             echo "removed_csv=$(csv "$removed")"
+            echo "link_md=${link_md}"
           } >> "$GITHUB_OUTPUT"
 
       # --- 7. Results summary --------------------------------------------------
@@ -547,7 +569,7 @@ jobs:
             {
               "channel": "${{ env.SLACK_CHANNEL }}",
               "thread_ts": "${{ steps.slack-positive.outputs.ts }}",
-              "text": "🔎 *Upstream op-surface drift* vs the pinned baseline (`${{ steps.op-drift.outputs.pinned_short }}`):\n🆕 added (${{ steps.op-drift.outputs.n_added }}): ${{ steps.op-drift.outputs.added_csv }}\n🗑️ removed (${{ steps.op-drift.outputs.n_removed }}): ${{ steps.op-drift.outputs.removed_csv }}\nℹ️ Canonical heads-up: the `Spec-bump check: camunda-hub drifted from the pin` tracking issue."
+              "text": "🔎 *Upstream op-surface drift* vs the pinned baseline (`${{ steps.op-drift.outputs.pinned_short }}`):\n🆕 added (${{ steps.op-drift.outputs.n_added }}): ${{ steps.op-drift.outputs.added_csv }}\n🗑️ removed (${{ steps.op-drift.outputs.n_removed }}): ${{ steps.op-drift.outputs.removed_csv }}\n${{ steps.op-drift.outputs.link_md }}"
             }
 
       - name: Notify Slack (negative suite)


### PR DESCRIPTION
Closes #435.

## Context
#435 asked to give the hub nightly the operation-surface heads-up the OCA dry-run has. Since then, **#434's `spec-bump-check` matrix already delivered steps 2–3 for hub** — it diffs the pinned-vs-latest operation surface and opens a rolling tracking issue (`Spec-bump check: camunda-hub drifted from the pin`) daily. So the canonical GitHub-issue signal already exists.

This PR adds the **one remaining, non-duplicated piece**: surfacing that drift to the nightly's Slack audience (`#camunda-hub-api-test-results`).

## What it does
A threaded reply on the nightly's positive-suite Slack message listing which operationIds **appeared / disappeared** in latest `camunda-hub@main` vs the recorded pin (`configs/camunda-hub/spec-pin.json`):

```
🔎 Upstream op-surface drift vs the pinned baseline (333dc1b1f5f6):
🆕 added (2): createClusterRegistration, getClusterUsageMetrics
🗑️ removed (0):
ℹ️ Canonical heads-up: the `Spec-bump check: camunda-hub drifted from the pin` tracking issue.
```

- **Reuses `spec-operations`** (config-driven) — no new diff logic beyond a 3-line `comm`.
- **Post-run + `continue-on-error`:** it re-checks out the pin in the sibling and re-bundles, which is only safe after the suites (which need the latest bundle) finish. `generate` never re-bundles, so the on-disk bundle is still latest when we read it; then we swap to pinned. Notification infra can't fail the run.
- **Silent when clean:** only posts when the surface actually differs, so a fresh pin (the current state — pinned and latest have identical surfaces) posts nothing.

## Why not duplicate the tracking issue?
The `spec-bump-check` hub leg already files it daily. Re-filing from the nightly would double the signal. This intentionally only adds the Slack delivery and points back at that issue as canonical.

## Verification
- `spec-operations` confirmed working on the current hub bundle (41 ops).
- Diff + csv-join + empty-case logic smoke-tested locally (added=2 renders correctly; empty surface → `n=0` so the Slack step is gated off).
- YAML + actionlint (incl. embedded shellcheck) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)