### PR TITLE
fix(run-hub): auto-re-bundle the hub spec from the sibling before generate

### DIFF
--- a/.github/workflows/nightly-camunda-hub.yml
+++ b/.github/workflows/nightly-camunda-hub.yml
@@ -167,6 +167,10 @@ jobs:
           # are positive-suppressed in configs/camunda-hub/positive-suppress.json.
           STEPS: 'generate run'
           RV_PROFILES: 'secured rbac'
+          # The "Bundle latest camunda-hub spec" step above already re-bundled
+          # from the fresh latest-main clone, so skip run-hub.sh's own re-bundle
+          # (which exists for local runs against a possibly-stale on-disk bundle).
+          SKIP_BUNDLE: '1'
         run: ./scripts/e2e/run-hub.sh
 
       # --- Always stop Hub + collect artifacts ---------------------------------

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,8 +180,9 @@ ref that clone currently has checked out. Implications:
 - **Running the hub suites locally (the nightly's path):** the hub spec is bundled
   from the `../camunda-hub` **sibling clone** at runtime and is **gitignored** — no
   branch commit or the spec-pin governs it (local runs are unpinned, like the
-  nightly). The prebuilt Hub always runs **latest** `SNAPSHOT`, so keep the sibling
-  at latest for spec↔runtime parity:
+  nightly). The prebuilt Hub runs the `camunda/hub:${HUB_IMAGE_TAG:-SNAPSHOT}` image
+  (`SNAPSHOT` = latest published build; override `HUB_IMAGE_TAG` to pin), so keep the
+  sibling at the matching ref for spec↔runtime parity:
   ```bash
   git -C ../camunda-hub checkout main && git -C ../camunda-hub pull   # sibling → latest
   HUB_MODE=prebuilt ./docker/start-hub.sh start

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,22 @@ ref that clone currently has checked out. Implications:
 - The nightly (`.github/workflows/nightly-camunda-hub.yml`) runs hub **unpinned**
   (clones `camunda-hub@main`, bundles latest) — the pin governs only the
   Layer-3 invariants in `configs/camunda-hub/regression-invariants.test.ts`.
+- **Running the hub suites locally (the nightly's path):** the hub spec is bundled
+  from the `../camunda-hub` **sibling clone** at runtime and is **gitignored** — no
+  branch commit or the spec-pin governs it (local runs are unpinned, like the
+  nightly). The prebuilt Hub always runs **latest** `SNAPSHOT`, so keep the sibling
+  at latest for spec↔runtime parity:
+  ```bash
+  git -C ../camunda-hub checkout main && git -C ../camunda-hub pull   # sibling → latest
+  HUB_MODE=prebuilt ./docker/start-hub.sh start
+  STEPS="generate run" RV_PROFILES="secured rbac" ./scripts/e2e/run-hub.sh
+  ```
+  `run-hub.sh`'s `generate` step **auto-re-bundles** from the sibling (so it never
+  runs against a stale on-disk bundle — this bit us once: a day-old bundle marked
+  `page.startCursor/endCursor` `required` while latest had dropped them, producing
+  false search-op failures). Set `SKIP_BUNDLE=1` to run against the current on-disk
+  bundle instead. Don't invoke `npx playwright` directly — that skips the
+  `POS_FIXTURE_*` env `run-hub.sh` sets (e.g. valid-BPMN `POS_FIXTURE_FILE_CONTENT`).
 
 ## Code style & lint (Biome)
 

--- a/scripts/e2e/run-hub.sh
+++ b/scripts/e2e/run-hub.sh
@@ -117,10 +117,11 @@ if step generate; then
   echo "── generate ─────────────────────────────"
   # Re-bundle the spec from the ../camunda-hub sibling so generation reflects the
   # sibling's CURRENT checkout — never a stale on-disk bundle (the "forgot to
-  # fetch-spec and used yesterday's spec" footgun). The prebuilt Hub runs LATEST
-  # main, so the sibling must be at latest for spec<->runtime parity — surfaced
-  # below. SKIP_BUNDLE=1 opts out (the nightly bundles in its own step from a
-  # fresh clone; or a dev deliberately running against the current on-disk bundle).
+  # fetch-spec and used yesterday's spec" footgun). The prebuilt Hub runs the
+  # camunda/hub:${HUB_IMAGE_TAG:-SNAPSHOT} image (SNAPSHOT = latest published
+  # build), so the sibling must match that image for spec<->runtime parity —
+  # surfaced below. SKIP_BUNDLE=1 opts out (the nightly bundles in its own step
+  # from a fresh clone; or a dev deliberately running the current on-disk bundle).
   if [ -z "${SKIP_BUNDLE:-}" ]; then
     # >/dev/null drops only the noisy success stdout; fetch-spec + the bundler
     # write errors to stderr (visible), and set -e aborts on failure. Add an

--- a/scripts/e2e/run-hub.sh
+++ b/scripts/e2e/run-hub.sh
@@ -115,6 +115,19 @@ fi
 # ============================ 1. GENERATE ============================
 if step generate; then
   echo "── generate ─────────────────────────────"
+  # Re-bundle the spec from the ../camunda-hub sibling so generation reflects the
+  # sibling's CURRENT checkout — never a stale on-disk bundle (the "forgot to
+  # fetch-spec and used yesterday's spec" footgun). The prebuilt Hub runs LATEST
+  # main, so the sibling must be at latest for spec<->runtime parity — surfaced
+  # below. SKIP_BUNDLE=1 opts out (the nightly bundles in its own step from a
+  # fresh clone; or a dev deliberately running against the current on-disk bundle).
+  if [ -z "${SKIP_BUNDLE:-}" ]; then
+    CONFIG="$CONFIG" npm run fetch-spec >/dev/null
+    sib="$(git -C ../camunda-hub rev-parse --short HEAD 2>/dev/null || echo '?')"
+    echo "  ✓ spec re-bundled from ../camunda-hub @ ${sib}"
+    echo "    ↳ prebuilt Hub runs LATEST main; if ${sib} is behind, run"
+    echo "      'git -C ../camunda-hub checkout main && git -C ../camunda-hub pull' then re-run."
+  fi
   if [ -z "${SKIP_POSITIVE:-}" ]; then
     CONFIG="$CONFIG" npm run extract-graph >/dev/null
     CONFIG="$CONFIG" npm run generate:scenarios >/dev/null

--- a/scripts/e2e/run-hub.sh
+++ b/scripts/e2e/run-hub.sh
@@ -131,8 +131,9 @@ if step generate; then
     fi
     sib="$(git -C ../camunda-hub rev-parse --short HEAD 2>/dev/null || echo '?')"
     echo "  ✓ spec re-bundled from ../camunda-hub @ ${sib}"
-    echo "    ↳ prebuilt Hub runs LATEST main; if ${sib} is behind, run"
-    echo "      'git -C ../camunda-hub checkout main && git -C ../camunda-hub pull' then re-run."
+    echo "    ↳ prebuilt Hub runs camunda/hub:\${HUB_IMAGE_TAG:-SNAPSHOT} (SNAPSHOT = latest"
+    echo "      published build); if ${sib} lags that image, run 'git -C ../camunda-hub"
+    echo "      checkout main && git -C ../camunda-hub pull' then re-run."
   fi
   if [ -z "${SKIP_POSITIVE:-}" ]; then
     CONFIG="$CONFIG" npm run extract-graph >/dev/null

--- a/scripts/e2e/run-hub.sh
+++ b/scripts/e2e/run-hub.sh
@@ -122,7 +122,13 @@ if step generate; then
   # below. SKIP_BUNDLE=1 opts out (the nightly bundles in its own step from a
   # fresh clone; or a dev deliberately running against the current on-disk bundle).
   if [ -z "${SKIP_BUNDLE:-}" ]; then
-    CONFIG="$CONFIG" npm run fetch-spec >/dev/null
+    # >/dev/null drops only the noisy success stdout; fetch-spec + the bundler
+    # write errors to stderr (visible), and set -e aborts on failure. Add an
+    # actionable hint for the common local cause (sibling unreadable / wrong ref).
+    if ! CONFIG="$CONFIG" npm run fetch-spec >/dev/null; then
+      echo "::error:: re-bundle failed — is ../camunda-hub readable and checked out at the intended ref? (see the error above; or set SKIP_BUNDLE=1 to use the current on-disk bundle)"
+      exit 1
+    fi
     sib="$(git -C ../camunda-hub rev-parse --short HEAD 2>/dev/null || echo '?')"
     echo "  ✓ spec re-bundled from ../camunda-hub @ ${sib}"
     echo "    ↳ prebuilt Hub runs LATEST main; if ${sib} is behind, run"


### PR DESCRIPTION
## Problem
Local hub runs can silently use a **stale on-disk spec bundle**. `run-hub.sh` (`STEPS="generate run"`) and `testsuite:generate` read whatever is already in `spec/camunda-hub/bundled/` — they don't re-bundle; only `npm run fetch-spec` does, which the nightly runs as a **separate step**. Skip that locally and you generate + run against a day-old spec.

This bit us: a day-old bundle still marked `page.startCursor/endCursor` `required` while latest main had dropped them → false `*/search` failures I briefly mis-filed as an upstream bug (#457, closed). The hub spec is gitignored + bundled from the `../camunda-hub` sibling at runtime, so no branch commit / spec-pin governs a local unpinned run.

## Change
- **`scripts/e2e/run-hub.sh`** — the `generate` step now re-bundles from the sibling by default and echoes the sibling HEAD with a "prebuilt Hub is LATEST — pull the sibling to match" reminder. `SKIP_BUNDLE=1` opts out.
- **`nightly-camunda-hub.yml`** — sets `SKIP_BUNDLE=1` (it already bundles from a fresh clone in its own step; CI unchanged).
- **`AGENTS.md`** — documents the canonical local flow + `SKIP_BUNDLE`.

## Verification
- `shellcheck -x scripts/e2e/run-hub.sh` + `actionlint` clean.
- **Proven end-to-end:** on a fresh/latest spec (bundle hash == the pin), the full nightly-style run is **positive 35/0, secured 300/0, rbac 6/0** — the search ops that failed on the stale spec all pass. `SKIP_BUNDLE=1` opt-out confirmed (uses the on-disk bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)