### PR TITLE
feat(request-validation): add malformed-json-body scenario kind (#499)

### DIFF
--- a/request-validation/scripts/generate.ts
+++ b/request-validation/scripts/generate.ts
@@ -19,6 +19,7 @@ import { generateConstraintViolations } from '../src/analysis/constraintViolatio
 import { generateDeepMissingRequired } from '../src/analysis/deepMissingRequired.js';
 import { generateDiscriminatorMismatch } from '../src/analysis/discriminatorMismatch.js';
 import { generateEnumViolations } from '../src/analysis/enumViolations.js';
+import { generateMalformedJsonBody } from '../src/analysis/malformedJsonBody.js';
 import { generateMissingRequired } from '../src/analysis/missingRequired.js';
 import { generateMissingRequiredCombos } from '../src/analysis/missingRequiredCombos.js';
 import { generateMultipartMissingRequired } from '../src/analysis/multipartMissingRequired.js';
@@ -443,6 +444,17 @@ async function main() {
     if (wantKind('body-top-type-mismatch')) {
       scenarios.push(
         ...generateBodyTopTypeMismatch(model.operations, {
+          onlyOperations: opts.onlyOperations,
+        }),
+      );
+    }
+    // Unparseable-JSON-syntax body (#499) — hits Spring's own deserialization
+    // exception path before any schema-driven validation runs; verified live
+    // that this returns a complete ProblemDetail (no knownProblemDetailShapeGaps
+    // entry needed).
+    if (wantKind('malformed-json-body')) {
+      scenarios.push(
+        ...generateMalformedJsonBody(model.operations, {
           onlyOperations: opts.onlyOperations,
         }),
       );

--- a/request-validation/src/analysis/malformedJsonBody.ts
+++ b/request-validation/src/analysis/malformedJsonBody.ts
@@ -1,0 +1,55 @@
+import type { OperationModel, ValidationScenario } from '../model/types.js';
+import { makeId } from './common.js';
+
+interface Opts {
+  onlyOperations?: Set<string>;
+}
+
+/**
+ * Every other kind sends a well-formed, `JSON.stringify`-able body with a
+ * wrong *value* — nothing sends a body that isn't parseable JSON at all.
+ * That hits Spring's deserialization exception path
+ * (`HttpMessageNotReadableException`) before the request ever reaches our
+ * schema-driven validation — a different code path than every other kind
+ * exercises (#499).
+ *
+ * Deliberately truncated (unterminated object) — invalid under any JSON
+ * parser, strict or lenient, and self-descriptive in a failure report.
+ *
+ * Verified live against a running camunda-oca cluster across 4 distinct
+ * operations (2 search, 2 non-search; different resources): uniformly
+ * `400` with a COMPLETE ProblemDetail (type/title/status/detail/instance
+ * all present) — unlike the shape gap camunda-hub#26448 found on other
+ * Spring-exception paths (missing multipart parts, missing query params).
+ * No `knownProblemDetailShapeGaps` entry needed for this kind today.
+ */
+const MALFORMED_JSON_BODY = '{"malformed": ';
+
+export function generateMalformedJsonBody(ops: OperationModel[], opts: Opts): ValidationScenario[] {
+  const out: ValidationScenario[] = [];
+  for (const op of ops) {
+    if (opts.onlyOperations && !opts.onlyOperations.has(op.operationId)) continue;
+    if (!op.requestBodySchema) continue;
+    out.push({
+      id: makeId([op.operationId, 'malformedJsonBody']),
+      operationId: op.operationId,
+      method: op.method,
+      path: op.path,
+      type: 'malformed-json-body',
+      requestBody: MALFORMED_JSON_BODY,
+      params: buildParams(op.path),
+      expectedStatus: 400,
+      description: 'Malformed/unparseable JSON body (truncated)',
+      headersAuth: true,
+    });
+  }
+  return out;
+}
+
+function buildParams(path: string): Record<string, string> | undefined {
+  const m = path.match(/\{([^}]+)}/g);
+  if (!m) return undefined;
+  const params: Record<string, string> = {};
+  for (const t of m) params[t.slice(1, -1)] = '1';
+  return params;
+}

--- a/request-validation/src/model/types.ts
+++ b/request-validation/src/model/types.ts
@@ -119,6 +119,7 @@ export const SCENARIO_KINDS = [
   'param-constraint-violation',
   'missing-body',
   'body-top-type-mismatch',
+  'malformed-json-body',
   'nested-additional-prop',
   'unique-items-violation',
   'multiple-of-violation',

--- a/request-validation/src/util/multipartSkip.ts
+++ b/request-validation/src/util/multipartSkip.ts
@@ -1,10 +1,10 @@
 import type { OperationModel, SchemaFragment, ValidationScenario } from '../model/types.js';
 
 /**
- * Multipart-only operations need four classes of JSON-derived
+ * Multipart-only operations need five classes of JSON-derived
  * validation scenarios dropped before the multipart-adaptation pass
  * tries to wrap them as form-data submissions (rules 1-3 from #135;
- * rule 4 from #364):
+ * rule 4 from #364; rule 5 from #499):
  *
  *   1. `body-top-type-mismatch` — there is no JSON top-level type to
  *      invert. Wrapping `[]` / scalar bodies as form data produces a
@@ -30,6 +30,16 @@ import type { OperationModel, SchemaFragment, ValidationScenario } from '../mode
  *
  *          POST /v2/documents -F file=x -F __unexpectedField=x   -> 201
  *
+ *   5. `malformed-json-body` (#499) — there is no JSON body concept to
+ *      send malformed JSON syntax for; sending `Content-Type:
+ *      application/json` at all is itself rejected. Verified live:
+ *
+ *          POST /v2/documents -H 'Content-Type: application/json' -d '{"malformed": '
+ *            -> 415 Unsupported Media Type, "Content-Type 'application/json' is not supported."
+ *
+ *      A malformed-*multipart*-syntax equivalent is a separate, out-of-scope
+ *      feature (see the #135 note below), not something to send as
+ *      "malformed JSON" against these operations.
  *
  * `shouldSkipForMultipart` returns `true` for scenarios that fall into
  * any of those classes on a multipart-only operation. Other scenarios
@@ -75,6 +85,7 @@ function isArrayPart(schema: SchemaFragment | undefined): boolean {
 export function shouldSkipForMultipart(scenario: ValidationScenario, op: OperationModel): boolean {
   if (!isMultipartOnly(op)) return false;
   if (scenario.type === 'body-top-type-mismatch') return true;
+  if (scenario.type === 'malformed-json-body') return true;
   // #364 — an unknown extra form part is ignored by multipart endpoints
   // (no additionalProperties:false on form data), so the upload returns 201
   // rather than 400. Drop regardless of target.

--- a/tests/request-validation/malformed-json-body.test.ts
+++ b/tests/request-validation/malformed-json-body.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { generateMalformedJsonBody } from '../../request-validation/src/analysis/malformedJsonBody.js';
+import type { OperationModel } from '../../request-validation/src/model/types.js';
+
+/**
+ * #499 — one raw, deliberately-unparseable JSON body per operation with a
+ * JSON request body. Verified live against a running camunda-oca cluster
+ * (4 distinct operations): uniformly 400 with a COMPLETE ProblemDetail — see
+ * malformedJsonBody.ts's header comment for the full verification detail.
+ */
+
+function op(
+  over: Partial<OperationModel> & Pick<OperationModel, 'operationId' | 'path'>,
+): OperationModel {
+  return {
+    method: 'POST',
+    tags: [],
+    parameters: [],
+    ...over,
+  };
+}
+
+describe('request-validation: malformed-json-body generation (#499)', () => {
+  it('emits one scenario for an operation with a JSON request body', () => {
+    const ops = [
+      op({
+        operationId: 'createUser',
+        path: '/users',
+        requestBodySchema: { type: 'object', properties: { name: { type: 'string' } } },
+      }),
+    ];
+    const out = generateMalformedJsonBody(ops, {});
+    expect(out).toHaveLength(1);
+    const [s] = out;
+    expect(s.type).toBe('malformed-json-body');
+    expect(s.expectedStatus).toBe(400);
+    expect(s.operationId).toBe('createUser');
+    const { requestBody } = s;
+    expect(typeof requestBody).toBe('string');
+    if (typeof requestBody !== 'string') return;
+    // Guaranteed-invalid under any JSON parser, strict or lenient.
+    expect(() => JSON.parse(requestBody)).toThrow();
+  });
+
+  it('emits nothing for an operation with no JSON request body (e.g. a bare GET)', () => {
+    const ops = [op({ operationId: 'getUser', path: '/users/{userKey}', method: 'GET' })];
+    expect(generateMalformedJsonBody(ops, {})).toHaveLength(0);
+  });
+
+  it('fills path params with the standard filler value', () => {
+    const ops = [
+      op({
+        operationId: 'searchUserTasks',
+        path: '/user-tasks/{userTaskKey}/search',
+        requestBodySchema: { type: 'object', properties: { filter: { type: 'object' } } },
+      }),
+    ];
+    const [s] = generateMalformedJsonBody(ops, {});
+    expect(s.params).toEqual({ userTaskKey: '1' });
+  });
+
+  it('respects onlyOperations', () => {
+    const ops = [
+      op({
+        operationId: 'createUser',
+        path: '/users',
+        requestBodySchema: { type: 'object' },
+      }),
+      op({
+        operationId: 'createGroup',
+        path: '/groups',
+        requestBodySchema: { type: 'object' },
+      }),
+    ];
+    const out = generateMalformedJsonBody(ops, { onlyOperations: new Set(['createGroup']) });
+    expect(out).toHaveLength(1);
+    expect(out[0].operationId).toBe('createGroup');
+  });
+});

--- a/tests/request-validation/multipart-skip.test.ts
+++ b/tests/request-validation/multipart-skip.test.ts
@@ -206,4 +206,22 @@ describe('shouldSkipForMultipart (#135)', () => {
     const s = scenario({ type: 'additional-prop', requestBody: { name: 'x', __extra__: 1 } });
     expect(shouldSkipForMultipart(s, op)).toBe(false);
   });
+
+  it('skips malformed-json-body on multipart-only ops (#499 — Content-Type: application/json itself is rejected → 415)', () => {
+    const op = multipartOnlyOp({
+      operationId: 'createDocument',
+      multipartSchema: {
+        type: 'object',
+        properties: { file: { type: 'string', format: 'binary' } },
+      },
+    });
+    const s = scenario({ type: 'malformed-json-body', requestBody: '{"malformed": ' });
+    expect(shouldSkipForMultipart(s, op)).toBe(true);
+  });
+
+  it('does NOT skip malformed-json-body on JSON-body ops', () => {
+    const op = jsonOp();
+    const s = scenario({ type: 'malformed-json-body', requestBody: '{"malformed": ' });
+    expect(shouldSkipForMultipart(s, op)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Implements #499 (part of tracking issue #498).

Every other negative-test kind sends well-formed JSON with a wrong *value*
(wrong type, missing key, extra property, etc.). Nothing sent a body that
isn't parseable JSON at all — that hits Spring's own deserialization
exception path (`HttpMessageNotReadableException`) before the request ever
reaches our schema-driven validation, a code path none of the other ~30
kinds exercise.

### Approach (matches the issue's suggestion)

Sends one raw, deliberately-truncated string (`'{"malformed": '`) as the
request body — guaranteed invalid under any JSON parser, strict or lenient —
for one representative scenario per operation with a JSON request body.
Playwright sends a string `data` as-is (no re-serialization), and
`jsonHeaders()` already sets `Content-Type: application/json` explicitly, so
this reliably reaches the server's JSON deserializer and fails there.

### Verified live before implementing (the issue's own flagged risk)

The issue specifically worried this might surface the same ProblemDetail
shape gap camunda-hub#26448 found on other Spring-exception paths (missing
multipart parts, missing query params — responses missing the required
`type` field). Checked directly against a running camunda-oca cluster across
4 distinct operations (2 search, 2 non-search, different resources) *before*
writing any code: uniformly **400** with a **complete** ProblemDetail
(`type`/`title`/`status`/`detail`/`instance` all present). No
`knownProblemDetailShapeGaps` entry needed for this kind.

### Bug found and fixed by the live run, not guessed

Generating for real against camunda-oca produced 119 scenarios but 3 failed
live: `createDeployment`, `createDocument`, `createDocuments` are
multipart-only operations that don't accept `application/json` **at all** —
sending it returns **415** ("Content-Type 'application/json' is not
supported"), not 400. Root cause: my generator only gated on
`op.requestBodySchema` presence, which these ops still have even though
their actual accepted content type is multipart-only.

Fixed by adding `malformed-json-body` as a 5th skip case to the existing
`multipartSkip.ts` rule set (#135) — same reasoning as its
`body-top-type-mismatch` rule: there's no JSON body concept to send
malformed JSON syntax *for* on these operations. 119 → 116 scenarios after
the fix; all 116 now pass.

## Test plan

- [x] `npx tsc --noEmit -p request-validation/tsconfig.json` — clean
- [x] `npm run lint` — clean (Biome zero-warnings)
- [x] `npm test` — 897/897 passing (6 new unit tests: generator behavior + 2
  new `multipartSkip` cases), zero regressions
- [x] Live generation against both configs — camunda-oca: 116 scenarios
  (after the multipart fix), camunda-hub: 17 scenarios
- [x] **Live end-to-end run against a real camunda-oca cluster**: 116/116
  passing in both the `unsecured` and `secured` profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)