### PR TITLE
fix(hub-pr-check): scope the status token to camunda-hub (#462)

### DIFF
--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -114,6 +114,10 @@ jobs:
           vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           vault-url: ${{ secrets.VAULT_ADDR }}
+          # Scope the token to camunda-hub (the repo we post the status on) —
+          # without this it defaults to the current repo and the POST 404s.
+          owner: camunda
+          repositories: camunda-hub
 
       - name: Report status back to the camunda-hub PR
         if: steps.status-token.outputs.token != ''


### PR DESCRIPTION
## What

The `report` job in `hub-pr-check.yml` minted the qa-processes token without `owner`/`repositories`, so it defaulted to the current repo (api-test-generator). The `POST repos/camunda/camunda-hub/statuses/<sha>` then returned **404** (token can't see camunda-hub) rather than posting the status.

Fix: scope the mint to `owner: camunda`, `repositories: camunda-hub`.

## How it was found

Tier-1 smoke test of the merged receiver — manual `repository_dispatch` (`camunda-hub-pr`) with a real hub PR's `source_sha` ([run](https://github.com/camunda/api-test-generator/actions/runs/29091732238)). Everything passed end-to-end:

- `validate` (40-hex SHA) ✅
- clone camunda-hub @ sha ✅
- **registry login + team-hub pull** of `hub-restapi-self-managed:pr-<sha>` ✅
- **PR image boots under our compose, `/api/v2/` ready** ✅
- generate + run full suite ✅ (`RESULT: success`)
- report status back ❌ → 404 (this fix)

## Note

This unmasks the separate, still-open infra item: the qa-processes App needs **`Commit statuses: write`** on camunda-hub. With this scoping fix the token can *reach* camunda-hub; once the scope is granted the POST will succeed (until then it'll 403, still `continue-on-error`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)