### PR TITLE
fix(hub-pr-check): harden classify prompt against false hub-medic pings

### DIFF
--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -307,8 +307,26 @@ jobs:
              unhandled new construct) -> category "generator-gap" (api-test-generator
              does not yet correctly handle this shape; NOT a hub bug).
           4. If the operationId is UNCHANGED by this PR and its response contradicts
-             the (unchanged) spec -> category "product" (a likely real regression;
-             this PR probably broke something via a shared code path).
+             the (unchanged) spec, that is EITHER a regression this PR introduced via
+             a shared code path, OR a standing, pre-existing bug this PR happens to
+             also expose -- "unchanged and still broken" does not by itself tell you
+             which. This especially applies to a broad/blanket-acceptance failure
+             (e.g. a handler that accepts any malformed input regardless of shape) --
+             that pattern is far more often "this endpoint has probably always
+             behaved this way" than "this specific PR just introduced it". Only use
+             category "product" with confidence "high" when you have a SPECIFIC
+             causal link to THIS PR (its own diff touches a shared
+             validation/deserialization path, a dependency bump, a config change
+             plausibly affecting this behavior, etc.) -- never solely because the op
+             is unchanged and the response is wrong. Absent that causal link: use
+             "generator-gap" if the test's own assumption looks over-generalized
+             (assumes uniform behavior across operations that don't actually all
+             share it), or "unknown" (confidence "low") if you can't tell either way
+             -- and say explicitly in your summary that you could not establish this
+             PR caused it, so a maintainer should verify before treating it as a
+             regression. Getting this wrong pages a real person (hub-medic) for
+             something they didn't cause -- bias toward NOT paging, not toward
+             paging.
           5. Reconcile against the known-issue configs first — if the failure matches
              an existing knownIssue/knownProblemDetailShapeGaps entry, use its real
              category and note it is already tracked in your summary.
@@ -479,11 +497,22 @@ jobs:
           ta_medic='<!subteam^S09UF0EV0HG|test-automation-medic>'
           # product ALSO pings hub-medic — it's their pipeline (this PR) that
           # a confirmed regression implicates, same "whoever owns the broken
-          # thing" routing every AlwaysGreen variant we looked at uses.
+          # thing" routing every AlwaysGreen variant we looked at uses. BUT
+          # only at confidence "high" — the prompt's own rule #4 now requires
+          # a specific causal link to this PR before it may say "product" at
+          # high confidence; anything less means classify itself couldn't
+          # rule out a standing, pre-existing bug unrelated to this PR. A
+          # medium/low-confidence guess still isn't worth paging a human over
+          # (defense-in-depth alongside the prompt hardening, not a
+          # replacement for it — the LLM can still misjudge).
           case "$CATEGORY" in
             product)
               verdict="Likely a real regression from this PR (confidence: ${CONFIDENCE}). ${SUMMARY}"
-              ping="${hub_medic} ${ta_medic}"
+              if [ "$CONFIDENCE" = "high" ]; then
+                ping="${hub_medic} ${ta_medic}"
+              else
+                ping="${ta_medic}"
+              fi
               ;;
             generator-gap)
               verdict="Likely api-test-generator not yet handling a new/changed endpoint shape, not a hub bug (confidence: ${CONFIDENCE}). ${SUMMARY}"

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -255,6 +255,12 @@ jobs:
           REPORTS_DIR: ${{ github.workspace }}/test-results/e2e-camunda-hub
           SPEC_DIR: ${{ github.workspace }}/../camunda-hub/restapi/public-api/src/main/resources/openapi/v2
           SPEC_DIFF_FILE: ${{ github.workspace }}/spec-diff.txt
+          # The clone-hub-sibling action does a full clone, not a sparse/
+          # openapi-only one -- the agent runs as a real tool-using session
+          # (claude -p), so it can inspect this itself (git diff/log/grep)
+          # rather than being limited to the pre-computed SPEC_DIFF_FILE,
+          # which only ever covers the OpenAPI YAML.
+          HUB_REPO_DIR: ${{ github.workspace }}/../camunda-hub
           # From _hub-suite-run.yml's own coverage check — comma-separated,
           # empty if none. This is the ONE failure mode with no failing test
           # to read at all (a silent skip, not an assertion failure), so it
