### PR TITLE
fix(hub-pr-check): checkout repo in report job so Slack alerts actually fire

### DIFF
--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -29,18 +29,6 @@ name: Hub PR check
 on:
   repository_dispatch:
     types: [camunda-hub-pr]
-  # TEMPORARY — testing #507's Slack-alert fix on this branch (repository_dispatch
-  # always runs the version of this workflow on main, so it can't exercise a
-  # not-yet-merged fix). Remove before merge.
-  workflow_dispatch:
-    inputs:
-      source_sha:
-        description: 'TEST-ONLY: 40-char hex SHA (fake is fine — only exercises validate/report)'
-        required: true
-      pr_number:
-        required: false
-      caller_run_url:
-        required: false
 
 permissions:
   contents: read
@@ -49,7 +37,7 @@ permissions:
 concurrency:
   # Fall back to source_sha so a missing/blank pr_number can't collapse unrelated
   # dispatches into the constant group `hub-pr-check-` (they'd cancel each other).
-  group: hub-pr-check-${{ github.event.client_payload.pr_number || github.event.client_payload.source_sha || github.event.inputs.source_sha }}
+  group: hub-pr-check-${{ github.event.client_payload.pr_number || github.event.client_payload.source_sha }}
   cancel-in-progress: true
 
 jobs:
@@ -69,7 +57,7 @@ jobs:
       - name: Validate source_sha is a 40-char hex commit SHA
         id: v
         env:
-          SHA: ${{ github.event.client_payload.source_sha || github.event.inputs.source_sha }}
+          SHA: ${{ github.event.client_payload.source_sha }}
         run: |
           set -euo pipefail
           if ! printf '%s' "$SHA" | grep -qiE '^[0-9a-f]{40}$'; then
@@ -86,7 +74,7 @@ jobs:
       - name: Validate caller_run_url (optional; empty if missing/invalid)
         id: caller
         env:
-          URL: ${{ github.event.client_payload.caller_run_url || github.event.inputs.caller_run_url }}
+          URL: ${{ github.event.client_payload.caller_run_url }}
         run: |
           set -euo pipefail
           if printf '%s' "$URL" | grep -qE '^https://github\.com/camunda/camunda-hub/actions/runs/[0-9]+$'; then
@@ -104,7 +92,7 @@ jobs:
       - name: Validate pr_number (optional; empty if missing/invalid)
         id: prnum
         env:
-          N: ${{ github.event.client_payload.pr_number || github.event.inputs.pr_number }}
+          N: ${{ github.event.client_payload.pr_number }}
         run: |
           set -euo pipefail
           if printf '%s' "$N" | grep -qE '^[1-9][0-9]*$'; then

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -382,6 +382,16 @@ jobs:
     if: always() && needs.validate.result == 'success'
     runs-on: ubuntu-latest
     steps:
+      # Needed for the local `./.github/actions/slack-token` action below —
+      # without this, that step fails to resolve ("Can't find 'action.yml'")
+      # and, since it's continue-on-error, fails silently: SLACK_BOT_TOKEN
+      # comes back empty, the Notify Slack step's `if` is false, and every
+      # hub-suite failure since #495 has gone unreported to Slack.
+      - name: Checkout api-test-generator
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       # PREREQ #2: mint a token that can write statuses on camunda/camunda-hub
       # (qa-processes App installed there with Statuses: write). continue-on-error
       # so an unprovisioned App just skips the report rather than failing the run.

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -146,7 +146,13 @@ jobs:
   classify:
     name: Classify hub-suite failure (read-only)
     needs: [validate, run]
-    if: needs.run.result == 'failure'
+    # `always()` is required, not decorative: a job-level `if:` that doesn't
+    # reference a status-check function gets an implicit `success() &&`
+    # prepended by GitHub Actions, which is always false here (`run` failed)
+    # — so without this, the condition below never actually runs the job.
+    # Confirmed this is exactly what happened: every failing run to date
+    # (including the real ones from 2026-08-02) shows this job with steps: [].
+    if: always() && needs.run.result == 'failure'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -29,6 +29,18 @@ name: Hub PR check
 on:
   repository_dispatch:
     types: [camunda-hub-pr]
+  # TEMPORARY — testing #507's Slack-alert fix on this branch (repository_dispatch
+  # always runs the version of this workflow on main, so it can't exercise a
+  # not-yet-merged fix). Remove before merge.
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: 'TEST-ONLY: 40-char hex SHA (fake is fine — only exercises validate/report)'
+        required: true
+      pr_number:
+        required: false
+      caller_run_url:
+        required: false
 
 permissions:
   contents: read
@@ -37,7 +49,7 @@ permissions:
 concurrency:
   # Fall back to source_sha so a missing/blank pr_number can't collapse unrelated
   # dispatches into the constant group `hub-pr-check-` (they'd cancel each other).
