### PR TITLE
fix(triage): trim noisy zero counters and shorten thread bullets

### DIFF
--- a/resources/workspace-templates/camunda-hub-nightlies/camunda-hub-nightlies.guidance.md
+++ b/resources/workspace-templates/camunda-hub-nightlies/camunda-hub-nightlies.guidance.md
@@ -62,7 +62,7 @@ For each entry in `unmappedOperations`: this is a generator/ontology gap, not a 
 
 **Critical disambiguation — the API matching the spec is NOT a product bug.** When the response and the OpenAPI spec **agree** with each other but the *test* failed, the **generated test** built a wrong request or asserted the wrong expectation — a **test-generation bug in api-test-generator**, not a camunda-hub defect. Do not classify it `product` and do not file a camunda-hub issue. Report it with `category: "product"` reasoning noted, `subcategory: "test-generation"`. This is one of the two cases where you may open an api-test-generator PR instead of just reporting — see "Fixing a test-generation / coverage bug" below for when that's appropriate versus falling back to `action: "report-only"`. A filed camunda-hub issue is only ever correct when the response **contradicts** the spec.
 
-If you genuinely cannot determine the category from the evidence, classify as **infrastructure** with `confidence: "low"` and say exactly what evidence was missing — never guess "product".
+If you genuinely cannot determine the category from the evidence, do not guess "product". Set `category: "infrastructure"` and `confidence: "low"`, and say exactly what evidence was missing in `evidence`. This exact combination is treated as an explicit **could-not-classify** signal downstream: the Slack thread calls it out distinctly (not as an ordinary infrastructure finding) and pings the test-automation medic so a human makes the call — so use it honestly whenever you're genuinely unsure, rather than picking a category just to fill the field.
 
 ## Known-issue reconciliation (do this before calling anything a NEW bug)
 

--- a/scripts/triage/hub-triage-format-slack.sh
+++ b/scripts/triage/hub-triage-format-slack.sh
@@ -190,6 +190,12 @@ case "$MODE" in
       # (not a "(no URL recorded)" fallback) is deliberate: this compact line
       # only shows what IS there, it does not call out what is missing.
       def compactLink(url; icon): if has_url(url) then icon + " <" + s(url; "") + ">" else "" end;
