### PR TITLE
feat(ci): hub Slack drift-notify fires on missing coverage too

### DIFF
--- a/.github/workflows/spec-bump-check.yml
+++ b/.github/workflows/spec-bump-check.yml
@@ -385,16 +385,22 @@ jobs:
       # --- Hub-only: Slack heads-up on OPERATION-surface drift (#435) -----------
       # The hub team lives in #camunda-hub-api-test-results, so mirror the
       # GitHub artifact this run just created (bump PR or tracking issue) as a
-      # Slack alert. Only when the operationId surface actually changed
-      # (n_added/n_removed) — a field-level-only content change is silent here.
-      # The diff is already computed above (steps.opdiff), so this just formats +
-      # links; no recomputation. content_changed=='true' is the sentinel that the
-      # opdiff step ran (it's unset when drifted=='false').
+      # Slack alert. Fires when the operationId surface actually changed
+      # (n_added/n_removed) OR when unmapped (uncovered) operations blocked the
+      # auto-adopt path — that second case matters even with zero op-count
+      # churn (e.g. an existing op regresses to uncovered), and without it the
+      # only place that signal shows up is the GitHub tracking issue itself,
+      # which nobody's watching by default. A field-level-only content change
+      # with neither is still silent here. The diff is already computed above
+      # (steps.opdiff), so this just formats + links; no recomputation.
+      # content_changed=='true' is the sentinel that the opdiff step ran (it's
+      # unset when drifted=='false').
       - name: Fetch Slack bot token from Vault (hub drift)
         id: slack-secrets
         if: >-
           matrix.private && steps.opdiff.outputs.content_changed == 'true' &&
-          (steps.opdiff.outputs.n_added != '0' || steps.opdiff.outputs.n_removed != '0')
+          (steps.opdiff.outputs.n_added != '0' || steps.opdiff.outputs.n_removed != '0' ||
+           steps.unmapped.outputs.has_unmapped == 'true')
         continue-on-error: true
         uses: ./.github/actions/slack-token
         with:
@@ -407,7 +413,8 @@ jobs:
         id: slack-payload
         if: >-
           matrix.private && steps.opdiff.outputs.content_changed == 'true' &&
-          (steps.opdiff.outputs.n_added != '0' || steps.opdiff.outputs.n_removed != '0') &&
+          (steps.opdiff.outputs.n_added != '0' || steps.opdiff.outputs.n_removed != '0' ||
+           steps.unmapped.outputs.has_unmapped == 'true') &&
           steps.slack-secrets.outputs.SLACK_BOT_TOKEN != ''
         # Notification formatting must not fail the run (gh/API transient errors).
         continue-on-error: true
@@ -421,6 +428,7 @@ jobs:
           REMOVED: ${{ steps.opdiff.outputs.removed }}
           N_ADDED: ${{ steps.opdiff.outputs.n_added }}
           N_REMOVED: ${{ steps.opdiff.outputs.n_removed }}
+          UNMAPPED: ${{ steps.unmapped.outputs.unmapped }}
         run: |
           set -uo pipefail
           # ISSUE_TITLE + CONFIG (matrix env) are the single source of truth for
@@ -457,15 +465,19 @@ jobs:
           # template refs read from process.env, not shell expansions.
           ADDED_CSV="$(csv "${ADDED:-}" "${N_ADDED:-0}")" \
           REMOVED_CSV="$(csv "${REMOVED:-}" "${N_REMOVED:-0}")" \
+          UNMAPPED_CSV="$(csv "${UNMAPPED:-}" 0)" \
           LINK="$link" \
           node -e '
             const e = process.env;
+            const unmappedLine = e.UNMAPPED_CSV
+              ? `\n🚫 *missing coverage* (blocks auto-adopt): ${e.UNMAPPED_CSV}`
+              : "";
             const text =
               `🔎 *camunda-hub upstream op-surface drift* vs the pin ` +
               `(\`${e.PINNED}\` → latest \`${e.LATEST}\`):\n` +
               `🆕 added (${e.N_ADDED}): ${e.ADDED_CSV}\n` +
-              `🗑️ removed (${e.N_REMOVED}): ${e.REMOVED_CSV}\n` +
-              `${e.LINK}`;
+              `🗑️ removed (${e.N_REMOVED}): ${e.REMOVED_CSV}` +
+              unmappedLine + `\n${e.LINK}`;
             require("fs").appendFileSync(process.env.GITHUB_OUTPUT, `text_json=${JSON.stringify(text)}\n`);
           '
 
@@ -474,7 +486,8 @@ jobs:
         # half-built message if slack-payload errored under continue-on-error).
         if: >-
           matrix.private && steps.opdiff.outputs.content_changed == 'true' &&