-  group: hub-pr-check-${{ github.event.client_payload.pr_number || github.event.client_payload.source_sha }}
+  group: hub-pr-check-${{ github.event.client_payload.pr_number || github.event.client_payload.source_sha || github.event.inputs.source_sha }}
   cancel-in-progress: true
 
 jobs:
@@ -57,7 +69,7 @@ jobs:
       - name: Validate source_sha is a 40-char hex commit SHA
         id: v
         env:
-          SHA: ${{ github.event.client_payload.source_sha }}
+          SHA: ${{ github.event.client_payload.source_sha || github.event.inputs.source_sha }}
         run: |
           set -euo pipefail
           if ! printf '%s' "$SHA" | grep -qiE '^[0-9a-f]{40}$'; then
@@ -74,7 +86,7 @@ jobs:
       - name: Validate caller_run_url (optional; empty if missing/invalid)
         id: caller
         env:
-          URL: ${{ github.event.client_payload.caller_run_url }}
+          URL: ${{ github.event.client_payload.caller_run_url || github.event.inputs.caller_run_url }}
         run: |
           set -euo pipefail
           if printf '%s' "$URL" | grep -qE '^https://github\.com/camunda/camunda-hub/actions/runs/[0-9]+$'; then
@@ -92,7 +104,7 @@ jobs:
       - name: Validate pr_number (optional; empty if missing/invalid)
         id: prnum
         env:
-          N: ${{ github.event.client_payload.pr_number }}
+          N: ${{ github.event.client_payload.pr_number || github.event.inputs.pr_number }}
         run: |
           set -euo pipefail
           if printf '%s' "$N" | grep -qE '^[1-9][0-9]*$'; then


### PR DESCRIPTION
## Summary

Root-caused why `hub-pr-check.yml` had failing runs on 2026-08-02 but nothing useful landed in `#camunda-hub-pr-e2e-results`. Two independent bugs, both fixed here, both confirmed live via a temporary `workflow_dispatch` test trigger on this branch (added, exercised, then reverted — not part of the final diff).

### Bug 1 — Slack alert never fired at all

The `report` job never runs `actions/checkout`, but its "Fetch Slack bot token from Vault" step resolves the **local** composite action `./.github/actions/slack-token`, which requires the repo to already be checked out. Without it:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '.../.github/actions/slack-token'.
Did you forget to run actions/checkout before running your local action?
```

That step is `continue-on-error: true`, so the failure was silent: `SLACK_BOT_TOKEN` came back empty, "Notify Slack"'s `if` was false, and it was skipped with no visible error. Broken since #495 — no hub-suite failure has ever reached Slack.

**Fix:** add `actions/checkout` as the first step of `report`, same as every other job here.

### Bug 2 — the classification job never actually ran, so every alert was generic

`classify`'s job-level condition is `if: needs.run.result == 'failure'` — no `success()`/`failure()`/`always()`/`cancelled()` call. GitHub Actions implicitly prepends `success()` to a job-level `if:` that doesn't reference one of those functions, and that implicit `success()` is always false here (`run`, i.e. the suite, just failed) — so `classify` was skipped on *every single run*, always falling through to the generic three-way hedge in the Slack message ("could be a real regression, an unhandled case, or infra/flakiness"). The three sibling `needs.run.result == 'failure'` checks elsewhere in this same file already correctly prefix with `always() &&` — this job-level one was just missed.

Confirmed via the API: `classify`'s job JSON showed `"steps": []` on every failing run checked, including the real 2026-08-02 ones.

**Fix:** `if: always() && needs.run.result == 'failure'`.

## Live verification (temporary workflow_dispatch, reverted before merge)

Dispatched this branch directly with a syntactically-valid-but-fake `source_sha` so `run` fails fast without needing a real camunda-hub PR:

- **Before fix 1**: `report` job "succeeded" while silently skipping Notify Slack (exact annotation reproduced).
- **After fix 1, before fix 2**: `classify` job showed `steps: []` (skipped); Slack message posted but used the generic fallback text.
- **After both fixes**: `classify` ran 15 real steps and produced an actual classification; the resulting Slack message read *"Looks like an infrastructure failure, not a regression (confidence: medium). CI setup failed: camunda-hub clone is empty..."* — correct for a fake SHA, and proof the whole pipeline (checkout → classify → categorized Slack alert) now works end-to-end.

## Test plan

- [x] `actionlint .github/workflows/hub-pr-check.yml` passes
- [x] YAML parses
- [x] Both bugs reproduced against real 2026-08-02 failing runs before fixing
- [x] Both fixes verified live via temporary `workflow_dispatch` dispatch on this branch (test-only commits added then reverted — final diff is just the two fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)