### PR TITLE
feat(ci): add a live-Hub check on every PR (not just manual dispatch)

### DIFF
--- a/.github/workflows/hub-pr-live-check.yml
+++ b/.github/workflows/hub-pr-live-check.yml
@@ -1,0 +1,88 @@
+# Live-Hub check for every api-test-generator PR — closes the gap left by
+# ci.yml's `hub-invariants` job, which only checks the PINNED hub spec
+# (ci.yml:131-135), never a live Hub. hub-ondemand-test.yml already does a
+# real generate+run against a live Hub, but is workflow_dispatch-only, so
+# nobody actually runs it before merging unless they remember to.
+#
+# hub-ondemand-test.yml is itself just a thin wrapper around _hub-suite-run.yml
+# (the same reusable hub-pr-check.yml also calls). Calling that reusable
+# directly from a `pull_request`-triggered workflow makes the result a real,
+# native GitHub Actions check on the PR — no polling or manual status-posting
+# needed, unlike the dispatch→poll→comment pattern used for the (fire-and-
+# forget, non-blocking) spec-bump PR validation link.
+name: Hub PR live check
+
+on:
+  pull_request:
+    # Default types (opened, synchronize, reopened) — re-validates on every
+    # push, matching how every other check in this repo already behaves.
+
+concurrency:
+  group: hub-pr-live-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Guard (fork / .github diff)
+    runs-on: ubuntu-latest
+    # Real forks get no repo secrets (the run job would just fail at the
+    # Vault step for reasons unrelated to the change); Dependabot PRs are
+    # same-repo but also get no secrets (a GitHub Actions restriction) — skip
+    # both up front. Same fork check as ci.yml's hub-invariants job
+    # (ci.yml:151-153).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - name: Check for .github/** changes
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # SECURITY (mirrors triage-camunda-hub-nightly.yml's identical
+          # guard): calling a local reusable workflow (`uses: ./...`) resolves
+          # to the version of that file AS IT EXISTS ON THE PR's OWN COMMIT —
+          # a PR that modifies _hub-suite-run.yml or this workflow file would
+          # have its own modified version execute with production Vault
+          # secrets, no human review required. Fail CLOSED (skip) if the diff
+          # can't even be checked — the cost of an unnecessary manual dispatch
+          # is trivial next to the cost of a wrong guess here.
+          if changed=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only 2>/dev/null); then
+            if grep -qE '^\.github/' <<<"$changed"; then
+              echo "::warning::PR touches .github/** — skipping the live-Hub check for safety; a maintainer must review the workflow changes and run hub-ondemand-test.yml manually before merging."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "proceed=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "::warning::Could not fetch the changed-files list for this PR — skipping the live-Hub check out of caution."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  run:
+    name: Live Hub suite
+    needs: guard
+    if: needs.guard.outputs.proceed == 'true'
+    permissions:
+      contents: read
+      id-token: write # OIDC → Vault (same as hub-ondemand-test.yml)
+    uses: ./.github/workflows/_hub-suite-run.yml
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_JWT_PATH: ${{ secrets.VAULT_JWT_PATH }}
+      VAULT_JWT_ROLE: ${{ secrets.VAULT_JWT_ROLE }}
+      VAULT_JWT_AUDIENCE: ${{ secrets.VAULT_JWT_AUDIENCE }}
+    with:
+      # hub_ref/hub_image left at _hub-suite-run.yml's defaults (main /
+      # camunda/hub:SNAPSHOT) — this PR's own generator code is checked out
+      # implicitly (the reusable's own checkout step resolves to the calling
+      # context's SHA), tested against Hub's CURRENT mainline: exactly "does
+      # this PR still pass against a real Hub."
+      summary_heading: |
+        ## Hub PR live check — #${{ github.event.pull_request.number }}
+        `${{ github.event.pull_request.head.sha }}` against camunda-hub main / camunda/hub:SNAPSHOT

--- a/.github/workflows/hub-pr-live-check.yml
+++ b/.github/workflows/hub-pr-live-check.yml
@@ -14,6 +14,11 @@ name: Hub PR live check
 
 on:
   pull_request:
