### PR TITLE
TEMPORARY TEST — un-suppress createVersion on main (will revert immediately)

### DIFF
--- a/configs/camunda-hub/positive-suppress.json
+++ b/configs/camunda-hub/positive-suppress.json
@@ -18,14 +18,6 @@
       }
     },
     {
-      "operationId": "createVersion",
-      "reason": "Versions are unobtainable via the public API: every file it can create lives inside a project (process application), and those cannot be versioned (400 'Cannot create a version for file … as it is located inside a process application'). Blocked on camunda/camunda-hub#25801; tracked here via #419. Re-enable once versioning is unblocked.",
-      "knownIssue": {
-        "summary": "Versions can't be created via the public API",
-        "url": "https://github.com/camunda/camunda-hub/issues/25801"
-      }
-    },
-    {
       "operationId": "getVersion",
       "reason": "Depends on a version existing, which requires createVersion — unobtainable via the public API (camunda/camunda-hub#25801, tracked via #419).",
       "knownIssue": {


### PR DESCRIPTION
## ⚠️ TEMPORARY TEST — will be merged, tested, and reverted within the hour

Not a real change. Un-suppresses `createVersion` (camunda-hub#25801, a real, already-tracked bug) to reproduce the failure on `main` itself, so the triage agent (#472) can be live-tested end-to-end: does it correctly open a suppress PR + ping test-automation-medic when the known-issue suppression is genuinely missing from `main`, not just from a throwaway branch.

A revert PR will follow immediately after the test completes. Do not build on top of this branch.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>