### PR TITLE
feat(hub-ci): surface unmapped spec operations in the run summary

### DIFF
--- a/.github/actions/hub-run-summary/action.yml
+++ b/.github/actions/hub-run-summary/action.yml
@@ -28,12 +28,13 @@ runs:
         # Config drift: positive-suppress entries no longer in the bundled spec
         # (materializer records these on coverage.json rather than failing generate).
         stale="$(python3 -c "import json; print(', '.join(json.load(open('generated/camunda-hub/playwright/coverage.json')).get('staleSuppressedOpIds',[])))" 2>/dev/null || true)"
-        # Unmapped operations: spec ops with zero generated test coverage (no
-        # entity-kind/scenario-template maps to them and they're not in
-        # positive-suppress.json either) — e.g. a new endpoint the ontology
-        # hasn't caught up with. The materializer records these but never fails
-        # generate on them, so a new operation could otherwise ship untested
-        # with a fully green run. Non-blocking, same as the drift note above.
+        # Unmapped operations: any spec op with zero generated test coverage
+        # right now — no entity-kind/scenario-template maps to it and it's not
+        # in positive-suppress.json either. Could be a new endpoint the
+        # ontology hasn't caught up with, or an existing op that lost coverage.
+        # The materializer records these but never fails generate on them, so
+        # this could otherwise ship untested with a fully green run.
+        # Non-blocking, same as the drift note above.
         unmapped="$(python3 -c "import json; print(', '.join(json.load(open('generated/camunda-hub/playwright/coverage.json')).get('summary',{}).get('unmappedOperations',[])))" 2>/dev/null || true)"
         {
           printf '%s\n' "$HEADING"
@@ -42,7 +43,7 @@ runs:
             echo ""
           fi
           if [ -n "$unmapped" ]; then
-            echo "> ⚠️ **Coverage gap:** \`${unmapped}\` — new spec operation(s) not covered by any generated test. Run \`npm run coverage:report\` locally for details."
+            echo "> ⚠️ **Coverage gap:** \`${unmapped}\` — spec operation(s) not covered by any generated test (not necessarily new — could be an existing op that lost coverage). Run \`npm run coverage:report\` locally for details."
             echo ""
           fi
           echo "### Positive (lifecycle)"

--- a/.github/actions/hub-run-summary/action.yml
+++ b/.github/actions/hub-run-summary/action.yml
@@ -28,10 +28,21 @@ runs:
         # Config drift: positive-suppress entries no longer in the bundled spec
         # (materializer records these on coverage.json rather than failing generate).
         stale="$(python3 -c "import json; print(', '.join(json.load(open('generated/camunda-hub/playwright/coverage.json')).get('staleSuppressedOpIds',[])))" 2>/dev/null || true)"
+        # Unmapped operations: spec ops with zero generated test coverage (no
+        # entity-kind/scenario-template maps to them and they're not in
+        # positive-suppress.json either) — e.g. a new endpoint the ontology
+        # hasn't caught up with. The materializer records these but never fails
+        # generate on them, so a new operation could otherwise ship untested
+        # with a fully green run. Non-blocking, same as the drift note above.
+        unmapped="$(python3 -c "import json; print(', '.join(json.load(open('generated/camunda-hub/playwright/coverage.json')).get('summary',{}).get('unmappedOperations',[])))" 2>/dev/null || true)"
         {
           printf '%s\n' "$HEADING"
           if [ -n "$stale" ]; then
             echo "> ⚠️ **Config drift:** \`positive-suppress.json\` lists \`${stale}\` no longer in the spec (renamed/removed upstream?) — update the suppress list."
+            echo ""
+          fi
+          if [ -n "$unmapped" ]; then
+            echo "> ⚠️ **Coverage gap:** \`${unmapped}\` — new spec operation(s) not covered by any generated test. Run \`npm run coverage:report\` locally for details."
             echo ""
           fi
           echo "### Positive (lifecycle)"


### PR DESCRIPTION
## Summary
- `coverage.json`'s `summary.unmappedOperations` already tracks spec operations with zero generated test coverage (not suppressed, not mapped by any entity-kind/scenario-template) — but nothing surfaced it. A new camunda-hub endpoint the ontology hasn't modeled yet would silently ship untested, with `generate` staying green.
- Extends `hub-run-summary`'s existing `staleSuppressedOpIds` config-drift check with the same read/warn pattern for `unmappedOperations`. Non-blocking (informational note in the job summary), shared automatically by nightly, on-demand, and the #462 hub PR-check since they all already call this composite action.

## Test plan
- [x] Verified `coverage.json`'s actual schema — `unmappedOperations` is nested under `summary`, not top-level (confirmed by reading the live artifact).
- [x] Simulated the new bash logic against both an empty (`[]`) and synthetic non-empty coverage.json — correct output in both cases.
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML is well-formed (actionlint doesn't parse composite `action.yml` files, only workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)