### PR TITLE
fix(ci): gate spec-bump auto-adopt on unmapped-operation coverage

### DIFF
--- a/.github/scripts/spec-bump-report.sh
+++ b/.github/scripts/spec-bump-report.sh
@@ -8,7 +8,10 @@
 #
 # Required env: GH_TOKEN, CONFIG, ISSUE_TITLE, DRIFT_LABEL, UPSTREAM_REPO,
 # UPSTREAM_BRANCH, PINNED, LATEST, N_ADDED, N_REMOVED, ADDED, REMOVED,
-# GEN_OUTCOME, INV_OUTCOME. GitHub provides GITHUB_* automatically.
+# GEN_OUTCOME, INV_OUTCOME. Optional: UNMAPPED (comma-separated operationIds
+# with no generated test coverage — see the "Check for unmapped operations"
+# step; empty when generate didn't succeed or nothing's unmapped). GitHub
+# provides GITHUB_* automatically.
 set -euo pipefail
 
 : "${GH_TOKEN:?GH_TOKEN required for gh auth}"
@@ -18,6 +21,7 @@ N_ADDED="${N_ADDED:-0}"
 N_REMOVED="${N_REMOVED:-0}"
 GEN_OUTCOME="${GEN_OUTCOME:-unknown}"
 INV_OUTCOME="${INV_OUTCOME:-unknown}"
+UNMAPPED="${UNMAPPED:-}"
 
 # shellcheck source=.github/scripts/spec-bump-common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/spec-bump-common.sh"
@@ -37,8 +41,13 @@ body_file="$(mktemp)"
   echo "| Latest \`${UPSTREAM_BRANCH}\` | \`${LATEST}\` ([compare](${compare_url})) |"
   echo "| Generate pipeline | $(emoji "$GEN_OUTCOME") \`${GEN_OUTCOME}\` |"
   echo "| Regression invariants | $(emoji "$INV_OUTCOME") \`${INV_OUTCOME}\` |"
+  echo "| Unmapped (uncovered) operations | $([ -n "$UNMAPPED" ] && echo "❌ ${UNMAPPED}" || echo "✅ none") |"
   echo "| Operations added / removed | ${N_ADDED} / ${N_REMOVED} |"
   echo
+  if [ -n "$UNMAPPED" ]; then
+    echo "⚠️ **Generate and invariants both passed, but this is still not safe to auto-adopt**: \`${UNMAPPED}\` has no generated test coverage at all (no entity-kind/scenario-template maps it, and it's not in \`positive-suppress.json\` either) — model it before bumping, or add it to the suppress list with a tracked reason."
+    echo
+  fi
   echo "🆕 **Added operations** (new upstream surface to model):"
   list_or_none "${ADDED:-}"
   echo
@@ -60,7 +69,7 @@ existing="$(find_rolling_issue)"
 if [ -n "$existing" ]; then
   echo "Updating existing tracking issue #${existing}"
   gh issue edit "$existing" --body-file "$body_file" >/dev/null
-  gh issue comment "$existing" --body "🔁 Re-checked against \`${LATEST}\` — still drifted (generate: \`${GEN_OUTCOME}\`, invariants: \`${INV_OUTCOME}\`, +${N_ADDED}/-${N_REMOVED} ops). [Run](${run_url})" >/dev/null
+  gh issue comment "$existing" --body "🔁 Re-checked against \`${LATEST}\` — still drifted (generate: \`${GEN_OUTCOME}\`, invariants: \`${INV_OUTCOME}\`, unmapped: \`${UNMAPPED:-none}\`, +${N_ADDED}/-${N_REMOVED} ops). [Run](${run_url})" >/dev/null
 else
   echo "Opening new tracking issue"
   gh issue create --title "$ISSUE_TITLE" --body-file "$body_file" --label "$DRIFT_LABEL" >/dev/null

--- a/.github/workflows/spec-bump-check.yml
+++ b/.github/workflows/spec-bump-check.yml
@@ -280,6 +280,30 @@ jobs:
             npm test
           fi
 
+      # generate/invariants passing only proves the KNOWN, modeled surface still
+      # works — regression-invariants.test.ts asserts specific hand-picked
+      # behaviors, not blanket coverage. A new upstream operation the ontology
+      # hasn't caught up with yet generates zero tests for it (silent skip, not
+      # a failure) and would otherwise sail through as "clean" and get
+      # auto-bumped via the PR below with no test coverage at all. Read the
+      # same summary.unmappedOperations coverage.json already records (see
+      # hub-run-summary's job-summary warning) and treat non-empty as NOT
+      # clean, same as a generate/invariants failure.
+      - name: Check for unmapped operations against latest
+        id: unmapped
+        if: >-
+          steps.refs.outputs.drifted == 'true' && steps.opdiff.outputs.content_changed == 'true' &&
+          steps.generate.outcome == 'success'
+        run: |
+          unmapped="$(python3 -c "import json; print(', '.join(json.load(open('generated/${CONFIG}/playwright/coverage.json')).get('summary',{}).get('unmappedOperations',[])))" 2>/dev/null || true)"
+          echo "unmapped=${unmapped}" >> "$GITHUB_OUTPUT"
+          if [ -n "$unmapped" ]; then
+            echo "has_unmapped=true" >> "$GITHUB_OUTPUT"
+            echo "Unmapped (uncovered) operations: ${unmapped}"
+          else
+            echo "has_unmapped=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # --- Mint the qa-processes App token for the bump PR (clean drift only) --
       # Same wiring as camunda/camunda's nightly-fix workflow (which opens PRs as
       # app/qa-processes, e.g. camunda/camunda#56716): the shared composite action