+    # Scoped to main, matching ci.yml's own pull_request trigger (ci.yml:4-6)
+    # — this check gates PRs into main; a live-Hub run is secrets-consuming
+    # and shouldn't fire for PRs targeting some other branch.
+    branches:
+      - main
     # Default types (opened, synchronize, reopened) — re-validates on every
     # push, matching how every other check in this repo already behaves.
 
@@ -25,6 +30,12 @@ jobs:
   guard:
     name: Guard (fork / .github diff)
     runs-on: ubuntu-latest
+    # An explicit `permissions:` block replaces the default token scope
+    # entirely — without pull-requests: read, `gh pr diff` below 403s and
+    # this job silently fails closed (skipping the live-Hub run) on every
+    # PR. Same requirement, same fix, as triage-camunda-hub-nightly.yml:47-51.
+    permissions:
+      pull-requests: read
     # Real forks get no repo secrets (the run job would just fail at the
     # Vault step for reasons unrelated to the change); Dependabot PRs are
     # same-repo but also get no secrets (a GitHub Actions restriction) — skip


### PR DESCRIPTION
## Summary

`ci.yml`'s `hub-invariants` job already runs on every PR, but only checks the
**pinned** hub spec — never a live Hub. `hub-ondemand-test.yml` does a real
generate+run against a live Hub, but is `workflow_dispatch`-only, so a
generator regression against Hub's actual current behavior wasn't caught
until the nightly or someone remembered to dispatch it manually.

`hub-ondemand-test.yml` is itself a thin wrapper around `_hub-suite-run.yml`
— the same reusable `hub-pr-check.yml` also calls directly. This PR adds a
new `pull_request`-triggered workflow that calls that reusable directly,
which makes the result a **real, native GitHub Actions check** on every PR —
no polling or manual status-posting code needed (unlike the
dispatch→poll→comment pattern used for the fire-and-forget spec-bump PR
validation link, which exists specifically because that caller can't invoke
a `workflow_dispatch`-only workflow any other way).

### Behavior
- Re-runs on every push (`opened`/`synchronize`/`reopened`) — matches how
  every other check in this repo already behaves.
- Plain pass/fail — no AI classify step. Unlike `hub-pr-check.yml`'s
  genuinely 3-way-ambiguous case (hub bug vs. generator gap vs. infra), a
  failure here almost always means *this* PR broke something.
- No extra PR comment — the native check itself is the surfaced result.
- `hub_ref`/`hub_image` stay at `_hub-suite-run.yml`'s defaults (`main` /
  `camunda/hub:SNAPSHOT`) — this PR's own generator code is checked out
  implicitly (the reusable's checkout resolves to the calling context's SHA),
  tested against Hub's current mainline.

### Guards
- Skips for real forks and Dependabot PRs — same check as `ci.yml`'s
  `hub-invariants` job.
- Skips (fail-closed) for any PR touching `.github/**` — mirrors
  `triage-camunda-hub-nightly.yml`'s identical guard: a local reusable
  workflow reference resolves to the version on the PR's **own** commit, so a
  PR modifying `_hub-suite-run.yml` or this workflow file would have its
  modified version execute with production Vault secrets, unreviewed. A
  maintainer must review + dispatch `hub-ondemand-test.yml` manually in that
  case.

### A platform note on testing this PR

GitHub only runs a `pull_request`-triggered workflow that already exists on
the **base** branch — a brand-new workflow file introduced by a PR can't
trigger on that same PR. So this PR itself won't show the new check running;
that's expected, not a bug. I verified the guard's core logic directly
against this real PR instead (see test plan) and will verify the check
actually appears/runs on a subsequent PR once this merges.

## Test plan

- [x] `actionlint .github/workflows/hub-pr-live-check.yml` — clean
- [x] YAML parses
- [x] Verified the guard's `.github/**`-diff logic directly against this PR's real diff (see below)
- [ ] Once merged: confirm the check appears natively in a subsequent PR's Checks tab, re-triggers on push, and the `run` job actually boots a live Hub and passes/fails correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)