### PR TITLE
feat(spec-bump): automatically detect field-level schema changes

### DIFF
--- a/.github/scripts/spec-bump-open-pr.sh
+++ b/.github/scripts/spec-bump-open-pr.sh
@@ -111,6 +111,19 @@ body_file="$(mktemp)"
   echo "🗑️ **Operations removed** (${N_REMOVED}):"
   list_or_none "${REMOVED:-}"
   echo
+  # Only shown when there's something to show (#492) — the common case is no
+  # field-level change, and an empty section every PR would just be clutter.
+  # Newly-required request properties never reach here: they gate this PR
+  # path entirely and route to the tracking issue instead (see fielddiff's
+  # has_newly_required check in the workflow).
+  if [ "${N_FIELD_ADDED:-0}" != "0" ] || [ "${N_FIELD_REMOVED:-0}" != "0" ]; then
+    echo "🔬 **Field-level schema changes** within existing operations (informational — additive/optional changes need no generator update; see #492):"
+    echo "- Added (${N_FIELD_ADDED:-0}):"
+    list_or_none "${FIELD_ADDED:-}"
+    echo "- Removed (${N_FIELD_REMOVED:-0}):"
+    list_or_none "${FIELD_REMOVED:-}"
+    echo
+  fi
   echo "✅ Validated green by the check: [generate + invariants run](${run_url})."
   echo "⚠️ If CI here flags any invariant whose value legitimately changed, update \`configs/${CONFIG}/regression-invariants.test.ts\` in this PR before merging."
   echo

--- a/.github/scripts/spec-bump-report.sh
+++ b/.github/scripts/spec-bump-report.sh
@@ -10,8 +10,11 @@
 # UPSTREAM_BRANCH, PINNED, LATEST, N_ADDED, N_REMOVED, ADDED, REMOVED,
 # GEN_OUTCOME, INV_OUTCOME. Optional: UNMAPPED (comma-separated operationIds
 # with no generated test coverage — see the "Check for unmapped operations"
-# step; empty when generate didn't succeed or nothing's unmapped). GitHub
-# provides GITHUB_* automatically.
+# step; empty when generate didn't succeed or nothing's unmapped). NEWLY_REQUIRED
+# (#492; newline-separated "operationId (side): property (type)" lines — a
+# request property that's brand-new-and-required, or flipped from optional to
+# required, with no existing fixture; see the "Diff field-level schema changes"
+# step) / N_NEWLY_REQUIRED. GitHub provides GITHUB_* automatically.
 set -euo pipefail
 
 : "${GH_TOKEN:?GH_TOKEN required for gh auth}"
@@ -22,6 +25,8 @@ N_REMOVED="${N_REMOVED:-0}"
 GEN_OUTCOME="${GEN_OUTCOME:-unknown}"
 INV_OUTCOME="${INV_OUTCOME:-unknown}"
 UNMAPPED="${UNMAPPED:-}"
+NEWLY_REQUIRED="${NEWLY_REQUIRED:-}"
+N_NEWLY_REQUIRED="${N_NEWLY_REQUIRED:-0}"
 
 # shellcheck source=.github/scripts/spec-bump-common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/spec-bump-common.sh"
@@ -42,10 +47,18 @@ body_file="$(mktemp)"
   echo "| Generate pipeline | $(emoji "$GEN_OUTCOME") \`${GEN_OUTCOME}\` |"
   echo "| Regression invariants | $(emoji "$INV_OUTCOME") \`${INV_OUTCOME}\` |"
   echo "| Unmapped (uncovered) operations | $([ -n "$UNMAPPED" ] && echo "❌ ${UNMAPPED}" || echo "✅ none") |"
+  echo "| Newly-required properties (no fixture) | $([ "$N_NEWLY_REQUIRED" != "0" ] && echo "❌ ${N_NEWLY_REQUIRED}" || echo "✅ none") |"
   echo "| Operations added / removed | ${N_ADDED} / ${N_REMOVED} |"
   echo
   if [ -n "$UNMAPPED" ]; then
     echo "⚠️ **Generate and invariants both passed, but this is still not safe to auto-adopt**: \`${UNMAPPED}\` has no generated test coverage at all (no entity-kind/scenario-template maps it, and it's not in \`positive-suppress.json\` either) — model it before bumping, or add it to the suppress list with a tracked reason."
+    echo
+  fi
+  if [ "$N_NEWLY_REQUIRED" != "0" ]; then
+    echo "⚠️ **Generate and invariants both passed, but this is still not safe to auto-adopt** (#492): the properties below are brand-new-and-required, or flipped from optional to required, on an EXISTING operation's request body — no existing fixture provides them, so requests built from this pin's minimal request bodies may now 400 where they didn't before. Add a fixture/semantic-type mapping (see \`resourceFixtures\`/\`pathResourceFixtures\` in \`configs/${CONFIG}/request-validation.json\`) before bumping."
+    echo
+    echo "🆕 **Newly-required properties**:"
+    list_or_none "${NEWLY_REQUIRED}"
     echo
   fi
   echo "🆕 **Added operations** (new upstream surface to model):"
