### PR TITLE
feat(request-validation): add explicit-null-required scenario kind (#500)

### DIFF
--- a/request-validation/scripts/generate.ts
+++ b/request-validation/scripts/generate.ts
@@ -1086,6 +1086,22 @@ async function main() {
           applicable.add('missing-required');
           if (reqList.length > 1) applicable.add('missing-required-combo');
         }
+        // explicit-null-required (#500) is narrower than missing-required:
+        // JSON bodies only. `body` above is `op.requestBodySchema ||
+        // op.multipartSchema` — for a multipart-only op with its own
+        // `required` array, that would make `Array.isArray(body.required)`
+        // true even though explicitNullRequired.ts's own gate requires
+        // `op.requestBodySchema` specifically (never falls back to
+        // multipartSchema), so this checks that field directly instead of
+        // going through the merged `body`/`reqList` variables above.
+        if (
+          op.requestBodySchema?.type === 'object' &&
+          Array.isArray(op.requestBodySchema.required) &&
+          op.requestBodySchema.required.length &&
+          (!op.mediaTypes || op.mediaTypes.includes('application/json'))
+        ) {
+          applicable.add('explicit-null-required');
+        }
         applicable.add('type-mismatch');
         applicable.add('body-top-type-mismatch');
         applicable.add('additional-prop-general');

--- a/request-validation/scripts/generate.ts
+++ b/request-validation/scripts/generate.ts
@@ -19,6 +19,7 @@ import { generateConstraintViolations } from '../src/analysis/constraintViolatio
 import { generateDeepMissingRequired } from '../src/analysis/deepMissingRequired.js';
 import { generateDiscriminatorMismatch } from '../src/analysis/discriminatorMismatch.js';
 import { generateEnumViolations } from '../src/analysis/enumViolations.js';
+import { generateExplicitNullRequired } from '../src/analysis/explicitNullRequired.js';
 import { generateMalformedJsonBody } from '../src/analysis/malformedJsonBody.js';
 import { generateMissingRequired } from '../src/analysis/missingRequired.js';
 import { generateMissingRequiredCombos } from '../src/analysis/missingRequiredCombos.js';
@@ -258,6 +259,16 @@ async function main() {
         }),
       );
     }
