### PR TITLE
feat(hub-pr-check): fail the check when a camunda-hub PR introduces an unmapped operation

### DIFF
--- a/.github/workflows/_hub-suite-run.yml
+++ b/.github/workflows/_hub-suite-run.yml
@@ -35,6 +35,16 @@ on:
           be provided.
         type: string
         default: ''
+    outputs:
+      unmapped_operations:
+        description: >-
+          Comma-separated operationIds with zero generated test coverage
+          (empty if none). coverage.json itself isn't in the uploaded
+          hub-suite-reports artifact (a different directory), so a caller
+          needing this — e.g. hub-pr-check.yml's classify step, to tell a
+          real regression apart from "the generator hasn't modelled this
+          new/changed operation yet" — reads it from here instead.
+        value: ${{ jobs.run.outputs.unmapped_operations }}
     # Declared explicitly (not `inherit`) so the interface is least-privilege and
     # callers can't accidentally omit one. Used by the hub-clone-token action.
     secrets:
@@ -77,6 +87,8 @@ jobs:
     name: Generate + run hub suites (${{ inputs.hub_ref }})
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    outputs:
+      unmapped_operations: ${{ steps.unmapped.outputs.unmapped }}
     steps:
       - name: Checkout api-test-generator
         uses: actions/checkout@v6
@@ -179,6 +191,33 @@ jobs:
           STEPS: generate run
           RV_PROFILES: secured rbac
         run: ./scripts/e2e/run-hub.sh
+
+      # An unmapped operation is a SILENT skip, not a generate failure (see
+      # AGENTS.md → "Coverage has two axes") — the materializer records it in
+      # coverage.json but never fails generate on it, so a run with a
+      # genuinely new/changed spec operation the generator can't model yet
+      # would otherwise stay fully green here (every generated test still
+      # passes; there's just no test at all for the new one). hub-run-summary
+      # below already surfaces this as a non-blocking ⚠️ note in the job
+      # summary, easy to miss — this makes it an actual failure instead, so
+      # callers (hub-pr-check.yml in particular, run on every camunda-hub PR)
+      # catch a coverage gap on the PR that introduced it rather than a day
+      # later via the separate spec-bump tracking issue. `if: always()`: run
+      # this even if the suite run above already failed for an unrelated
+      # reason, so both signals surface together instead of one hiding the other.
+      - name: Fail if any operation has no generated test coverage
+        id: unmapped
+        if: always()
+        run: |
+          set -euo pipefail
+          unmapped="$(python3 -c "import json; print(', '.join(json.load(open('generated/camunda-hub/playwright/coverage.json')).get('summary',{}).get('unmappedOperations',[])))" 2>/dev/null || true)"
+          echo "unmapped=${unmapped}" >> "$GITHUB_OUTPUT"
+          if [ -n "$unmapped" ]; then
+            echo "::error::Coverage gap: operation(s) with no generated test at all: ${unmapped}. This is not a Playwright failure — the generator's ontology/scenario-templates don't model this operation yet (see AGENTS.md → \"Coverage has two axes\")."
+            exit 1
+          fi
+          echo "No unmapped (uncovered) operations."
+          echo "No unmapped (uncovered) operations."
 
       - name: Stop Hub
         if: always()

--- a/.github/workflows/_hub-suite-run.yml
+++ b/.github/workflows/_hub-suite-run.yml
@@ -210,13 +210,32 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          unmapped="$(python3 -c "import json; print(', '.join(json.load(open('generated/camunda-hub/playwright/coverage.json')).get('summary',{}).get('unmappedOperations',[])))" 2>/dev/null || true)"
+          # A read/parse failure (missing file, corrupt JSON) is NOT the same
+          # as "no unmapped operations" — the old `2>/dev/null || true` swallowed
+          # both identically and would have printed a false "clean" message even
+          # when coverage.json was missing/broken (e.g. an earlier crash). This
+          # step's whole point is to be a trustworthy gate, so a read/parse
+          # failure now fails loudly and distinctly instead.
+          unmapped_script='
+          import json, sys
+          try:
+              with open("generated/camunda-hub/playwright/coverage.json") as f:
+                  data = json.load(f)
+          except Exception as e:
+              print(f"ERROR: {e}", file=sys.stderr)
+              sys.exit(2)
+          print(", ".join(data.get("summary", {}).get("unmappedOperations", [])))
+          '
+          if ! unmapped="$(python3 -c "$unmapped_script")"; then
+            echo "::error::Could not read/parse generated/camunda-hub/playwright/coverage.json — treating this as a coverage-check failure rather than silently assuming there are no unmapped operations."
+            echo "unmapped=" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
           echo "unmapped=${unmapped}" >> "$GITHUB_OUTPUT"
           if [ -n "$unmapped" ]; then
             echo "::error::Coverage gap: operation(s) with no generated test at all: ${unmapped}. This is not a Playwright failure — the generator's ontology/scenario-templates don't model this operation yet (see AGENTS.md → \"Coverage has two axes\")."
             exit 1
           fi