@@ -67,6 +80,7 @@ body_file="$(mktemp)"
 gh label create "$DRIFT_LABEL" --color BFD4F2 --description "Upstream spec drifted from the pin (spec-bump check)" 2>/dev/null || true
 gh label create auto-generated --color ededed --description "Opened by automation, not a human" 2>/dev/null || true
 gh label create missing-coverage --color D93F0B --description "A spec operation has no generated test coverage" 2>/dev/null || true
+gh label create needs-fixture --color D93F0B --description "A newly-required request property has no existing fixture (#492)" 2>/dev/null || true
 
 # --- Find the rolling issue by exact title ----------------------------------
 existing="$(find_rolling_issue)"
@@ -90,7 +104,13 @@ if [ -n "$existing" ]; then
   else
     gh issue edit "$existing" --remove-label missing-coverage >/dev/null 2>&1 || true
   fi
-  gh issue comment "$existing" --body "🔁 Re-checked against \`${LATEST}\` — still drifted (generate: \`${GEN_OUTCOME}\`, invariants: \`${INV_OUTCOME}\`, unmapped: \`${UNMAPPED:-none}\`, +${N_ADDED}/-${N_REMOVED} ops). [Run](${run_url})" >/dev/null
+  # Same sync pattern as missing-coverage above, for the newly-required-field blocker (#492).
+  if [ "$N_NEWLY_REQUIRED" != "0" ]; then
+    gh issue edit "$existing" --add-label needs-fixture >/dev/null || true
+  else
+    gh issue edit "$existing" --remove-label needs-fixture >/dev/null 2>&1 || true
+  fi
+  gh issue comment "$existing" --body "🔁 Re-checked against \`${LATEST}\` — still drifted (generate: \`${GEN_OUTCOME}\`, invariants: \`${INV_OUTCOME}\`, unmapped: \`${UNMAPPED:-none}\`, newly-required: \`${N_NEWLY_REQUIRED}\`, +${N_ADDED}/-${N_REMOVED} ops). [Run](${run_url})" >/dev/null
 else
   echo "Opening new tracking issue"
   # Create with only the always-present labels — if missing-coverage's create
@@ -101,6 +121,9 @@ else
   echo "Opened ${new_url}"
   if [ -n "$UNMAPPED" ]; then
     gh issue edit "${new_url##*/}" --add-label missing-coverage >/dev/null || true
+  fi
+  if [ "$N_NEWLY_REQUIRED" != "0" ]; then
+    gh issue edit "${new_url##*/}" --add-label needs-fixture >/dev/null || true
   fi
 fi
 

--- a/.github/workflows/spec-bump-check.yml
+++ b/.github/workflows/spec-bump-check.yml
@@ -178,6 +178,11 @@ jobs:
           fi
           npm run -s spec-operations > /tmp/pinned-ops.txt
           echo "Pinned operations: $(wc -l < /tmp/pinned-ops.txt)"
+          # Companion field-level fingerprint (#492) — spec-operations.ts only
+          # sees whole operationIds, so a property added/removed/newly-required
+          # WITHIN an existing operation is otherwise invisible until a human
+          # hand-diffs the upstream YAML (as happened investigating #494).
+          npm run -s spec-fields > /tmp/pinned-fields.json
 
       # Fetch latest LAST so the latest bundle is what generate + invariants see
       # (and, for hub, so the sibling is left checked out at latest for the bump).
@@ -197,6 +202,7 @@ jobs:
           fi
           npm run -s spec-operations > /tmp/latest-ops.txt
           echo "Latest operations: $(wc -l < /tmp/latest-ops.txt)"
+          npm run -s spec-fields > /tmp/latest-fields.json
 
       - name: Diff operation surface
         id: opdiff
@@ -245,6 +251,53 @@ jobs:
           else
             echo "content_changed=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # #492: catches a property added/removed/newly-required WITHIN an
