### PR TITLE
feat(request-validation): add pagination-limit-invalid scenario kind (#501)

### DIFF
--- a/request-validation/scripts/generate.ts
+++ b/request-validation/scripts/generate.ts
@@ -30,6 +30,7 @@ import {
 } from '../src/analysis/oneOfAdvanced.js';
 import { generateOneOfAmbiguous } from '../src/analysis/oneOfAmbiguous.js';
 import { generateOneOfNoneMatch } from '../src/analysis/oneOfNoneMatch.js';
+import { generatePaginationLimitInvalid } from '../src/analysis/paginationLimit.js';
 import { generateParamConstraintViolations } from '../src/analysis/paramConstraintViolations.js';
 import {
   generateParamEnumViolation,
@@ -323,6 +324,17 @@ async function main() {
     if (wantKind('constraint-violation')) {
       scenarios.push(
         ...generateConstraintViolations(model.operations, {
+          capPerOperation: undefined,
+          onlyOperations: opts.onlyOperations,
+        }),
+      );
+    }
+    // page.limit (search/list pagination) carries a real minimum/maximum but is
+    // invisible to the walker-based constraint-violation generator above — see
+    // paginationLimit.ts's header comment (#501).
+    if (wantKind('pagination-limit-invalid')) {
+      scenarios.push(
+        ...generatePaginationLimitInvalid(model.operations, {
           capPerOperation: undefined,
           onlyOperations: opts.onlyOperations,
         }),

--- a/request-validation/src/analysis/paginationLimit.ts
+++ b/request-validation/src/analysis/paginationLimit.ts
@@ -1,0 +1,135 @@
+import type { OperationModel, SchemaFragment, ValidationScenario } from '../model/types.js';
+import { buildBaselineBody } from '../schema/baseline.js';
+import { makeId } from './common.js';
+
+interface Opts {
+  onlyOperations?: Set<string>;
+  capPerOperation?: number;
+}
+
+interface PaginationLimitField {
+  pageProp: string;
+  minimum?: number;
+  maximum?: number;
+}
+
+/**
+ * Search/list bodies model pagination as a `page` property whose schema is
+ * `{ allOf: [<oneOf of LimitPagination/OffsetPagination/CursorForward.../
+ * CursorBackward...>] }` — two hops below the request body root, and `page`
+ * itself typically lives inside one of the root schema's OWN `allOf`
+ * branches (e.g. `ProcessInstanceSearchQuery = { allOf: [SearchQueryRequest,
+ * {filter...}] }`), not directly on `root.properties` — a third hop. The
+ * generic `oneof-*` kinds only look at a root-level `oneOf` (never present
+ * here), and the shared walker's `mergeAllOf` bails on the page-level shape
+ * (an `allOf` branch with `oneOf` and no `type`), so `page.limit` is
+ * invisible to every walker-based kind too (`constraint-violation` included)
+ * even though it carries a real `minimum`/`maximum`. `op.requestBodySchema`
+ * is already fully dereferenced (see `spec/loader.ts`'s
+ * `SwaggerParser.dereference`), so no `$ref`-following is needed here — just
+ * unwrap single-entry `allOf` wrappers.
+ *
+ * Matched by shape, not by schema title: the wrapper is named
+ * `SearchQueryPageRequest` in camunda-oca but `SearchQueryPage` in
+ * camunda-hub, even though both are the same pagination-family shape.
+ */
+export function findPaginationLimitField(op: OperationModel): PaginationLimitField | undefined {
+  const root = op.requestBodySchema;
+  if (!root) return undefined;
+  for (const [propName, propSchema] of Object.entries(collectTopLevelProperties(root))) {
+    const unwrapped = unwrapSingleAllOf(propSchema);
+    if (!unwrapped || !Array.isArray(unwrapped.oneOf)) continue;
+    for (const branch of unwrapped.oneOf) {
+      const keys = Object.keys(branch.properties ?? {});
+      if (keys.length !== 1 || keys[0] !== 'limit') continue;
+      const limitSchema = branch.properties?.limit;
+      if (typeof limitSchema?.minimum !== 'number' && typeof limitSchema?.maximum !== 'number') {
+        continue;
+      }
+      return { pageProp: propName, minimum: limitSchema?.minimum, maximum: limitSchema?.maximum };
+    }
+  }
+  return undefined;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+// One level only: every concrete search-request schema observed merges its
+// own `filter`/`sort` object directly alongside a shared base (e.g.
+// `SearchQueryRequest`) via a flat `allOf: [base, {filter,sort}]` — never a
+// nested allOf-of-allOf for the root itself.
+function collectTopLevelProperties(root: SchemaFragment): Record<string, SchemaFragment> {
+  const props: Record<string, SchemaFragment> = { ...root.properties };
+  if (Array.isArray(root.allOf)) {
+    for (const branch of root.allOf) {
+      if (branch.properties) Object.assign(props, branch.properties);
+    }
+  }
+  return props;
+}
+
+function unwrapSingleAllOf(schema: SchemaFragment): SchemaFragment {
+  if (Array.isArray(schema.allOf) && schema.allOf.length === 1 && !schema.oneOf) {
+    return schema.allOf[0];
+  }
+  return schema;
+}
+
+function planLimitMutations(minimum?: number, maximum?: number): { kind: string; value: number }[] {
+  const out: { kind: string; value: number }[] = [];
+  if (typeof minimum === 'number') {
+    out.push({ kind: 'belowMinimum', value: minimum - 1 });
+    out.push({ kind: 'wayBelowMinimum', value: minimum - 100 });
+  }
+  if (typeof maximum === 'number') {
+    out.push({ kind: 'aboveMaximum', value: maximum + 1 });
+    out.push({ kind: 'wayAboveMaximum', value: maximum + 100 });
+  }
+  return out;
+}
+
+export function generatePaginationLimitInvalid(
+  ops: OperationModel[],
+  opts: Opts,
+): ValidationScenario[] {
+  const out: ValidationScenario[] = [];
+  for (const op of ops) {
+    if (opts.onlyOperations && !opts.onlyOperations.has(op.operationId)) continue;
+    const field = findPaginationLimitField(op);
+    if (!field) continue;
+    const baseline = buildBaselineBody(op);
+    if (!isRecord(baseline)) continue;
+    const mutations = planLimitMutations(field.minimum, field.maximum);
+    let produced = 0;
+    for (const mut of mutations) {
+      if (opts.capPerOperation && produced >= opts.capPerOperation) break;
+      const body = structuredClone(baseline);
+      body[field.pageProp] = { limit: mut.value };
+      out.push({
+        id: makeId([op.operationId, 'paginationLimit', mut.kind]),
+        operationId: op.operationId,
+        method: op.method,
+        path: op.path,
+        type: 'pagination-limit-invalid',
+        target: `${field.pageProp}.limit`,
+        requestBody: body,
+        params: buildParams(op.path),
+        expectedStatus: 400,
+        description: `Pagination limit ${mut.kind} (${field.pageProp}.limit)`,
+        headersAuth: true,
+      });
+      produced++;
+    }
+  }
+  return out;
+}
+
+function buildParams(path: string): Record<string, string> | undefined {
+  const m = path.match(/\{([^}]+)}/g);
+  if (!m) return undefined;
+  const params: Record<string, string> = {};
+  for (const t of m) params[t.slice(1, -1)] = '1';
+  return params;
+}

--- a/request-validation/src/model/types.ts
+++ b/request-validation/src/model/types.ts
@@ -130,6 +130,7 @@ export const SCENARIO_KINDS = [
   'allof-missing-required',
   'allof-conflict',
   'not-found-fake-id',
+  'pagination-limit-invalid',
   'auth-absent',
   'auth-invalid',
   'auth-deny',

--- a/tests/request-validation/pagination-limit-invalid.test.ts
+++ b/tests/request-validation/pagination-limit-invalid.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from 'vitest';
+import {
+  findPaginationLimitField,
+  generatePaginationLimitInvalid,
+} from '../../request-validation/src/analysis/paginationLimit.js';
+import type { OperationModel, SchemaFragment } from '../../request-validation/src/model/types.js';
+
+/**
+ * #501 — `page.limit` bounds. `page` is `{ allOf: [<oneOf of pagination
+ * modes>] }`, two hops below the request body root, so it's invisible to
+ * the generic oneof-* kinds (root-oneOf only) and to the walker-based
+ * constraint-violation kind (mergeAllOf bails on an allOf branch that has
+ * `oneOf` and no `type`) even though `limit` carries a real
+ * minimum/maximum. Matched by shape (a branch whose only property is
+ * `limit`), not by schema title, since the wrapper is named
+ * `SearchQueryPageRequest` in camunda-oca but `SearchQueryPage` in
+ * camunda-hub.
+ */
+
+function op(
+  over: Partial<OperationModel> & Pick<OperationModel, 'operationId' | 'path'>,
+): OperationModel {
+  return {
+    method: 'POST',
+    tags: [],
+    parameters: [],
+    ...over,
+  };
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function pageLimit(body: unknown): number | undefined {
+  if (!isPlainObject(body) || !isPlainObject(body.page)) return undefined;
+  const { limit } = body.page;
+  return typeof limit === 'number' ? limit : undefined;
+}
+
+// camunda-hub shape: page's oneOf has only 2 branches (no cursor pagination).
+const hubPageSchema: SchemaFragment = {
+  allOf: [
+    {
+      oneOf: [
+        { type: 'object', properties: { limit: { type: 'integer', minimum: 1, maximum: 10000 } } },
+        {
+          type: 'object',
+          properties: {
+            from: { type: 'integer', minimum: 0 },
+            limit: { type: 'integer', minimum: 1 },
+          },
+        },
+      ],
+    },
+  ],
+};
+
+// camunda-oca shape: page's oneOf has all 4 branches, including cursor pagination.
+const ocaPageSchema: SchemaFragment = {
+  allOf: [
+    {
+      oneOf: [
+        { type: 'object', properties: { limit: { type: 'integer', minimum: 1, maximum: 10000 } } },
+        {
+          type: 'object',
+          properties: {
+            from: { type: 'integer', minimum: 0 },
+            limit: { type: 'integer', minimum: 1 },
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            after: { type: 'string', format: 'base64' },
+            limit: { type: 'integer', minimum: 1, maximum: 10000 },
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            before: { type: 'string', format: 'base64' },
+            limit: { type: 'integer', minimum: 1, maximum: 10000 },
+          },
+        },
+      ],
+    },
+  ],
+};
+
+describe('request-validation: pagination limit field detection (#501)', () => {
+  it('finds the {limit}-only branch in a 2-branch (hub) page oneOf', () => {
+    const o = op({
+      operationId: 'searchFiles',
+      path: '/files/search',
+      requestBodySchema: { type: 'object', properties: { page: hubPageSchema } },
+    });
+    expect(findPaginationLimitField(o)).toEqual({ pageProp: 'page', minimum: 1, maximum: 10000 });
+  });
+
+  it('finds the {limit}-only branch in a 4-branch (oca) page oneOf, ignoring from/after/before branches', () => {
+    const o = op({
+      operationId: 'searchProcessInstances',
+      path: '/process-instances/search',
+      requestBodySchema: { type: 'object', properties: { page: ocaPageSchema } },
+    });
+    expect(findPaginationLimitField(o)).toEqual({ pageProp: 'page', minimum: 1, maximum: 10000 });
+  });
+
+  it("finds `page` when it sits inside the ROOT schema's own allOf branch (real-spec shape)", () => {
+    // Every concrete search body in the real bundled spec is
+    // `{ allOf: [{ properties: { page, sort } }, { properties: { filter } }] }`
+    // — `page` is never a direct `root.properties` key. A detector that only
+    // checked `root.properties` directly would silently find nothing here.
+    const o = op({
+      operationId: 'searchProcessInstances',
+      path: '/process-instances/search',
+      requestBodySchema: {
+        type: 'object',
+        allOf: [
+          { type: 'object', properties: { page: hubPageSchema, sort: { type: 'array' } } },
+          { type: 'object', properties: { filter: { type: 'object' } } },
+        ],
+      },
+    });
+    expect(findPaginationLimitField(o)).toEqual({ pageProp: 'page', minimum: 1, maximum: 10000 });
+  });
+
+  it('returns undefined when there is no page property', () => {
+    const o = op({
+      operationId: 'createThing',
+      path: '/things',
+      requestBodySchema: { type: 'object', properties: { name: { type: 'string' } } },
+    });
+    expect(findPaginationLimitField(o)).toBeUndefined();
+  });
+
+  it('returns undefined when page has no oneOf wrapper', () => {
+    const o = op({
+      operationId: 'weirdSearch',
+      path: '/weird/search',
+      requestBodySchema: {
+        type: 'object',
+        properties: { page: { type: 'object', properties: { limit: { type: 'integer' } } } },
+      },
+    });
+    expect(findPaginationLimitField(o)).toBeUndefined();
+  });
+
+  it('returns undefined when no oneOf branch is a {limit}-only shape', () => {
+    const o = op({
+      operationId: 'notPagination',
+      path: '/not-pagination',
+      requestBodySchema: {
+        type: 'object',
+        properties: {
+          page: {
+            allOf: [
+              {
+                oneOf: [
+                  { type: 'object', properties: { a: { type: 'string' } } },
+                  { type: 'object', properties: { b: { type: 'string' } } },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    });
+    expect(findPaginationLimitField(o)).toBeUndefined();
+  });
+
+  it('returns undefined for a {limit}-only branch with no minimum/maximum declared', () => {
+    const o = op({
+      operationId: 'unconstrainedLimit',
+      path: '/unconstrained/search',
+      requestBodySchema: {
+        type: 'object',
+        properties: {
+          page: {
+            allOf: [{ oneOf: [{ type: 'object', properties: { limit: { type: 'integer' } } }] }],
+          },
+        },
+      },
+    });
+    expect(findPaginationLimitField(o)).toBeUndefined();
+  });
+});
+
+describe('request-validation: pagination-limit-invalid generation (#501)', () => {
+  it('emits below/way-below-minimum and above/way-above-maximum scenarios for a hub-style page', () => {
+    const ops = [
+      op({
+        operationId: 'searchFiles',
+        path: '/files/search',
+        requestBodySchema: { type: 'object', properties: { page: hubPageSchema } },
+      }),
+    ];
+    const out = generatePaginationLimitInvalid(ops, {});
+    expect(out).toHaveLength(4);
+    for (const s of out) {
+      expect(s.type).toBe('pagination-limit-invalid');
+      expect(s.expectedStatus).toBe(400);
+      expect(s.target).toBe('page.limit');
+      expect(s.operationId).toBe('searchFiles');
+      // The mutated body carries ONLY `page.limit` — no leftover baseline
+      // pagination fields from a different branch.
+      expect(isPlainObject(s.requestBody) && Object.keys(s.requestBody)).toEqual(['page']);
+      const { page } = isPlainObject(s.requestBody) ? s.requestBody : { page: undefined };
+      expect(isPlainObject(page) && Object.keys(page)).toEqual(['limit']);
+    }
+    const values = out.map((s) => pageLimit(s.requestBody)).sort((a, b) => (a ?? 0) - (b ?? 0));
+    expect(values).toEqual([-99, 0, 10001, 10100]);
+  });
+
+  it('emits the same 4 scenarios for an oca-style page (cursor branches ignored)', () => {
+    const ops = [
+      op({
+        operationId: 'searchProcessInstances',
+        path: '/process-instances/search',
+        requestBodySchema: { type: 'object', properties: { page: ocaPageSchema } },
+      }),
+    ];
+    const out = generatePaginationLimitInvalid(ops, {});
+    expect(out).toHaveLength(4);
+    const values = out.map((s) => pageLimit(s.requestBody)).sort((a, b) => (a ?? 0) - (b ?? 0));
+    expect(values).toEqual([-99, 0, 10001, 10100]);
+  });
+
+  it('emits nothing for an operation with no pagination page field', () => {
+    const ops = [
+      op({
+        operationId: 'createThing',
+        path: '/things',
+        requestBodySchema: { type: 'object', properties: { name: { type: 'string' } } },
+      }),
+    ];
+    expect(generatePaginationLimitInvalid(ops, {})).toHaveLength(0);
+  });
+
+  it('respects onlyOperations', () => {
+    const ops = [
+      op({
+        operationId: 'searchFiles',
+        path: '/files/search',
+        requestBodySchema: { type: 'object', properties: { page: hubPageSchema } },
+      }),
+      op({
+        operationId: 'searchProjects',
+        path: '/projects/search',
+        requestBodySchema: { type: 'object', properties: { page: hubPageSchema } },
+      }),
+    ];
+    const out = generatePaginationLimitInvalid(ops, {
+      onlyOperations: new Set(['searchProjects']),
+    });
+    expect(out).toHaveLength(4);
+    expect(out.every((s) => s.operationId === 'searchProjects')).toBe(true);
+  });
+
+  it('respects capPerOperation', () => {
+    const ops = [
+      op({
+        operationId: 'searchFiles',
+        path: '/files/search',
+        requestBodySchema: { type: 'object', properties: { page: hubPageSchema } },
+      }),
+    ];
+    const out = generatePaginationLimitInvalid(ops, { capPerOperation: 2 });
+    expect(out).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `limit`-bounds sub-case of #501 (part of tracking issue #498).

`page.limit` on every search/list operation carries a real `minimum`/`maximum`
constraint in the spec — but it's invisible to **every** existing scenario kind:

- The generic `oneof-*` kinds only look at a root-level `oneOf` (`op.requestBodySchema.oneOf`) — `page`'s `oneOf` is two hops deep (`page: { allOf: [<oneOf>] }`), so it never matches.
- The shared walker's `mergeAllOf` bails on that exact shape (an `allOf` branch with `oneOf` and no `type`), so `constraint-violation` (and every other walker-based kind) can't see it either.

Confirmed empirically against the real bundled specs: no `oneof-*`/pagination-touching
kind fires on any search operation today, in either config. So this isn't "add a case
to an existing gap" — pagination has **zero** negative-test coverage at all right now.

### Detection

New `findPaginationLimitField` in `request-validation/src/analysis/paginationLimit.ts`
matches by **structural shape** (a `oneOf` branch whose only property is `limit`), not
by schema title — the wrapper is named `SearchQueryPageRequest` in camunda-oca but
`SearchQueryPage` in camunda-hub, even though it's the same pagination family. It also
handles `page` living inside the *root* schema's own `allOf` branch (the real shape
every concrete search body actually uses — `ProcessInstanceSearchQuery = { allOf:
[SearchQueryRequest, {filter...}] }`), not just a direct `root.properties.page` — this
was a bug I caught via live generation (initially 0 scenarios produced against the real
spec despite passing unit tests written against a simplified fixture; added a
regression test for this exact shape once found).

### Verified against both configs' real bundled specs

- `camunda-oca`: **180** scenarios generated (45 search ops × 4 mutations: below/way-below-minimum, above/way-above-maximum).
- `camunda-hub`: **24** scenarios generated (6 search ops × 4 mutations) — proves the detector is portable across the 2-branch (hub) and 4-branch-with-cursor (oca) shapes.

Emitted test example (`processinstances-validation-api-tests.spec.ts`):
```ts
const requestBody = { page: { limit: 10001 } };
const res = await request.post(url, { headers: jsonHeaders(), data: requestBody });
await assertResponseStatus(testInfo, res, 400, { ... });
```

### Scope

This PR covers **only** the `limit`-bounds case — it's unambiguous (a real declared
schema constraint, same certainty as every other `constraint-violation` scenario).
#501's other two named cases (offset past total result count, stale/invalid cursor)
need their real expected status (`200`-empty vs. `400`) confirmed against a live
instance before writing generators for them — deliberately left as follow-up rather
than guessing and shipping a possibly-wrong assertion. Will comment on #501 with this
scope note.

## Test plan

- [x] `npx tsc --noEmit -p request-validation/tsconfig.json` — clean
- [x] `npm run lint` — clean (Biome zero-warnings, including the `no-unsafe-type-assertion` plugin)
- [x] `npm test` — 876/876 passing (12 new unit tests, zero regressions across the full 875-test baseline)
- [x] Live generation against both configs' real bundled specs (see counts above) — inspected emitted `.spec.ts` output directly
- [x] Full default `generate:request-validation` run (no `--only` filter) — camunda-oca 1688→1868 scenarios, camunda-hub picks up the new kind automatically, no dedupe collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)