-          echo "No unmapped (uncovered) operations."
           echo "No unmapped (uncovered) operations."
 
       - name: Stop Hub

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -249,6 +249,12 @@ jobs:
           REPORTS_DIR: ${{ github.workspace }}/test-results/e2e-camunda-hub
           SPEC_DIR: ${{ github.workspace }}/../camunda-hub/restapi/public-api/src/main/resources/openapi/v2
           SPEC_DIFF_FILE: ${{ github.workspace }}/spec-diff.txt
+          # From _hub-suite-run.yml's own coverage check — comma-separated,
+          # empty if none. This is the ONE failure mode with no failing test
+          # to read at all (a silent skip, not an assertion failure), so it
+          # needs to be handed to the agent directly rather than left for it
+          # to infer from reports that won't mention it.
+          UNMAPPED_OPERATIONS: ${{ needs.run.outputs.unmapped_operations }}
         run: |
           set -euo pipefail
           rm -f /tmp/hub-pr-classification.json
@@ -272,8 +278,20 @@ jobs:
           - Known-issue configs: configs/camunda-hub/positive-suppress.json and
             configs/camunda-hub/request-validation.json (their knownIssue /
             knownProblemDetailShapeGaps entries).
+          - Unmapped (uncovered) operationIds this run found, if any: ${UNMAPPED_OPERATIONS:-<none>}
+            -- these have NO generated test at all (a silent skip, not a failing
+            test you'll find in the reports). This is the reason the run may have
+            failed even with zero failing tests in the Playwright reports.
 
           Do this:
+          0. If UNMAPPED_OPERATIONS is non-empty, check the spec diff for each
+             listed operationId first: a new/changed operation the generator has
+             never modelled yet is expected to be unmapped -> category
+             "generator-gap", confidence "high", summary naming the operationId(s)
+             and that api-test-generator's ontology/scenario-templates don't cover
+             them yet. This is NOT a hub bug. Only fall through to the steps below
+             if UNMAPPED_OPERATIONS is empty, OR the run has ADDITIONAL failing
+             tests beyond just the unmapped ones (classify those the normal way).
           1. Parse the reports and enumerate every failing test, with its request/
              response evidence from the trace/HTML report.
           2. Resolve each failing operationId in the OpenAPI spec at this PR's sha.


### PR DESCRIPTION
## Summary
An unmapped operation (no generated test at all) was previously only a non-blocking warning note buried in the GitHub Actions run summary. A camunda-hub PR adding a genuinely new/changed operation the generator can't model yet would go fully green on `hub-pr-check.yml` — the gap only surfaced the next day via the separate spec-bump-check tracking issue, after the PR had already merged.

- `_hub-suite-run.yml` (shared by `hub-pr-check.yml` and `hub-ondemand-test.yml`) now fails the run when `coverage.json`'s `unmappedOperations` is non-empty, and exposes the list as a `workflow_call` output (needed since `coverage.json` itself isn't in the uploaded `hub-suite-reports` artifact).
- `hub-pr-check.yml`'s `classify` step now receives that list directly — an unmapped operation has no failing test to find in the reports at all, so without this the agent had no way to explain why the run failed. It now classifies straight to `generator-gap` (high confidence) when the list is non-empty.

## Test plan
- [x] Confirmed `main`'s current pinned spec has zero unmapped operations right now — this doesn't retroactively fail anything today, only fires on a genuinely new gap
- [x] Tested the `${UNMAPPED_OPERATIONS:-<none>}` heredoc expansion locally for both empty and populated cases
- [x] `actionlint` clean
- [x] Full test suite (864 tests) passes
- [ ] Not yet exercised live (would need a real camunda-hub PR introducing an unmapped operation) — flagging for reviewer awareness, same caveat as #495