+      # EXISTING operation — spec-operations.ts's diff above only sees whole
+      # operationIds, so this is otherwise invisible until a human hand-diffs
+      # the upstream YAML (as happened investigating #494's clusters.profiles
+      # addition). Gated on content_changed like generate/invariants below —
+      # a byte-identical bundle has nothing to field-diff either.
+      #
+      # A brand-new-or-newly-required REQUEST property is the one case that
+      # can silently need generator work (no existing fixture provides it) —
+      # spec-field-diff.ts exits 1 when it finds one, which becomes the
+      # has_newly_required gate below. Everything else (added/removed
+      # properties otherwise) is informational only, same as
+      # clusters.profiles: additive, optional, needed no generator change.
+      - name: Diff field-level schema changes
+        id: fielddiff
+        if: steps.refs.outputs.drifted == 'true' && steps.opdiff.outputs.content_changed == 'true'
+        run: |
+          set -euo pipefail
+          if npm run -s spec-field-diff -- /tmp/pinned-fields.json /tmp/latest-fields.json > /tmp/field-diff.json; then
+            echo "has_newly_required=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_newly_required=true" >> "$GITHUB_OUTPUT"
+          fi
+          # Rendered as "operationId (side): property (type)" lines, same
+          # capped-preview convention as opdiff's added/removed above — counts
+          # stay exact (from the full JSON), only the rendered preview is capped.
+          # shellcheck disable=SC2016  # single quotes intentional: ${...} are JS
+          # template refs evaluated by node, not shell expansions.
+          node -e '
+            const d = JSON.parse(require("fs").readFileSync("/tmp/field-diff.json", "utf8"));
+            const render = (c) => `${c.operationId} (${c.side}): ${c.property}` + (c.type ? ` (${c.type})` : "");
+            const cap = (arr) => arr.slice(0, 200).map(render).join("\n");
+            console.log("added<<EOF");
+            console.log(cap(d.added));
+            console.log("EOF");
+            console.log("removed<<EOF");
+            console.log(cap(d.removed));
+            console.log("EOF");
+            console.log("newly_required<<EOF");
+            console.log(cap(d.newlyRequired));
+            console.log("EOF");
+            console.log(`n_added=${d.added.length}`);
+            console.log(`n_removed=${d.removed.length}`);
+            console.log(`n_newly_required=${d.newlyRequired.length}`);
+          ' >> "$GITHUB_OUTPUT"
+          echo "Field changes — added: $(node -e "console.log(JSON.parse(require('fs').readFileSync('/tmp/field-diff.json','utf8')).added.length)"), removed: $(node -e "console.log(JSON.parse(require('fs').readFileSync('/tmp/field-diff.json','utf8')).removed.length)"), newly required: $(node -e "console.log(JSON.parse(require('fs').readFileSync('/tmp/field-diff.json','utf8')).newlyRequired.length)")"
 
       - name: Generate pipeline against latest
         id: generate
@@ -318,7 +371,8 @@ jobs:
         if: >-
           steps.refs.outputs.drifted == 'true' && steps.opdiff.outputs.content_changed == 'true' &&
           steps.generate.outcome == 'success' && steps.invariants.outcome == 'success' &&
-          steps.unmapped.outputs.has_unmapped != 'true'
+          steps.unmapped.outputs.has_unmapped != 'true' &&
+          steps.fielddiff.outputs.has_newly_required != 'true'
         continue-on-error: true
         # Pinned to a full commit SHA (supply-chain hardening): this sub-action
         # has no release tag of its own, so we pin main's HEAD and bump it
@@ -341,6 +395,7 @@ jobs:
           steps.refs.outputs.drifted == 'true' && steps.opdiff.outputs.content_changed == 'true' &&
           steps.generate.outcome == 'success' && steps.invariants.outcome == 'success' &&
           steps.unmapped.outputs.has_unmapped != 'true' &&
+          steps.fielddiff.outputs.has_newly_required != 'true' &&
           steps.app-token.outputs.token != ''
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -349,17 +404,24 @@ jobs:
           N_REMOVED: ${{ steps.opdiff.outputs.n_removed }}
           ADDED: ${{ steps.opdiff.outputs.added }}
           REMOVED: ${{ steps.opdiff.outputs.removed }}
+          FIELD_ADDED: ${{ steps.fielddiff.outputs.added }}
+          FIELD_REMOVED: ${{ steps.fielddiff.outputs.removed }}
+          N_FIELD_ADDED: ${{ steps.fielddiff.outputs.n_added }}
+          N_FIELD_REMOVED: ${{ steps.fielddiff.outputs.n_removed }}
         run: bash .github/scripts/spec-bump-open-pr.sh
 
-      # BROKEN drift (generate/invariants failed), unmapped (uncovered) operations,
-      # OR clean-but-no-App-token → the tracking issue (fallback preserves the
-      # signal, and blocks the auto-bump path so an uncovered op can't get
-      # silently adopted).
+      # BROKEN drift (generate/invariants failed), unmapped (uncovered)
+      # operations, a newly-required request property with no existing
+      # fixture (#492), OR clean-but-no-App-token → the tracking issue
+      # (fallback preserves the signal, and blocks the auto-bump path so an
+      # uncovered op / unfixtured required field can't get silently adopted).
       - name: Report drift to the rolling tracking issue
         if: >-
           steps.refs.outputs.drifted == 'true' && steps.opdiff.outputs.content_changed == 'true' &&
           (steps.generate.outcome != 'success' || steps.invariants.outcome != 'success' ||
-           steps.unmapped.outputs.has_unmapped == 'true' || steps.app-token.outputs.token == '')
+           steps.unmapped.outputs.has_unmapped == 'true' ||
+           steps.fielddiff.outputs.has_newly_required == 'true' ||
+           steps.app-token.outputs.token == '')
         env:
           GH_TOKEN: ${{ github.token }}
           PINNED: ${{ steps.refs.outputs.pinned }}
