### PR TITLE
feat(ci): hub PR check — run the suite on camunda-hub PRs, report back (#462) [DRAFT]

### DIFF
--- a/.github/workflows/_hub-suite-run.yml
+++ b/.github/workflows/_hub-suite-run.yml
@@ -126,9 +126,11 @@ jobs:
           # hub_image can come from an untrusted dispatch payload. Require a single
           # well-formed image reference (no whitespace/control chars) before it's
           # matched, logged, or handed to docker/compose downstream.
+          # :tag is required (not optional) so this stays consistent with the
+          # tag-prefixed HUB_IMAGE_ALLOWLIST below and the PR-image format.
           if [ "$(printf '%s' "$HUB_IMAGE" | wc -l)" -ne 0 ] \
-             || ! printf '%s' "$HUB_IMAGE" | grep -qE '^[A-Za-z0-9][A-Za-z0-9._/-]*(:[A-Za-z0-9._-]+)?(@sha256:[a-f0-9]+)?$'; then
-            echo "::error::hub_image='$HUB_IMAGE' is not a well-formed single image reference."
+             || ! printf '%s' "$HUB_IMAGE" | grep -qE '^[A-Za-z0-9][A-Za-z0-9._/-]*:[A-Za-z0-9._-]+(@sha256:[a-f0-9]+)?$'; then
+            echo "::error::hub_image='$HUB_IMAGE' is not a well-formed single image reference (repo:tag required)."
             exit 1
           fi
           # Only send credentials to an allowlisted host — hub_registry may come

--- a/.github/workflows/_hub-suite-run.yml
+++ b/.github/workflows/_hub-suite-run.yml
@@ -16,8 +16,9 @@ on:
         default: main
       hub_image:
         description: >-
-          Full Hub image ref to run (e.g. camunda/hub:SNAPSHOT, or an internal
-          registry ref like registry.camunda.cloud/team-hub/hub:pr-<sha>).
+          Full Hub image ref to run (e.g. camunda/hub:SNAPSHOT, or the internal
+          PR image registry.camunda.cloud/team-hub/hub-restapi-self-managed:pr-<sha>,
+          which is the same artifact published as camunda/hub).
         type: string
         default: camunda/hub:SNAPSHOT
       summary_heading:
@@ -27,9 +28,11 @@ on:
       hub_registry:
         description: >-
           Optional container registry host to `docker login` before pulling
-          hub_image (e.g. registry.camunda.cloud for a private pr-<sha> image).
-          Leave empty for public camunda/hub. When set, REGISTRY_USERNAME/PASSWORD
-          must be provided.
+          hub_image (e.g. registry.camunda.cloud for the private
+          hub-restapi-self-managed:pr-<sha> image). Leave empty for public
+          camunda/hub. When set, it must be on HUB_REGISTRY_ALLOWLIST, hub_image
+          must be under HUB_IMAGE_ALLOWLIST, and REGISTRY_USERNAME/PASSWORD must
+          be provided.
         type: string
         default: ''
     # Declared explicitly (not `inherit`) so the interface is least-privilege and

--- a/.github/workflows/_hub-suite-run.yml
+++ b/.github/workflows/_hub-suite-run.yml
@@ -57,6 +57,11 @@ env:
   CONFIG: camunda-hub
   HUB_UI_PORT: '8088'
   KEYCLOAK_PORT: '18080'
+  # Registries the login step is allowed to send credentials to. hub_registry
+  # can arrive from an external repository_dispatch payload (hub-pr-check), so
+  # it is validated against this allowlist before `docker login` to prevent
+  # credential exfiltration to an attacker-controlled host. Space-separated.
+  HUB_REGISTRY_ALLOWLIST: registry.camunda.cloud
 
 jobs:
   run:
@@ -104,9 +109,28 @@ jobs:
         if: inputs.hub_registry != ''
         env:
           REGISTRY: ${{ inputs.hub_registry }}
+          HUB_IMAGE: ${{ inputs.hub_image }}
           REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
         run: |
+          # Only send credentials to an allowlisted host — hub_registry may come
+          # from an untrusted dispatch payload. Reject anything else.
+          allowed=false
+          for r in $HUB_REGISTRY_ALLOWLIST; do
+            [ "$REGISTRY" = "$r" ] && allowed=true
+          done
+          if [ "$allowed" != true ]; then
+            echo "::error::hub_registry='$REGISTRY' is not in the allowlist ($HUB_REGISTRY_ALLOWLIST)."
+            exit 1
+          fi
+          # The image must actually live in that registry, else login is pointless
+          # (and a mismatch signals a crafted payload).
+          case "$HUB_IMAGE" in
+            "$REGISTRY"/*) ;;
+            *)
+              echo "::error::hub_image='$HUB_IMAGE' does not start with hub_registry='$REGISTRY/'."
+              exit 1 ;;
+          esac
           if [ -z "$REGISTRY_USERNAME" ] || [ -z "$REGISTRY_PASSWORD" ]; then
             echo "::error::hub_registry=$REGISTRY set but REGISTRY_USERNAME/PASSWORD not provided."
             exit 1

--- a/.github/workflows/_hub-suite-run.yml
+++ b/.github/workflows/_hub-suite-run.yml
@@ -24,6 +24,14 @@ on:
         description: Markdown heading block for the run summary.
         type: string
         required: true
+      hub_registry:
+        description: >-
+          Optional container registry host to `docker login` before pulling
+          hub_image (e.g. registry.camunda.cloud for a private pr-<sha> image).
+          Leave empty for public camunda/hub. When set, REGISTRY_USERNAME/PASSWORD
+          must be provided.
+        type: string
+        default: ''
     # Declared explicitly (not `inherit`) so the interface is least-privilege and
     # callers can't accidentally omit one. Used by the hub-clone-token action.
     secrets:
@@ -35,6 +43,11 @@ on:
         required: true
       VAULT_JWT_AUDIENCE:
         required: true
+      # Only needed when hub_registry is set (private pr-<sha> image pulls).
+      REGISTRY_USERNAME:
+        required: false
+      REGISTRY_PASSWORD:
+        required: false
 
 permissions:
   contents: read
@@ -84,6 +97,21 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # Only for a private image (e.g. the PR check's internal pr-<sha>); skipped
+      # for public camunda/hub. Uses --password-stdin (no token in argv/logs).
+      - name: Log in to the Hub image registry
+        if: inputs.hub_registry != ''
+        env:
+          REGISTRY: ${{ inputs.hub_registry }}
+          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        run: |
+          if [ -z "$REGISTRY_USERNAME" ] || [ -z "$REGISTRY_PASSWORD" ]; then
+            echo "::error::hub_registry=$REGISTRY set but REGISTRY_USERNAME/PASSWORD not provided."
+            exit 1
+          fi
+          printf '%s' "$REGISTRY_PASSWORD" | docker login "$REGISTRY" -u "$REGISTRY_USERNAME" --password-stdin
 
       - name: Start Hub (prebuilt image)
         env:

--- a/.github/workflows/_hub-suite-run.yml
+++ b/.github/workflows/_hub-suite-run.yml
@@ -63,9 +63,11 @@ env:
   # credential exfiltration to an attacker-controlled host. Space-separated.
   HUB_REGISTRY_ALLOWLIST: registry.camunda.cloud
   # Image repository prefixes we're willing to pull + run when a registry is set.
-  # Tighter than "any image in the allowlisted registry" so a crafted payload
-  # can't run some other image under registry.camunda.cloud. Space-separated.
-  HUB_IMAGE_ALLOWLIST: registry.camunda.cloud/team-hub/
+  # Pinned to the specific Hub PR image repo (the restapi-self-managed component
+  # is the same artifact published as camunda/hub) — not the whole team-hub org —
+  # so a crafted payload can't run some other team-hub image with these creds.
+  # Space-separated.
+  HUB_IMAGE_ALLOWLIST: 'registry.camunda.cloud/team-hub/hub-restapi-self-managed:'
 
 jobs:
   run:

--- a/.github/workflows/_hub-suite-run.yml
+++ b/.github/workflows/_hub-suite-run.yml
@@ -62,6 +62,10 @@ env:
   # it is validated against this allowlist before `docker login` to prevent
   # credential exfiltration to an attacker-controlled host. Space-separated.
   HUB_REGISTRY_ALLOWLIST: registry.camunda.cloud
+  # Image repository prefixes we're willing to pull + run when a registry is set.
+  # Tighter than "any image in the allowlisted registry" so a crafted payload
+  # can't run some other image under registry.camunda.cloud. Space-separated.
+  HUB_IMAGE_ALLOWLIST: registry.camunda.cloud/team-hub/
 
 jobs:
   run:
@@ -123,14 +127,16 @@ jobs:
             echo "::error::hub_registry='$REGISTRY' is not in the allowlist ($HUB_REGISTRY_ALLOWLIST)."
             exit 1
           fi
-          # The image must actually live in that registry, else login is pointless
-          # (and a mismatch signals a crafted payload).
-          case "$HUB_IMAGE" in
-            "$REGISTRY"/*) ;;
-            *)
-              echo "::error::hub_image='$HUB_IMAGE' does not start with hub_registry='$REGISTRY/'."
-              exit 1 ;;
-          esac
+          # The image must live under an allowlisted repository path (not just the
+          # allowlisted registry) — limits blast radius and catches crafted payloads.
+          image_ok=false
+          for p in $HUB_IMAGE_ALLOWLIST; do
+            case "$HUB_IMAGE" in "$p"*) image_ok=true ;; esac
+          done
+          if [ "$image_ok" != true ]; then
+            echo "::error::hub_image='$HUB_IMAGE' is not under an allowed path ($HUB_IMAGE_ALLOWLIST)."
+            exit 1
+          fi
           if [ -z "$REGISTRY_USERNAME" ] || [ -z "$REGISTRY_PASSWORD" ]; then
             echo "::error::hub_registry=$REGISTRY set but REGISTRY_USERNAME/PASSWORD not provided."
             exit 1

--- a/.github/workflows/_hub-suite-run.yml
+++ b/.github/workflows/_hub-suite-run.yml
@@ -122,6 +122,15 @@ jobs:
           REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
         run: |
+          set -euo pipefail
+          # hub_image can come from an untrusted dispatch payload. Require a single
+          # well-formed image reference (no whitespace/control chars) before it's
+          # matched, logged, or handed to docker/compose downstream.
+          if [ "$(printf '%s' "$HUB_IMAGE" | wc -l)" -ne 0 ] \
+             || ! printf '%s' "$HUB_IMAGE" | grep -qE '^[A-Za-z0-9][A-Za-z0-9._/-]*(:[A-Za-z0-9._-]+)?(@sha256:[a-f0-9]+)?$'; then
+            echo "::error::hub_image='$HUB_IMAGE' is not a well-formed single image reference."
+            exit 1
+          fi
           # Only send credentials to an allowlisted host — hub_registry may come
           # from an untrusted dispatch payload. Reject anything else.
           allowed=false

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -18,9 +18,10 @@
 #   3. The camunda-hub-side dispatch workflow (Part B, camunda-hub#26236)
 #      sending the repository_dispatch.
 #
-# Expected client_payload: { source_sha, pr_number, hub_image }. The registry is
-# NOT taken from the payload — it's fixed to registry.camunda.cloud below so the
-# login + image-allowlist validation always runs (see the `hub_registry` input).
+# Expected client_payload: { source_sha, pr_number }. The image ref and registry
+# are NOT taken from the payload — they're derived/fixed below (image =
+# .../hub-restapi-self-managed:pr-<source_sha>, registry = registry.camunda.cloud)
+# so the image can't drift from the reported commit and validation always runs.
 name: Hub PR check
 
 on:
@@ -51,15 +52,19 @@ jobs:
       REGISTRY_PASSWORD: ${{ secrets.CAMUNDA_CONTAINER_REGISTRY_PASSWORD }}
     with:
       hub_ref: ${{ github.event.client_payload.source_sha }}
-      hub_image: ${{ github.event.client_payload.hub_image }}
+      # DERIVED from source_sha, NOT taken from the payload: a payload-supplied
+      # hub_image could point at a different tag than the reported commit (run
+      # image X, report status on SHA Y). Building it here pins the image to the
+      # exact commit we report on. registry + repo are fixed; only the pr-<sha>
+      # tag varies. The reusable still validates the result (well-formed + path).
+      hub_image: registry.camunda.cloud/team-hub/hub-restapi-self-managed:pr-${{ github.event.client_payload.source_sha }}
       # Hardcoded, NOT taken from the payload: forwarding an untrusted
       # hub_registry lets a caller send '' to skip the login + image-allowlist
-      # validation entirely (then run an arbitrary public hub_image). Fixing it
-      # here guarantees validation always runs for the PR-check path.
+      # validation entirely. Fixing it here guarantees validation always runs.
       hub_registry: registry.camunda.cloud
       summary_heading: |
         ## Hub PR check — camunda-hub#${{ github.event.client_payload.pr_number }}
-        source_sha: `${{ github.event.client_payload.source_sha }}` · image: `${{ github.event.client_payload.hub_image }}`
+        source_sha: `${{ github.event.client_payload.source_sha }}` · image: `registry.camunda.cloud/team-hub/hub-restapi-self-managed:pr-${{ github.event.client_payload.source_sha }}`
 
   # Report the run's pass/fail back onto the camunda-hub PR as a commit status.
   report:

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -1,0 +1,91 @@
+# Hub PR check (#462) — run our generated hub suite against a camunda-hub PR's
+# build and report the result back onto the PR.
+#
+# Triggered by a repository_dispatch (type: camunda-hub-pr) sent FROM a
+# camunda/camunda-hub PR workflow (Part B, lives in that repo), carrying the PR's
+# source SHA + the pr-<sha> image ref. It runs the shared hub-suite reusable
+# against that ref/image (our own Keycloak; #462 decision) and PATCHes a commit
+# status back onto the camunda-hub PR — mirroring how c8-cross-component-e2e-tests
+# reports on hub PRs.
+#
+# ⚠️ PREREQS (not yet provisioned — see #462; this stays a DRAFT until they land):
+#   1. Registry read creds to pull the private pr-<sha> image
+#      (HUB_REGISTRY_USERNAME / HUB_REGISTRY_PASSWORD repo secrets, or a Vault path).
+#   2. A token that can write commit statuses on camunda/camunda-hub — the
+#      qa-processes App installed there with `Statuses: write` (the report job below
+#      mints it; it no-ops if the App can't reach camunda-hub yet).
+#   3. The camunda-hub-side dispatch workflow (Part B) sending the repository_dispatch.
+#
+# Expected client_payload: { source_sha, pr_number, hub_image, hub_registry }.
+name: Hub PR check
+
+on:
+  repository_dispatch:
+    types: [camunda-hub-pr]
+
+permissions:
+  contents: read
+  id-token: write # OIDC → Vault (clone token in the reusable)
+
+concurrency:
+  group: hub-pr-check-${{ github.event.client_payload.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    uses: ./.github/workflows/_hub-suite-run.yml
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_JWT_PATH: ${{ secrets.VAULT_JWT_PATH }}
+      VAULT_JWT_ROLE: ${{ secrets.VAULT_JWT_ROLE }}
+      VAULT_JWT_AUDIENCE: ${{ secrets.VAULT_JWT_AUDIENCE }}
+      # PREREQ #1: private pr-<sha> image pull creds (empty until provisioned).
+      REGISTRY_USERNAME: ${{ secrets.HUB_REGISTRY_USERNAME }}
+      REGISTRY_PASSWORD: ${{ secrets.HUB_REGISTRY_PASSWORD }}
+    with:
+      hub_ref: ${{ github.event.client_payload.source_sha }}
+      hub_image: ${{ github.event.client_payload.hub_image }}
+      hub_registry: ${{ github.event.client_payload.hub_registry }}
+      summary_heading: |
+        ## Hub PR check — camunda-hub#${{ github.event.client_payload.pr_number }}
+        source_sha: `${{ github.event.client_payload.source_sha }}` · image: `${{ github.event.client_payload.hub_image }}`
+
+  # Report the run's pass/fail back onto the camunda-hub PR as a commit status.
+  report:
+    needs: run
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      # PREREQ #2: mint a token that can write statuses on camunda/camunda-hub
+      # (qa-processes App installed there with Statuses: write). continue-on-error
+      # so an unprovisioned App just skips the report rather than failing the run.
+      - name: Mint camunda-hub status token (qa-processes App)
+        id: status-token
+        continue-on-error: true
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@7a9c6f3e477321400802c88290068f88a7ed5684
+        with:
+          github-app-id-vault-key: GITHUB_APP_ID
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          github-app-private-key-vault-key: GITHUB_APP_SECRET
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+
+      - name: Report status back to the camunda-hub PR
+        if: steps.status-token.outputs.token != ''
+        env:
+          GH_TOKEN: ${{ steps.status-token.outputs.token }}
+          SHA: ${{ github.event.client_payload.source_sha }}
+          RESULT: ${{ needs.run.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          state="failure"; [ "$RESULT" = "success" ] && state="success"
+          gh api -X POST "repos/camunda/camunda-hub/statuses/${SHA}" \
+            -f state="$state" \
+            -f target_url="$RUN_URL" \
+            -f context="api-test-generator/hub-suite" \
+            -f description="Generated hub suite: ${state}" >/dev/null
+          echo "Reported '${state}' on camunda-hub@${SHA:0:12}"

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -85,7 +85,14 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          state="failure"; [ "$RESULT" = "success" ] && state="success"
+          # Map the run result to a commit-status state. cancelled/skipped map to
+          # "error" (an infra/manual condition, not a test failure) so a genuine
+          # "failure" stays meaningful.
+          case "$RESULT" in
+            success) state=success ;;
+            failure) state=failure ;;
+            *)       state=error ;;
+          esac
           gh api -X POST "repos/camunda/camunda-hub/statuses/${SHA}" \
             -f state="$state" \
             -f target_url="$RUN_URL" \

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -8,13 +8,15 @@
 # status back onto the camunda-hub PR — mirroring how c8-cross-component-e2e-tests
 # reports on hub PRs.
 #
-# ⚠️ PREREQS (not yet provisioned — see #462; this stays a DRAFT until they land):
-#   1. Registry read creds to pull the private pr-<sha> image
-#      (HUB_REGISTRY_USERNAME / HUB_REGISTRY_PASSWORD repo secrets, or a Vault path).
-#   2. A token that can write commit statuses on camunda/camunda-hub — the
-#      qa-processes App installed there with `Statuses: write` (the report job below
-#      mints it; it no-ops if the App can't reach camunda-hub yet).
-#   3. The camunda-hub-side dispatch workflow (Part B) sending the repository_dispatch.
+# ⚠️ PREREQS (see #462; this stays a DRAFT until they land):
+#   1. Registry read creds to pull the private pr-<sha> image — reuses the
+#      existing CAMUNDA_CONTAINER_REGISTRY_USER/PASSWORD secrets (same pair
+#      camunda-hub uses to pull team-hub images). ✅ already provisioned.
+#   2. The qa-processes App (installed on camunda/camunda-hub) needs
+#      `Commit statuses: write` so the report job can PATCH a status — it no-ops
+#      (continue-on-error) until the scope is granted.
+#   3. The camunda-hub-side dispatch workflow (Part B, camunda-hub#26236)
+#      sending the repository_dispatch.
 #
 # Expected client_payload: { source_sha, pr_number, hub_image, hub_registry }.
 name: Hub PR check
@@ -39,9 +41,10 @@ jobs:
       VAULT_JWT_PATH: ${{ secrets.VAULT_JWT_PATH }}
       VAULT_JWT_ROLE: ${{ secrets.VAULT_JWT_ROLE }}
       VAULT_JWT_AUDIENCE: ${{ secrets.VAULT_JWT_AUDIENCE }}
-      # PREREQ #1: private pr-<sha> image pull creds (empty until provisioned).
-      REGISTRY_USERNAME: ${{ secrets.HUB_REGISTRY_USERNAME }}
-      REGISTRY_PASSWORD: ${{ secrets.HUB_REGISTRY_PASSWORD }}
+      # Registry creds to pull the private team-hub pr-<sha> image (the same
+      # pair camunda-hub uses for team-hub pulls).
+      REGISTRY_USERNAME: ${{ secrets.CAMUNDA_CONTAINER_REGISTRY_USER }}
+      REGISTRY_PASSWORD: ${{ secrets.CAMUNDA_CONTAINER_REGISTRY_PASSWORD }}
     with:
       hub_ref: ${{ github.event.client_payload.source_sha }}
       hub_image: ${{ github.event.client_payload.hub_image }}

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -4,21 +4,23 @@
 # Triggered by a repository_dispatch (type: camunda-hub-pr) sent FROM a
 # camunda/camunda-hub PR workflow (Part B, lives in that repo), carrying the PR's
 # source SHA + the pr-<sha> image ref. It runs the shared hub-suite reusable
-# against that ref/image (our own Keycloak; #462 decision) and PATCHes a commit
-# status back onto the camunda-hub PR — mirroring how c8-cross-component-e2e-tests
-# reports on hub PRs.
+# against that ref/image (our own Keycloak; #462 decision) and posts a commit
+# status back onto the camunda-hub PR (POST .../statuses/{sha}) — mirroring how
+# c8-cross-component-e2e-tests reports on hub PRs.
 #
 # ⚠️ PREREQS (see #462; this stays a DRAFT until they land):
 #   1. Registry read creds to pull the private pr-<sha> image — reuses the
 #      existing CAMUNDA_CONTAINER_REGISTRY_USER/PASSWORD secrets (same pair
 #      camunda-hub uses to pull team-hub images). ✅ already provisioned.
 #   2. The qa-processes App (installed on camunda/camunda-hub) needs
-#      `Commit statuses: write` so the report job can PATCH a status — it no-ops
-#      (continue-on-error) until the scope is granted.
+#      `Commit statuses: write` so the report job can post a status
+#      (POST .../statuses/{sha}) — it no-ops (continue-on-error) until granted.
 #   3. The camunda-hub-side dispatch workflow (Part B, camunda-hub#26236)
 #      sending the repository_dispatch.
 #
-# Expected client_payload: { source_sha, pr_number, hub_image, hub_registry }.
+# Expected client_payload: { source_sha, pr_number, hub_image }. The registry is
+# NOT taken from the payload — it's fixed to registry.camunda.cloud below so the
+# login + image-allowlist validation always runs (see the `hub_registry` input).
 name: Hub PR check
 
 on:

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -30,7 +30,9 @@ permissions:
   id-token: write # OIDC → Vault (clone token in the reusable)
 
 concurrency:
-  group: hub-pr-check-${{ github.event.client_payload.pr_number }}
+  # Fall back to source_sha so a missing/blank pr_number can't collapse unrelated
+  # dispatches into the constant group `hub-pr-check-` (they'd cancel each other).
+  group: hub-pr-check-${{ github.event.client_payload.pr_number || github.event.client_payload.source_sha }}
   cancel-in-progress: true
 
 jobs:
@@ -85,6 +87,13 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
+          # source_sha comes from an untrusted dispatch payload; a malformed value
+          # (e.g. containing slashes) would craft an unexpected API path. Require a
+          # full 40-char hex commit SHA before touching the statuses endpoint.
+          if ! printf '%s' "$SHA" | grep -qiE '^[0-9a-f]{40}$'; then
+            echo "::error::source_sha '$SHA' is not a 40-char hex commit SHA."
+            exit 1
+          fi
           # Map the run result to a commit-status state. cancelled/skipped map to
           # "error" (an infra/manual condition, not a test failure) so a genuine
           # "failure" stays meaningful.

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -2,11 +2,11 @@
 # build and report the result back onto the PR.
 #
 # Triggered by a repository_dispatch (type: camunda-hub-pr) sent FROM a
-# camunda/camunda-hub PR workflow (Part B, lives in that repo), carrying the PR's
-# source SHA + the pr-<sha> image ref. It runs the shared hub-suite reusable
-# against that ref/image (our own Keycloak; #462 decision) and posts a commit
-# status back onto the camunda-hub PR (POST .../statuses/{sha}) — mirroring how
-# c8-cross-component-e2e-tests reports on hub PRs.
+# camunda/camunda-hub PR workflow (Part B, lives in that repo), carrying just the
+# PR's source SHA + number. It derives the pr-<sha> image ref, runs the shared
+# hub-suite reusable against it (our own Keycloak; #462 decision) and posts a
+# commit status back onto the camunda-hub PR (POST .../statuses/{sha}) — mirroring
+# how c8-cross-component-e2e-tests reports on hub PRs.
 #
 # ⚠️ PREREQS (see #462; this stays a DRAFT until they land):
 #   1. Registry read creds to pull the private pr-<sha> image — reuses the
@@ -39,7 +39,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Gate the whole workflow on a well-formed source_sha. clone-hub-sibling accepts
+  # arbitrary refs (branches/tags), so without this a non-SHA payload (e.g. `main`)
+  # would run the full suite and try to pull `...:pr-main` before failing in the
+  # reporter. Validating up front means the run job never starts for a bad SHA,
+  # and downstream jobs consume the validated value (not the raw payload).
+  validate:
+    name: Validate dispatch payload
+    runs-on: ubuntu-latest
+    outputs:
+      source_sha: ${{ steps.v.outputs.source_sha }}
+    steps:
+      - name: Validate source_sha is a 40-char hex commit SHA
+        id: v
+        env:
+          SHA: ${{ github.event.client_payload.source_sha }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$SHA" | grep -qiE '^[0-9a-f]{40}$'; then
+            echo "::error::source_sha '$SHA' is not a 40-char hex commit SHA."
+            exit 1
+          fi
+          echo "source_sha=$SHA" >> "$GITHUB_OUTPUT"
+
   run:
+    needs: validate
     uses: ./.github/workflows/_hub-suite-run.yml
     secrets:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
@@ -51,25 +75,27 @@ jobs:
       REGISTRY_USERNAME: ${{ secrets.CAMUNDA_CONTAINER_REGISTRY_USER }}
       REGISTRY_PASSWORD: ${{ secrets.CAMUNDA_CONTAINER_REGISTRY_PASSWORD }}
     with:
-      hub_ref: ${{ github.event.client_payload.source_sha }}
-      # DERIVED from source_sha, NOT taken from the payload: a payload-supplied
-      # hub_image could point at a different tag than the reported commit (run
-      # image X, report status on SHA Y). Building it here pins the image to the
-      # exact commit we report on. registry + repo are fixed; only the pr-<sha>
-      # tag varies. The reusable still validates the result (well-formed + path).
-      hub_image: registry.camunda.cloud/team-hub/hub-restapi-self-managed:pr-${{ github.event.client_payload.source_sha }}
+      hub_ref: ${{ needs.validate.outputs.source_sha }}
+      # DERIVED from the validated source_sha, NOT taken from the payload: a
+      # payload-supplied hub_image could point at a different tag than the
+      # reported commit (run image X, report status on SHA Y). Building it here
+      # pins the image to the exact commit we report on. registry + repo are
+      # fixed; only the pr-<sha> tag varies. The reusable still validates it.
+      hub_image: registry.camunda.cloud/team-hub/hub-restapi-self-managed:pr-${{ needs.validate.outputs.source_sha }}
       # Hardcoded, NOT taken from the payload: forwarding an untrusted
       # hub_registry lets a caller send '' to skip the login + image-allowlist
       # validation entirely. Fixing it here guarantees validation always runs.
       hub_registry: registry.camunda.cloud
       summary_heading: |
         ## Hub PR check — camunda-hub#${{ github.event.client_payload.pr_number }}
-        source_sha: `${{ github.event.client_payload.source_sha }}` · image: `registry.camunda.cloud/team-hub/hub-restapi-self-managed:pr-${{ github.event.client_payload.source_sha }}`
+        source_sha: `${{ needs.validate.outputs.source_sha }}` · image: `registry.camunda.cloud/team-hub/hub-restapi-self-managed:pr-${{ needs.validate.outputs.source_sha }}`
 
   # Report the run's pass/fail back onto the camunda-hub PR as a commit status.
   report:
-    needs: run
-    if: always()
+    needs: [validate, run]
+    # Report whenever the SHA was valid (whatever the run result). If validate
+    # failed there's no real commit to post a status on, so skip.
+    if: always() && needs.validate.result == 'success'
     runs-on: ubuntu-latest
     steps:
       # PREREQ #2: mint a token that can write statuses on camunda/camunda-hub
@@ -93,18 +119,12 @@ jobs:
         if: steps.status-token.outputs.token != ''
         env:
           GH_TOKEN: ${{ steps.status-token.outputs.token }}
-          SHA: ${{ github.event.client_payload.source_sha }}
+          # Already validated as a 40-char hex SHA by the `validate` job.
+          SHA: ${{ needs.validate.outputs.source_sha }}
           RESULT: ${{ needs.run.result }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          # source_sha comes from an untrusted dispatch payload; a malformed value
-          # (e.g. containing slashes) would craft an unexpected API path. Require a
-          # full 40-char hex commit SHA before touching the statuses endpoint.
-          if ! printf '%s' "$SHA" | grep -qiE '^[0-9a-f]{40}$'; then
-            echo "::error::source_sha '$SHA' is not a 40-char hex commit SHA."
-            exit 1
-          fi
           # Map the run result to a commit-status state. cancelled/skipped map to
           # "error" (an infra/manual condition, not a test failure) so a genuine
           # "failure" stays meaningful.

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -50,7 +50,11 @@ jobs:
     with:
       hub_ref: ${{ github.event.client_payload.source_sha }}
       hub_image: ${{ github.event.client_payload.hub_image }}
-      hub_registry: ${{ github.event.client_payload.hub_registry }}
+      # Hardcoded, NOT taken from the payload: forwarding an untrusted
+      # hub_registry lets a caller send '' to skip the login + image-allowlist
+      # validation entirely (then run an arbitrary public hub_image). Fixing it
+      # here guarantees validation always runs for the PR-check path.
+      hub_registry: registry.camunda.cloud
       summary_heading: |
         ## Hub PR check — camunda-hub#${{ github.event.client_payload.pr_number }}
         source_sha: `${{ github.event.client_payload.source_sha }}` · image: `${{ github.event.client_payload.hub_image }}`


### PR DESCRIPTION
**DRAFT — slice 2 of #462, stacked on #464** (the reusable `_hub-suite-run.yml`). It'll show #464's commits until that merges, then I'll rebase.

## What this adds
- **`hub-pr-check.yml`** — `repository_dispatch(camunda-hub-pr)` → runs the shared reusable against the PR's `source_sha` + `pr-<sha>` image (our own Keycloak, per the #462 decision) → **PATCHes a commit status** back onto the camunda-hub PR (mirrors how `c8-cross-component-e2e-tests` reports on hub PRs).
- **Reusable** gains an optional gated `docker login` (inputs `hub_registry` + `REGISTRY_*` secrets) to pull the private `pr-<sha>` image; public `camunda/hub` runs are unaffected.

Expected `client_payload`: `{ source_sha, pr_number, hub_image, hub_registry }`.

## Why DRAFT
1. **Untestable until on `main`** — `repository_dispatch` only fires from the default-branch copy of the workflow (same gotcha as before). Testable via `gh api .../dispatches` once merged.
2. **Non-functional until 3 infra prereqs land** (all flagged in-file + #462):
   - **Registry read creds** for the private `pr-<sha>` image (`HUB_REGISTRY_USERNAME`/`_PASSWORD`).
   - **A `Statuses: write` token on `camunda/camunda-hub`** — the qa-processes App installed there (the report job mints it; no-ops until then).
   - **The camunda-hub-side dispatch workflow (Part B)** — lives in `camunda/camunda-hub`, needs the hub team.

## Part B — the camunda-hub-side workflow (for the hub team; can't add it from here)
```yaml
# in camunda/camunda-hub: .github/workflows/api-test-generator-dispatch.yml
name: Dispatch api-test-generator hub PR check
on:
  pull_request:
    types: [labeled, synchronize]
jobs:
  dispatch:
    if: contains(github.event.pull_request.labels.*.name, 'api-test')   # label-gated
    runs-on: ubuntu-latest
    steps:
      - env:
          GH_TOKEN: ${{ secrets.API_TEST_GENERATOR_DISPATCH_TOKEN }}     # dispatch perms on api-test-generator
          SHA: ${{ github.event.pull_request.head.sha }}
        run: |
          gh api -X POST repos/camunda/api-test-generator/dispatches \
            -f event_type=camunda-hub-pr \
            -F "client_payload[source_sha]=$SHA" \
            -F "client_payload[pr_number]=${{ github.event.pull_request.number }}" \
            -F "client_payload[hub_image]=registry.camunda.cloud/team-hub/hub:pr-$SHA" \
            -F "client_payload[hub_registry]=registry.camunda.cloud"
```
(Adjust the registry/image path to wherever the PR build actually lands.)

## Verification so far
YAML + `actionlint` clean on the reusable + new workflow. End-to-end verification waits on merge + the prereqs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)