### PR TITLE
test(camunda-hub): un-suppress getClusterRegistrations (upstream #25908 fixed)

### DIFF
--- a/configs/camunda-hub/positive-suppress.json
+++ b/configs/camunda-hub/positive-suppress.json
@@ -2,14 +2,6 @@
   "$comment": "Per-config positive-suite suppression list. Each entry removes an operation's feature/variant spec from the generated positive suite. Use it — sparingly, always with a documented reason + tracking issue — for operations that either (a) the planner cannot produce a passing test for and no scenario template covers, or (b) are intentionally out of scope for the suite (e.g. an opt-in / feature-flagged operator surface the default run shouldn't exercise). Revisit when the gap closes or scope changes. knownIssue (#425): each suppress entry may carry an optional knownIssue { summary, url, tracker? }, surfaced in the nightly's \"skipped due to known issues\" Slack thread. Entries pointing at the same issue url MUST share the same summary (the thread dedupes bullets by url) — enforced by tests/codegen/known-issue-summary-consistency.test.ts. Omit knownIssue for ops suppressed by choice rather than a bug (an intentionally out-of-scope surface).",
   "suppress": [
     {
-      "operationId": "getClusterRegistrations",
-      "reason": "Dynamic-cluster-management surface (DYNAMIC_CLUSTER_MANAGEMENT_ENABLED, enabled in the nightly). Currently broken: GET /clusters returns 500 for every request even with the flag on (camunda/camunda-hub#25908). (Renamed from getClusters upstream, camunda/camunda-hub#25876.)",
-      "knownIssue": {
-        "summary": "GET /clusters returns 500 for every request",
-        "url": "https://github.com/camunda/camunda-hub/issues/25908"
-      }
-    },
-    {
       "operationId": "removeClusterRegistration",
       "reason": "Dynamic-cluster-management surface (DYNAMIC_CLUSTER_MANAGEMENT_ENABLED, enabled in the nightly). Needs a chainable clusterId to test: clusterId isn't modelled as a semantic type, so createClusterRegistration -> removeClusterRegistration can't chain (camunda/camunda-hub#25907). (Renamed from deleteCluster upstream, camunda/camunda-hub#25876.)",
       "knownIssue": {

--- a/docker/docker-compose.hub.yml
+++ b/docker/docker-compose.hub.yml
@@ -226,12 +226,9 @@ services:
       FEATURE_CATALOG_ENABLED: "true"
       CAMUNDA_MODELER_FEATURE_CONSOLE_ENABLED: "true"
       FEATURE_GLOBAL_NAVIGATION_V2_ENABLED: "true"
-      # Dynamic cluster management: exposes the v2 /clusters surface. ON so the
-      # nightly covers createClusterRegistration + getClusterRegistrations (GET
-      # /clusters, unblocked once camunda/camunda-hub#25908 was fixed). The
-      # remaining cluster ops stay suppressed with known-issue links —
-      # removeClusterRegistration + getClusterUsageMetrics (#25907, need a
-      # chainable clusterId) — see configs/camunda-hub/positive-suppress.json.
+      # Dynamic cluster management: exposes the v2 /clusters surface so the suite
+      # can exercise the cluster ops. Which cluster ops run vs stay suppressed
+      # (with known-issue links) lives in configs/camunda-hub/positive-suppress.json.
       DYNAMIC_CLUSTER_MANAGEMENT_ENABLED: "true"
 
 volumes:

--- a/docker/docker-compose.hub.yml
+++ b/docker/docker-compose.hub.yml
@@ -227,9 +227,9 @@ services:
       CAMUNDA_MODELER_FEATURE_CONSOLE_ENABLED: "true"
       FEATURE_GLOBAL_NAVIGATION_V2_ENABLED: "true"
       # Dynamic cluster management: exposes the v2 /clusters surface. ON so the
-      # nightly covers createClusterRegistration (the only cluster op that
-      # passes). The other cluster ops stay suppressed with known-issue links —
-      # getClusterRegistrations (#25908, GET /clusters 500),
+      # nightly covers createClusterRegistration + getClusterRegistrations (GET
+      # /clusters, unblocked once camunda/camunda-hub#25908 was fixed). The
+      # remaining cluster ops stay suppressed with known-issue links —
       # removeClusterRegistration + getClusterUsageMetrics (#25907, need a
       # chainable clusterId) — see configs/camunda-hub/positive-suppress.json.
       DYNAMIC_CLUSTER_MANAGEMENT_ENABLED: "true"


### PR DESCRIPTION
## Why
[camunda/camunda-hub#25908](https://github.com/camunda/camunda-hub/issues/25908) — `GET /clusters` returned 500 for every request — was **fixed upstream** (closed 2026-07-07). That was the sole blocker for `getClusterRegistrations`, so it can now produce a passing positive test.

## Change
- Remove the `getClusterRegistrations` entry from `configs/camunda-hub/positive-suppress.json`.
- Refresh the `docker-compose.hub.yml` cluster-flag note.

## Verified locally
Against the prebuilt `camunda/hub:SNAPSHOT` with `DYNAMIC_CLUSTER_MANAGEMENT_ENABLED=true`:
```
✓ getClusterRegistrations.feature.spec.ts › feature-1 - base (1)  (GET /clusters → 200)
  1 passed
```
Regenerated the hub suite (spec emitted, no longer in coverage's suppressed list); `known-issue-summary-consistency` + hub Layer-3 invariants stay green (12 tests).

## Scope
Does **not** close #425 — `removeClusterRegistration` + `getClusterUsageMetrics` remain suppressed, still blocked on [camunda/camunda-hub#25907](https://github.com/camunda/camunda-hub/issues/25907) (chainable client-minted `clusterId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)