@@ -371,6 +433,8 @@ jobs:
           GEN_OUTCOME: ${{ steps.generate.outcome }}
           INV_OUTCOME: ${{ steps.invariants.outcome }}
           UNMAPPED: ${{ steps.unmapped.outputs.unmapped }}
+          NEWLY_REQUIRED: ${{ steps.fielddiff.outputs.newly_required }}
+          N_NEWLY_REQUIRED: ${{ steps.fielddiff.outputs.n_newly_required }}
         run: bash .github/scripts/spec-bump-report.sh
 
       # No meaningful drift (pin at latest, or content byte-identical) → close

--- a/.github/workflows/spec-bump-check.yml
+++ b/.github/workflows/spec-bump-check.yml
@@ -269,12 +269,24 @@ jobs:
         id: fielddiff
         if: steps.refs.outputs.drifted == 'true' && steps.opdiff.outputs.content_changed == 'true'
         run: |
-          set -euo pipefail
-          if npm run -s spec-field-diff -- /tmp/pinned-fields.json /tmp/latest-fields.json > /tmp/field-diff.json; then
-            echo "has_newly_required=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_newly_required=true" >> "$GITHUB_OUTPUT"
-          fi
+          set -uo pipefail
+          npm run -s spec-field-diff -- /tmp/pinned-fields.json /tmp/latest-fields.json > /tmp/field-diff.json
+          diff_rc=$?
+          set -e
+          # Exit 1 is spec-field-diff.ts's deliberate "found a newly-required
+          # request property" signal — but exit 2 is a real failure (unreadable
+          # file, invalid JSON), and anything else is unexpected. Only exit 1
+          # gets treated as the intentional signal; any other non-zero code
+          # fails this step loudly instead of silently routing a script crash
+          # down the same "newly required" path as a genuine finding.
+          case "$diff_rc" in
+            0) echo "has_newly_required=false" >> "$GITHUB_OUTPUT" ;;
+            1) echo "has_newly_required=true" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "::error::spec-field-diff exited ${diff_rc} (expected 0 or 1) — see the log above for the cause."
+              exit "$diff_rc"
+              ;;
+          esac
           # Rendered as "operationId (side): property (type)" lines, same
           # capped-preview convention as opdiff's added/removed above — counts
           # stay exact (from the full JSON), only the rendered preview is capped.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "fetch-spec": "tsx scripts/fetch-spec.ts",
     "fetch-spec:ref": "tsx scripts/fetch-spec.ts --ref-required",
     "spec-operations": "tsx scripts/spec-operations.ts",
+    "spec-fields": "tsx scripts/spec-fields.ts",
+    "spec-field-diff": "tsx scripts/spec-field-diff.ts",
     "fetch-sdk-maps": "tsx scripts/fetch-sdk-maps.ts",
     "list-targets": "tsx materializer/src/index.ts list-targets",
     "with-config": "tsx scripts/with-config.ts",

--- a/scripts/spec-field-diff.ts
+++ b/scripts/spec-field-diff.ts
@@ -44,8 +44,27 @@ interface Change {
   type?: string;
 }
 
