### PR TITLE
feat(hub-ci): auto-open a tracking issue for unmapped spec operations

### DIFF
--- a/.github/scripts/hub-unmapped-issue.sh
+++ b/.github/scripts/hub-unmapped-issue.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Rolling tracking issue for camunda-hub unmapped spec operations (#471 follow-up).
+#
+# Single issue found by exact title (same pattern as spec-bump-check.yml's
+# tracking issue) — no duplicate spam across nightly runs. Opens when
+# summary.unmappedOperations is non-empty, updates the body if the list
+# changed, closes it once the list is empty again.
+set -euo pipefail
+
+ISSUE_TITLE='camunda-hub: unmapped spec operations have no generated test coverage'
+RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+unmapped="$(python3 -c "
+import json
+try:
+    d = json.load(open('generated/camunda-hub/playwright/coverage.json'))
+    print(', '.join(d.get('summary', {}).get('unmappedOperations', [])))
+except Exception:
+    pass
+")"
+
+existing_num="$(gh issue list --state open --search "in:title \"${ISSUE_TITLE}\"" \
+  --json number,title --jq "[.[] | select(.title == \"${ISSUE_TITLE}\")] | .[0].number // empty")"
+
+if [ -z "$unmapped" ]; then
+  if [ -n "$existing_num" ]; then
+    gh issue comment "$existing_num" --body "Resolved — the latest nightly run found no unmapped operations. [Run]($RUN_URL)"
+    gh issue close "$existing_num"
+    echo "Closed #${existing_num} (unmapped list is now empty)."
+  else
+    echo "No unmapped operations, no tracking issue open — nothing to do."
+  fi
+  exit 0
+fi
+
+body="Spec operation(s) with zero generated test coverage — no entity-kind or scenario-template maps them, and they aren't in \`positive-suppress.json\` either. Run \`npm run coverage:report\` locally for details.
+
+**Unmapped:** \`${unmapped}\`
+
+[Latest run]($RUN_URL)"
+
+if [ -n "$existing_num" ]; then
+  gh issue comment "$existing_num" --body "Still unmapped as of the latest nightly run.
+
+**Unmapped:** \`${unmapped}\`
+
+[Run]($RUN_URL)"
+  echo "Updated #${existing_num}."
+else
+  url="$(gh issue create --title "$ISSUE_TITLE" --body "$body")"
+  echo "Opened ${url}."
+fi

--- a/.github/workflows/nightly-camunda-hub.yml
+++ b/.github/workflows/nightly-camunda-hub.yml
@@ -25,6 +25,9 @@ permissions:
   # Mint a GitHub OIDC token so Vault can authenticate this job via JWT (no
   # long-lived role-id/secret-id stored as repo secrets — smaller blast radius).
   id-token: write
+  # Rolling tracking issue for unmapped spec operations (#471) — open/update/
+  # close a single issue via the built-in GITHUB_TOKEN, no App token needed.
+  issues: write
 
 # Don't pile up overlapping nightly runs.
 concurrency:
@@ -165,6 +168,21 @@ jobs:
         uses: ./.github/actions/hub-run-summary
         with:
           heading: '## Nightly — camunda-hub API tests'
+
+      # --- Unmapped-operations tracking issue (#471) ---------------------------
+      # hub-run-summary already warns in the job summary when generate produces
+      # coverage.json with a non-empty summary.unmappedOperations, but that's
+      # easy to miss on a nightly nobody's watching. This makes it durable: a
+      # single rolling issue (found by exact title, no spam) opens on the first
+      # occurrence, updates if the list changes, and auto-closes once it's
+      # empty again — same pattern spec-bump-check.yml uses for its tracking
+      # issue. Nightly-only (not hub-pr-check): a cross-cutting coverage gap
+      # isn't the fault of whichever PR happened to trigger a dispatch.
+      - name: Open/update/close unmapped-operations tracking issue
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/hub-unmapped-issue.sh
 
       # --- Publish to TestRail (mirrors camunda/camunda's trcli step) ----------
       # Fetch the TestRail creds from Vault via the same GitHub OIDC/JWT auth used


### PR DESCRIPTION
## Summary
- #470 (merged) added a non-blocking job-summary warning when `coverage.json`'s `summary.unmappedOperations` is non-empty — but that's easy to miss on an unattended nightly nobody's watching.
- This makes the signal durable: a single rolling tracking issue (found by exact title, so no duplicate spam across runs), following the same open/update/close pattern `spec-bump-check.yml` already uses for its own tracking issue.
  - Opens `camunda-hub: unmapped spec operations have no generated test coverage` on first occurrence.
  - Updates the issue (adds a comment with the current list) if it's still non-empty on a later run.
  - Auto-closes it once `unmappedOperations` is empty again.
- **Nightly-only**, not wired into `hub-pr-check.yml` — a cross-cutting coverage gap isn't the fault of whichever camunda-hub PR happened to trigger that particular dispatch, so opening it there would misattribute the signal (mirrors why `spec-bump-check.yml`'s Slack drift-notify is nightly/hub-only too, never on `pull_request`).
- Adds `issues: write` to `nightly-camunda-hub.yml`'s permissions (needed to open/comment/close via the built-in `GITHUB_TOKEN` — no new App token required).

Closes #471.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow — valid YAML.
- [x] `actionlint .github/workflows/nightly-camunda-hub.yml` — clean.
- [x] `bash -n` + `shellcheck` on `.github/scripts/hub-unmapped-issue.sh` — clean.
- [x] Verified the `unmappedOperations` extraction against both the real (currently empty) `coverage.json` and a synthetic non-empty one — correct output both ways.
- [ ] Live-fires next nightly run (02:00 UTC) — currently a no-op since `unmappedOperations` is empty; will only visibly exercise the open/close path once there's a real gap (or a manual `workflow_dispatch` against a deliberately-broken sibling, if we want to force it sooner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)