### PR TITLE
fix(nightly): include knownProblemDetailShapeGaps in the negative known-issues thread

### DIFF
--- a/.github/workflows/nightly-camunda-hub.yml
+++ b/.github/workflows/nightly-camunda-hub.yml
@@ -365,21 +365,25 @@ jobs:
                   return {}
           def as_list(v):
               return v if isinstance(v, list) else []
-          # Per-op knownIssue (from suppress/exclude entries) + suite-wide
-          # top-level knownIssues[] (skips not tied to a single op, e.g. the
-          # generator-level wrong-type-key skip). Guards for list/dict shapes so
-          # a wrong JSON shape can't throw here.
-          def known(c, entries_key):
+          # Per-op knownIssue (from suppress/exclude entries, one or more
+          # array keys per config — request-validation.json has both
+          # excludeOperations[] and the scenario-kind-scoped
+          # knownProblemDetailShapeGaps[], #484) + suite-wide top-level
+          # knownIssues[] (skips not tied to a single op, e.g. the
+          # generator-level wrong-type-key skip). Guards for list/dict shapes
+          # so a wrong JSON shape can't throw here.
+          def known(c, entries_keys):
               perop = [
                   e["knownIssue"]
-                  for e in as_list(c.get(entries_key))
+                  for key in entries_keys
+                  for e in as_list(c.get(key))
                   if isinstance(e, dict) and e.get("knownIssue")
               ]
               return perop + as_list(c.get("knownIssues"))
           pos = cfg("configs/camunda-hub/positive-suppress.json")
           neg = cfg("configs/camunda-hub/request-validation.json")
-          print(f"positive_known_issues={bullets(known(pos, 'suppress'))}")
-          print(f"negative_known_issues={bullets(known(neg, 'excludeOperations'))}")
+          print(f"positive_known_issues={bullets(known(pos, ['suppress']))}")
+          print(f"negative_known_issues={bullets(known(neg, ['excludeOperations', 'knownProblemDetailShapeGaps']))}")
           PY
 
       # Fetch the Slack bot token from Vault via the same GitHub OIDC/JWT auth used

--- a/tests/codegen/known-issue-summary-consistency.test.ts
+++ b/tests/codegen/known-issue-summary-consistency.test.ts
@@ -85,7 +85,7 @@ function inspectKnownIssues(
 // (config-file relative path, entry-array keys carrying per-entry knownIssue).
 const SOURCES: { file: string; entryKeys: string[] }[] = [
   { file: 'positive-suppress.json', entryKeys: ['suppress'] },
-  { file: 'request-validation.json', entryKeys: ['excludeOperations'] },
+  { file: 'request-validation.json', entryKeys: ['excludeOperations', 'knownProblemDetailShapeGaps'] },
 ];
 
 function configNames(): string[] {

--- a/tests/codegen/known-issue-summary-consistency.test.ts
+++ b/tests/codegen/known-issue-summary-consistency.test.ts
@@ -85,7 +85,10 @@ function inspectKnownIssues(
 // (config-file relative path, entry-array keys carrying per-entry knownIssue).
 const SOURCES: { file: string; entryKeys: string[] }[] = [
   { file: 'positive-suppress.json', entryKeys: ['suppress'] },
-  { file: 'request-validation.json', entryKeys: ['excludeOperations', 'knownProblemDetailShapeGaps'] },
+  {
+    file: 'request-validation.json',
+    entryKeys: ['excludeOperations', 'knownProblemDetailShapeGaps'],
+  },
 ];
 
 function configNames(): string[] {


### PR DESCRIPTION
## Summary
- camunda-hub#26447 (every 401 returns an empty body instead of a ProblemDetail) is tracked via `request-validation.json`'s `knownProblemDetailShapeGaps[]` (added in #484), a separate array from `excludeOperations[]`/`knownIssues[]`.
- The nightly's "Derive known-issue bullets" step only ever read the latter two arrays, so #26447 never showed up in the negative suite's "skipped due to known issues" Slack thread — even though it's a real, currently-active known-issue skip.
- `known()` now takes a list of entry-array keys instead of one; the negative-suite call includes `knownProblemDetailShapeGaps` alongside `excludeOperations`.
- `known-issue-summary-consistency.test.ts` had the identical blind spot (would not catch a future summary mismatch on a `knownProblemDetailShapeGaps` entry) — fixed the same way.

## Test plan
- [x] Extracted and ran the exact python aggregation block against the real config files — #26447 now appears in `negative_known_issues`, dedup on #26448 (2 ops sharing one issue) still works, #25801/#25926 unaffected
- [x] `npx vitest run tests/codegen/known-issue-summary-consistency.test.ts` — 4 passed
- [x] YAML re-parses cleanly