### PR TITLE
fix(ci): retry the camunda-hub clone fetch on transient "Repository not found"

### DIFF
--- a/.github/actions/clone-hub-sibling/action.yml
+++ b/.github/actions/clone-hub-sibling/action.yml
@@ -47,7 +47,7 @@ runs:
               fetch --depth 1 origin "$HUB_REF"; do
           fetch_attempts=$((fetch_attempts + 1))
           if [ "$fetch_attempts" -ge 5 ]; then
-            echo "::error::git fetch of camunda-hub failed after ${fetch_attempts} attempts."
+            echo "::error::git fetch of camunda-hub ref '${HUB_REF}' failed after ${fetch_attempts} attempts."
             exit 1
           fi
           echo "fetch failed (likely transient App-token propagation) — retry ${fetch_attempts}/5 in 10s..."

--- a/.github/actions/clone-hub-sibling/action.yml
+++ b/.github/actions/clone-hub-sibling/action.yml
@@ -38,7 +38,20 @@ runs:
         dest="${GITHUB_WORKSPACE}/../camunda-hub"
         mkdir -p "$dest" && cd "$dest" && git init -q
         git remote get-url origin >/dev/null 2>&1 || git remote add origin https://github.com/camunda/camunda-hub.git
-        git -c "url.https://x-access-token:${HUB_TOKEN}@github.com/.insteadOf=https://github.com/" \
-          fetch --depth 1 origin "$HUB_REF"
+        # Retry to absorb transient "Repository not found" fetch failures — a
+        # freshly-minted App installation token occasionally isn't fully
+        # propagated on GitHub's side yet when the fetch fires immediately
+        # after minting; a short retry clears it without any code change.
+        fetch_attempts=0
+        until git -c "url.https://x-access-token:${HUB_TOKEN}@github.com/.insteadOf=https://github.com/" \
+              fetch --depth 1 origin "$HUB_REF"; do
+          fetch_attempts=$((fetch_attempts + 1))
+          if [ "$fetch_attempts" -ge 5 ]; then
+            echo "::error::git fetch of camunda-hub failed after ${fetch_attempts} attempts."
+            exit 1
+          fi
+          echo "fetch failed (likely transient App-token propagation) — retry ${fetch_attempts}/5 in 10s..."
+          sleep 10
+        done
         git checkout -q --detach FETCH_HEAD
         echo "camunda-hub @ $(git rev-parse --short HEAD) (ref: $HUB_REF)"


### PR DESCRIPTION
## What

Wraps the `git fetch` in `clone-hub-sibling` with a retry loop (5 attempts, 10s delay), matching the existing retry convention already used in `start-hub.sh` (docker-compose-up retry) — no new dependency, same style.

## Why

We've hit this specific transient failure repeatedly across hub CI runs (nightly, on-demand, and #462's PR-check):

```
remote: Repository not found.
fatal: repository 'https://github.com/camunda/camunda-hub.git/' not found
```

...for a real, private-but-accessible repo. The working theory (consistent with it always clearing on a manual re-run): a freshly-minted App installation token (from `hub-clone-token`'s Vault OIDC mint) occasionally isn't fully propagated on GitHub's side yet when the `git fetch` fires immediately after minting. This makes the workaround self-healing instead of requiring someone to notice a red run and manually re-run it — most recently hit on api-test-generator#468.

## Verified

Tested the retry logic directly (mocked `git` failing N times then succeeding): confirms it recovers within the attempt budget, and fails with a clear, specific error once attempts are exhausted rather than retrying forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)