### PR TITLE
chore: rename Slack channel to #camunda-hub-nightly-test-results

### DIFF
--- a/.github/workflows/nightly-camunda-hub.yml
+++ b/.github/workflows/nightly-camunda-hub.yml
@@ -36,8 +36,8 @@ env:
   HUB_UI_PORT: '8088'
   KEYCLOAK_PORT: '18080'
   # Channel to publish results to. The Slack bot must be invited to this channel
-  # for chat.postMessage to succeed (`/invite @<bot>` in #camunda-hub-api-test-results).
-  SLACK_CHANNEL: '#camunda-hub-api-test-results'
+  # for chat.postMessage to succeed (`/invite @<bot>` in #camunda-hub-nightly-test-results).
+  SLACK_CHANNEL: '#camunda-hub-nightly-test-results'
 
 jobs:
   nightly-hub:
@@ -390,7 +390,7 @@ jobs:
       # for the clone token (no token stored as a repo secret). Lives at
       # secret/data/products/qa/ci/common, key SLACK_BOT_USER_OAUTH_TOKEN — the
       # bound Vault role must be granted read on that path. always() so a failed
-      # run still notifies. The bot must be invited to #camunda-hub-api-test-results.
+      # run still notifies. The bot must be invited to #camunda-hub-nightly-test-results.
       # Notification infra must not fail an otherwise-complete run — continue-on-
       # error, and the Notify steps skip on the empty token output. Shared with
       # spec-bump-check — see .github/actions/slack-token.

--- a/.github/workflows/spec-bump-check.yml
+++ b/.github/workflows/spec-bump-check.yml
@@ -461,7 +461,7 @@ jobs:
         run: bash .github/scripts/spec-bump-resolve.sh
 
       # --- Hub-only: Slack heads-up on ANY content drift (#435) -----------------
-      # The hub team lives in #camunda-hub-api-test-results, so mirror the
+      # The hub team lives in #camunda-hub-nightly-test-results, so mirror the
       # GitHub artifact this run just created (bump PR or tracking issue) as a
       # Slack alert. Fires on ANY real content drift (content_changed=='true',
       # the sentinel that the opdiff step actually ran — unset when
@@ -581,7 +581,7 @@ jobs:
           # string, so interpolate it raw as the value — no surrounding quotes.
           payload: |
             {
-              "channel": "#camunda-hub-api-test-results",
+              "channel": "#camunda-hub-nightly-test-results",
               "text": ${{ steps.slack-payload.outputs.text_json }}
             }
 

--- a/.github/workflows/triage-camunda-hub-nightly.yml
+++ b/.github/workflows/triage-camunda-hub-nightly.yml
@@ -11,7 +11,7 @@
 #              asymmetric: camunda-hub gets issues only (never code); api-test-
 #              generator may get a PR for a confirmed test-generation bug or a
 #              coverage gap with an obvious minimal fix. Posts a triaged digest to
-#              #camunda-hub-api-test-results.
+#              #camunda-hub-nightly-test-results.
 # type: CI
 # owner: @camunda/test-automation-team
 ---
@@ -31,7 +31,7 @@ on:
         required: true
       slack_channel:
         description: 'Slack channel to post to (name or ID). Override for test runs.'
-        default: '#camunda-hub-api-test-results'
+        default: '#camunda-hub-nightly-test-results'
         required: false
 
 defaults:
@@ -57,7 +57,7 @@ concurrency:
 
 env:
   CONFIG: camunda-hub
-  SLACK_CHANNEL: ${{ github.event.inputs.slack_channel || '#camunda-hub-api-test-results' }}
+  SLACK_CHANNEL: ${{ github.event.inputs.slack_channel || '#camunda-hub-nightly-test-results' }}
   # Where the downloaded nightly reports land (exported to the agent as $REPORTS_DIR).
   REPORTS_DIR: ${{ github.workspace }}/hub-reports
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -526,7 +526,7 @@ the PR via `ci.yml` only checks static invariants against the pinned spec),
 then comments the run link on the PR — mirrors the "trigger the on-demand
 workflow + patch the PR" step from the c8-orchestration-cluster-e2e-nightly-fix.yml
 reference this agent is modeled on. It posts a triaged digest to
-`#camunda-hub-api-test-results` via the same Slack bot. Auth: `CLAUDE_API_KEY`
+`#camunda-hub-nightly-test-results` via the same Slack bot. Auth: `CLAUDE_API_KEY`
 at `secret/data/products/qa/ci/common`
 (agent) + [`slack-token`](.github/actions/slack-token) (Slack) +
 [`hub-clone-token`](.github/actions/hub-clone-token) (workspace-cli clone of the
@@ -580,7 +580,7 @@ push.
 
 For **camunda-hub** only, when the *operation* surface changed (an operationId
 added/removed, not just a field), it also posts a Slack alert to
-`#camunda-hub-api-test-results` (Slack bot token via the same Vault JWT auth)
+`#camunda-hub-nightly-test-results` (Slack bot token via the same Vault JWT auth)
 linking the bump PR / tracking issue it just created — so the hub team sees a
 new upstream domain in their channel, not only as a GitHub issue (#435). The
 op-surface diff is already computed for the routing above, so the Slack step


### PR DESCRIPTION
## Summary
Renamed the Slack channel `#camunda-hub-api-test-results` → `#camunda-hub-nightly-test-results` in all 10 references across:
- `.github/workflows/nightly-camunda-hub.yml` (default channel + bot-invite comment)
- `.github/workflows/spec-bump-check.yml` (hub-drift alert channel)
- `.github/workflows/triage-camunda-hub-nightly.yml` (default/fallback channel, doc comment)
- `AGENTS.md` (docs)

## Test plan
- [x] `grep` confirms no remaining references to the old name anywhere in the repo
- [x] `actionlint` clean on all three workflow files (pre-existing, unrelated SC2016 warnings confirmed identical to `main`)
- [ ] The Slack bot needs to be invited to `#camunda-hub-nightly-test-results` before merging, or these notifications will silently fail to post