+      # operationId with a fallback to spec when it is missing OR an empty
+      # string — plain `//` alone would not catch the empty-string case,
+      # since jq only treats null/false as falsy, not "".
+      def opLabel(f):
+        (f.operationId // "") as $o
+        | if ($o | type) == "string" and ($o | length) > 0 then $o else s(f.spec; "?") end;
       # Owner→medic Slack subteam mentions — pings the actual on-call group,
       # not plain text (same mechanism as the camunda/camunda AlwaysGreen
       # feedback.mjs / alwaysgreen-streak-detector.yml). Fires on:
@@ -201,7 +207,10 @@ case "$MODE" in
       #     fix_pr_url (a fresh generator-side fix PR) OR a non-empty
       #     suppress_pr_url (a suppress PR — also lives in api-test-generator,
       #     needs our review) OR its own could-not-classify signal
-      #     (confidence: "low", per the classification fallback above)
+      #     (category: "infrastructure" AND confidence: "low", the exact
+      #     fallback combination the classification guidance defines —
+      #     NOT any low-confidence finding, an unrelated future use of
+      #     confidence should not page anyone)
       #     — deduped to exactly one mention even if more than one of these
       #     happened to be true for the same finding (the schema does not
       #     declare them mutually exclusive).
@@ -225,7 +234,20 @@ case "$MODE" in
       # test-automation medic so a human makes the call, rather than the
       # low confidence going unnoticed under a category label that reads
       # as a settled decision.
-      def undecided(f): (f.confidence // "") == "low";
+      def undecided(f): (f.category // "") == "infrastructure" and (f.confidence // "") == "low";
+      # related_commit carries a sha/url per the guidance (proof of the
+      # "explained by recent intentional change" skip decision) — render it
+      # as a link when it actually looks like one, else as inline text,
+      # rather than collapsing it to a generic marker that loses the actual
+      # reference. has_url() only checks "non-empty string" (fine for the
+      # other fields here, which the schema always populates with real
+      # URLs) — a bare commit sha would satisfy that and get wrongly
+      # wrapped in the Slack <...> link syntax, so this needs its own,
+      # stricter check for an actual http(s) URL.
+      def relatedCommitNote(x):
+        if has_url(x) and (x | test("^https?://")) then compactLink(x; ":fast_forward:")
+        elif (x | type) == "string" and (x | length) > 0 then ":fast_forward: " + x
+        else "" end;
       # Compact per-finding line: title (category, operationId, short
       # expected/actual) + one links line (icon+URL only, whichever are
       # present — nothing shown for whichever are absent) + medic ping(s) +
@@ -236,12 +258,12 @@ case "$MODE" in
         ((((f.action // "") == "fix-pr" and has_url(f.fix_pr_url)) or has_url(f.suppress_pr_url)) or undecided(f)) as $needs_ta_medic
         | ([
             (if (f.known_issue // false) then compactLink(f.known_issue_url; ":ticket:") else "" end),
-            (if (f.related_commit // null) != null then ":fast_forward: recent change" else "" end),
+            relatedCommitNote(f.related_commit),
             compactLink(f.issue_url; ":memo:"),
             compactLink(f.fix_pr_url; if (f.action // "") == "skip" then ":recycle:" else ":hammer_and_wrench:" end),
             compactLink(f.suppress_pr_url; ":no_entry:")
           ] | map(select(length > 0)) | join("  ")) as $links_line
-        | "• " + icon(f) + " " + catlabel(f) + " — `" + s(f.operationId; "?")
+        | "• " + icon(f) + " " + catlabel(f) + " — `" + opLabel(f)
         + "` — expected " + leadNum(f.expected; "?") + ", got " + leadNum(f.actual; "?")
         + (if undecided(f) then "\n    :grey_question: *could not confidently classify — needs human triage*" else "" end)
         + (if ($links_line | length) > 0 then "\n    " + $links_line else "" end)

--- a/scripts/triage/hub-triage-format-slack.sh
+++ b/scripts/triage/hub-triage-format-slack.sh
@@ -200,7 +200,9 @@ case "$MODE" in
       #   - test_automation_medic: action == "fix-pr" with a non-empty
       #     fix_pr_url (a fresh generator-side fix PR) OR a non-empty
       #     suppress_pr_url (a suppress PR — also lives in api-test-generator,
-      #     needs our review) — deduped to exactly one mention even if both
+      #     needs our review) OR its own could-not-classify signal
+      #     (confidence: "low", per the classification fallback above)
+      #     — deduped to exactly one mention even if more than one of these
       #     happened to be true for the same finding (the schema does not
       #     declare them mutually exclusive).
       #
@@ -217,6 +219,13 @@ case "$MODE" in
       # top-level summary message) so it stays precise, not a blanket ping.
       def hub_medic: "<!subteam^S014VK4482H|hub-medic>";
       def test_automation_medic: "<!subteam^S09UF0EV0HG|test-automation-medic>";
+      # An admission from the agent that it could not confidently pick a
+      # category — never silently folded into an ordinary infrastructure
+      # finding. Called out with its own line AND routed to the
+      # test-automation medic so a human makes the call, rather than the
+      # low confidence going unnoticed under a category label that reads
+      # as a settled decision.
+      def undecided(f): (f.confidence // "") == "low";
       # Compact per-finding line: title (category, operationId, short
       # expected/actual) + one links line (icon+URL only, whichever are
       # present — nothing shown for whichever are absent) + medic ping(s) +
@@ -224,7 +233,7 @@ case "$MODE" in
       # reasoning, response bodies, etc.) lives in the linked issue, PR, or
       # nightly run, not repeated here — this is a pointer, not the evidence.
       def line(f):
-        (((f.action // "") == "fix-pr" and has_url(f.fix_pr_url)) or has_url(f.suppress_pr_url)) as $needs_ta_medic
+        ((((f.action // "") == "fix-pr" and has_url(f.fix_pr_url)) or has_url(f.suppress_pr_url)) or undecided(f)) as $needs_ta_medic
         | ([
             (if (f.known_issue // false) then compactLink(f.known_issue_url; ":ticket:") else "" end),
             (if (f.related_commit // null) != null then ":fast_forward: recent change" else "" end),
@@ -234,6 +243,7 @@ case "$MODE" in
           ] | map(select(length > 0)) | join("  ")) as $links_line
         | "• " + icon(f) + " " + catlabel(f) + " — `" + s(f.operationId; "?")
         + "` — expected " + leadNum(f.expected; "?") + ", got " + leadNum(f.actual; "?")
+        + (if undecided(f) then "\n    :grey_question: *could not confidently classify — needs human triage*" else "" end)
         + (if ($links_line | length) > 0 then "\n    " + $links_line else "" end)
         + (if (f.action // "") == "file" and has_url(f.issue_url)
            then "\n    :rotating_light: " + hub_medic else "" end)

--- a/scripts/triage/hub-triage-format-slack.sh
+++ b/scripts/triage/hub-triage-format-slack.sh
@@ -69,6 +69,12 @@ case "$MODE" in
       # all-clear — exactly what this script exists to prevent. Caught
       # separately below, before the normal zero-failures path can fire.
       def bad_type(x): x as $v | ($v != null) and (($v|type) != "array");
+      # Category breakdown lines: only the categories that actually happened
+      # tonight, not a wall of "label: 0"s for every category the schema
+      # happens to define. Same "only show a non-zero one" rule the coverage
+      # line below already uses.
+      def counters(items):
+        items | map(select(.count > 0)) | map(.icon + " " + .label + ": " + (.count|tostring)) | join("   ");
       # No-false-all-clear: an inconclusive / crashed run must say so, never green.
       if (.inconclusive // false) then
         ":warning: *Inconclusive* — the nightly produced no report artifact to triage. The test run may have crashed before uploading results; check the nightly run."
@@ -108,6 +114,17 @@ case "$MODE" in
                + " operation(s) with no generated test — " + ($unmapped_fixed|tostring) + " fix PR(s) opened."
           end
         ) as $coverage_line
+      | (counters([
+          {icon: ":package:", label: "product", count: n($c.product)},
+          {icon: ":wrench:", label: "infrastructure", count: n($c.infrastructure)},
+          {icon: ":game_die:", label: "flakiness", count: n($c.flakiness)},
+          {icon: ":test_tube:", label: "test-generation", count: n($c.test_generation)}
+        ])) as $cat_line
+      | (counters([
+          {icon: ":ticket:", label: "known issue", count: n($c.known_issue)},
+          {icon: ":memo:", label: "filed", count: n($c.filed)},
+          {icon: ":fast_forward:", label: "skipped (recent change)", count: n($c.skipped_recent_change)}
+        ])) as $meta_line
       # No-false-all-clear applies here too: zero failing TESTS is not the same
       # as zero gaps — a suite can be all-green while an operation has no test
       # at all (it never appears as a failure). Only call the night fully clean
@@ -119,13 +136,8 @@ case "$MODE" in
         else
           $suites
           + "\n*Triage — " + ($total|tostring) + " failing test(s):*"
-          + "\n  :package: product: " + (n($c.product)|tostring)
-          + "   :wrench: infrastructure: " + (n($c.infrastructure)|tostring)
-          + "   :game_die: flakiness: " + (n($c.flakiness)|tostring)
-          + "   :test_tube: test-generation: " + (n($c.test_generation)|tostring)
-          + "\n  :ticket: known issue: " + (n($c.known_issue)|tostring)
-          + "   :memo: filed: " + (n($c.filed)|tostring)
-          + "   :fast_forward: skipped (recent change): " + (n($c.skipped_recent_change)|tostring)
+          + (if ($cat_line|length) > 0 then "\n  " + $cat_line else "" end)
+          + (if ($meta_line|length) > 0 then "\n  " + $meta_line else "" end)
           + $coverage_line
         end
       )
@@ -145,12 +157,14 @@ case "$MODE" in
       # object, or null slipping past `// "?"` — must still degrade to a
       # readable line instead of a jq "cannot add ... and string" error).
       def s(x; d): ((x // d) | tostring);
-      # Defensive cap on a per-finding display field (expected/actual) — the
-      # guidance asks the agent for a short one-line value here, evidence and
-      # reasoning belong in `evidence` instead, but this is a jq-level backstop
-      # in case a future run still writes something long: a single overlong
-      # field must not make the whole thread reply unreadable.
-      def cap(x; d; n): s(x; d) as $v | if ($v | length) > n then ($v[0:n] + "…") else $v end;
+      # Leading numeric token (a status code, in practice) if the value starts
+      # with one, else the value itself capped short — the compact title line
+      # wants just "expected 200, got 400", not the full reasoning string the
+      # guidance already asks the agent to keep out of these fields anyway.
+      def leadNum(x; d):
+        (s(x; d)) as $v
+        | (try ($v | capture("^(?<n>[0-9]+)").n) catch null)
+          // (if ($v | length) > 20 then ($v[0:20] + "…") else $v end);
       def icon(f):
         if (f.subcategory // "") == "test-generation" then ":test_tube:"
         elif f.category == "product" then ":package:"
@@ -167,15 +181,15 @@ case "$MODE" in
       # pages real on-call groups (and, below, renders a Slack link), so only
       # a genuine string counts either way.
       def has_url(x): (x | type) == "string" and (x | length) > 0;
-      # Only render a knownIssue/URL-style link when the URL is actually a
-      # present, non-empty string — the same has_url() rule the medic-ping
-      # triggers use. Without this, a schema-violating non-string value (true,
-      # 42, {}) would stringify via s()/tostring into something non-empty and
-      # render as a garbage Slack link (<true>, <42>) instead of falling back
-      # to "(no URL recorded)".
-      def link_or_note(url; linklabel):
-        if has_url(url) then "\n    " + linklabel + ": <" + s(url; "") + ">"
-        else "\n    " + linklabel + ": (no URL recorded)" end;
+      # Compact icon+link, e.g. ":ticket: <url>" — no text label, the icon
+      # carries the meaning (matches the rest of this compact per-finding
+      # line). Only rendered when the URL is actually a present, non-empty
+      # string — the same has_url() rule the medic-ping triggers use, so a
+      # schema-violating non-string value (true, 42, {}) is silently omitted
+      # here rather than rendered as a garbage link (<true>, <42>). Omitting
+      # (not a "(no URL recorded)" fallback) is deliberate: this compact line
+      # only shows what IS there, it does not call out what is missing.
+      def compactLink(url; icon): if has_url(url) then icon + " <" + s(url; "") + ">" else "" end;
       # Owner→medic Slack subteam mentions — pings the actual on-call group,
       # not plain text (same mechanism as the camunda/camunda AlwaysGreen
       # feedback.mjs / alwaysgreen-streak-detector.yml). Fires on:
@@ -203,21 +217,26 @@ case "$MODE" in
       # top-level summary message) so it stays precise, not a blanket ping.
       def hub_medic: "<!subteam^S014VK4482H|hub-medic>";
       def test_automation_medic: "<!subteam^S09UF0EV0HG|test-automation-medic>";
+      # Compact per-finding line: title (category, operationId, short
+      # expected/actual) + one links line (icon+URL only, whichever are
+      # present — nothing shown for whichever are absent) + medic ping(s) +
+      # any operational error warnings. Full detail (the full agent
+      # reasoning, response bodies, etc.) lives in the linked issue, PR, or
+      # nightly run, not repeated here — this is a pointer, not the evidence.
       def line(f):
         (((f.action // "") == "fix-pr" and has_url(f.fix_pr_url)) or has_url(f.suppress_pr_url)) as $needs_ta_medic
-        | "• " + icon(f) + " *" + catlabel(f) + "* — `"
-        + s(f.spec // f.operationId; "?") + "` — " + s(f.test; "")
-        + "\n    expected: " + cap(f.expected; "?"; 120) + "  |  actual: " + cap(f.actual; "?"; 120)
-        + (if (f.known_issue // false) then link_or_note(f.known_issue_url; ":ticket: known issue") else "" end)
-        + (if (f.related_commit // null) != null then "\n    :fast_forward: skipped — explained by recent change: " + s(f.related_commit; "") else "" end)
-        + (if (f.issue_url // null) != null then link_or_note(f.issue_url; ":memo: filed") else "" end)
+        | ([
+            (if (f.known_issue // false) then compactLink(f.known_issue_url; ":ticket:") else "" end),
+            (if (f.related_commit // null) != null then ":fast_forward: recent change" else "" end),
+            compactLink(f.issue_url; ":memo:"),
+            compactLink(f.fix_pr_url; if (f.action // "") == "skip" then ":recycle:" else ":hammer_and_wrench:" end),
+            compactLink(f.suppress_pr_url; ":no_entry:")
+          ] | map(select(length > 0)) | join("  ")) as $links_line
+        | "• " + icon(f) + " " + catlabel(f) + " — `" + s(f.operationId; "?")
+        + "` — expected " + leadNum(f.expected; "?") + ", got " + leadNum(f.actual; "?")
+        + (if ($links_line | length) > 0 then "\n    " + $links_line else "" end)
         + (if (f.action // "") == "file" and has_url(f.issue_url)
            then "\n    :rotating_light: " + hub_medic else "" end)
-        + (if (f.fix_pr_url // null) != null then
-             link_or_note(f.fix_pr_url;
-               if (f.action // "") == "skip" then ":recycle: already being fixed" else ":hammer_and_wrench: fix PR" end)
-           else "" end)
-        + (if (f.suppress_pr_url // null) != null then link_or_note(f.suppress_pr_url; ":no_entry: suppressed") else "" end)
         + (if $needs_ta_medic then "\n    :rotating_light: " + test_automation_medic else "" end)
         + (if (f.action // "") == "report-only" and ((f.file_error // "") != "") then
              (if (f.subcategory // "") == "test-generation"
@@ -228,13 +247,11 @@ case "$MODE" in
              "\n    :warning: could not suppress: " + s(f.suppress_error; "")
            else "" end);
       def uline(u):
-        "• :no_entry_sign: *unmapped* — `" + s(u.operationId; "?") + "` — no generated test"
-        + (if (u.fix_pr_url // null) != null then
-             link_or_note(u.fix_pr_url;
-               if (u.action // "") == "skip" then ":recycle: already being fixed" else ":hammer_and_wrench: fix PR" end)
-           else "" end)
-        + (if (u.action // "") == "fix-pr" and has_url(u.fix_pr_url)
-           then "\n    :rotating_light: " + test_automation_medic else "" end)
+        ((u.action // "") == "fix-pr" and has_url(u.fix_pr_url)) as $needs_ta_medic
+        | (compactLink(u.fix_pr_url; if (u.action // "") == "skip" then ":recycle:" else ":hammer_and_wrench:" end)) as $link
+        | "• :no_entry_sign: unmapped — `" + s(u.operationId; "?") + "` — no generated test"
+        + (if ($link | length) > 0 then "\n    " + $link else "" end)
+        + (if $needs_ta_medic then "\n    :rotating_light: " + test_automation_medic else "" end)
         + (if (u.action // "") == "report-only" and ((u.file_error // "") != "") then "\n    :warning: could not open fix PR: " + s(u.file_error; "") else "" end);
       # Guard against the schema being violated (e.g. failures/unmapped_operations
       # written as an object or string instead of an array) — arr() coerces


### PR DESCRIPTION
## Summary
- Real nightly Slack output showed `:wrench: infrastructure: 0` and `:game_die: flakiness: 0` cluttering the summary line — now only non-zero category counters are shown.
- Thread bullets repeated the full test title and verbose per-link filler text — now compacted to one operationId/expected/actual line plus a single combined links line.

Follow-up to #487 (merged) — that PR had already landed before this formatting fix was ready, so this is a separate PR off current `main` rather than a reopened #487.

## Test plan
- [x] Re-ran the full synthetic fixture battery (8 cases covering every medic-ping/category/link-type edge case) through both `summary` and `thread` modes — no change to trigger logic, only formatting
- [x] Verified against the exact real nightly scenario the user reported (`createVersion` failure) — output matches the selected compact format
- [x] `shellcheck` clean
- [x] `bash -n` syntax check clean