@@ -291,7 +315,8 @@ jobs:
         id: app-token
         if: >-
           steps.refs.outputs.drifted == 'true' && steps.opdiff.outputs.content_changed == 'true' &&
-          steps.generate.outcome == 'success' && steps.invariants.outcome == 'success'
+          steps.generate.outcome == 'success' && steps.invariants.outcome == 'success' &&
+          steps.unmapped.outputs.has_unmapped != 'true'
         continue-on-error: true
         # Pinned to a full commit SHA (supply-chain hardening): this sub-action
         # has no release tag of its own, so we pin main's HEAD and bump it
@@ -313,6 +338,7 @@ jobs:
         if: >-
           steps.refs.outputs.drifted == 'true' && steps.opdiff.outputs.content_changed == 'true' &&
           steps.generate.outcome == 'success' && steps.invariants.outcome == 'success' &&
+          steps.unmapped.outputs.has_unmapped != 'true' &&
           steps.app-token.outputs.token != ''
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -323,13 +349,15 @@ jobs:
           REMOVED: ${{ steps.opdiff.outputs.removed }}
         run: bash .github/scripts/spec-bump-open-pr.sh
 
-      # BROKEN drift (generate/invariants failed) OR clean-but-no-App-token
-      # → the tracking issue (fallback preserves the signal).
+      # BROKEN drift (generate/invariants failed), unmapped (uncovered) operations,
+      # OR clean-but-no-App-token → the tracking issue (fallback preserves the
+      # signal, and blocks the auto-bump path so an uncovered op can't get
+      # silently adopted).
       - name: Report drift to the rolling tracking issue
         if: >-
           steps.refs.outputs.drifted == 'true' && steps.opdiff.outputs.content_changed == 'true' &&
           (steps.generate.outcome != 'success' || steps.invariants.outcome != 'success' ||
-           steps.app-token.outputs.token == '')
+           steps.unmapped.outputs.has_unmapped == 'true' || steps.app-token.outputs.token == '')
         env:
           GH_TOKEN: ${{ github.token }}
           PINNED: ${{ steps.refs.outputs.pinned }}
@@ -340,6 +368,7 @@ jobs:
           REMOVED: ${{ steps.opdiff.outputs.removed }}
           GEN_OUTCOME: ${{ steps.generate.outcome }}
           INV_OUTCOME: ${{ steps.invariants.outcome }}
+          UNMAPPED: ${{ steps.unmapped.outputs.unmapped }}
         run: bash .github/scripts/spec-bump-report.sh
 
       # No meaningful drift (pin at latest, or content byte-identical) → close


### PR DESCRIPTION
## Summary

Follow-up to #470/#471 — after closing #474 (a nightly-only tracking issue) in favor of fixing this at the source: `spec-bump-check.yml`'s "clean drift" classification (generate + invariants both pass → auto-open a "safe to adopt" bump PR, e.g. #467) never checked whether the latest spec's operations actually have test coverage.

`regression-invariants.test.ts` asserts specific, hand-picked behaviors — not blanket coverage — so a brand-new upstream operation the ontology hasn't modeled yet generates **zero tests for it** (a silent skip, not a failure) and would sail through as "clean." That's a real gap: a bump PR could get auto-opened and merged for a spec that includes a completely untested new operation, and nothing would say so.

## Change
- New step "Check for unmapped operations against latest": reads `coverage.json`'s `summary.unmappedOperations` (same field the nightly's `hub-run-summary` job-summary warning already surfaces) right after `generate` succeeds.
- Both the App-token mint and "Open/update the auto-bump PR" now also require `has_unmapped != 'true'` — a spec with an uncovered operation is no longer classified as clean.
- "Report drift to the rolling tracking issue" now also fires when `has_unmapped == 'true'`, so the signal isn't lost — it routes to the existing tracking-issue path instead.
- `spec-bump-report.sh` renders a dedicated "Unmapped (uncovered) operations" row + a callout explaining *why* it's blocked even when generate/invariants both show ✅ (otherwise the issue would look self-contradictory).

Applies to both configs (oca + hub) — verified `testsuite:generate` produces `generated/<config>/playwright/coverage.json` for both.

Closes #471.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` + `actionlint` on the workflow — clean.
- [x] `bash -n` + `shellcheck` on `spec-bump-report.sh` — no new findings (diffed against `main`'s existing shellcheck output; the two pre-existing `run_url`/`SC1091` notes are from the sourced `spec-bump-common.sh`, unrelated to this change).
- [x] Simulated the new gate logic against synthetic non-empty and empty `coverage.json` — `has_unmapped` computed correctly both ways.
- [x] Rendered `spec-bump-report.sh`'s new table row + callout with synthetic `GEN_OUTCOME=success INV_OUTCOME=success UNMAPPED=newHubOp` — reads clearly, not contradictory.
- [ ] Live-fires next scheduled run (06:00 UTC) — currently a no-op on the clean path since today's pin has no unmapped ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)