@@ -281,6 +287,13 @@ jobs:
             camunda-hub clone step failed; treat as unavailable, don't guess).
           - Spec diff (this PR's sha vs camunda-hub main), OpenAPI dir only: ${SPEC_DIFF_FILE}
             (empty file = this PR does not touch the API spec, or the diff step failed).
+          - Full camunda-hub checkout AT THIS PR's SHA: ${HUB_REPO_DIR} (the complete
+            repo, not just the spec dir -- may be absent under the same condition as
+            the spec dir above). SPEC_DIFF_FILE only ever covers the OpenAPI YAML;
+            for step 4 below, use this to inspect the PR's actual CODE changes
+            yourself, e.g. \`git -C ${HUB_REPO_DIR} diff origin/main -- PATH\`
+            (start with \`--stat\` against the whole repo to scope down before diffing
+            anything large).
           - Known-issue configs: configs/camunda-hub/positive-suppress.json and
             configs/camunda-hub/request-validation.json (their knownIssue /
             knownProblemDetailShapeGaps entries).
@@ -313,12 +326,18 @@ jobs:
              which. This especially applies to a broad/blanket-acceptance failure
              (e.g. a handler that accepts any malformed input regardless of shape) --
              that pattern is far more often "this endpoint has probably always
-             behaved this way" than "this specific PR just introduced it". Only use
-             category "product" with confidence "high" when you have a SPECIFIC
-             causal link to THIS PR (its own diff touches a shared
-             validation/deserialization path, a dependency bump, a config change
-             plausibly affecting this behavior, etc.) -- never solely because the op
-             is unchanged and the response is wrong. Absent that causal link: use
+             behaved this way" than "this specific PR just introduced it". To look
+             for that causal link, DO NOT rely on the spec diff alone -- it only
+             covers the OpenAPI YAML, not the actual implementation. Inspect the
+             PR's real code diff yourself in the full checkout (see Inputs above):
+             run a \`--stat\` diff against camunda-hub main first to see which files
+             changed at all, then look closer at anything touching this operation's
+             controller/handler, request-body deserialization, or shared
+             validation/config code. Only use category "product" with confidence
+             "high" when that code diff gives you a SPECIFIC causal link to THIS PR
+             -- never solely because the op is unchanged and the response is wrong,
+             and never from the spec diff alone (it can't show a code-only change).
+             Absent that causal link: use
              "generator-gap" if the test's own assumption looks over-generalized
              (assumes uniform behavior across operations that don't actually all
              share it), or "unknown" (confidence "low") if you can't tell either way

--- a/.github/workflows/hub-pr-check.yml
+++ b/.github/workflows/hub-pr-check.yml
@@ -526,9 +526,23 @@ jobs:
               verdict="Looks flaky, not a regression (confidence: ${CONFIDENCE}). ${SUMMARY}"
               ping="${ta_medic}"
               ;;
+            unknown)
+              # Rule #4's hardening made this category more likely to fire —
+              # ${SUMMARY} is never empty here: it's either the agent's own
+              # "couldn't establish causation" explanation, or (if classify
+              # errored/produced no usable output at all) the parse step's
+              # "did not produce a usable result" fallback text. Either way,
+              # showing it beats discarding it into the generic three-way
+              # hedge below, which forces a reader to open the run just to
+              # see a one-line diagnostic that was already computed.
+              verdict="Could not confirm this is a real regression from this PR (confidence: ${CONFIDENCE}). ${SUMMARY}"
+              ping="${ta_medic}"
+              ;;
             *)
-              # classify didn't run, errored, or genuinely couldn't tell —
-              # same three-way hedge this alert shipped with originally.
+              # Unreachable in practice — the parse step's own enum
+              # validation already guarantees $CATEGORY is one of the five
+              # cases above by the time it gets here. Kept as a defensive
+              # fallback in case that guarantee is ever weakened upstream.
               verdict="Could be a real regression from this PR, an unhandled case in api-test-generator for a new/changed endpoint (unmapped operation, unmodelled schema shape), or infra/flakiness — check the run to tell which before this merges."
               ping="${ta_medic}"
               ;;


### PR DESCRIPTION
## Summary

Investigated a burst of 12 failing `hub-pr-check.yml` runs (2026-08-04, 11:11–12:02 UTC,
across 8 distinct camunda-hub PRs) that got wildly inconsistent `classify` verdicts for
the *identical* underlying issue (`createWorkspace` accepting malformed JSON,
camunda-hub#27155) — sometimes `generator-gap` (no hub-medic ping), sometimes `product`
(pings hub-medic) at varying confidence, with different wording every time.

**Timeline** (fully traced via CI logs):
- All 12 failures: 11:11–12:02 UTC.
- #512 merged at 12:20:15 UTC, adding a `knownIssue` config entry for this exact case.
- Every run since (checked ~25 consecutive runs from 12:22 UTC onward): clean.

So the specific storm is already resolved — this PR hardens the pipeline for the *next*
standing issue that hasn't been added to config yet, not this one.

## Root cause

Rule #4 told `classify` to call it `product` whenever the operation is unchanged by the
PR and the response contradicts the spec — without distinguishing "this PR broke it via
a shared code path" from "this is a standing, pre-existing bug this PR happens to also
expose" (the far more likely explanation for a blanket-acceptance failure mode like this
one — an endpoint accepting *any* malformed input is unlikely to be something one PR
just introduced). At the time of these runs, the config also had no matching
`knownIssue` entry yet (that's exactly what #512 added, 18 minutes after the last
failure), so rule #5's "reconcile against known-issue configs" had nothing to match.

## Changes

1. **Rewrote rule #4**: `product` at confidence `high` now requires a *specific* causal
   link to the PR's own diff — not merely "unchanged and still broken". Absent that
   link: `generator-gap` if the test's own assumption looks over-generalized, or
   `unknown` (confidence `low`) if genuinely unclear, with an explicit note that
   causation couldn't be established. Explicit framing: a false `product` classification
   pages a real person for something they didn't cause — bias toward not paging.

2. **Defense-in-depth in the `report` job**: `hub-medic` is now only pinged for
   `product` at confidence `high` — medium/low guesses still report as "likely a real
   regression" in the message text, but only page `test-automation-medic`. Verified with
   a mock harness across all category values.

3. **`unknown` was silently discarding the agent's summary** (caught by review): it had
   no explicit case in the Slack-alert switch and fell into the generic three-way-hedge
   catch-all, dropping the agent's own "couldn't establish causation" explanation —
   exactly the diagnostic text rule #4's hardening was supposed to produce. Made worse by
   this PR, since `unknown` now fires more often. Added an explicit `unknown` case using
   the real summary text, like every other category already does.

4. **The agent could never actually satisfy rule #4's new evidence bar for a code-only
   regression.** Rule #4 demands a causal link to the PR's diff, but the only diff
   evidence handed to the agent (`SPEC_DIFF_FILE`) is scoped to the OpenAPI YAML only —
   for any regression caused by an actual code change (the common case), the agent
   structurally couldn't find that evidence and would under-call real regressions. The
   `clone-hub-sibling` action already does a full repo clone (not spec-only), and the
   agent runs as a real tool-using session (`claude -p`), not a static prompt — it
   already had everything it needed, nothing told it to look. Added `HUB_REPO_DIR` (the
   full checkout) to the agent's inputs and told rule #4 to inspect the actual code diff
   itself (`git diff --stat` first to scope down, then look closer at anything touching
   the failing operation's handler or shared validation/config code) before crediting a
   causal link — `origin/main` is already fetched into that sibling by the earlier
   "Diff the OpenAPI spec against main" step in the same job.

## Test plan

- [x] `actionlint .github/workflows/hub-pr-check.yml` — clean
- [x] YAML parses
- [x] Verified the confidence-gating bash logic against a mock harness for all
  category/confidence combinations, including the previously-broken `unknown` case
- [x] Extracted the actual classify step's `run:` script via PyYAML, swapped the real
  `claude -p` call for an echo, and ran the whole thing with `bash -x` under mock env
  vars to see the exact, fully-expanded prompt text end to end — caught and fixed my own
  unescaped-backtick / `<path>`-as-redirection mistakes this way before they'd have
  broken the real workflow
- [ ] Next real `hub-pr-check.yml` failure should show the agent actually consulting the
  code diff (not just the spec diff) when reasoning about causality, and `hub-medic`
  pinged only at confidence `high`

🤖 Generated with [Claude Code](https://claude.com/claude-code)