+// Exit 2 on any read/parse failure — NOT the bare 1 an uncaught exception
+// would otherwise produce (confirmed: Node exits 1 on an uncaught JSON.parse
+// SyntaxError), which would be indistinguishable from main()'s intentional
+// exit-1 "newlyRequired found" signal. The workflow depends on that
+// distinction (0 = clean, 1 = newly-required, anything else = real failure)
+// to avoid silently routing a script crash down the same path as a genuine
+// newly-required-field finding.
 function loadSnapshot(path: string): Snapshot {
-  return JSON.parse(readFileSync(path, 'utf8'));
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (err) {
+    console.error(`[spec-field-diff] cannot read ${path}: ${String(err)}`);
+    process.exit(2);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    console.error(`[spec-field-diff] ${path} is not valid JSON: ${String(err)}`);
+    process.exit(2);
+  }
 }
 
 function diffSide(

--- a/scripts/spec-field-diff.ts
+++ b/scripts/spec-field-diff.ts
@@ -1,0 +1,119 @@
+#!/usr/bin/env tsx
+/**
+ * spec-field-diff — compare two spec-fields.ts JSON snapshots (old vs new) and
+ * report, per operation present in BOTH (an added/removed operationId is
+ * already handled by spec-operations.ts's diff, and is out of scope here):
+ *   - added properties (request or response)
+ *   - removed properties (request or response)
+ *   - newly-required properties, REQUEST side only
+ *
+ * A newly-required request property is the one case that can silently need
+ * generator work (a fixture/semantic-type mapping an existing minimal request
+ * body doesn't provide) without the generate/invariants/unmapped-operations
+ * checks necessarily catching it — everything else here is purely
+ * informational (an added/removed property doesn't by itself mean the
+ * generator is wrong, see #492's clusters.profiles precedent: additive,
+ * nullable, optional, needed no generator change).
+ *
+ * Usage: spec-field-diff.ts <old.json> <new.json>
+ * Prints a JSON report to stdout: { added: [...], removed: [...], newlyRequired: [...] }
+ * and exits 1 if newlyRequired is non-empty (so the workflow can gate on it
+ * with a plain `if` on the exit code, same convention as the rest of this
+ * pipeline's shell scripts).
+ */
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+
+interface FieldInfo {
+  type: string;
+  required: boolean;
+}
+interface SideFields {
+  properties: Record<string, FieldInfo>;
+}
+interface OperationFields {
+  request: SideFields | null;
+  response: SideFields | null;
+}
+type Snapshot = Record<string, OperationFields>;
+
+interface Change {
+  operationId: string;
+  side: 'request' | 'response';
+  property: string;
+  type?: string;
+}
+
+function loadSnapshot(path: string): Snapshot {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function diffSide(
+  operationId: string,
+  side: 'request' | 'response',
+  oldSide: SideFields | null,
+  newSide: SideFields | null,
+  added: Change[],
+  removed: Change[],
+  newlyRequired: Change[],
+): void {
+  const oldProps = oldSide?.properties ?? {};
+  const newProps = newSide?.properties ?? {};
+  for (const [name, info] of Object.entries(newProps)) {
+    const isNew = !(name in oldProps);
+    if (isNew) {
+      added.push({ operationId, side, property: name, type: info.type });
+    }
+    // A brand-new required property is at least as significant as an
+    // existing one flipping to required — there is no existing fixture for
+    // it either way, so both land in newlyRequired (in addition to `added`
+    // for a brand-new one, for visibility).
+    const becameRequired =
+      side === 'request' && info.required && (isNew || !oldProps[name].required);
+    if (becameRequired) {
+      newlyRequired.push({ operationId, side, property: name, type: info.type });
+    }
+  }
+  for (const name of Object.keys(oldProps)) {
+    if (!(name in newProps)) {
+      removed.push({ operationId, side, property: name });
+    }
+  }
+}
+
+function main(): void {
+  const [oldPath, newPath] = process.argv.slice(2);
+  if (!oldPath || !newPath) {
+    console.error('Usage: spec-field-diff.ts <old.json> <new.json>');
+    process.exit(2);
+  }
+  const oldSnap = loadSnapshot(oldPath);
+  const newSnap = loadSnapshot(newPath);
+
+  const added: Change[] = [];
+  const removed: Change[] = [];
+  const newlyRequired: Change[] = [];
+
+  // Only operations present in BOTH snapshots — an added/removed operationId
+  // is spec-operations.ts's job, not this script's.
+  for (const operationId of Object.keys(newSnap)) {
+    if (!(operationId in oldSnap)) continue;
+    const oldOp = oldSnap[operationId];
+    const newOp = newSnap[operationId];
+    diffSide(operationId, 'request', oldOp.request, newOp.request, added, removed, newlyRequired);
+    diffSide(
+      operationId,
+      'response',
+      oldOp.response,
+      newOp.response,
+      added,
+      removed,
+      newlyRequired,
+    );
+  }
+
+  console.log(JSON.stringify({ added, removed, newlyRequired }, null, 2));
+  if (newlyRequired.length > 0) process.exit(1);
+}
+
+main();

--- a/scripts/spec-fields.ts
+++ b/scripts/spec-fields.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env tsx
+/**
+ * spec-fields — print, as JSON, a TOP-LEVEL-ONLY property fingerprint of every
+ * operation in the active config's bundled spec: for each operationId, the
+ * request body's and primary success response's property names, a compact
+ * type descriptor, and which are required.
+ *
+ * Used by the scheduled spec-bump check (.github/workflows/spec-bump-check.yml)
+ * to diff the pinned spec's field surface against latest upstream — the
+ * companion to spec-operations.ts, which only diffs whole operationIds added/
+ * removed. This catches a property added to (or removed from, or newly
+ * required on) an EXISTING operation's schema — the case spec-operations.ts
+ * is blind to, since the operationId itself doesn't change.
+ *
+ * Deliberately top-level only (not deep-recursive into nested objects): this
+ * stays cheap and readable, and top-level is where the signal that matters
+ * lives — a nested $ref'd sub-object's own internal changes are out of scope
+ * (recorded as an opaque "ref"/"allOf" type descriptor here, not expanded).
+ *
+ * Reads spec/<config>/bundled/rest-api.bundle.json (produced by fetch-spec), so
+ * run fetch-spec for the desired ref first. Config comes from CONFIG (default
+ * from configs.json), resolved the same way as the rest of the pipeline.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { getSpecBundleDir } from '../path-analyser/src/configResolver.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), '..');
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+const HTTP_METHODS = new Set(['get', 'put', 'post', 'delete', 'patch', 'options', 'head', 'trace']);
+
+interface FieldInfo {
+  type: string;
+  required: boolean;
+}
+
+interface SideFields {
+  properties: Record<string, FieldInfo>;
+}
+
+interface OperationFields {
+  request: SideFields | null;
+  response: SideFields | null;
+}
+
+// One level of $ref resolution into components.schemas, unwrapping a single
+// allOf wrapper too (the common "description + $ref" pattern seen in this
+// spec, e.g. CreateClusterRequest.license) — anything deeper stays opaque.
+function resolveSchema(
+  schema: unknown,
+  components: Record<string, unknown>,
+): Record<string, unknown> | null {
+  if (!isRecord(schema)) return null;
+  if (typeof schema.$ref === 'string') {
+    const name = schema.$ref.split('/').pop();
+    const schemas = isRecord(components.schemas) ? components.schemas : {};
+    const resolved = name ? schemas[name] : undefined;
+    return isRecord(resolved) ? resolved : null;
+  }
+  if (Array.isArray(schema.allOf) && schema.allOf.length === 1) {
+    return resolveSchema(schema.allOf[0], components);
+  }
+  return schema;
+}
+
+// Compact, top-level-only type descriptor — not a full schema dump, just
+// enough to see WHAT changed in a diff (e.g. "array<string>?" for a new
+// nullable string array) without expanding nested refs.
+function describeType(propSchema: unknown): string {
+  if (!isRecord(propSchema)) return 'unknown';
+  const nullableSuffix = propSchema.nullable === true ? '?' : '';
+  if (typeof propSchema.$ref === 'string') return 'ref';
+  if (Array.isArray(propSchema.allOf)) return 'allOf';
+  if (propSchema.type === 'array') {
+    const items = propSchema.items;
+    let itemType = 'unknown';
+    if (isRecord(items)) {
+      itemType =
+        typeof items.$ref === 'string'
+          ? 'ref'
+          : typeof items.type === 'string'
+            ? items.type
+            : 'unknown';
+    }
+    return `array<${itemType}>${nullableSuffix}`;
+  }
+  return `${typeof propSchema.type === 'string' ? propSchema.type : 'unknown'}${nullableSuffix}`;
+}
+
+function extractFields(schema: unknown, components: Record<string, unknown>): SideFields | null {
+  const resolved = resolveSchema(schema, components);
+  if (!resolved || !isRecord(resolved.properties)) return null;
+  const required = new Set(Array.isArray(resolved.required) ? resolved.required : []);
+  const properties: Record<string, FieldInfo> = {};
+  for (const [name, propSchema] of Object.entries(resolved.properties)) {
+    properties[name] = { type: describeType(propSchema), required: required.has(name) };
+  }
+  return { properties };
+}
+
+// First 2xx response with a JSON body — the "primary success response" this
+// tool cares about. A 204 (no content) or error-only operation legitimately
+// has no response fields to fingerprint (response: null).
+function primarySuccessSchema(
+  responses: unknown,
+  components: Record<string, unknown>,
+): SideFields | null {
+  if (!isRecord(responses)) return null;
+  for (const [status, resp] of Object.entries(responses)) {
+    if (!status.startsWith('2') || !isRecord(resp)) continue;
+    const content = resp.content;
+    if (!isRecord(content)) continue;
+    const json = content['application/json'];
+    if (!isRecord(json)) continue;
+    return extractFields(json.schema, components);
+  }
+  return null;
+}
+
+function collectOperationFields(bundle: unknown): Record<string, OperationFields> {
+  if (!isRecord(bundle) || !isRecord(bundle.paths)) {
+    throw new Error('bundle has no `paths` object — not a valid OpenAPI bundle');
+  }
+  const components = isRecord(bundle.components) ? bundle.components : {};
+  const out: Record<string, OperationFields> = {};
+  for (const item of Object.values(bundle.paths)) {
+    if (!isRecord(item)) continue;
+    for (const [method, op] of Object.entries(item)) {
+      if (!HTTP_METHODS.has(method.toLowerCase())) continue;
+      if (!isRecord(op) || typeof op.operationId !== 'string' || op.operationId.trim() === '')
+        continue;
+
+      let request: SideFields | null = null;
+      if (isRecord(op.requestBody)) {
+        const content = op.requestBody.content;
+        const json = isRecord(content) ? content['application/json'] : undefined;
+        if (isRecord(json)) request = extractFields(json.schema, components);
+      }
+      const response = primarySuccessSchema(op.responses, components);
+      out[op.operationId] = { request, response };
+    }
+  }
+  return out;
+}
+
+function main(): void {
+  const bundlePath = join(getSpecBundleDir(REPO_ROOT), 'rest-api.bundle.json');
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(bundlePath, 'utf8'));
+  } catch (err) {
+    console.error(
+      `[spec-fields] cannot read bundle at ${bundlePath} — run fetch-spec first.\n${String(err)}`,
+    );
+    process.exit(2);
+  }
+  let fields: Record<string, OperationFields>;
+  try {
+    fields = collectOperationFields(raw);
+  } catch (err) {
+    console.error(`[spec-fields] ${bundlePath}: ${String(err)} — re-run fetch-spec.`);
+    process.exit(2);
+  }
+  console.log(JSON.stringify(fields, null, 2));
+}
+
+main();

--- a/scripts/spec-fields.ts
+++ b/scripts/spec-fields.ts
@@ -50,22 +50,49 @@ interface OperationFields {
   response: SideFields | null;
 }
 
-// One level of $ref resolution into components.schemas, unwrapping a single
-// allOf wrapper too (the common "description + $ref" pattern seen in this
-// spec, e.g. CreateClusterRequest.license) — anything deeper stays opaque.
+// $ref resolution into components.schemas, plus allOf composition: a
+// single-branch allOf is the common "description + $ref" wrapper pattern
+// (e.g. CreateClusterRequest.license) and unwraps to that one branch; a
+// genuine multi-branch allOf (composing a base schema + operation-specific
+// fields — not currently used at the top level of any request/response in
+// this spec, but a plausible upstream pattern) has its branches' properties
+// and required arrays MERGED, not dropped. Silently returning {} for a
+// multi-branch allOf would defeat this tool's entire point: missing exactly
+// the kind of field-level change a human wouldn't otherwise catch either.
+// Anything deeper than one level of composition stays opaque (top-level only
+// by design — see the file header).
+//
+// `seen` guards against a $ref cycle (schema A -> B -> A) recursing forever;
+// each $ref is added before resolving its target and any repeat short-
+// circuits to null rather than looping.
 function resolveSchema(
   schema: unknown,
   components: Record<string, unknown>,
+  seen: ReadonlySet<string> = new Set(),
 ): Record<string, unknown> | null {
   if (!isRecord(schema)) return null;
   if (typeof schema.$ref === 'string') {
+    if (seen.has(schema.$ref)) return null;
     const name = schema.$ref.split('/').pop();
     const schemas = isRecord(components.schemas) ? components.schemas : {};
     const resolved = name ? schemas[name] : undefined;
-    return isRecord(resolved) ? resolved : null;
+    if (!isRecord(resolved)) return null;
+    return resolveSchema(resolved, components, new Set([...seen, schema.$ref]));
   }
-  if (Array.isArray(schema.allOf) && schema.allOf.length === 1) {
-    return resolveSchema(schema.allOf[0], components);
+  if (Array.isArray(schema.allOf)) {
+    if (schema.allOf.length === 1) return resolveSchema(schema.allOf[0], components, seen);
+    const properties: Record<string, unknown> = {};
+    const required: string[] = [];
+    for (const branch of schema.allOf) {
+      const resolvedBranch = resolveSchema(branch, components, seen);
+      if (resolvedBranch && isRecord(resolvedBranch.properties)) {
+        Object.assign(properties, resolvedBranch.properties);
+      }
+      if (resolvedBranch && Array.isArray(resolvedBranch.required)) {
+        required.push(...resolvedBranch.required);
+      }
+    }
+    return { properties, required };
   }
   return schema;
 }

--- a/scripts/spec-fields.ts
+++ b/scripts/spec-fields.ts
@@ -121,6 +121,27 @@ function describeType(propSchema: unknown): string {
   return `${typeof propSchema.type === 'string' ? propSchema.type : 'unknown'}${nullableSuffix}`;
 }
 
+// Resolves a $ref pointing into a top-level components bucket OTHER than
+// schemas — e.g. an operation's requestBody as `$ref: "#/components/
+// requestBodies/Foo"`, or a response entry as `$ref: "#/components/
+// responses/Foo"`. Distinct from resolveSchema (which only ever resolves
+// into components.schemas): these two component kinds live in their own
+// buckets, so the bucket name is a parameter, not hardcoded.
+function resolveComponentRef(
+  obj: unknown,
+  bucketKey: string,
+  components: Record<string, unknown>,
+): Record<string, unknown> | null {
+  if (!isRecord(obj)) return null;
+  if (typeof obj.$ref === 'string') {
+    const name = obj.$ref.split('/').pop();
+    const bucket = isRecord(components[bucketKey]) ? components[bucketKey] : {};
+    const resolved = name ? bucket[name] : undefined;
+    return isRecord(resolved) ? resolved : null;
+  }
+  return obj;
+}
+
 function extractFields(schema: unknown, components: Record<string, unknown>): SideFields | null {
   const resolved = resolveSchema(schema, components);
   if (!resolved || !isRecord(resolved.properties)) return null;
@@ -140,8 +161,10 @@ function primarySuccessSchema(
   components: Record<string, unknown>,
 ): SideFields | null {
   if (!isRecord(responses)) return null;
-  for (const [status, resp] of Object.entries(responses)) {
-    if (!status.startsWith('2') || !isRecord(resp)) continue;
+  for (const [status, respRaw] of Object.entries(responses)) {
+    if (!status.startsWith('2')) continue;
+    const resp = resolveComponentRef(respRaw, 'responses', components);
+    if (!resp) continue;
     const content = resp.content;
     if (!isRecord(content)) continue;
     const json = content['application/json'];
@@ -165,8 +188,9 @@ function collectOperationFields(bundle: unknown): Record<string, OperationFields
         continue;
 
       let request: SideFields | null = null;
-      if (isRecord(op.requestBody)) {
-        const content = op.requestBody.content;
+      const requestBody = resolveComponentRef(op.requestBody, 'requestBodies', components);
+      if (requestBody) {
+        const content = requestBody.content;
         const json = isRecord(content) ? content['application/json'] : undefined;
         if (isRecord(json)) request = extractFields(json.schema, components);
       }
@@ -193,6 +217,16 @@ function main(): void {
     fields = collectOperationFields(raw);
   } catch (err) {
     console.error(`[spec-fields] ${bundlePath}: ${String(err)} — re-run fetch-spec.`);
+    process.exit(2);
+  }
+  // Same refusal as spec-operations.ts: an empty surface here would let
+  // spec-field-diff.ts silently report "no field changes" for a run whose
+  // bundle is actually broken/reshaped, which could let an unsafe drift
+  // auto-adopt instead of failing loudly.
+  if (Object.keys(fields).length === 0) {
+    console.error(
+      `[spec-fields] no operations found in ${bundlePath} — refusing to emit an empty field surface (it would corrupt the field-diff). Re-run fetch-spec.`,
+    );
     process.exit(2);
   }
   console.log(JSON.stringify(fields, null, 2));

--- a/scripts/spec-fields.ts
+++ b/scripts/spec-fields.ts
@@ -80,9 +80,20 @@ function resolveSchema(
     return resolveSchema(resolved, components, new Set([...seen, schema.$ref]));
   }
   if (Array.isArray(schema.allOf)) {
-    if (schema.allOf.length === 1) return resolveSchema(schema.allOf[0], components, seen);
+    // Single- and multi-branch allOf get the SAME treatment: merge every
+    // branch's properties/required AND the wrapper object's own top-level
+    // properties/required, if any. A single-branch allOf is NOT reliably a
+    // pure "description + $ref" wrapper with nothing of its own — confirmed
+    // in the real camunda-oca bundle, where the entire *SearchQuery/
+    // *SearchQueryResult family (105 schemas) uses exactly this shape, e.g.
+    // ProcessInstanceSearchQuery: `allOf: [{$ref: SearchQueryRequest}]` PLUS
+    // its own `sort`/`filter` properties sitting alongside allOf — a
+    // single-branch-only unwrap would have silently dropped both, the two
+    // most operation-specific fields on that request body.
     const properties: Record<string, unknown> = {};
     const required: string[] = [];
+    if (isRecord(schema.properties)) Object.assign(properties, schema.properties);
+    if (Array.isArray(schema.required)) required.push(...schema.required);
     for (const branch of schema.allOf) {
       const resolvedBranch = resolveSchema(branch, components, seen);
       if (resolvedBranch && isRecord(resolvedBranch.properties)) {


### PR DESCRIPTION
## Summary
- `spec-operations.ts`'s diff only sees whole operationIds added/removed — a property added to, removed from, or newly required on an **existing** operation's schema was otherwise invisible until a human hand-diffed the upstream YAML. That's exactly what happened investigating #494's `clusters.profiles` addition (386 commits of drift, zero operations added/removed, the actual change buried in 9 changed spec files).
- New `scripts/spec-fields.ts`: top-level-only property fingerprint (name, type, required) per operation's request body + primary success response, resolving one level of `$ref`/single-element-`allOf`.
- New `scripts/spec-field-diff.ts`: diffs two such snapshots → `added` / `removed` / `newlyRequired` properties. A brand-new-or-newly-required **request** property is the one case that can silently need generator work (no existing fixture provides it) — exits 1 when found; everything else is informational.
- Wired into `spec-bump-check.yml`'s existing pinned-vs-latest flow. A newly-required request property now **blocks auto-adopt** and routes to the tracking issue instead (new `needs-fixture` label). Non-blocking field changes get a new informational section in the bump PR body, shown only when non-empty.

## Test plan
- [x] `actionlint` + `shellcheck` clean (identical pre-existing warnings vs `main`, no new ones)
- [x] `biome check` clean
- [x] Full existing test suite (864 tests) passes
- [x] `spec-fields.ts` verified against the real post-#494 bundled spec — correctly resolves `$ref`/`allOf`, correctly finds `clusters.profiles`
- [x] `spec-field-diff.ts` verified against the real old-pin-vs-new-pin snapshots (profiles → added, non-blocking) and synthetic newly-required cases (existing property flipping to required, and a brand-new required property — both correctly block)
- [x] Both PR-body and tracking-issue rendering verified locally against real and synthetic diffs