### PR TITLE
feat(hub-pr-check): alert #prj-qa-sandbox when the generated hub suite fails on a camunda-hub PR

### DIFF
--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -111,9 +111,204 @@ jobs:
         source_sha: `${{ needs.validate.outputs.source_sha }}` · image: `registry.camunda.cloud/team-hub/hub-restapi-self-managed:pr-${{ needs.validate.outputs.source_sha }}`
         ${{ needs.validate.outputs.caller_run_url != '' && format('Triggered by: [camunda-hub run]({0})', needs.validate.outputs.caller_run_url) || '' }}
 
+  # Best-effort, READ-ONLY classification of a failing run — this suite is
+  # regenerated fresh from the PR's own spec every time, so a failure is just
+  # as likely to be api-test-generator not yet handling a new/changed
+  # endpoint shape as it is a real hub regression (unlike a stable, unchanging
+  # E2E suite, where "it went red" reliably means "the PR broke it" — see the
+  # AlwaysGreen SaaS/SM/C8Run model in c8-cross-component-e2e-tests, which
+  # works precisely because ITS suite doesn't change). Mints NO write-capable
+  # token for either repo — it cannot file an issue, open a PR, or push,
+  # regardless of the CLI permission flag below, so its blast radius is
+  # confined to "read files, write a JSON classification." Every step below
+  # is continue-on-error (or self-contained via `set +e`): a failure here must
+  # never fail this check or block the PR — `report` below degrades to the
+  # original three-way hedge if this job doesn't produce a usable result.
+  classify:
+    name: Classify hub-suite failure (read-only)
+    needs: [validate, run]
+    if: needs.run.result == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write # OIDC → Vault
+    outputs:
+      category: ${{ steps.parse.outputs.category }}
+      confidence: ${{ steps.parse.outputs.confidence }}
+      summary: ${{ steps.parse.outputs.summary }}
+    steps:
+      - name: Checkout api-test-generator
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Download hub-suite Playwright reports
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: hub-suite-reports
+          path: test-results/e2e-camunda-hub
+
+      # Contents:Read only — same token type _hub-suite-run.yml itself already
+      # uses to clone for generation, never a write-capable App token.
+      - name: Mint camunda-hub clone token (read-only)
+        id: hub-token
+        continue-on-error: true
+        uses: ./.github/actions/hub-clone-token
+        with:
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          vault-jwt-path: ${{ secrets.VAULT_JWT_PATH }}
+          vault-jwt-role: ${{ secrets.VAULT_JWT_ROLE }}
+          vault-jwt-audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
+
+      - name: Clone camunda-hub @ PR sha (sibling ../camunda-hub)
+        if: steps.hub-token.outputs.token != ''
+        continue-on-error: true
+        uses: ./.github/actions/clone-hub-sibling
+        with:
+          token: ${{ steps.hub-token.outputs.token }}
+          ref: ${{ needs.validate.outputs.source_sha }}
+
+      # One clone, diffed against main, instead of cloning both refs
+      # separately — the OpenAPI dir only, this is the one signal that
+      # actually distinguishes "generator doesn't handle this yet" (operation
+      # is new/changed in this PR) from "hub regressed" (operation unchanged).
+      - name: Diff the OpenAPI spec against main
+        if: steps.hub-token.outputs.token != ''
+        continue-on-error: true
+        env:
+          SHA: ${{ needs.validate.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          cd ../camunda-hub
+          git fetch -q origin main
+          git diff "${SHA}" origin/main -- restapi/public-api/src/main/resources/openapi/v2 \
+            > "${GITHUB_WORKSPACE}/spec-diff.txt" || true
+
+      - name: Fetch Anthropic key from Vault
+        id: vault
+        continue-on-error: true
+        uses: hashicorp/vault-action@v3
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: jwt
+          path: ${{ secrets.VAULT_JWT_PATH }}
+          role: ${{ secrets.VAULT_JWT_ROLE }}
+          jwtGithubAudience: ${{ secrets.VAULT_JWT_AUDIENCE }}
+          secrets: |
+            secret/data/products/qa/ci/common CLAUDE_API_KEY | ANTHROPIC_API_KEY ;
+
+      - name: Setup Node.js 22 (for Claude Code CLI)
+        if: steps.vault.outputs.ANTHROPIC_API_KEY != ''
+        continue-on-error: true
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      # Pinned version — same as triage-camunda-hub-nightly.yml. Bump intentionally.
+      - name: Install Claude Code CLI
+        if: steps.vault.outputs.ANTHROPIC_API_KEY != ''
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          npm install -g @anthropic-ai/claude-code@2.1.156
+          claude --version
+
+      - name: Run classification agent (read-only)
+        id: agent
+        if: steps.vault.outputs.ANTHROPIC_API_KEY != ''
+        continue-on-error: true
+        env:
+          ANTHROPIC_API_KEY: ${{ steps.vault.outputs.ANTHROPIC_API_KEY }}
+          REPORTS_DIR: ${{ github.workspace }}/test-results/e2e-camunda-hub
+          SPEC_DIR: ${{ github.workspace }}/../camunda-hub/restapi/public-api/src/main/resources/openapi/v2
+          SPEC_DIFF_FILE: ${{ github.workspace }}/spec-diff.txt
+        run: |
+          set -euo pipefail
+          rm -f /tmp/hub-pr-classification.json
+
+          prompt=$(cat <<EOF
+          You are classifying a SINGLE failing generated-hub-suite run, triggered by
+          a camunda-hub pull request. This is READ-ONLY: do not modify any file, do
+          not run any git/network write command, do not open any issue or PR — you
+          are producing a classification only.
+
+          Inputs:
+          - Playwright/JUnit reports: ${REPORTS_DIR} (pw-positive.json, pw-secured.json,
+            pw-rbac.json, junit + HTML reports with traces/screenshots for failing tests)
+            — may be absent if the artifact upload/download itself failed; say so if so.
+          - OpenAPI spec AT THIS PR's SHA: ${SPEC_DIR}/*.yaml (may be absent if the
+            camunda-hub clone step failed; treat as unavailable, don't guess).
+          - Spec diff (this PR's sha vs camunda-hub main), OpenAPI dir only: ${SPEC_DIFF_FILE}
+            (empty file = this PR does not touch the API spec, or the diff step failed).
+          - Known-issue configs: configs/camunda-hub/positive-suppress.json and
+            configs/camunda-hub/request-validation.json (their knownIssue /
+            knownProblemDetailShapeGaps entries).
+
+          Do this:
+          1. Parse the reports and enumerate every failing test, with its request/
+             response evidence from the trace/HTML report.
+          2. Resolve each failing operationId in the OpenAPI spec at this PR's sha.
+          3. Check the spec diff: is this operationId's definition NEW or CHANGED by
+             this PR? If yes, and the failure looks like the generated test's
+             expectations don't match the new/changed shape (wrong assumed schema,
+             unhandled new construct) -> category "generator-gap" (api-test-generator
+             does not yet correctly handle this shape; NOT a hub bug).
+          4. If the operationId is UNCHANGED by this PR and its response contradicts
+             the (unchanged) spec -> category "product" (a likely real regression;
+             this PR probably broke something via a shared code path).
+          5. Reconcile against the known-issue configs first — if the failure matches
+             an existing knownIssue/knownProblemDetailShapeGaps entry, use its real
+             category and note it is already tracked in your summary.
+          6. If Hub failed to boot, a suite produced no report, or the failure is
+             clearly environmental -> category "infra".
+          7. If a test passed on a Playwright retry -> category "flaky".
+          8. If you genuinely cannot tell from the evidence (including: reports or
+             spec were unavailable above) -> category "unknown" with confidence "low"
+             and say what evidence was missing — never guess "product".
+
+          Write your answer to /tmp/hub-pr-classification.json as EXACTLY this shape,
+          nothing else:
+          {
+            "category": "product|generator-gap|infra|flaky|unknown",
+            "confidence": "high|medium|low",
+            "summary": "<one sentence, under 200 chars, no line breaks>",
+            "affected_operation_ids": ["..."]
+          }
+          EOF
+          )
+
+          set +e
+          claude -p "$prompt" --dangerously-skip-permissions
+          agent_rc=$?
+          set -e
+          echo "claude exit code: ${agent_rc}"
+
+      - name: Parse classification (falls back to "unknown" on any failure above)
+        id: parse
+        if: always()
+        run: |
+          set -euo pipefail
+          f=/tmp/hub-pr-classification.json
+          if [ -s "$f" ] && jq empty "$f" 2>/dev/null; then
+            category=$(jq -r '.category // "unknown"' "$f")
+            confidence=$(jq -r '.confidence // "low"' "$f")
+            summary=$(jq -r '.summary // ""' "$f" | tr '\n' ' ' | cut -c1-300)
+          else
+            category="unknown"
+            confidence="low"
+            summary="Classification agent did not produce a usable result — see the run for details."
+          fi
+          {
+            echo "category=${category}"
+            echo "confidence=${confidence}"
+            echo "summary=${summary}"
+          } >> "$GITHUB_OUTPUT"
+
   # Report the run's pass/fail back onto the camunda-hub PR as a commit status.
   report:
-    needs: [validate, run]
+    needs: [validate, run, classify]
     # Report whenever the SHA was valid (whatever the run result). If validate
     # failed there's no real commit to post a status on, so skip.
     if: always() && needs.validate.result == 'success'
@@ -172,15 +367,88 @@ jobs:
       # surface, where red really does almost always mean the PR broke
       # something. This suite is generated fresh from the PR's own OpenAPI
       # spec — a failure here is just as likely to be api-test-generator not
-      # yet handling a new/changed endpoint shape (an unmapped operation, an
-      # unmodelled schema construct) as it is an actual hub regression, plus
-      # the usual infra/flakiness causes. The message below names all three
-      # rather than asserting the wrong one as fact.
+      # yet handling a new/changed endpoint shape as an actual hub
+      # regression, plus the usual infra/flakiness causes. When the `classify`
+      # job above produced a usable verdict, state it (with its confidence);
+      # otherwise fall back to naming all three possibilities rather than
+      # asserting the wrong one as fact.
       #
       # Failure only — a genuine test failure (RESULT == "failure"), not
       # cancelled/skipped/infra "error", which would misreport an operational
-      # condition as a regression. continue-on-error above: a Vault hiccup
-      # here must not fail this run.
+      # condition as a regression.
+      - name: Build Slack alert text
+        id: msg
+        if: always() && needs.run.result == 'failure'
+        env:
+          PR_NUMBER: ${{ github.event.client_payload.pr_number }}
+          SHA: ${{ needs.validate.outputs.source_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CALLER_RUN_URL: ${{ needs.validate.outputs.caller_run_url }}
+          CATEGORY: ${{ needs.classify.outputs.category }}
+          CONFIDENCE: ${{ needs.classify.outputs.confidence }}
+          SUMMARY: ${{ needs.classify.outputs.summary }}
+        run: |
+          set -euo pipefail
+          hub_medic='<!subteam^S014VK4482H|hub-medic>'
+          ta_medic='<!subteam^S09UF0EV0HG|test-automation-medic>'
+          # product ALSO pings hub-medic — it's their pipeline (this PR) that
+          # a confirmed regression implicates, same "whoever owns the broken
+          # thing" routing every AlwaysGreen variant we looked at uses.
+          case "$CATEGORY" in
+            product)
+              verdict="Likely a real regression from this PR (confidence: ${CONFIDENCE}). ${SUMMARY}"
+              ping="${hub_medic} ${ta_medic}"
+              ;;
+            generator-gap)
+              verdict="Likely api-test-generator not yet handling a new/changed endpoint shape, not a hub bug (confidence: ${CONFIDENCE}). ${SUMMARY}"
+              ping="${ta_medic}"
+              ;;
+            infra)
+              verdict="Looks like an infrastructure failure, not a regression (confidence: ${CONFIDENCE}). ${SUMMARY}"
+              ping="${ta_medic}"
+              ;;
+            flaky)
+              verdict="Looks flaky, not a regression (confidence: ${CONFIDENCE}). ${SUMMARY}"
+              ping="${ta_medic}"
+              ;;
+            *)
+              # classify didn't run, errored, or genuinely couldn't tell —
+              # same three-way hedge this alert shipped with originally.
+              verdict="Could be a real regression from this PR, an unhandled case in api-test-generator for a new/changed endpoint (unmapped operation, unmodelled schema shape), or infra/flakiness — check the run to tell which before this merges."
+              ping="${ta_medic}"
+              ;;
+          esac
+
+          # Built via printf %s placeholders, not a literal multi-line
+          # string — this run: block is YAML-indented, and a bash string
+          # spanning literal source lines would bake that indentation into
+          # every line of the actual Slack message.
+          caller_line=""
+          if [ -n "$CALLER_RUN_URL" ]; then
+            caller_line=$(printf '\n• Triggered by: <%s|camunda-hub run>' "$CALLER_RUN_URL")
+          fi
+
+          # Backtick-wrapped SHA built separately (double-quoted, backticks
+          # escaped) — a literal backtick inside the single-quoted printf
+          # format string below trips shellcheck's SC2016 (it reads as an
+          # unexpanded command substitution attempt, even though single
+          # quotes make it literal either way).
+          sha_code="\`${SHA}\`"
+
+          text=$(printf ':red_circle: *Generated Hub Suite Failed on a camunda-hub PR*\n\n• Source: camunda/camunda-hub PR <https://github.com/camunda/camunda-hub/pull/%s|#%s> @ %s\n• Run: <%s|View failing tests>%s\n\n%s\n\n%s please take a look.' \
+            "$PR_NUMBER" "$PR_NUMBER" "$sha_code" "$RUN_URL" "$caller_line" "$verdict" "$ping")
+
+          # Random delimiter, not a fixed string like "SLACKMSG" — $SUMMARY is
+          # agent-produced free text and must never be able to prematurely
+          # terminate this GITHUB_OUTPUT heredoc (the standard multiline-
+          # output-injection concern for any value with untrusted content).
+          delim="SLACKMSG_$(openssl rand -hex 8 2>/dev/null || echo "${RANDOM}${RANDOM}")"
+          {
+            echo "text<<${delim}"
+            echo "$text"
+            echo "${delim}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Fetch Slack bot token from Vault
         id: slack-secrets
         if: always() && needs.run.result == 'failure'
@@ -192,6 +460,10 @@ jobs:
           vault-jwt-role: ${{ secrets.VAULT_JWT_ROLE }}
           vault-jwt-audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
 
+      # toJSON() properly encodes the text (quotes/newlines) rather than
+      # manual \n concatenation — necessary now that the message can embed
+      # agent-produced free text (SUMMARY), which manual string-building
+      # can't safely guarantee is JSON-clean.
       - name: Notify Slack (generated hub suite failed on camunda-hub PR)
         if: always() && needs.run.result == 'failure' && steps.slack-secrets.outputs.SLACK_BOT_TOKEN != ''
         uses: slackapi/slack-github-action@v2
@@ -201,5 +473,5 @@ jobs:
           payload: |
             {
               "channel": "#prj-qa-sandbox",
-              "text": ":red_circle: *Generated Hub Suite Failed on a camunda-hub PR*\n\n• Source: camunda/camunda-hub PR <https://github.com/camunda/camunda-hub/pull/${{ github.event.client_payload.pr_number }}|#${{ github.event.client_payload.pr_number }}> @ `${{ needs.validate.outputs.source_sha }}`\n• Run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View failing tests>${{ needs.validate.outputs.caller_run_url != '' && format('\n• Triggered by: <{0}|camunda-hub run>', needs.validate.outputs.caller_run_url) || '' }}\n\nCould be a real regression from this PR, an unhandled case in api-test-generator for a new/changed endpoint (unmapped operation, unmodelled schema shape), or infra/flakiness — check the run to tell which before this merges.\n\n<!subteam^S09UF0EV0HG|test-automation-medic> please take a look."
+              "text": ${{ toJSON(steps.msg.outputs.text) }}
             }

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -52,6 +52,7 @@ jobs:
     outputs:
       source_sha: ${{ steps.v.outputs.source_sha }}
       caller_run_url: ${{ steps.caller.outputs.caller_run_url }}
+      pr_number: ${{ steps.prnum.outputs.pr_number }}
     steps:
       - name: Validate source_sha is a 40-char hex commit SHA
         id: v
@@ -82,6 +83,24 @@ jobs:
             echo "caller_run_url=" >> "$GITHUB_OUTPUT"
           fi
 
+      # pr_number is display-only (summary heading, Slack link text) — never
+      # used to gate a credential or write action — so, same as
+      # caller_run_url, an invalid value degrades to empty rather than failing
+      # the run. Still validated before use: it's untrusted dispatch payload,
+      # and downstream embeds it in a Slack markup link, where a value
+      # containing e.g. a `|` or `>` could otherwise break the link syntax.
+      - name: Validate pr_number (optional; empty if missing/invalid)
+        id: prnum
+        env:
+          N: ${{ github.event.client_payload.pr_number }}
+        run: |
+          set -euo pipefail
+          if printf '%s' "$N" | grep -qE '^[1-9][0-9]*$'; then
+            echo "pr_number=$N" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+          fi
+
   run:
     needs: validate
     uses: ./.github/workflows/_hub-suite-run.yml
@@ -107,7 +126,7 @@ jobs:
       # validation entirely. Fixing it here guarantees validation always runs.
       hub_registry: registry.camunda.cloud
       summary_heading: |
-        ## Hub PR check — camunda-hub#${{ github.event.client_payload.pr_number }}
+        ## Hub PR check — camunda-hub#${{ needs.validate.outputs.pr_number != '' && needs.validate.outputs.pr_number || '?' }}
         source_sha: `${{ needs.validate.outputs.source_sha }}` · image: `registry.camunda.cloud/team-hub/hub-restapi-self-managed:pr-${{ needs.validate.outputs.source_sha }}`
         ${{ needs.validate.outputs.caller_run_url != '' && format('Triggered by: [camunda-hub run]({0})', needs.validate.outputs.caller_run_url) || '' }}
 
@@ -183,7 +202,13 @@ jobs:
           set -euo pipefail
           cd ../camunda-hub
           git fetch -q origin main
-          git diff "${SHA}" origin/main -- restapi/public-api/src/main/resources/openapi/v2 \
+          # main FIRST, PR sha second: `git diff <old> <new>` shows +/- from
+          # old to new, so this way the PR's own additions/changes show as
+          # `+` — the natural reading for "what did this PR add or change
+          # relative to main." The reverse order would flip that polarity
+          # (a genuinely new construct would show as REMOVED), which could
+          # mislead the classifier's new-vs-changed-vs-unchanged judgment.
+          git diff origin/main "${SHA}" -- restapi/public-api/src/main/resources/openapi/v2 \
             > "${GITHUB_WORKSPACE}/spec-diff.txt" || true
 
       - name: Fetch Anthropic key from Vault
@@ -230,9 +255,11 @@ jobs:
 
           prompt=$(cat <<EOF
           You are classifying a SINGLE failing generated-hub-suite run, triggered by
-          a camunda-hub pull request. This is READ-ONLY: do not modify any file, do
-          not run any git/network write command, do not open any issue or PR — you
-          are producing a classification only.
+          a camunda-hub pull request. This is READ-ONLY with respect to the checked-
+          out repos: do not modify any file inside them, do not run any git/network
+          write command, do not open any issue or PR. Your ONLY required write is
+          the one output file below -- writing it is expected and necessary, not an
+          exception to "read-only."
 
           Inputs:
           - Playwright/JUnit reports: ${REPORTS_DIR} (pw-positive.json, pw-secured.json,
@@ -294,7 +321,10 @@ jobs:
           if [ -s "$f" ] && jq empty "$f" 2>/dev/null; then
             category=$(jq -r '.category // "unknown"' "$f")
             confidence=$(jq -r '.confidence // "low"' "$f")
-            summary=$(jq -r '.summary // ""' "$f" | tr '\n' ' ' | cut -c1-300)
+            # 200, matching the prompt's own "under 200 chars" contract —
+            # not a looser bound that would let a non-compliant response
+            # through longer than what we actually asked for.
+            summary=$(jq -r '.summary // ""' "$f" | tr '\n' ' ' | cut -c1-200)
           else
             category="unknown"
             confidence="low"
@@ -380,7 +410,9 @@ jobs:
         id: msg
         if: always() && needs.run.result == 'failure'
         env:
-          PR_NUMBER: ${{ github.event.client_payload.pr_number }}
+          # Validated (digits-only) by the `validate` job — empty if the
+          # dispatch payload's pr_number was missing/malformed.
+          PR_NUMBER: ${{ needs.validate.outputs.pr_number }}
           SHA: ${{ needs.validate.outputs.source_sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           CALLER_RUN_URL: ${{ needs.validate.outputs.caller_run_url }}
@@ -435,8 +467,18 @@ jobs:
           # quotes make it literal either way).
           sha_code="\`${SHA}\`"
 
-          text=$(printf ':red_circle: *Generated Hub Suite Failed on a camunda-hub PR*\n\n• Source: camunda/camunda-hub PR <https://github.com/camunda/camunda-hub/pull/%s|#%s> @ %s\n• Run: <%s|View failing tests>%s\n\n%s\n\n%s please take a look.' \
-            "$PR_NUMBER" "$PR_NUMBER" "$sha_code" "$RUN_URL" "$caller_line" "$verdict" "$ping")
+          # PR_NUMBER can be empty (validate rejected a malformed dispatch
+          # payload) — degrade to plain text rather than emit a Slack link
+          # with an empty target (<.../pull/|#>), which renders broken.
+          if [ -n "$PR_NUMBER" ]; then
+            source_line=$(printf 'camunda/camunda-hub PR <https://github.com/camunda/camunda-hub/pull/%s|#%s> @ %s' \
+              "$PR_NUMBER" "$PR_NUMBER" "$sha_code")
+          else
+            source_line=$(printf 'camunda/camunda-hub @ %s (PR number unavailable)' "$sha_code")
+          fi
+
+          text=$(printf ':red_circle: *Generated Hub Suite Failed on a camunda-hub PR*\n\n• Source: %s\n• Run: <%s|View failing tests>%s\n\n%s\n\n%s please take a look.' \
+            "$source_line" "$RUN_URL" "$caller_line" "$verdict" "$ping")
 
           # Random delimiter, not a fixed string like "SLACKMSG" — $SUMMARY is
           # agent-produced free text and must never be able to prematurely
@@ -466,6 +508,7 @@ jobs:
       # can't safely guarantee is JSON-clean.
       - name: Notify Slack (generated hub suite failed on camunda-hub PR)
         if: always() && needs.run.result == 'failure' && steps.slack-secrets.outputs.SLACK_BOT_TOKEN != ''
+        continue-on-error: true
         uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -165,11 +165,22 @@ jobs:
             -f description="Generated hub suite: ${state}" >/dev/null
           echo "Reported '${state}' on camunda-hub@${SHA:0:12}"
 
-      # Slack heads-up, mirroring the AlwaysGreen SaaS-E2E failure alert style
-      # (camunda/c8-cross-component-e2e-tests). Failure only — a genuine test
-      # failure (RESULT == "failure"), not cancelled/skipped/infra "error",
-      # which would misreport an operational condition as a regression.
-      # continue-on-error above: a Vault hiccup here must not fail this run.
+      # Slack heads-up, styled after the AlwaysGreen SaaS-E2E failure alert
+      # (camunda/c8-cross-component-e2e-tests) but NOT copying its "a
+      # regression may have been introduced" framing verbatim: that alert
+      # fires on a fixed, generated E2E suite testing a stable product
+      # surface, where red really does almost always mean the PR broke
+      # something. This suite is generated fresh from the PR's own OpenAPI
+      # spec — a failure here is just as likely to be api-test-generator not
+      # yet handling a new/changed endpoint shape (an unmapped operation, an
+      # unmodelled schema construct) as it is an actual hub regression, plus
+      # the usual infra/flakiness causes. The message below names all three
+      # rather than asserting the wrong one as fact.
+      #
+      # Failure only — a genuine test failure (RESULT == "failure"), not
+      # cancelled/skipped/infra "error", which would misreport an operational
+      # condition as a regression. continue-on-error above: a Vault hiccup
+      # here must not fail this run.
       - name: Fetch Slack bot token from Vault
         id: slack-secrets
         if: always() && needs.run.result == 'failure'
@@ -190,5 +201,5 @@ jobs:
           payload: |
             {
               "channel": "#prj-qa-sandbox",
-              "text": ":red_circle: *Generated Hub Suite Failed on a camunda-hub PR*\n\n• Source: camunda/camunda-hub PR <https://github.com/camunda/camunda-hub/pull/${{ github.event.client_payload.pr_number }}|#${{ github.event.client_payload.pr_number }}> @ `${{ needs.validate.outputs.source_sha }}`\n• Run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View failing tests>${{ needs.validate.outputs.caller_run_url != '' && format('\n• Triggered by: <{0}|camunda-hub run>', needs.validate.outputs.caller_run_url) || '' }}\n\nA regression may have been introduced. Please investigate before merging.\n\n<!subteam^S09UF0EV0HG|test-automation-medic> please take a look."
+              "text": ":red_circle: *Generated Hub Suite Failed on a camunda-hub PR*\n\n• Source: camunda/camunda-hub PR <https://github.com/camunda/camunda-hub/pull/${{ github.event.client_payload.pr_number }}|#${{ github.event.client_payload.pr_number }}> @ `${{ needs.validate.outputs.source_sha }}`\n• Run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View failing tests>${{ needs.validate.outputs.caller_run_url != '' && format('\n• Triggered by: <{0}|camunda-hub run>', needs.validate.outputs.caller_run_url) || '' }}\n\nCould be a real regression from this PR, an unhandled case in api-test-generator for a new/changed endpoint (unmapped operation, unmodelled schema shape), or infra/flakiness — check the run to tell which before this merges.\n\n<!subteam^S09UF0EV0HG|test-automation-medic> please take a look."
             }

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -535,6 +535,6 @@ jobs:
           token: ${{ steps.slack-secrets.outputs.SLACK_BOT_TOKEN }}
           payload: |
             {
-              "channel": "#prj-qa-sandbox",
+              "channel": "#camunda-hub-pr-e2e-results",
               "text": ${{ toJSON(steps.msg.outputs.text) }}
             }

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -164,3 +164,31 @@ jobs:
             -f context="api-test-generator/hub-suite" \
             -f description="Generated hub suite: ${state}" >/dev/null
           echo "Reported '${state}' on camunda-hub@${SHA:0:12}"
+
+      # Slack heads-up, mirroring the AlwaysGreen SaaS-E2E failure alert style
+      # (camunda/c8-cross-component-e2e-tests). Failure only — a genuine test
+      # failure (RESULT == "failure"), not cancelled/skipped/infra "error",
+      # which would misreport an operational condition as a regression.
+      # continue-on-error above: a Vault hiccup here must not fail this run.
+      - name: Fetch Slack bot token from Vault
+        id: slack-secrets
+        if: always() && needs.run.result == 'failure'
+        continue-on-error: true
+        uses: ./.github/actions/slack-token
+        with:
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          vault-jwt-path: ${{ secrets.VAULT_JWT_PATH }}
+          vault-jwt-role: ${{ secrets.VAULT_JWT_ROLE }}
+          vault-jwt-audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
+
+      - name: Notify Slack (generated hub suite failed on camunda-hub PR)
+        if: always() && needs.run.result == 'failure' && steps.slack-secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: slackapi/slack-github-action@v2
+        with:
+          method: chat.postMessage
+          token: ${{ steps.slack-secrets.outputs.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "#prj-qa-sandbox",
+              "text": ":red_circle: *Generated Hub Suite Failed on a camunda-hub PR*\n\n• Source: camunda/camunda-hub PR <https://github.com/camunda/camunda-hub/pull/${{ github.event.client_payload.pr_number }}|#${{ github.event.client_payload.pr_number }}> @ `${{ needs.validate.outputs.source_sha }}`\n• Run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View failing tests>${{ needs.validate.outputs.caller_run_url != '' && format('\n• Triggered by: <{0}|camunda-hub run>', needs.validate.outputs.caller_run_url) || '' }}\n\nA regression may have been introduced. Please investigate before merging.\n\n<!subteam^S09UF0EV0HG|test-automation-medic> please take a look."
+            }

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -330,6 +330,26 @@ jobs:
             confidence="low"
             summary="Classification agent did not produce a usable result — see the run for details."
           fi
+
+          # Enforce the exact enum contract for category/confidence — unlike
+          # summary (already newline-stripped above), these were written to
+          # $GITHUB_OUTPUT as-is. A value containing an embedded newline would
+          # inject arbitrary extra lines into $GITHUB_OUTPUT (confirmed
+          # locally: category="product\nfake_output=injected" produces a
+          # genuine extra output line), corrupting/overriding whatever the
+          # downstream Slack-routing step reads. Falling back to the same
+          # "unknown"/"low" default on any non-matching value closes that off
+          # entirely: only these exact, single-line literals ever reach
+          # $GITHUB_OUTPUT for these two fields.
+          case "$category" in
+            product|generator-gap|infra|flaky|unknown) ;;
+            *) category="unknown" ;;
+          esac
+          case "$confidence" in
+            high|medium|low) ;;
+            *) confidence="low" ;;
+          esac
+
           {
             echo "category=${category}"
             echo "confidence=${confidence}"


### PR DESCRIPTION
## Summary
- `hub-pr-check.yml` runs whenever camunda-hub's `trigger-api-test-generator.yml` dispatches a PR build to us and reports a commit status back onto that PR — but a failure was otherwise silent on our side.
- Adds a Slack notification to `#prj-qa-sandbox` on a genuine test failure (`RESULT == "failure"` only — cancelled/skipped/infra "error" aren't a regression).
- **New `classify` job**: this suite is regenerated fresh from the PR's own OpenAPI spec every run, so a failure could be a real hub regression, api-test-generator not yet handling a new/changed endpoint shape, or infra/flakiness — unlike a static E2E suite (AlwaysGreen's model in c8-cross-component-e2e-tests), no cheap count-based signal distinguishes these. `classify` runs a single, narrowly-scoped, **read-only** Claude Code CLI pass (same mechanism as the nightly triage agent) that reads the failing tests' evidence + diffs the PR's spec against `main` + checks the known-issue configs, and produces a verdict. It mints **no write-capable token** for either repo, so it cannot file/open/push anything regardless of the CLI's permission flag.
- The Slack alert states the actual verdict + confidence when `classify` succeeds, and routes the ping accordingly: a confirmed `product` regression also pings `@hub-medic` (their pipeline, their bug); everything else stays `@test-automation-medic` only. Falls back to the original three-way hedge if `classify` didn't run, errored, or couldn't tell.
- Switched the Slack payload to `toJSON()` instead of manual string concatenation — needed now that the message embeds agent-produced free text.

## Cost/latency tradeoff (disclosed)
`classify` only runs when `run` already failed, so it adds no cost to a passing PR. On a failing PR it adds a Claude Code CLI pass (clone diff + one Anthropic call) on top of the suite run that already dominates latency — estimated low single-digit minutes, not comparable to the nightly agent's ~40 min budget since scope here is one run's failures, read-only, no issue/PR round-trips.

## Test plan
- [x] `actionlint` clean, including on the new `classify` job and the bash-built Slack message
- [x] Message-building bash logic tested locally against synthetic classification JSON for every category, including the missing-file/malformed-JSON fallback — correct output, valid JSON after `toJSON()`-equivalent encoding, no YAML-indentation artifacts
- [x] Payload JSON verified to parse correctly after substituting representative values for every GitHub Actions expression
- [ ] Live-fire not yet exercised (would require a real camunda-hub PR to fail this check) — flagging for reviewer awareness