### PR TITLE
feat(triage): ping the owning medic on fresh findings

### DIFF
--- a/resources/workspace-templates/camunda-hub-nightlies/camunda-hub-nightlies.guidance.md
+++ b/resources/workspace-templates/camunda-hub-nightlies/camunda-hub-nightlies.guidance.md
@@ -185,6 +185,14 @@ If `gh pr create` fails (empty `GH_TOKEN_GENERATOR` / push rejected), do not fai
 
 Emit exactly this shape (the workflow reads it to build the Slack digest and to know which issues you filed):
 
+**`expected` and `actual` are short values, not explanations.** One line each —
+the status/value and a brief pointer (e.g. `"422 (asserted by the generated
+test)"`, `"400 — {\"title\":\"Bad Request\",...}"`), matching the schema
+example below. Your reasoning, root-cause analysis, and evidence trail belong
+in `evidence` (or the issue/PR body you file), not here — these two fields
+get rendered directly in the Slack thread, one line each, and a paragraph in
+either makes the digest unreadable.
+
 ```json
 {
   "run_url": "<nightly run URL from $NIGHTLY_RUN_URL>",

--- a/scripts/triage/hub-triage-format-slack.sh
+++ b/scripts/triage/hub-triage-format-slack.sh
@@ -163,30 +163,39 @@ case "$MODE" in
           else "\n    " + linklabel + ": (no URL recorded)" end;
       # Owner→medic Slack subteam mentions — pings the actual on-call group,
       # not plain text (same mechanism as the camunda/camunda AlwaysGreen
-      # feedback.mjs / alwaysgreen-streak-detector.yml). Only on a FRESH
-      # filing/fix this run (action == "file" / "fix-pr"), never on an
-      # already-known recurrence (action == "report-only"/"skip") — otherwise
-      # the medic gets paged nightly for something already tracked and
-      # unfixed. One mention per finding, inline in the thread reply only
+      # feedback.mjs / alwaysgreen-streak-detector.yml). Fires on:
+      #   - hub_medic: action == "file" AND a non-empty issue_url — a FRESH
+      #     hub issue was actually filed this run. Requiring the URL guards
+      #     against paging on a schema-violating/incomplete agent-authored
+      #     entry that claims action "file" without one.
+      #   - test_automation_medic: action == "fix-pr" (a fresh generator-side
+      #     fix PR) OR suppress_pr_url present (a suppress PR — also lives in
+      #     api-test-generator) — deduped to exactly one mention even if both
+      #     happened to be true for the same finding (the schema does not
+      #     declare them mutually exclusive).
+      # Never on an already-known recurrence (action == "report-only"/"skip")
+      # — otherwise the medic gets paged nightly for something already tracked
+      # and unfixed. One mention per finding, inline in the thread reply only
       # (never the top-level summary message) so it stays precise, not a
       # blanket ping.
       def hub_medic: "<!subteam^S014VK4482H|hub-medic>";
       def test_automation_medic: "<!subteam^S09UF0EV0HG|test-automation-medic>";
       def line(f):
-        "• " + icon(f) + " *" + catlabel(f) + "* — `"
+        (((f.action // "") == "fix-pr") or ((f.suppress_pr_url // null) != null)) as $needs_ta_medic
+        | "• " + icon(f) + " *" + catlabel(f) + "* — `"
         + s(f.spec // f.operationId; "?") + "` — " + s(f.test; "")
         + "\n    expected: " + s(f.expected; "?") + "  |  actual: " + s(f.actual; "?")
         + (if (f.known_issue // false) then link_or_note(f.known_issue_url; ":ticket: known issue") else "" end)
         + (if (f.related_commit // null) != null then "\n    :fast_forward: skipped — explained by recent change: " + s(f.related_commit; "") else "" end)
         + (if (f.issue_url // null) != null then link_or_note(f.issue_url; ":memo: filed") else "" end)
-        + (if (f.action // "") == "file" then "\n    :rotating_light: " + hub_medic else "" end)
+        + (if (f.action // "") == "file" and ((s(f.issue_url; "")) | length) > 0
+           then "\n    :rotating_light: " + hub_medic else "" end)
         + (if (f.fix_pr_url // null) != null then
              link_or_note(f.fix_pr_url;
                if (f.action // "") == "skip" then ":recycle: already being fixed" else ":hammer_and_wrench: fix PR" end)
            else "" end)
-        + (if (f.action // "") == "fix-pr" then "\n    :rotating_light: " + test_automation_medic else "" end)
         + (if (f.suppress_pr_url // null) != null then link_or_note(f.suppress_pr_url; ":no_entry: suppressed") else "" end)
-        + (if (f.suppress_pr_url // null) != null then "\n    :rotating_light: " + test_automation_medic else "" end)
+        + (if $needs_ta_medic then "\n    :rotating_light: " + test_automation_medic else "" end)
         + (if (f.action // "") == "report-only" and ((f.file_error // "") != "") then
              (if (f.subcategory // "") == "test-generation"
               then "\n    :warning: could not open fix PR: "

--- a/scripts/triage/hub-triage-format-slack.sh
+++ b/scripts/triage/hub-triage-format-slack.sh
@@ -173,16 +173,24 @@ case "$MODE" in
       #     hub issue was actually filed this run. Requiring the URL guards
       #     against paging on a schema-violating/incomplete agent-authored
       #     entry that claims action "file" without one.
-      #   - test_automation_medic: action == "fix-pr" (a fresh generator-side
-      #     fix PR) OR suppress_pr_url present (a suppress PR — also lives in
-      #     api-test-generator) — deduped to exactly one mention even if both
+      #   - test_automation_medic: action == "fix-pr" with a non-empty
+      #     fix_pr_url (a fresh generator-side fix PR) OR a non-empty
+      #     suppress_pr_url (a suppress PR — also lives in api-test-generator,
+      #     needs our review) — deduped to exactly one mention even if both
       #     happened to be true for the same finding (the schema does not
       #     declare them mutually exclusive).
-      # Never on an already-known recurrence (action == "report-only"/"skip")
-      # — otherwise the medic gets paged nightly for something already tracked
-      # and unfixed. One mention per finding, inline in the thread reply only
-      # (never the top-level summary message) so it stays precise, not a
-      # blanket ping.
+      #
+      # hub_medic never fires on an already-known recurrence (action ==
+      # "report-only"/"skip") — otherwise it gets paged nightly for something
+      # already tracked and unfixed. The test_automation_medic suppress_pr_url
+      # trigger is intentionally independent of action: per the guidance, a
+      # suppress PR is opened for every confirmed bug, including one already
+      # known (action == "report-only", known_issue == true) — the PR is
+      # fresh and needs review either way, even though the underlying hub
+      # issue is not.
+      #
+      # One mention per finding, inline in the thread reply only (never the
+      # top-level summary message) so it stays precise, not a blanket ping.
       def hub_medic: "<!subteam^S014VK4482H|hub-medic>";
       def test_automation_medic: "<!subteam^S09UF0EV0HG|test-automation-medic>";
       def line(f):

--- a/scripts/triage/hub-triage-format-slack.sh
+++ b/scripts/triage/hub-triage-format-slack.sh
@@ -145,6 +145,12 @@ case "$MODE" in
       # object, or null slipping past `// "?"` — must still degrade to a
       # readable line instead of a jq "cannot add ... and string" error).
       def s(x; d): ((x // d) | tostring);
+      # Defensive cap on a per-finding display field (expected/actual) — the
+      # guidance asks the agent for a short one-line value here, evidence and
+      # reasoning belong in `evidence` instead, but this is a jq-level backstop
+      # in case a future run still writes something long: a single overlong
+      # field must not make the whole thread reply unreadable.
+      def cap(x; d; n): s(x; d) as $v | if ($v | length) > n then ($v[0:n] + "…") else $v end;
       def icon(f):
         if (f.subcategory // "") == "test-generation" then ":test_tube:"
         elif f.category == "product" then ":package:"
@@ -198,7 +204,7 @@ case "$MODE" in
         (((f.action // "") == "fix-pr" and has_url(f.fix_pr_url)) or has_url(f.suppress_pr_url)) as $needs_ta_medic
         | "• " + icon(f) + " *" + catlabel(f) + "* — `"
         + s(f.spec // f.operationId; "?") + "` — " + s(f.test; "")
-        + "\n    expected: " + s(f.expected; "?") + "  |  actual: " + s(f.actual; "?")
+        + "\n    expected: " + cap(f.expected; "?"; 120) + "  |  actual: " + cap(f.actual; "?"; 120)
         + (if (f.known_issue // false) then link_or_note(f.known_issue_url; ":ticket: known issue") else "" end)
         + (if (f.related_commit // null) != null then "\n    :fast_forward: skipped — explained by recent change: " + s(f.related_commit; "") else "" end)
         + (if (f.issue_url // null) != null then link_or_note(f.issue_url; ":memo: filed") else "" end)

--- a/scripts/triage/hub-triage-format-slack.sh
+++ b/scripts/triage/hub-triage-format-slack.sh
@@ -161,6 +161,17 @@ case "$MODE" in
         s(url; "") as $u
         | if ($u | length) > 0 then "\n    " + linklabel + ": <" + $u + ">"
           else "\n    " + linklabel + ": (no URL recorded)" end;
+      # Owner→medic Slack subteam mentions — pings the actual on-call group,
+      # not plain text (same mechanism as the camunda/camunda AlwaysGreen
+      # feedback.mjs / alwaysgreen-streak-detector.yml). Only on a FRESH
+      # filing/fix this run (action == "file" / "fix-pr"), never on an
+      # already-known recurrence (action == "report-only"/"skip") — otherwise
+      # the medic gets paged nightly for something already tracked and
+      # unfixed. One mention per finding, inline in the thread reply only
+      # (never the top-level summary message) so it stays precise, not a
+      # blanket ping.
+      def hub_medic: "<!subteam^S014VK4482H|hub-medic>";
+      def test_automation_medic: "<!subteam^S09UF0EV0HG|test-automation-medic>";
       def line(f):
         "• " + icon(f) + " *" + catlabel(f) + "* — `"
         + s(f.spec // f.operationId; "?") + "` — " + s(f.test; "")
@@ -168,11 +179,14 @@ case "$MODE" in
         + (if (f.known_issue // false) then link_or_note(f.known_issue_url; ":ticket: known issue") else "" end)
         + (if (f.related_commit // null) != null then "\n    :fast_forward: skipped — explained by recent change: " + s(f.related_commit; "") else "" end)
         + (if (f.issue_url // null) != null then link_or_note(f.issue_url; ":memo: filed") else "" end)
+        + (if (f.action // "") == "file" then "\n    :rotating_light: " + hub_medic else "" end)
         + (if (f.fix_pr_url // null) != null then
              link_or_note(f.fix_pr_url;
                if (f.action // "") == "skip" then ":recycle: already being fixed" else ":hammer_and_wrench: fix PR" end)
            else "" end)
+        + (if (f.action // "") == "fix-pr" then "\n    :rotating_light: " + test_automation_medic else "" end)
         + (if (f.suppress_pr_url // null) != null then link_or_note(f.suppress_pr_url; ":no_entry: suppressed") else "" end)
+        + (if (f.suppress_pr_url // null) != null then "\n    :rotating_light: " + test_automation_medic else "" end)
         + (if (f.action // "") == "report-only" and ((f.file_error // "") != "") then
              (if (f.subcategory // "") == "test-generation"
               then "\n    :warning: could not open fix PR: "
@@ -187,6 +201,7 @@ case "$MODE" in
              link_or_note(u.fix_pr_url;
                if (u.action // "") == "skip" then ":recycle: already being fixed" else ":hammer_and_wrench: fix PR" end)
            else "" end)
+        + (if (u.action // "") == "fix-pr" then "\n    :rotating_light: " + test_automation_medic else "" end)
         + (if (u.action // "") == "report-only" and ((u.file_error // "") != "") then "\n    :warning: could not open fix PR: " + s(u.file_error; "") else "" end);
       # Guard against the schema being violated (e.g. failures/unmapped_operations
       # written as an object or string instead of an array) — arr() coerces

--- a/scripts/triage/hub-triage-format-slack.sh
+++ b/scripts/triage/hub-triage-format-slack.sh
@@ -161,6 +161,11 @@ case "$MODE" in
         s(url; "") as $u
         | if ($u | length) > 0 then "\n    " + linklabel + ": <" + $u + ">"
           else "\n    " + linklabel + ": (no URL recorded)" end;
+      # True only for an actually-present, non-empty URL string — a present
+      # key with an empty value ("" — a schema violation / agent bug) must
+      # not count as a real link present, same rule link_or_note itself
+      # already applies when deciding whether to render "(no URL recorded)".
+      def has_url(x): (s(x; "") | length) > 0;
       # Owner→medic Slack subteam mentions — pings the actual on-call group,
       # not plain text (same mechanism as the camunda/camunda AlwaysGreen
       # feedback.mjs / alwaysgreen-streak-detector.yml). Fires on:
@@ -181,14 +186,14 @@ case "$MODE" in
       def hub_medic: "<!subteam^S014VK4482H|hub-medic>";
       def test_automation_medic: "<!subteam^S09UF0EV0HG|test-automation-medic>";
       def line(f):
-        (((f.action // "") == "fix-pr") or ((f.suppress_pr_url // null) != null)) as $needs_ta_medic
+        (((f.action // "") == "fix-pr" and has_url(f.fix_pr_url)) or has_url(f.suppress_pr_url)) as $needs_ta_medic
         | "• " + icon(f) + " *" + catlabel(f) + "* — `"
         + s(f.spec // f.operationId; "?") + "` — " + s(f.test; "")
         + "\n    expected: " + s(f.expected; "?") + "  |  actual: " + s(f.actual; "?")
         + (if (f.known_issue // false) then link_or_note(f.known_issue_url; ":ticket: known issue") else "" end)
         + (if (f.related_commit // null) != null then "\n    :fast_forward: skipped — explained by recent change: " + s(f.related_commit; "") else "" end)
         + (if (f.issue_url // null) != null then link_or_note(f.issue_url; ":memo: filed") else "" end)
-        + (if (f.action // "") == "file" and ((s(f.issue_url; "")) | length) > 0
+        + (if (f.action // "") == "file" and has_url(f.issue_url)
            then "\n    :rotating_light: " + hub_medic else "" end)
         + (if (f.fix_pr_url // null) != null then
              link_or_note(f.fix_pr_url;
@@ -210,7 +215,8 @@ case "$MODE" in
              link_or_note(u.fix_pr_url;
                if (u.action // "") == "skip" then ":recycle: already being fixed" else ":hammer_and_wrench: fix PR" end)
            else "" end)
-        + (if (u.action // "") == "fix-pr" then "\n    :rotating_light: " + test_automation_medic else "" end)
+        + (if (u.action // "") == "fix-pr" and has_url(u.fix_pr_url)
+           then "\n    :rotating_light: " + test_automation_medic else "" end)
         + (if (u.action // "") == "report-only" and ((u.file_error // "") != "") then "\n    :warning: could not open fix PR: " + s(u.file_error; "") else "" end);
       # Guard against the schema being violated (e.g. failures/unmapped_operations
       # written as an object or string instead of an array) — arr() coerces

--- a/scripts/triage/hub-triage-format-slack.sh
+++ b/scripts/triage/hub-triage-format-slack.sh
@@ -161,11 +161,12 @@ case "$MODE" in
         s(url; "") as $u
         | if ($u | length) > 0 then "\n    " + linklabel + ": <" + $u + ">"
           else "\n    " + linklabel + ": (no URL recorded)" end;
-      # True only for an actually-present, non-empty URL string — a present
-      # key with an empty value ("" — a schema violation / agent bug) must
-      # not count as a real link present, same rule link_or_note itself
-      # already applies when deciding whether to render "(no URL recorded)".
-      def has_url(x): (s(x; "") | length) > 0;
+      # True only for an actual, non-empty URL string. Checks (x|type) itself
+      # rather than routing through s()/tostring: a schema-violating non-
+      # string value (true, 42, {}) would stringify to something non-empty
+      # ("true", "42", "{}") and be wrongly treated as a present URL — this
+      # pages real on-call groups, so only a genuine string counts.
+      def has_url(x): (x | type) == "string" and (x | length) > 0;
       # Owner→medic Slack subteam mentions — pings the actual on-call group,
       # not plain text (same mechanism as the camunda/camunda AlwaysGreen
       # feedback.mjs / alwaysgreen-streak-detector.yml). Fires on:

--- a/scripts/triage/hub-triage-format-slack.sh
+++ b/scripts/triage/hub-triage-format-slack.sh
@@ -160,19 +160,22 @@ case "$MODE" in
       def catlabel(f):
         if (f.subcategory // "") == "test-generation" then "test-generation (api-test-generator)"
         else s(f.category; "?") end;
-      # Only render a knownIssue/URL-style link when the URL is actually
-      # present — an empty/null url must not render as a bare "<>", which
-      # looks like a broken link rather than a missing one.
-      def link_or_note(url; linklabel):
-        s(url; "") as $u
-        | if ($u | length) > 0 then "\n    " + linklabel + ": <" + $u + ">"
-          else "\n    " + linklabel + ": (no URL recorded)" end;
       # True only for an actual, non-empty URL string. Checks (x|type) itself
       # rather than routing through s()/tostring: a schema-violating non-
       # string value (true, 42, {}) would stringify to something non-empty
       # ("true", "42", "{}") and be wrongly treated as a present URL — this
-      # pages real on-call groups, so only a genuine string counts.
+      # pages real on-call groups (and, below, renders a Slack link), so only
+      # a genuine string counts either way.
       def has_url(x): (x | type) == "string" and (x | length) > 0;
+      # Only render a knownIssue/URL-style link when the URL is actually a
+      # present, non-empty string — the same has_url() rule the medic-ping
+      # triggers use. Without this, a schema-violating non-string value (true,
+      # 42, {}) would stringify via s()/tostring into something non-empty and
+      # render as a garbage Slack link (<true>, <42>) instead of falling back
+      # to "(no URL recorded)".
+      def link_or_note(url; linklabel):
+        if has_url(url) then "\n    " + linklabel + ": <" + s(url; "") + ">"
+        else "\n    " + linklabel + ": (no URL recorded)" end;
       # Owner→medic Slack subteam mentions — pings the actual on-call group,
       # not plain text (same mechanism as the camunda/camunda AlwaysGreen
       # feedback.mjs / alwaysgreen-streak-detector.yml). Fires on:


### PR DESCRIPTION
## Summary

Closes #486. Same mechanism as camunda/camunda#57903: a real Slack subteam mention (`<!subteam^ID|handle>`), not plain text, so the digest actually pages the on-call group instead of just linking the issue/PR.

- **hub-medic** (`<!subteam^S014VK4482H|hub-medic>`) on a freshly filed camunda-hub issue this run (`action == "file"`) — never on an already-known recurrence (`action == "report-only"`), so it doesn't page nightly for something already tracked and unfixed.
- **test-automation-medic** (`<!subteam^S09UF0EV0HG|test-automation-medic>`) on a fresh test-generation/coverage-gap fix PR (`action == "fix-pr"`) or a suppress PR (`suppress_pr_url` present) — both live in api-test-generator and need our review.

Inline per-finding in the `thread` reply only, never the top-level `summary` message — precise, not a blanket ping.

## Verification

7 synthetic cases against `hub-triage-format-slack.sh thread` directly (fresh filing, already-known, fresh fix PR, already-in-flight fix, suppress PR, fresh coverage-gap fix, already-in-flight coverage-gap fix) — mentions fire exactly on the intended cases and nowhere else. `summary` mode and the empty-file/malformed-JSON early-exit paths are unaffected. Shellcheck clean.

Not live-dispatched: this would post a real message with a working subteam mention to `#camunda-hub-api-test-results`, paging real people — didn't want to trigger that without an explicit ask.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>