-          (steps.opdiff.outputs.n_added != '0' || steps.opdiff.outputs.n_removed != '0') &&
+          (steps.opdiff.outputs.n_added != '0' || steps.opdiff.outputs.n_removed != '0' ||
+           steps.unmapped.outputs.has_unmapped == 'true') &&
           steps.slack-secrets.outputs.SLACK_BOT_TOKEN != '' &&
           steps.slack-payload.outcome == 'success'
         continue-on-error: true

--- a/.github/workflows/spec-bump-check.yml
+++ b/.github/workflows/spec-bump-check.yml
@@ -465,19 +465,27 @@ jobs:
           # template refs read from process.env, not shell expansions.
           ADDED_CSV="$(csv "${ADDED:-}" "${N_ADDED:-0}")" \
           REMOVED_CSV="$(csv "${REMOVED:-}" "${N_REMOVED:-0}")" \
-          UNMAPPED_CSV="$(csv "${UNMAPPED:-}" 0)" \
+          UNMAPPED_LIST="${UNMAPPED:-}" \
           LINK="$link" \
           node -e '
             const e = process.env;
-            const unmappedLine = e.UNMAPPED_CSV
-              ? `\n🚫 *missing coverage* (blocks auto-adopt): ${e.UNMAPPED_CSV}`
+            // UNMAPPED is already ", "-joined by the python step that produces it
+            // (a single line, not newline-separated like ADDED/REMOVED) — used
+            // directly, not through the csv() helper above (which expects
+            // newline-separated input and would double the comma-spacing).
+            const unmappedLine = e.UNMAPPED_LIST
+              ? `\n🚫 *missing coverage* (blocks auto-adopt): ${e.UNMAPPED_LIST}`
               : "";
-            const text =
-              `🔎 *camunda-hub upstream op-surface drift* vs the pin ` +
-              `(\`${e.PINNED}\` → latest \`${e.LATEST}\`):\n` +
-              `🆕 added (${e.N_ADDED}): ${e.ADDED_CSV}\n` +
-              `🗑️ removed (${e.N_REMOVED}): ${e.REMOVED_CSV}` +
-              unmappedLine + `\n${e.LINK}`;
+            // Only claim "op-surface drift" when there is actual operationId
+            // churn — this notify can now fire on missing-coverage alone (zero
+            // added/removed), where that headline would be misleading.
+            const hasChurn = e.N_ADDED !== "0" || e.N_REMOVED !== "0";
+            const headline = hasChurn
+              ? `🔎 *camunda-hub upstream op-surface drift* vs the pin (\`${e.PINNED}\` → latest \`${e.LATEST}\`):\n` +
+                `🆕 added (${e.N_ADDED}): ${e.ADDED_CSV}\n` +
+                `🗑️ removed (${e.N_REMOVED}): ${e.REMOVED_CSV}`
+              : `🔎 *camunda-hub coverage regression* vs latest \`${e.LATEST}\` (no operationId churn):`;
+            const text = headline + unmappedLine + `\n${e.LINK}`;
             require("fs").appendFileSync(process.env.GITHUB_OUTPUT, `text_json=${JSON.stringify(text)}\n`);
           '
 


### PR DESCRIPTION
## Summary

Follow-up to #475/#476. The hub Slack drift-notify (#435, `#camunda-hub-api-test-results`) only fired on operationId churn (`n_added != '0' || n_removed != '0'`). That meant #475's unmapped-operations gate could silently block a hub bump PR with **zero Slack signal** whenever the blocker wasn't tied to an added/removed op — e.g. an existing operation regresses to uncovered with no op-count change. In that case the only place the block was visible was the GitHub tracking issue itself (now carrying the `missing-coverage` label from #476), which nobody's watching by default.

## Change
- Loosens the three Slack steps' `if:` gate to also fire on `steps.unmapped.outputs.has_unmapped == 'true'`, independent of op-count churn.
- Adds an explicit `🚫 missing coverage (blocks auto-adopt): ...` line to the Slack message so it's clear *why* it's blocked without clicking through to the issue.
- Scoped to hub only (`matrix.private`), matching this notify's existing scope — oca has no Slack wiring for this at all; standing that up would be new infra (channel, etc.), a separate decision.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` + `actionlint` — clean.
- [x] Simulated the message-building `node -e` snippet against three synthetic cases: (a) op-count churn + unmapped, (b) **zero op-count churn but unmapped present** (the exact gap this fixes — message still includes the missing-coverage line), (c) no unmapped (existing format unchanged). All three render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)