### PR TITLE
feat(request-validation): add pagination-offset-past-total and pagination-cursor-invalid (#501)

### DIFF
--- a/request-validation/scripts/generate.ts
+++ b/request-validation/scripts/generate.ts
@@ -30,7 +30,9 @@ import {
 } from '../src/analysis/oneOfAdvanced.js';
 import { generateOneOfAmbiguous } from '../src/analysis/oneOfAmbiguous.js';
 import { generateOneOfNoneMatch } from '../src/analysis/oneOfNoneMatch.js';
+import { generatePaginationCursorInvalid } from '../src/analysis/paginationCursor.js';
 import { generatePaginationLimitInvalid } from '../src/analysis/paginationLimit.js';
+import { generatePaginationOffsetPastTotal } from '../src/analysis/paginationOffset.js';
 import { generateParamConstraintViolations } from '../src/analysis/paramConstraintViolations.js';
 import {
   generateParamEnumViolation,
@@ -336,6 +338,26 @@ async function main() {
       scenarios.push(
         ...generatePaginationLimitInvalid(model.operations, {
           capPerOperation: undefined,
+          onlyOperations: opts.onlyOperations,
+        }),
+      );
+    }
+    // page.from past the real result count -> 200 with an empty page (verified
+    // live against camunda-oca); NOT the same as an out-of-window 500, which
+    // paginationOffset.ts's header comment explains why it's deliberately not
+    // modeled here.
+    if (wantKind('pagination-offset-past-total')) {
+      scenarios.push(
+        ...generatePaginationOffsetPastTotal(model.operations, {
+          onlyOperations: opts.onlyOperations,
+        }),
+      );
+    }
+    // page.after/before that's base64-pattern-valid but doesn't decode to a
+    // real cursor -> 400 (verified live against camunda-oca).
+    if (wantKind('pagination-cursor-invalid')) {
+      scenarios.push(
+        ...generatePaginationCursorInvalid(model.operations, {
           onlyOperations: opts.onlyOperations,
         }),
       );

--- a/request-validation/src/analysis/paginationCursor.ts
+++ b/request-validation/src/analysis/paginationCursor.ts
@@ -1,0 +1,67 @@
+import type { OperationModel, ValidationScenario } from '../model/types.js';
+import { buildBaselineBody } from '../schema/baseline.js';
+import { makeId } from './common.js';
+import { findCursorFields, findPaginationPage, isRecord } from './paginationShape.js';
+
+interface Opts {
+  onlyOperations?: Set<string>;
+}
+
+/**
+ * `after`/`before` (`EndCursor`/`StartCursor`) only constrain the base64
+ * CHARSET via a `pattern` — not whether the content actually decodes to a
+ * valid cursor. Verified live against a running camunda-oca cluster:
+ *   - base64 of NON-JSON garbage bytes (still pattern-valid) → `400` with
+ *     `{"title":"INVALID_ARGUMENT","detail":"Cannot decode pagination
+ *     cursor '...'"}"` — a clean, well-formed ProblemDetail. This is the
+ *     "schema-valid but semantically meaningless" case this kind targets.
+ *   - a well-formed-but-past-the-end cursor (valid JSON sort-key array,
+ *     just pointing past all real data) → `200`, `items: []` — the SAME
+ *     graceful behavior as pagination-offset-past-total, so not modeled as
+ *     a separate kind (would need per-operation sort-key-shape awareness
+ *     for no additional coverage value over the `from` case).
+ * The garbage value is universal — it never needs to look like a real sort
+ * key, so no per-operation awareness of sort-key shape is needed here,
+ * unlike the deferred "past-the-end cursor" case above.
+ */
+const UNDECODABLE_CURSOR = Buffer.from('not a real cursor payload', 'utf8').toString('base64');
+
+export function generatePaginationCursorInvalid(
+  ops: OperationModel[],
+  opts: Opts,
+): ValidationScenario[] {
+  const out: ValidationScenario[] = [];
+  for (const op of ops) {
+    if (opts.onlyOperations && !opts.onlyOperations.has(op.operationId)) continue;
+    const page = findPaginationPage(op);
+    if (!page) continue;
+    const baseline = buildBaselineBody(op);
+    if (!isRecord(baseline)) continue;
+    for (const field of findCursorFields(page.branches)) {
+      const body = structuredClone(baseline);
+      body[page.pageProp] = { [field]: UNDECODABLE_CURSOR };
+      out.push({
+        id: makeId([op.operationId, 'paginationCursor', field, 'undecodable']),
+        operationId: op.operationId,
+        method: op.method,
+        path: op.path,
+        type: 'pagination-cursor-invalid',
+        target: `${page.pageProp}.${field}`,
+        requestBody: body,
+        params: buildParams(op.path),
+        expectedStatus: 400,
+        description: `Pagination cursor undecodable (${page.pageProp}.${field})`,
+        headersAuth: true,
+      });
+    }
+  }
+  return out;
+}
+
+function buildParams(path: string): Record<string, string> | undefined {
+  const m = path.match(/\{([^}]+)}/g);
+  if (!m) return undefined;
+  const params: Record<string, string> = {};
+  for (const t of m) params[t.slice(1, -1)] = '1';
+  return params;
+}

--- a/request-validation/src/analysis/paginationLimit.ts
+++ b/request-validation/src/analysis/paginationLimit.ts
@@ -1,6 +1,7 @@
-import type { OperationModel, SchemaFragment, ValidationScenario } from '../model/types.js';
+import type { OperationModel, ValidationScenario } from '../model/types.js';
 import { buildBaselineBody } from '../schema/baseline.js';
 import { makeId } from './common.js';
+import { findLimitOnlyBranch, findPaginationPage, isRecord } from './paginationShape.js';
 
 interface Opts {
   onlyOperations?: Set<string>;
@@ -14,67 +15,20 @@ interface PaginationLimitField {
 }
 
 /**
- * Search/list bodies model pagination as a `page` property whose schema is
- * `{ allOf: [<oneOf of LimitPagination/OffsetPagination/CursorForward.../
- * CursorBackward...>] }` — two hops below the request body root, and `page`
- * itself typically lives inside one of the root schema's OWN `allOf`
- * branches (e.g. `ProcessInstanceSearchQuery = { allOf: [SearchQueryRequest,
- * {filter...}] }`), not directly on `root.properties` — a third hop. The
- * generic `oneof-*` kinds only look at a root-level `oneOf` (never present
- * here), and the shared walker's `mergeAllOf` bails on the page-level shape
- * (an `allOf` branch with `oneOf` and no `type`), so `page.limit` is
- * invisible to every walker-based kind too (`constraint-violation` included)
- * even though it carries a real `minimum`/`maximum`. `op.requestBodySchema`
- * is already fully dereferenced (see `spec/loader.ts`'s
- * `SwaggerParser.dereference`), so no `$ref`-following is needed here — just
- * unwrap single-entry `allOf` wrappers.
- *
- * Matched by shape, not by schema title: the wrapper is named
- * `SearchQueryPageRequest` in camunda-oca but `SearchQueryPage` in
- * camunda-hub, even though both are the same pagination-family shape.
+ * `page.limit`'s `minimum`/`maximum` (see `paginationShape.ts` for why it's
+ * invisible to every other kind) — matched via the `LimitPagination` branch
+ * (the `oneOf` branch whose only property is `limit`), present in every
+ * config's pagination family.
  */
 export function findPaginationLimitField(op: OperationModel): PaginationLimitField | undefined {
-  const root = op.requestBodySchema;
-  if (!root) return undefined;
-  for (const [propName, propSchema] of Object.entries(collectTopLevelProperties(root))) {
-    const unwrapped = unwrapSingleAllOf(propSchema);
-    if (!unwrapped || !Array.isArray(unwrapped.oneOf)) continue;
-    for (const branch of unwrapped.oneOf) {
-      const keys = Object.keys(branch.properties ?? {});
-      if (keys.length !== 1 || keys[0] !== 'limit') continue;
-      const limitSchema = branch.properties?.limit;
-      if (typeof limitSchema?.minimum !== 'number' && typeof limitSchema?.maximum !== 'number') {
-        continue;
-      }
-      return { pageProp: propName, minimum: limitSchema?.minimum, maximum: limitSchema?.maximum };
-    }
+  const page = findPaginationPage(op);
+  if (!page) return undefined;
+  const branch = findLimitOnlyBranch(page.branches);
+  const limitSchema = branch?.properties?.limit;
+  if (typeof limitSchema?.minimum !== 'number' && typeof limitSchema?.maximum !== 'number') {
+    return undefined;
   }
-  return undefined;
-}
-
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return !!v && typeof v === 'object' && !Array.isArray(v);
-}
-
-// One level only: every concrete search-request schema observed merges its
-// own `filter`/`sort` object directly alongside a shared base (e.g.
-// `SearchQueryRequest`) via a flat `allOf: [base, {filter,sort}]` — never a
-// nested allOf-of-allOf for the root itself.
-function collectTopLevelProperties(root: SchemaFragment): Record<string, SchemaFragment> {
-  const props: Record<string, SchemaFragment> = { ...root.properties };
-  if (Array.isArray(root.allOf)) {
-    for (const branch of root.allOf) {
-      if (branch.properties) Object.assign(props, branch.properties);
-    }
-  }
-  return props;
-}
-
-function unwrapSingleAllOf(schema: SchemaFragment): SchemaFragment {
-  if (Array.isArray(schema.allOf) && schema.allOf.length === 1 && !schema.oneOf) {
-    return schema.allOf[0];
-  }
-  return schema;
+  return { pageProp: page.pageProp, minimum: limitSchema?.minimum, maximum: limitSchema?.maximum };
 }
 
 function planLimitMutations(minimum?: number, maximum?: number): { kind: string; value: number }[] {

--- a/request-validation/src/analysis/paginationOffset.ts
+++ b/request-validation/src/analysis/paginationOffset.ts
@@ -1,0 +1,67 @@
+import type { OperationModel, ValidationScenario } from '../model/types.js';
+import { buildBaselineBody } from '../schema/baseline.js';
+import { makeId } from './common.js';
+import { findOffsetBranch, findPaginationPage, isRecord } from './paginationShape.js';
+
+interface Opts {
+  onlyOperations?: Set<string>;
+}
+
+/**
+ * A schema-valid `page.from` value can still be semantically meaningless: an
+ * offset past the real result count. Verified live against a running
+ * camunda-oca cluster (203 real process instances):
+ *   - `from: 250` (just past total, well under the ES window) → `200`,
+ *     `items: []` — the correct, intended graceful behavior this kind tests.
+ *   - `from: 10000`+ → `500` (Elasticsearch's default `index.max_result_window`
+ *     kicking in) — a DIFFERENT failure mode tied to a fixed numeric
+ *     threshold, not "past the real total". Deliberately not modeled as a
+ *     scenario here: a 500 isn't something to assert as "expected" (that
+ *     would enshrine what looks like a real product gap — no graceful 400
+ *     for from+limit exceeding the search backend's window — as correct
+ *     behavior). Worth its own bug report, not a generated negative test.
+ * `5000` is comfortably under that window (10x any realistic seeded dataset,
+ * safely below where the window bug kicks in) — reliably "past total" without
+ * tripping the unrelated 500.
+ */
+const PAST_TOTAL_FROM = 5000;
+
+export function generatePaginationOffsetPastTotal(
+  ops: OperationModel[],
+  opts: Opts,
+): ValidationScenario[] {
+  const out: ValidationScenario[] = [];
+  for (const op of ops) {
+    if (opts.onlyOperations && !opts.onlyOperations.has(op.operationId)) continue;
+    const page = findPaginationPage(op);
+    if (!page) continue;
+    const branch = findOffsetBranch(page.branches);
+    if (!branch) continue;
+    const baseline = buildBaselineBody(op);
+    if (!isRecord(baseline)) continue;
+    const body = structuredClone(baseline);
+    body[page.pageProp] = { from: PAST_TOTAL_FROM };
+    out.push({
+      id: makeId([op.operationId, 'paginationOffset', 'pastTotal']),
+      operationId: op.operationId,
+      method: op.method,
+      path: op.path,
+      type: 'pagination-offset-past-total',
+      target: `${page.pageProp}.from`,
+      requestBody: body,
+      params: buildParams(op.path),
+      expectedStatus: 200,
+      description: `Pagination offset past total result count (${page.pageProp}.from=${PAST_TOTAL_FROM})`,
+      headersAuth: true,
+    });
+  }
+  return out;
+}
+
+function buildParams(path: string): Record<string, string> | undefined {
+  const m = path.match(/\{([^}]+)}/g);
+  if (!m) return undefined;
+  const params: Record<string, string> = {};
+  for (const t of m) params[t.slice(1, -1)] = '1';
+  return params;
+}

--- a/request-validation/src/analysis/paginationShape.ts
+++ b/request-validation/src/analysis/paginationShape.ts
@@ -1,0 +1,94 @@
+import type { OperationModel, SchemaFragment } from '../model/types.js';
+
+export interface PaginationPage {
+  /** The request-body property carrying pagination criteria (usually `page`). */
+  pageProp: string;
+  /** The oneOf branches of the pagination-mode wrapper (LimitPagination et al). */
+  branches: SchemaFragment[];
+}
+
+/**
+ * Search/list bodies model pagination as a property whose schema is
+ * `{ allOf: [<oneOf of LimitPagination/OffsetPagination/CursorForward.../
+ * CursorBackward...>] }` — two hops below the request body root, and that
+ * property typically lives inside one of the root schema's OWN `allOf`
+ * branches (e.g. `ProcessInstanceSearchQuery = { allOf: [SearchQueryRequest,
+ * {filter...}] }`), not directly on `root.properties` — a third hop. The
+ * generic `oneof-*` kinds only look at a root-level `oneOf` (never present
+ * here), and the shared walker's `mergeAllOf` bails on the page-level shape
+ * (an `allOf` branch with `oneOf` and no `type`), so every pagination field
+ * is invisible to every walker-based kind too (`constraint-violation`
+ * included) even though several carry real constraints. `op.requestBodySchema`
+ * is already fully dereferenced (see `spec/loader.ts`'s
+ * `SwaggerParser.dereference`), so no `$ref`-following is needed here — just
+ * unwrap single-entry `allOf` wrappers.
+ *
+ * Matched by shape, not by schema title: the wrapper is named
+ * `SearchQueryPageRequest` in camunda-oca but `SearchQueryPage` in
+ * camunda-hub, even though both are the same pagination-family shape.
+ */
+export function findPaginationPage(op: OperationModel): PaginationPage | undefined {
+  const root = op.requestBodySchema;
+  if (!root) return undefined;
+  for (const [propName, propSchema] of Object.entries(collectTopLevelProperties(root))) {
+    const unwrapped = unwrapSingleAllOf(propSchema);
+    if (unwrapped && Array.isArray(unwrapped.oneOf)) {
+      return { pageProp: propName, branches: unwrapped.oneOf };
+    }
+  }
+  return undefined;
+}
+
+// One level only: every concrete search-request schema observed merges its
+// own `filter`/`sort` object directly alongside a shared base (e.g.
+// `SearchQueryRequest`) via a flat `allOf: [base, {filter,sort}]` — never a
+// nested allOf-of-allOf for the root itself.
+function collectTopLevelProperties(root: SchemaFragment): Record<string, SchemaFragment> {
+  const props: Record<string, SchemaFragment> = { ...root.properties };
+  if (Array.isArray(root.allOf)) {
+    for (const branch of root.allOf) {
+      if (branch.properties) Object.assign(props, branch.properties);
+    }
+  }
+  return props;
+}
+
+function unwrapSingleAllOf(schema: SchemaFragment): SchemaFragment {
+  if (Array.isArray(schema.allOf) && schema.allOf.length === 1 && !schema.oneOf) {
+    return schema.allOf[0];
+  }
+  return schema;
+}
+
+/** The `oneOf` branch whose only property is `limit` (the `LimitPagination` shape). */
+export function findLimitOnlyBranch(branches: SchemaFragment[]): SchemaFragment | undefined {
+  for (const branch of branches) {
+    const keys = Object.keys(branch.properties ?? {});
+    if (keys.length === 1 && keys[0] === 'limit') return branch;
+  }
+  return undefined;
+}
+
+/** The `oneOf` branch carrying an offset field (`from`) alongside `limit` (`OffsetPagination`). */
+export function findOffsetBranch(branches: SchemaFragment[]): SchemaFragment | undefined {
+  for (const branch of branches) {
+    const keys = Object.keys(branch.properties ?? {});
+    if (keys.length === 2 && keys.includes('from') && keys.includes('limit')) return branch;
+  }
+  return undefined;
+}
+
+/** Every cursor field name (`after`/`before`) present across the oneOf branches. */
+export function findCursorFields(branches: SchemaFragment[]): string[] {
+  const fields = new Set<string>();
+  for (const branch of branches) {
+    for (const key of Object.keys(branch.properties ?? {})) {
+      if (key === 'after' || key === 'before') fields.add(key);
+    }
+  }
+  return [...fields];
+}
+
+export function isRecord(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}

--- a/request-validation/src/emit/qaEmitter.ts
+++ b/request-validation/src/emit/qaEmitter.ts
@@ -132,6 +132,17 @@ function buildFile(
         'they are not supported in legacy QA-tree mode (--no-standalone / --qa-import-depth).',
     );
   }
+  // pagination-offset-past-total relies on assertResponseStatus's
+  // expectEmptyItems opt, which only exists in the vendored standalone
+  // support module (see http.ts). Same guard shape as auth-deny above.
+  const usesEmptyItemsCheck = scenarios.some((s) => s.type === 'pagination-offset-past-total');
+  if (usesEmptyItemsCheck && !standalone) {
+    throw new Error(
+      'pagination-offset-past-total scenarios require the standalone support module ' +
+        "(assertResponseStatus's expectEmptyItems); they are not supported in legacy QA-tree " +
+        'mode (--no-standalone / --qa-import-depth).',
+    );
+  }
   const usesAuthHeaders = scenarios.some(
     (s) => s.type !== 'auth-deny' && s.headersAuth && s.bodyEncoding === 'multipart',
   );
@@ -363,7 +374,12 @@ function renderScenario(
     // this scenario kind (see knownProblemDetailShapeGaps) — the status-code
     // assertion above/below is unaffected, only assertResponseStatus's body
     // shape check is skipped for this call.
-    const assertOpts = skipProblemDetailShape ? ', { skipProblemDetailShape: true }' : '';
+    // expectEmptyItems: pagination-offset-past-total's 200 response is a
+    // genuinely empty page, not a ProblemDetail — see http.ts.
+    const assertOptFields: string[] = [];
+    if (skipProblemDetailShape) assertOptFields.push('skipProblemDetailShape: true');
+    if (s.type === 'pagination-offset-past-total') assertOptFields.push('expectEmptyItems: true');
+    const assertOpts = assertOptFields.length ? `, { ${assertOptFields.join(', ')} }` : '';
     lines.push(
       `    await assertResponseStatus(testInfo, res, ${s.expectedStatus}, { ${ctxParts.join(', ')} }${assertOpts});`,
     );

--- a/request-validation/src/model/types.ts
+++ b/request-validation/src/model/types.ts
@@ -131,6 +131,8 @@ export const SCENARIO_KINDS = [
   'allof-conflict',
   'not-found-fake-id',
   'pagination-limit-invalid',
+  'pagination-offset-past-total',
+  'pagination-cursor-invalid',
   'auth-absent',
   'auth-invalid',
   'auth-deny',

--- a/request-validation/templates/support/http.ts
+++ b/request-validation/templates/support/http.ts
@@ -116,6 +116,28 @@ function validateProblemDetailShape(
 }
 
 /**
+ * Check `body` for a genuinely empty result page (`items: []`). Used for a
+ * `200`-expecting scenario, not a `ProblemDetail` — see `expectEmptyItems`.
+ */
+function validateEmptyItemsShape(body: unknown, parseError: string | undefined): string[] {
+  if (parseError) return [`response body is not valid JSON: ${parseError}`];
+  if (body === undefined) {
+    return ['response body is empty; expected an object with an empty `items` array'];
+  }
+  if (!isRecord(body)) {
+    const got = body === null ? 'null' : Array.isArray(body) ? 'array' : typeof body;
+    return [`response body is not a JSON object (got ${got})`];
+  }
+  if (!Array.isArray(body.items)) {
+    return [`response body.items is missing or not an array (got ${JSON.stringify(body.items)})`];
+  }
+  if (body.items.length !== 0) {
+    return [`response body.items expected to be empty but has ${body.items.length} item(s)`];
+  }
+  return [];
+}
+
+/**
  * Assert the server responded with the expected status AND, when it did, that
  * the error body conforms to the API's `ProblemDetail` shape (RFC 9457). On
  * either mismatch:
@@ -143,6 +165,15 @@ export async function assertResponseStatus(
      * request-validation config) — never to silence a one-off failure.
      */
     skipProblemDetailShape?: boolean;
+    /**
+     * Also assert the response body's `items` array is empty. For a handful
+     * of scenarios (e.g. a search `page` offset/cursor genuinely past the end
+     * of the real result set) the API's correct, verified behavior is `200`
+     * with an empty page, not an error — this is the 2xx-expecting case the
+     * `shouldCheckShape` comment below anticipated. Meaningless (ignored) when
+     * `expected` is not itself 2xx.
+     */
+    expectEmptyItems?: boolean;
   },
 ): Promise<void> {
   const actual = res.status();
@@ -152,14 +183,16 @@ export async function assertResponseStatus(
   // an error response — e.g. a 200 body when a 4xx was expected), the caller
   // hasn't opted this scenario out (see `opts.skipProblemDetailShape`), and
   // `expected` is itself an error status — `ProblemDetail` is only the
-  // declared shape for 4xx/5xx, so a 2xx-expecting caller (none exist today,
-  // but nothing statically prevents one) must never be shape-checked against
-  // it. This is knowable from the status alone, before reading the body, so a
-  // clean pass that needs no shape check never pays for reading/parsing a
-  // body it would only discard — the original "no body read on a plain
-  // match" behavior is preserved for that case.
+  // declared shape for 4xx/5xx, so a 2xx-expecting caller must never be
+  // shape-checked against it (see `shouldCheckEmptyItems` below for the one
+  // 2xx-expecting check that does exist). This is knowable from the status
+  // alone, before reading the body, so a clean pass that needs no shape check
+  // never pays for reading/parsing a body it would only discard — the
+  // original "no body read on a plain match" behavior is preserved for that
+  // case.
   const shouldCheckShape = !statusMismatch && expected >= 400 && !opts?.skipProblemDetailShape;
-  if (!statusMismatch && !shouldCheckShape) return;
+  const shouldCheckEmptyItems = !statusMismatch && !!opts?.expectEmptyItems;
+  if (!statusMismatch && !shouldCheckShape && !shouldCheckEmptyItems) return;
 
   let bodyText = '';
   try {
@@ -170,7 +203,7 @@ export async function assertResponseStatus(
   }
 
   let shapeErrors: string[] = [];
-  if (shouldCheckShape) {
+  if (shouldCheckShape || shouldCheckEmptyItems) {
     let bodyJson: unknown;
     let parseError: string | undefined;
     if (bodyText) {
@@ -180,7 +213,9 @@ export async function assertResponseStatus(
         parseError = e instanceof Error ? e.message : String(e);
       }
     }
-    shapeErrors = validateProblemDetailShape(bodyJson, expected, parseError);
+    shapeErrors = shouldCheckShape
+      ? validateProblemDetailShape(bodyJson, expected, parseError)
+      : validateEmptyItemsShape(bodyJson, parseError);
   }
 
   if (!statusMismatch && shapeErrors.length === 0) return;
@@ -211,7 +246,7 @@ export async function assertResponseStatus(
       body: tryParseJson(cappedBodyText.value) ?? cappedBodyText.value,
       bodyTruncated: cappedBodyText.truncated || undefined,
       bodyOriginalBytes: cappedBodyText.truncated ? cappedBodyText.originalBytes : undefined,
-      problemDetailShapeErrors: shapeErrors.length > 0 ? shapeErrors : undefined,
+      shapeErrors: shapeErrors.length > 0 ? shapeErrors : undefined,
     },
     null,
     2,
@@ -232,7 +267,7 @@ export async function assertResponseStatus(
     `  expected status: ${expected}\n` +
     `  actual status:   ${actual} ${res.statusText()}\n` +
     (shapeErrors.length > 0
-      ? `  ProblemDetail shape violations:\n${shapeErrors.map((e) => `    - ${e}`).join('\n')}\n`
+      ? `  Response body shape violations:\n${shapeErrors.map((e) => `    - ${e}`).join('\n')}\n`
       : '') +
     `  request body:    ${formatRequestPayload(ctx)}\n` +
     `  response body:   ${truncate(bodyText, 500)}`;

--- a/request-validation/templates/support/http.ts
+++ b/request-validation/templates/support/http.ts
@@ -191,7 +191,7 @@ export async function assertResponseStatus(
   // original "no body read on a plain match" behavior is preserved for that
   // case.
   const shouldCheckShape = !statusMismatch && expected >= 400 && !opts?.skipProblemDetailShape;
-  const shouldCheckEmptyItems = !statusMismatch && !!opts?.expectEmptyItems;
+  const shouldCheckEmptyItems = !statusMismatch && expected < 400 && !!opts?.expectEmptyItems;
   if (!statusMismatch && !shouldCheckShape && !shouldCheckEmptyItems) return;
 
   let bodyText = '';

--- a/tests/request-validation/pagination-offset-and-cursor.test.ts
+++ b/tests/request-validation/pagination-offset-and-cursor.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+import { generatePaginationCursorInvalid } from '../../request-validation/src/analysis/paginationCursor.js';
+import { generatePaginationOffsetPastTotal } from '../../request-validation/src/analysis/paginationOffset.js';
+import type { OperationModel, SchemaFragment } from '../../request-validation/src/model/types.js';
+
+/**
+ * #501 — `page.from` past the real result count, and an undecodable
+ * `page.after`/`page.before`. Both expected statuses were verified live
+ * against a running camunda-oca cluster (not guessed):
+ *   - `from` past total            -> 200, empty `items`
+ *   - undecodable cursor content   -> 400, ProblemDetail (INVALID_ARGUMENT)
+ * See paginationOffset.ts / paginationCursor.ts header comments for the full
+ * verification detail, including why an out-of-ES-window 500 and a
+ * well-formed-but-past-the-end cursor are deliberately NOT modeled here.
+ */
+
+function op(
+  over: Partial<OperationModel> & Pick<OperationModel, 'operationId' | 'path'>,
+): OperationModel {
+  return {
+    method: 'POST',
+    tags: [],
+    parameters: [],
+    ...over,
+  };
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+// oca-style: all 4 branches, including both cursor directions.
+const fourBranchPageSchema: SchemaFragment = {
+  allOf: [
+    {
+      oneOf: [
+        { type: 'object', properties: { limit: { type: 'integer', minimum: 1, maximum: 10000 } } },
+        {
+          type: 'object',
+          properties: {
+            from: { type: 'integer', minimum: 0 },
+            limit: { type: 'integer', minimum: 1 },
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            after: { type: 'string', format: 'base64' },
+            limit: { type: 'integer', minimum: 1, maximum: 10000 },
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            before: { type: 'string', format: 'base64' },
+            limit: { type: 'integer', minimum: 1, maximum: 10000 },
+          },
+        },
+      ],
+    },
+  ],
+};
+
+// hub-style: only limit + offset, no cursor pagination at all.
+const twoBranchPageSchema: SchemaFragment = {
+  allOf: [
+    {
+      oneOf: [
+        { type: 'object', properties: { limit: { type: 'integer', minimum: 1, maximum: 10000 } } },
+        {
+          type: 'object',
+          properties: {
+            from: { type: 'integer', minimum: 0 },
+            limit: { type: 'integer', minimum: 1 },
+          },
+        },
+      ],
+    },
+  ],
+};
+
+describe('request-validation: pagination-offset-past-total generation (#501)', () => {
+  it('emits one 200-expecting scenario with a large `from` for a 4-branch (oca) page', () => {
+    const ops = [
+      op({
+        operationId: 'searchProcessInstances',
+        path: '/process-instances/search',
+        requestBodySchema: { type: 'object', properties: { page: fourBranchPageSchema } },
+      }),
+    ];
+    const out = generatePaginationOffsetPastTotal(ops, {});
+    expect(out).toHaveLength(1);
+    const [s] = out;
+    expect(s.type).toBe('pagination-offset-past-total');
+    expect(s.expectedStatus).toBe(200);
+    expect(s.target).toBe('page.from');
+    const body = isPlainObject(s.requestBody) ? s.requestBody : {};
+    const page = isPlainObject(body.page) ? body.page : {};
+    const { from } = page;
+    expect(typeof from).toBe('number');
+    expect(from).toBeGreaterThan(1000);
+  });
+
+  it('also fires for a 2-branch (hub) page — offset pagination has no cursor branches', () => {
+    const ops = [
+      op({
+        operationId: 'searchFiles',
+        path: '/files/search',
+        requestBodySchema: { type: 'object', properties: { page: twoBranchPageSchema } },
+      }),
+    ];
+    expect(generatePaginationOffsetPastTotal(ops, {})).toHaveLength(1);
+  });
+
+  it('emits nothing for an operation with no offset branch (e.g. limit-only pagination)', () => {
+    const limitOnlyPage: SchemaFragment = {
+      allOf: [
+        { oneOf: [{ type: 'object', properties: { limit: { type: 'integer', minimum: 1 } } }] },
+      ],
+    };
+    const ops = [
+      op({
+        operationId: 'searchSomething',
+        path: '/something/search',
+        requestBodySchema: { type: 'object', properties: { page: limitOnlyPage } },
+      }),
+    ];
+    expect(generatePaginationOffsetPastTotal(ops, {})).toHaveLength(0);
+  });
+
+  it('respects onlyOperations', () => {
+    const ops = [
+      op({
+        operationId: 'searchFiles',
+        path: '/files/search',
+        requestBodySchema: { type: 'object', properties: { page: twoBranchPageSchema } },
+      }),
+      op({
+        operationId: 'searchProjects',
+        path: '/projects/search',
+        requestBodySchema: { type: 'object', properties: { page: twoBranchPageSchema } },
+      }),
+    ];
+    const out = generatePaginationOffsetPastTotal(ops, {
+      onlyOperations: new Set(['searchProjects']),
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].operationId).toBe('searchProjects');
+  });
+});
+
+describe('request-validation: pagination-cursor-invalid generation (#501)', () => {
+  it('emits one 400-expecting scenario per cursor field (after AND before) for a 4-branch (oca) page', () => {
+    const ops = [
+      op({
+        operationId: 'searchProcessInstances',
+        path: '/process-instances/search',
+        requestBodySchema: { type: 'object', properties: { page: fourBranchPageSchema } },
+      }),
+    ];
+    const out = generatePaginationCursorInvalid(ops, {});
+    expect(out).toHaveLength(2);
+    const targets = out.map((s) => s.target).sort();
+    expect(targets).toEqual(['page.after', 'page.before']);
+    for (const s of out) {
+      expect(s.type).toBe('pagination-cursor-invalid');
+      expect(s.expectedStatus).toBe(400);
+    }
+  });
+
+  it('emits nothing for a 2-branch (hub) page — no cursor pagination at all', () => {
+    const ops = [
+      op({
+        operationId: 'searchFiles',
+        path: '/files/search',
+        requestBodySchema: { type: 'object', properties: { page: twoBranchPageSchema } },
+      }),
+    ];
+    expect(generatePaginationCursorInvalid(ops, {})).toHaveLength(0);
+  });
+
+  it('respects onlyOperations', () => {
+    const ops = [
+      op({
+        operationId: 'searchProcessInstances',
+        path: '/process-instances/search',
+        requestBodySchema: { type: 'object', properties: { page: fourBranchPageSchema } },
+      }),
+      op({
+        operationId: 'searchDecisionInstances',
+        path: '/decision-instances/search',
+        requestBodySchema: { type: 'object', properties: { page: fourBranchPageSchema } },
+      }),
+    ];
+    const out = generatePaginationCursorInvalid(ops, {
+      onlyOperations: new Set(['searchDecisionInstances']),
+    });
+    expect(out).toHaveLength(2);
+    expect(out.every((s) => s.operationId === 'searchDecisionInstances')).toBe(true);
+  });
+});

--- a/tests/request-validation/problem-detail-shape.test.ts
+++ b/tests/request-validation/problem-detail-shape.test.ts
@@ -189,3 +189,73 @@ describe('assertResponseStatus — ProblemDetail shape check', () => {
     expect(textSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+/**
+ * expectEmptyItems (#501) — a 2xx-expecting scenario where the correct
+ * behavior is a genuinely empty result page, not an error (e.g.
+ * pagination-offset-past-total: `page.from` past the real total -> 200,
+ * `items: []`, verified live against camunda-oca).
+ */
+describe('assertResponseStatus — expectEmptyItems check', () => {
+  it('passes silently when items is a genuinely empty array', async () => {
+    const assertResponseStatus = await loadAssertResponseStatus();
+    const body = JSON.stringify({ items: [], page: { totalItems: 5 } });
+    await expect(
+      assertResponseStatus(fakeTestInfo(), fakeResponse(200, body), 200, ctx, {
+        expectEmptyItems: true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('fails when items is non-empty', async () => {
+    const assertResponseStatus = await loadAssertResponseStatus();
+    const body = JSON.stringify({ items: [{ id: 1 }], page: { totalItems: 5 } });
+    await expect(
+      assertResponseStatus(fakeTestInfo(), fakeResponse(200, body), 200, ctx, {
+        expectEmptyItems: true,
+      }),
+    ).rejects.toThrow(/response body\.items expected to be empty but has 1 item\(s\)/);
+  });
+
+  it('fails when items is missing or not an array', async () => {
+    const assertResponseStatus = await loadAssertResponseStatus();
+    const body = JSON.stringify({ page: { totalItems: 5 } });
+    await expect(
+      assertResponseStatus(fakeTestInfo(), fakeResponse(200, body), 200, ctx, {
+        expectEmptyItems: true,
+      }),
+    ).rejects.toThrow(/response body\.items is missing or not an array/);
+  });
+
+  it('fails when the body is not JSON at all', async () => {
+    const assertResponseStatus = await loadAssertResponseStatus();
+    await expect(
+      assertResponseStatus(fakeTestInfo(), fakeResponse(200, 'not json'), 200, ctx, {
+        expectEmptyItems: true,
+      }),
+    ).rejects.toThrow(/response body is not valid JSON/);
+  });
+
+  it('still fails on a status mismatch even when expectEmptyItems is set', async () => {
+    const assertResponseStatus = await loadAssertResponseStatus();
+    await expect(
+      assertResponseStatus(fakeTestInfo(), fakeResponse(500, ''), 200, ctx, {
+        expectEmptyItems: true,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('never reads the response body on a clean pass without expectEmptyItems set', async () => {
+    const assertResponseStatus = await loadAssertResponseStatus();
+    const { res, textSpy } = fakeResponseWithTextSpy(200, JSON.stringify({ items: [1] }));
+    await assertResponseStatus(fakeTestInfo(), res, 200, ctx);
+    expect(textSpy).not.toHaveBeenCalled();
+  });
+
+  it('does read the response body when expectEmptyItems is set', async () => {
+    const assertResponseStatus = await loadAssertResponseStatus();
+    const { res, textSpy } = fakeResponseWithTextSpy(200, JSON.stringify({ items: [] }));
+    await assertResponseStatus(fakeTestInfo(), res, 200, ctx, { expectEmptyItems: true });
+    expect(textSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/request-validation/problem-detail-shape.test.ts
+++ b/tests/request-validation/problem-detail-shape.test.ts
@@ -245,6 +245,19 @@ describe('assertResponseStatus — expectEmptyItems check', () => {
     ).rejects.toThrow();
   });
 
+  it('is ignored for a non-2xx expected status, even combined with skipProblemDetailShape', async () => {
+    // expectEmptyItems is documented as meaningless outside a 2xx `expected`
+    // — a caller combining it with skipProblemDetailShape on a 4xx/5xx
+    // scenario must NOT get an items-array check it never asked for.
+    const assertResponseStatus = await loadAssertResponseStatus();
+    await expect(
+      assertResponseStatus(fakeTestInfo(), fakeResponse(400, ''), 400, ctx, {
+        skipProblemDetailShape: true,
+        expectEmptyItems: true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it('never reads the response body on a clean pass without expectEmptyItems set', async () => {
     const assertResponseStatus = await loadAssertResponseStatus();
     const { res, textSpy } = fakeResponseWithTextSpy(200, JSON.stringify({ items: [1] }));


### PR DESCRIPTION
## Summary

Completes #501 (part of tracking issue #498) — the two cases deferred from #508 pending
live verification of their expected status. Verified directly against a running
camunda-oca cluster rather than guessing.

### `pagination-offset-past-total`

`page.from` past the real result count is schema-valid (no static constraint can
express "past the total") but was untested. Live-verified on a 203-row dataset:

- `from: 250` → **200**, `items: []` — the correct, intended graceful behavior.
- `from: 10000`+ → **500** — a *different*, unrelated failure: Elasticsearch's default
  `index.max_result_window` (10,000). Deliberately **not** modeled as a scenario — a
  500 isn't something to assert as "expected" (that would enshrine what looks like a
  separate product gap — no graceful 400 for `from+limit` exceeding the search
  backend's window — as correct behavior). Worth its own bug report, not a generated
  negative test; flagging it here rather than silently working around it.

New kind sends `from: 5000` (well clear of both the real total and the ES window),
expects `200` + empty `items`.

### `pagination-cursor-invalid`

`page.after`/`page.before` (`EndCursor`/`StartCursor`) only constrain the base64
**charset** via a schema `pattern` — not whether the content actually decodes to a
real cursor. Live-verified:

- base64 of non-JSON garbage (still pattern-valid) → **400**, clean ProblemDetail:
  `{"title":"INVALID_ARGUMENT","detail":"Cannot decode pagination cursor '...'"}`.
- A well-formed-but-past-the-end cursor (valid sort-key shape, just pointing past all
  real data) → **200**, `items: []` — the *same* behavior as the offset case above, so
  not worth modeling as a separate kind (no coverage value over the `from` case, and
  would need per-operation sort-key-shape awareness to construct correctly).

New kind sends a universal garbage base64 string (works identically for every
operation — no per-operation awareness needed), expects `400`.

### Supporting changes

- Extracted the page/`oneOf`-branch shape detector shared by all three pagination kinds
  into `paginationShape.ts`; `paginationLimit.ts` refactored to use it (behavior
  unchanged — its existing tests pass unmodified).
- Added `assertResponseStatus`'s `expectEmptyItems` opt (`templates/support/http.ts`)
  for the one 2xx-expecting kind — guarded to standalone-mode only in `qaEmitter.ts`,
  the same pattern `auth-deny`/`denyProbeHeaders` already uses (legacy QA-tree mode has
  no equivalent capability).

## Test plan

- [x] `npx tsc --noEmit -p request-validation/tsconfig.json` — clean
- [x] `npm run lint` — clean (Biome zero-warnings)
- [x] `npm test` — 890/890 passing (18 new unit tests: generator behavior + the new
  `expectEmptyItems` assertion-helper cases), zero regressions
- [x] Live generation against both configs — camunda-oca produces both new kinds
  (including 2 cursor scenarios per op with cursor pagination), camunda-hub correctly
  produces only `pagination-offset-past-total` (no cursor pagination at all)
- [x] **Live end-to-end run against a real camunda-oca cluster**: 166/166 pagination
  tests passing, in both the `unsecured` and `secured` profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)