### PR TITLE
feat(camunda-oca): model the agent-instance loop-iteration rename; adopt latest (closes #460)

### DIFF
--- a/configs/camunda-oca/ontology/entity-kinds.json
+++ b/configs/camunda-oca/ontology/entity-kinds.json
@@ -191,13 +191,13 @@
     },
     {
       "@type": "EntityKind",
-      "name": "AgentInstanceIteration",
+      "name": "AgentInstanceLoopIteration",
       "shape": "immutable-entity",
       "identifiers": [
-        "IterationId"
+        "LoopIterationId"
       ],
       "establishedBy": "createAgentInstanceHistoryItem",
-      "description": "#386 — a logical grouping of one LLM call, its tool dispatches, and their results within an agent instance's conversation history. Identified by a client-minted IterationId supplied in the createAgentInstanceHistoryItem body (so IterationId is a clientMintedIdentifier via the upstream x-semantic-establishes annotation, not a producer-chained key). Append-only: once written it is never updated or deleted, and it is read back only via searchAgentInstanceHistory (no canonical get-by-id), so it carries neither the CRUD triple nor a runtime fetcher — hence shape: immutable-entity."
+      "description": "#386 — a logical grouping of one LLM call, its tool dispatches, and their results within an agent instance's conversation history. Identified by a client-minted LoopIterationId supplied in the createAgentInstanceHistoryItem body (field `loopIteration`) by the AI Agent Connector (so LoopIterationId is a clientMintedIdentifier via the upstream x-semantic-establishes annotation, not a producer-chained key). Append-only: once written it is never updated or deleted, and it is read back only via searchAgentInstanceHistory (no canonical get-by-id), so it carries neither the CRUD triple nor a runtime fetcher — hence shape: immutable-entity. (Upstream renamed AgentInstanceIteration→AgentInstanceLoopIteration and IterationId→LoopIterationId.)"
     }
   ]
 }

--- a/configs/camunda-oca/spec-pin.json
+++ b/configs/camunda-oca/spec-pin.json
@@ -1,5 +1,5 @@
 {
   "$comment": "Spec pin for the bundled-spec invariants regression layer. The invariants in configs/camunda-oca/regression-invariants.test.ts assert named properties of the upstream spec content fingerprinted by `expectedSpecHash`. `specRef` MUST be a full 40-char commit SHA on camunda/camunda (not a branch like `main`) so the baseline does not drift on every upstream merge. CI fetches the spec at `specRef` (requires camunda-schema-bundler >= 2.1.0 for SHA support) and aborts early via tests/regression/spec-pin.setup.ts if its hash drifts, so reviewers see a clear 'spec changed upstream — re-pin' signal instead of confusing invariant failures. To bump: pick a newer SHA, run `SPEC_REF=<sha> npm run fetch-spec:ref`, regenerate the pipeline, update any invariants whose values legitimately changed, then update both fields below in the same PR.",
-  "specRef": "2d51d5a244b8a055dce4a7c2f544ad49d3a57276",
-  "expectedSpecHash": "sha256:5018d5a2c0a3ac4c901ce1d5ccd246e08960e1cf0c4d7e1af04fb2b548568c8a"
+  "specRef": "51b3e81c2d79346d9c107a226dd8e21de2e96716",
+  "expectedSpecHash": "sha256:280d2e6b69d447778def1673ffe33375e21960b31e259ddade66fc7feea6a3e1"
 }


### PR DESCRIPTION
Closes #460.

## Why
The daily spec-bump check flagged **broken drift** for camunda-oca (#460): `generate` passed but the entity-kinds ABox ↔ semantic-kinds invariants (#210) failed. Upstream `camunda/camunda` renamed the agent-instance history-iteration concept, and the OCA ontology still declared the old names:

| | old | new |
|---|---|---|
| kind | `AgentInstanceIteration` | **`AgentInstanceLoopIteration`** |
| identifier | `IterationId` | **`LoopIterationId`** |

`LoopIterationId` is client-minted in the `createAgentInstanceHistoryItem` body field `loopIteration` (per the upstream `x-semantic-establishes` annotation).

## Change
- `configs/camunda-oca/ontology/entity-kinds.json`: rename the kind + identifier. Same `establishedBy: createAgentInstanceHistoryItem`, same `shape: immutable-entity` — the append-only semantics (no CRUD, read-back via `searchAgentInstanceHistory`) are unchanged; only the names moved.
- `configs/camunda-oca/spec-pin.json`: bump `2d51d5a2` → `51b3e81c` to adopt latest (0 operations added/removed — a pure semantic rename).

## Verification
- `regression-invariants.test.ts`: **197 passed / 0 failed** (the 4 #210 cross-reference failures gone).
- Full `npm test`: **850 passed / 0 failed**.
- Regenerated both suites cleanly against the new pin.

Once merged, the spec-bump check's OCA drift clears and #460 auto-closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)