+  }
+  // Explicit `null` for a required field, distinct from omitting it
+  // entirely (#500) — same target-field selection as missing-required.
+  if (wantKind('explicit-null-required')) {
+    scenarios.push(
+      ...generateExplicitNullRequired(model.operations, {
+        capPerOperation: opts.maxMissing,
+        onlyOperations: opts.onlyOperations,
+      }),
+    );
   }
   if (opts.deep && wantKind('missing-required-combo')) {
     scenarios.push(

--- a/request-validation/src/analysis/explicitNullRequired.ts
+++ b/request-validation/src/analysis/explicitNullRequired.ts
@@ -1,4 +1,4 @@
-import type { OperationModel, ValidationScenario } from '../model/types.js';
+import type { OperationModel, SchemaFragment, ValidationScenario } from '../model/types.js';
 import { genPlaceholder, makeId } from './common.js';
 
 interface Opts {
@@ -17,11 +17,14 @@ interface Opts {
  * `requiredProps`, JSON bodies only) — mirrored deliberately, not shared,
  * since the only difference is the mutation itself (set `null` vs. omit).
  *
- * Skips a field whose schema allows `null` (OAS 3.1 `type` array including
- * `'null'`) — sending `null` there is schema-valid input, not a negative
- * test. (None of the 47 real top-level-required fields checked are
- * nullable today, but the check is part of this kind's own definition —
- * "required, NON-NULLABLE property" — not a hypothetical.)
+ * Skips a field whose schema allows `null` — either an OAS 3.1 `type` array
+ * including `'null'`, or a `oneOf`/`anyOf` branch of `{ type: 'null' }`
+ * (the other common way JSON Schema expresses nullability, typically when
+ * the nullable side is itself a `$ref`, which can't sit in a `type` array).
+ * Sending `null` in either case is schema-valid input, not a negative test.
+ * (None of the 47 real top-level-required fields checked are nullable
+ * today via either form, but the check is part of this kind's own
+ * definition — "required, NON-NULLABLE property" — not a hypothetical.)
  *
  * Verified live against a running camunda-oca cluster across 4 required
  * fields on 3 operations (string, and object-typed): uniformly 400, with
@@ -44,8 +47,7 @@ export function generateExplicitNullRequired(
     for (const prop of op.requiredProps) {
       if (opts.capPerOperation && count >= opts.capPerOperation) break;
       const schema = op.requestBodySchema.properties?.[prop];
-      const types = Array.isArray(schema?.type) ? schema.type : [schema?.type];
-      if (types.includes('null')) continue;
+      if (isNullable(schema)) continue;
       const body: Record<string, unknown> = {};
       for (const p of op.requiredProps) {
         body[p] = p === prop ? null : genPlaceholder(op.requestBodySchema.properties?.[p]);
@@ -68,6 +70,14 @@ export function generateExplicitNullRequired(
     }
   }
   return out;
+}
+
+function isNullable(schema: SchemaFragment | undefined): boolean {
+  if (!schema) return false;
+  const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+  if (types.includes('null')) return true;
+  const branches = [...(schema.oneOf ?? []), ...(schema.anyOf ?? [])];
+  return branches.some((b) => b.type === 'null');
 }
 
 function buildDummyParams(path: string): Record<string, string> | undefined {

--- a/request-validation/src/analysis/explicitNullRequired.ts
+++ b/request-validation/src/analysis/explicitNullRequired.ts
@@ -1,0 +1,79 @@
+import type { OperationModel, ValidationScenario } from '../model/types.js';
+import { genPlaceholder, makeId } from './common.js';
+
+interface Opts {
+  capPerOperation?: number;
+  onlyOperations?: Set<string>;
+}
+
+/**
+ * `missing-required` omits a required key from the body entirely.
+ * Jackson/Spring (and Bean Validation) can treat an explicit `null`
+ * differently from an absent key depending on how the field is annotated
+ * (`@NotNull` vs. relying purely on the JSON body's `required` array) — a
+ * distinct case `missing-required` never exercises (#500).
+ *
+ * Same target-field selection as `missingRequired.ts` (top-level
+ * `requiredProps`, JSON bodies only) — mirrored deliberately, not shared,
+ * since the only difference is the mutation itself (set `null` vs. omit).
+ *
+ * Skips a field whose schema allows `null` (OAS 3.1 `type` array including
+ * `'null'`) — sending `null` there is schema-valid input, not a negative
+ * test. (None of the 47 real top-level-required fields checked are
+ * nullable today, but the check is part of this kind's own definition —
+ * "required, NON-NULLABLE property" — not a hypothetical.)
+ *
+ * Verified live against a running camunda-oca cluster across 4 required
+ * fields on 3 operations (string, and object-typed): uniformly 400, with
+ * the exact same ProblemDetail `detail` message as the omitted-key case
+ * (`missing-required`) — confirms this API doesn't distinguish the two,
+ * but is still a genuinely different code path worth covering per #500's
+ * own reasoning (some APIs/frameworks do distinguish).
+ */
+export function generateExplicitNullRequired(
+  ops: OperationModel[],
+  opts: Opts,
+): ValidationScenario[] {
+  const out: ValidationScenario[] = [];
+  for (const op of ops) {
+    if (opts.onlyOperations && !opts.onlyOperations.has(op.operationId)) continue;
+    if (!op.requiredProps?.length) continue;
+    if (!op.requestBodySchema || op.requestBodySchema.type !== 'object') continue;
+    if (op.mediaTypes && !op.mediaTypes.includes('application/json')) continue;
+    let count = 0;
+    for (const prop of op.requiredProps) {
+      if (opts.capPerOperation && count >= opts.capPerOperation) break;
+      const schema = op.requestBodySchema.properties?.[prop];
+      const types = Array.isArray(schema?.type) ? schema.type : [schema?.type];
+      if (types.includes('null')) continue;
+      const body: Record<string, unknown> = {};
+      for (const p of op.requiredProps) {
+        body[p] = p === prop ? null : genPlaceholder(op.requestBodySchema.properties?.[p]);
+      }
+      out.push({
+        id: makeId([op.operationId, 'explicitNull', prop]),
+        operationId: op.operationId,
+        method: op.method,
+        path: op.path,
+        type: 'explicit-null-required',
+        target: prop,
+        requestBody: body,
+        params: buildDummyParams(op.path),
+        expectedStatus: 400,
+        description: `Explicit null for required field '${prop}' (not omitted)`,
+        headersAuth: true,
+        bodyEncoding: 'json',
+      });
+      count++;
+    }
+  }
+  return out;
+}
+
+function buildDummyParams(path: string): Record<string, string> | undefined {
+  const m = path.match(/\{([^}]+)}/g);
+  if (!m) return undefined;
+  const params: Record<string, string> = {};
+  for (const token of m) params[token.slice(1, -1)] = 'x';
+  return params;
+}

--- a/request-validation/src/model/types.ts
+++ b/request-validation/src/model/types.ts
@@ -104,6 +104,7 @@ export interface SpecModel {
  */
 export const SCENARIO_KINDS = [
   'missing-required',
+  'explicit-null-required',
   'missing-required-combo',
   'type-mismatch',
   'union',

--- a/tests/request-validation/explicit-null-required.test.ts
+++ b/tests/request-validation/explicit-null-required.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { generateExplicitNullRequired } from '../../request-validation/src/analysis/explicitNullRequired.js';
+import type { OperationModel } from '../../request-validation/src/model/types.js';
+
+/**
+ * #500 — explicit `null` for a required field, distinct from omitting it
+ * entirely (`missing-required`). Verified live against a running camunda-oca
+ * cluster (4 required fields across 3 operations): uniformly 400 with the
+ * SAME ProblemDetail detail message as the omitted-key case — see
+ * explicitNullRequired.ts's header comment for the full verification detail.
+ */
+
+function op(
+  over: Partial<OperationModel> & Pick<OperationModel, 'operationId' | 'path'>,
+): OperationModel {
+  return {
+    method: 'POST',
+    tags: [],
+    parameters: [],
+    mediaTypes: ['application/json'],
+    ...over,
+  };
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+describe('request-validation: explicit-null-required generation (#500)', () => {
+  it('emits one scenario per required field, setting it to null (not omitting)', () => {
+    const ops = [
+      op({
+        operationId: 'createGlobalClusterVariable',
+        path: '/cluster-variables/global',
+        requiredProps: ['name', 'value'],
+        requestBodySchema: {
+          type: 'object',
+          properties: { name: { type: 'string' }, value: { type: 'string' } },
+        },
+      }),
+    ];
+    const out = generateExplicitNullRequired(ops, {});
+    expect(out).toHaveLength(2);
+    const byTarget = new Map(out.map((s) => [s.target, s]));
+    for (const target of ['name', 'value']) {
+      const s = byTarget.get(target);
+      expect(s?.type).toBe('explicit-null-required');
+      expect(s?.expectedStatus).toBe(400);
+      const body = isPlainObject(s?.requestBody) ? s.requestBody : {};
+      // The mutated field is explicitly null...
+      expect(body[target]).toBeNull();
+      // ...while every OTHER required field is still present (unlike
+      // missing-required, which omits the target and keeps the rest).
+      for (const other of ['name', 'value']) {
+        if (other === target) continue;
+        expect(other in body).toBe(true);
+        expect(body[other]).not.toBeNull();
+      }
+    }
+  });
+
+  it('skips a required field whose schema explicitly allows null (OAS 3.1 type array)', () => {
+    const ops = [
+      op({
+        operationId: 'createThing',
+        path: '/things',
+        requiredProps: ['name', 'nullableField'],
+        requestBodySchema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            nullableField: { type: ['string', 'null'] },
+          },
+        },
+      }),
+    ];
+    const out = generateExplicitNullRequired(ops, {});
+    expect(out).toHaveLength(1);
+    expect(out[0].target).toBe('name');
+  });
+
+  it('emits nothing for an operation with no top-level required fields', () => {
+    const ops = [
+      op({
+        operationId: 'createOptionalThing',
+        path: '/optional-things',
+        requestBodySchema: { type: 'object', properties: { name: { type: 'string' } } },
+      }),
+    ];
+    expect(generateExplicitNullRequired(ops, {})).toHaveLength(0);
+  });
+
+  it('emits nothing for a multipart-only operation', () => {
+    const ops = [
+      op({
+        operationId: 'createDocument',
+        path: '/documents',
+        mediaTypes: ['multipart/form-data'],
+        requiredProps: ['file'],
+        requestBodySchema: { type: 'object', properties: { file: { type: 'string' } } },
+      }),
+    ];
+    expect(generateExplicitNullRequired(ops, {})).toHaveLength(0);
+  });
+
+  it('respects onlyOperations and capPerOperation', () => {
+    const ops = [
+      op({
+        operationId: 'createA',
+        path: '/a',
+        requiredProps: ['x', 'y'],
+        requestBodySchema: {
+          type: 'object',
+          properties: { x: { type: 'string' }, y: { type: 'string' } },
+        },
+      }),
+      op({
+        operationId: 'createB',
+        path: '/b',
+        requiredProps: ['x', 'y'],
+        requestBodySchema: {
+          type: 'object',
+          properties: { x: { type: 'string' }, y: { type: 'string' } },
+        },
+      }),
+    ];
+    const out = generateExplicitNullRequired(ops, {
+      onlyOperations: new Set(['createB']),
+      capPerOperation: 1,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].operationId).toBe('createB');
+  });
+});

--- a/tests/request-validation/explicit-null-required.test.ts
+++ b/tests/request-validation/explicit-null-required.test.ts
@@ -79,6 +79,29 @@ describe('request-validation: explicit-null-required generation (#500)', () => {
     expect(out[0].target).toBe('name');
   });
 
+  it('skips a required field whose schema allows null via a oneOf/anyOf branch', () => {
+    // The other common way JSON Schema/OAS 3.1 expresses nullability —
+    // typically when the nullable side is a $ref, which can't sit inside a
+    // `type` array directly.
+    const ops = [
+      op({
+        operationId: 'createThing',
+        path: '/things',
+        requiredProps: ['name', 'nullableRef'],
+        requestBodySchema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            nullableRef: { oneOf: [{ type: 'object' }, { type: 'null' }] },
+          },
+        },
+      }),
+    ];
+    const out = generateExplicitNullRequired(ops, {});
+    expect(out).toHaveLength(1);
+    expect(out[0].target).toBe('name');
+  });
+
   it('emits nothing for an operation with no top-level required fields', () => {
     const ops = [
       op({


### PR DESCRIPTION
## Summary

Implements #500 (part of tracking issue #498), completing that tracking issue.

`missing-required` omits a required key from the body entirely. Nothing sent
an explicit `"field": null` for a required, non-nullable property — a
distinct code path some frameworks/validators treat differently from a plain
omission (`@NotNull` vs. relying purely on the JSON body's `required` array).

### Approach (matches the issue's suggestion)

Mirrors `missingRequired.ts`'s exact target-field selection (top-level
`requiredProps`, JSON bodies only, same multipart/media-type gating) — the
only difference is the mutation: set the field to `null` instead of omitting
it, keeping every other required field present with its usual placeholder.

One addition beyond the issue's literal suggestion: skips a field whose
schema explicitly allows `null` (OAS 3.1 `type` array including `'null'`) —
sending `null` there is schema-valid input, not a negative test. (Checked:
none of the 47 real top-level-required fields in the current camunda-oca
spec are nullable today, but this is part of the kind's own definition —
"required, **non-nullable**" — not a hypothetical guard.)

### Verified live before implementing

Checked directly against a running camunda-oca cluster across 4 required
fields on 3 operations (string- and object-typed) *before* writing the
generator: uniformly **400**, with the exact same ProblemDetail `detail`
message as the omitted-key case. This particular API doesn't distinguish
explicit-null from omitted — still a genuinely different code path worth
covering per #500's own reasoning (some APIs/frameworks do distinguish), and
no shape gap or new assertion behavior was needed.

## Test plan

- [x] `npx tsc --noEmit -p request-validation/tsconfig.json` — clean
- [x] `npm run lint` — clean (Biome zero-warnings)
- [x] `npm test` — 902/902 passing (5 new unit tests), zero regressions
- [x] Live generation against both configs — camunda-oca: 66 scenarios,
  camunda-hub: 19 scenarios
- [x] **Live end-to-end run against a real camunda-oca cluster**: 64/64
  passing in both `unsecured` and `secured` profiles. (2 additional scenarios
  target `createAdminUser`, which fails identically to the already-shipped
  `missing-required` kind on the same operation on this specific long-running
  dev cluster — its one-time admin bootstrap was already consumed by earlier
  sessions, a pre-existing environmental state issue, not a bug introduced
  here. Confirmed by re-running `missing-required`'s existing tests against
  the same operation — they fail the same way.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)