### PR TITLE
chore(ci): run spec-bump-check earlier (03:00 UTC, was 06:00)

### DIFF
--- a/.github/workflows/spec-bump-check.yml
+++ b/.github/workflows/spec-bump-check.yml
@@ -44,10 +44,12 @@ name: Spec-bump check
 
 on:
   schedule:
-    # Daily 06:00 UTC — a heads-up on upstream drift, well clear of the 02:00 hub
-    # nightly. Cheap on no-op days (generate is gated on real content change) and
-    # non-spammy (an already-open bump PR is left untouched).
-    - cron: '0 6 * * *'
+    # Daily 03:00 UTC — a heads-up on upstream drift, ~1h after the 02:00 hub
+    # nightly (which has a 25min timeout) so it trails rather than races it,
+    # without the previous 4h gap. Cheap on no-op days (generate is gated on
+    # real content change) and non-spammy (an already-open bump PR is left
+    # untouched).
+    - cron: '0 3 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Tightens the gap between the 02:00 UTC hub nightly and spec-bump-check from 4h to ~1h — still clear of the nightly (which has a 25min timeout, so it trails rather than races it) without the drift signal sitting unreported for most of the morning.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` + `actionlint` — clean.
- [x] Rebased onto latest `main` (post #476/#478) — no conflicts, cron line intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)