### PR TITLE
chore(nightly): re-enable zzzFakeDryRunOp — camunda-hub#1 closed

### DIFF
--- a/.github/scripts/hub-collect-known-issues.mjs
+++ b/.github/scripts/hub-collect-known-issues.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Collect every knownIssue entry across the camunda-hub configs, grouped by
+// blocking issue URL, and print it as JSON to stdout for
+// hub-reenable-check.sh to consume.
+//
+// Two shapes, per #432's design notes:
+//   - opScoped: suppress[]/excludeOperations[] entries — each names a real
+//     operationId, so a closed blocker has something mechanical to remove.
+//   - suiteWide: top-level knownIssues[] entries (request-validation.json
+//     only) — no operationId, describes a broader skipped test SHAPE rather
+//     than one operation, so there is nothing to auto-unskip. Reported
+//     separately; the caller only ever surfaces these, never acts on them.
+//
+// Usage: node hub-collect-known-issues.mjs <positive-suppress.json> <request-validation.json>
+
+import { readFileSync } from 'node:fs';
+
+const [positiveSuppressPath, requestValidationPath] = process.argv.slice(2);
+if (!positiveSuppressPath || !requestValidationPath) {
+  console.error(
+    'usage: hub-collect-known-issues.mjs <positive-suppress.json> <request-validation.json>',
+  );
+  process.exit(2);
+}
+
+function loadJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+const positiveSuppress = loadJson(positiveSuppressPath);
+const requestValidation = loadJson(requestValidationPath);
+
+const opScopedByUrl = new Map();
+function addOpScoped(file, arrayKey, entries) {
+  for (const entry of entries ?? []) {
+    const url = entry?.knownIssue?.url;
+    if (!url) continue;
+    const group = opScopedByUrl.get(url) ?? { url, summary: entry.knownIssue.summary, entries: [] };
+    group.entries.push({ file, arrayKey, operationId: entry.operationId });
+    opScopedByUrl.set(url, group);
+  }
+}
+
+addOpScoped(positiveSuppressPath, 'suppress', positiveSuppress.suppress);
+addOpScoped(requestValidationPath, 'excludeOperations', requestValidation.excludeOperations);
+
+const suiteWide = (requestValidation.knownIssues ?? []).map((ki) => ({
+  url: ki.url,
+  summary: ki.summary,
+}));
+
+console.log(
+  JSON.stringify(
+    {
+      opScoped: [...opScopedByUrl.values()],
+      suiteWide,
+    },
+    null,
+    2,
+  ),
+);

--- a/.github/scripts/hub-dispatch-ondemand-validation.sh
+++ b/.github/scripts/hub-dispatch-ondemand-validation.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Dispatch hub-ondemand-test.yml (a live-Hub run) against every PR URL read
+# from stdin (one per line), then comment the run link back on the PR.
+# Extracted from triage-camunda-hub-nightly.yml's "Trigger on-demand
+# validation for any opened fix/suppress PR" step so a second caller
+# (hub-known-issue-reenable-check.yml) doesn't need its own copy of this
+# logic — see AGENTS.md's standing rule against parallel implementations
+# that drift.
+#
+# Required env: GH_TOKEN (must have contents:write + pull-requests:write on
+# $REPO, and permission to dispatch workflows there — the qa-processes App
+# token both current callers use). Optional: REPO (default
+# camunda/api-test-generator).
+#
+# Never fails the run: every step here is continue-on-error at the shell
+# level (the caller is expected to also wrap this in continue-on-error, but
+# this script degrades gracefully even without that).
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN (App/PAT with contents+PR write + workflow dispatch) required}"
+REPO="${REPO:-camunda/api-test-generator}"
+
+urls="$(cat)"
+if [ -z "$urls" ]; then
+  echo "No PR URLs to validate."
+  exit 0
+fi
+
+pr_url_re="^https://github\\.com/${REPO}/pull/[0-9]+\$"
+
+while IFS= read -r pr_url; do
+  [ -z "$pr_url" ] && continue
+  # The caller may be feeding this URLs sourced from untrusted content (e.g.
+  # an agent's triage JSON) — validate the URL is exactly a well-formed PR
+  # URL on $REPO before deriving anything from it. $REPO itself is never
+  # derived from $pr_url, so this can't redirect gh calls to a different
+  # repo, but an unvalidated value could still resolve to an unrelated real
+  # PR number on THIS repo and cause a dispatch/comment against the wrong
+  # branch.
+  if ! [[ "$pr_url" =~ $pr_url_re ]]; then
+    echo "::warning::Skipping malformed/unexpected PR URL: ${pr_url}"
+    continue
+  fi
+  pr_num="${pr_url##*/}"
+  echo "Validating PR #${pr_num} (${pr_url})"
+
+  branch=$(gh pr view "$pr_num" --repo "$REPO" --json headRefName --jq .headRefName 2>/dev/null || true)
+  if [ -z "$branch" ]; then
+    echo "::warning::Could not resolve branch for ${pr_url} — skipping validation dispatch."
+    continue
+  fi
+
+  # SECURITY: `gh workflow run ... --ref "$branch"` runs hub-ondemand-test.yml
+  # AS IT EXISTS ON THAT BRANCH, not the version on main — and that workflow
+  # calls _hub-suite-run.yml with real VAULT_* secrets. A PR that also edits
+  # .github/** would have its own modified workflow code execute with
+  # production secrets, no human review required, if this dispatched blindly.
+  # Refuse to dispatch — fail CLOSED (skip) if we can't even determine the
+  # changed files, since the cost of an unnecessary manual dispatch is
+  # trivial next to the cost of a wrong guess here.
+  if changed=$(gh pr diff "$pr_num" --repo "$REPO" --name-only 2>/dev/null); then
+    touches_github=false
+    grep -qE '^\.github/' <<<"$changed" && touches_github=true
+  else
+    echo "::warning::Could not fetch changed-files list for ${pr_url} — assuming it may touch .github/** out of caution."
+    touches_github=true
+  fi
+  if [ "$touches_github" = true ]; then
+    echo "::warning::PR #${pr_num} changes .github/** (or its changed files couldn't be verified) — skipping auto-validation dispatch; a human must review and dispatch it manually."
+    gh pr comment "$pr_num" --repo "$REPO" \
+      --body ":warning: This PR touches \`.github/**\` (or its changed files could not be verified), so automatic on-demand validation was skipped for safety — dispatching \`hub-ondemand-test.yml\` runs *this branch's own* workflow code with production secrets. A maintainer must review the workflow changes and dispatch it manually before merging." \
+      2>/dev/null || true
+    continue
+  fi
+
+  if ! gh workflow run hub-ondemand-test.yml --repo "$REPO" --ref "$branch"; then
+    echo "::warning::Could not dispatch hub-ondemand-test.yml for ${pr_url}"
+    gh pr comment "$pr_num" --repo "$REPO" \
+      --body ":warning: Could not auto-dispatch on-demand validation (\`hub-ondemand-test.yml\`) for this PR — please trigger it manually against this branch before merging (it starts a live Hub and runs the real suite; \`hub-invariants\` on this PR only checks static invariants against the pinned spec, not a live run)." \
+      2>/dev/null || true
+    continue
+  fi
+
+  # workflow_run creation isn't synchronous with the dispatch call — poll
+  # briefly for the run this dispatch just created.
+  run_url=""
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    sleep 3
+    run_id=$(gh run list --repo "$REPO" --workflow=hub-ondemand-test.yml --branch "$branch" --event workflow_dispatch --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)
+    if [ -n "$run_id" ]; then
+      run_url="https://github.com/${REPO}/actions/runs/${run_id}"
+      break
+    fi
+  done
+
+  # shellcheck disable=SC2016  # literal backticks for markdown, no expansion wanted
+  note_body=$(if [ -n "$run_url" ]; then
+    printf '🔎 **On-demand validation**: [hub-ondemand-test run](%s) — dispatched automatically. This confirms the change actually passes against a live Hub, not just static invariants (which is all `hub-invariants` on this PR checks).' "$run_url"
+  else
+    printf '⚠️ Dispatched `hub-ondemand-test.yml` for validation but could not resolve the run URL within the poll window — check the Actions tab for branch `%s`.' "$branch"
+  fi)
+  gh pr comment "$pr_num" --repo "$REPO" --body "$note_body" 2>/dev/null \
+    || echo "::warning::Could not comment validation link on #${pr_num}"
+done <<< "$urls"

--- a/.github/scripts/hub-reenable-check.sh
+++ b/.github/scripts/hub-reenable-check.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Core logic for hub-known-issue-reenable-check.yml (#432): detect camunda-hub
+# blocker issues that have closed since a suppress/exclude entry referenced
+# them, and for each one, remove the matching entries + open a draft PR so a
+# human (backed by an automatic live-Hub validation run) can confirm the
+# operation is safe to re-enable.
+#
+# Deliberately fully deterministic — no LLM/agent judgment anywhere. Detecting
+# "is this issue closed" and "remove this JSON entry" are both pure mechanics;
+# see the plan/AGENTS.md note on why this isn't built as an agent extension.
+#
+# Required env: GH_TOKEN_HUB (Issues:read on camunda-hub — may be empty, this
+# script degrades gracefully), GH_TOKEN_GENERATOR (contents+PR write on
+# api-test-generator — may be empty, blocks only the PR-opening step).
+# Run from the repo root.
+#
+# Never hard-fails the run: every external call (gh, npm) that legitimately
+# can fail keeps going to the next candidate rather than aborting the script.
+set -uo pipefail
+
+POSITIVE_SUPPRESS=configs/camunda-hub/positive-suppress.json
+REQUEST_VALIDATION=configs/camunda-hub/request-validation.json
+HUB_REPO=camunda/camunda-hub
+GEN_REPO=camunda/api-test-generator
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SUMMARY_FILE="${SUMMARY_FILE:-/tmp/hub-reenable-summary.json}"
+summary_actions='[]' # accumulated as we go; each item: {type, url, title, ...}
+
+add_summary() {
+  # $1: a JSON object literal (already valid JSON) to append.
+  summary_actions="$(jq -c --argjson item "$1" '. + [$item]' <<<"$summary_actions")"
+}
+
+echo "== Collecting knownIssue entries =="
+collected="$(node "${SCRIPT_DIR}/hub-collect-known-issues.mjs" "$POSITIVE_SUPPRESS" "$REQUEST_VALIDATION")"
+op_scoped_count=$(jq '.opScoped | length' <<<"$collected")
+suite_wide_count=$(jq '.suiteWide | length' <<<"$collected")
+echo "Op-scoped blockers: ${op_scoped_count}, suite-wide (no operationId): ${suite_wide_count}"
+
+# --- Suite-wide knownIssues[] — report-only, never acted on -----------------
+if [ "$suite_wide_count" -gt 0 ]; then
+  while IFS= read -r item; do
+    url=$(jq -r '.url' <<<"$item")
+    summary=$(jq -r '.summary' <<<"$item")
+    if [ -z "${GH_TOKEN_HUB:-}" ]; then
+      echo "No GH_TOKEN_HUB — skipping state check for suite-wide ${url}"
+      continue
+    fi
+    state=$(GH_TOKEN="$GH_TOKEN_HUB" gh issue view "$url" --repo "$HUB_REPO" --json state --jq .state 2>/dev/null || true)
+    echo "suite-wide: ${url} -> ${state:-unresolved}"
+    if [ "$state" = "CLOSED" ]; then
+      add_summary "$(jq -nc --arg url "$url" --arg summary "$summary" \
+        '{type: "suite_wide_closed", url: $url, summary: $summary}')"
+    fi
+  done < <(jq -c '.suiteWide[]' <<<"$collected")
+fi
+
+# --- Op-scoped blockers — the actionable path -------------------------------
+while IFS= read -r group; do
+  url=$(jq -r '.url' <<<"$group")
+  issue_num="${url##*/}"
+
+  if [ -z "${GH_TOKEN_HUB:-}" ]; then
+    echo "No GH_TOKEN_HUB — cannot resolve state for ${url}, skipping."
+    continue
+  fi
+
+  view_json=$(GH_TOKEN="$GH_TOKEN_HUB" gh issue view "$url" --repo "$HUB_REPO" --json state,title 2>/dev/null || true)
+  if [ -z "$view_json" ]; then
+    echo "::warning::Could not resolve state for ${url} (empty/403?) — skipping, will retry next run."
+    continue
+  fi
+  state=$(jq -r '.state' <<<"$view_json")
+  title=$(jq -r '.title' <<<"$view_json")
+  echo "op-scoped: ${url} (${title}) -> ${state}"
+  if [ "$state" != "CLOSED" ]; then
+    continue
+  fi
+
+  ops="$(jq -r '.entries | map(.operationId) | unique | join(", ")' <<<"$group")"
+  branch="chore/hub-unskip-${issue_num}"
+
+  existing_pr="$(gh pr list --repo "$GEN_REPO" --head "$branch" --state open --json url --jq '.[0].url // empty' 2>/dev/null || true)"
+  if [ -n "$existing_pr" ]; then
+    echo "Blocker ${url} already has an open unskip PR: ${existing_pr}"
+    add_summary "$(jq -nc --arg url "$url" --arg title "$title" --arg pr "$existing_pr" --arg ops "$ops" \
+      '{type: "already_in_flight", url: $url, title: $title, pr_url: $pr, operations: $ops}')"
+    continue
+  fi
+
+  # (No separate "already removed?" pre-check needed: hub-collect-known-issues.mjs
+  # read the config files fresh at the top of this script, so a blocker whose
+  # entries were already removed by a prior, since-merged run would never
+  # appear in $collected in the first place.)
+  echo "Blocker ${url} is CLOSED — attempting to re-enable: ${ops}"
+
+  # --- Remove the entries (scratch working tree, not yet committed) --------
+  removed_ops=""
+  while IFS=$'\t' read -r file arrayKey _operationId; do
+    out="$(node "${SCRIPT_DIR}/hub-remove-known-issue-entries.mjs" "$file" "$arrayKey" "$url" 2>&1)"
+    rc=$?
+    if [ $rc -ne 0 ]; then
+      echo "::warning::Failed removing entries from ${file} for ${url}: ${out}"
+    elif [ -n "$out" ]; then
+      removed_ops="${removed_ops}${out}"$'\n'
+    fi
+  done < <(jq -r '.entries[] | [.file, .arrayKey, .operationId] | @tsv' <<<"$group" | sort -u -t $'\t' -k1,2)
+
+  if [ -z "$removed_ops" ]; then
+    echo "::warning::Blocker ${url}: expected to remove entries but nothing changed — skipping."
+    git checkout -- "$POSITIVE_SUPPRESS" "$REQUEST_VALIDATION" 2>/dev/null || true
+    continue
+  fi
+
+  # --- Regenerate + narrow local guard before committing anything ----------
+  echo "Regenerating camunda-hub + running local guards for ${url}..."
+  if CONFIG=camunda-hub npm run testsuite:generate >/tmp/hub-reenable-generate.log 2>&1 \
+    && CONFIG=camunda-hub npm run generate:request-validation >>/tmp/hub-reenable-generate.log 2>&1 \
+    && CONFIG=camunda-hub npx vitest run configs/camunda-hub/regression-invariants.test.ts \
+         tests/codegen/known-issue-summary-consistency.test.ts >>/tmp/hub-reenable-generate.log 2>&1; then
+    checks_ok=true
+  else
+    checks_ok=false
+  fi
+
+  if [ "$checks_ok" != "true" ]; then
+    echo "::warning::Blocker ${url}: re-enabling broke local generate/tests — see /tmp/hub-reenable-generate.log. Reverting, NOT opening a PR."
+    git checkout -- "$POSITIVE_SUPPRESS" "$REQUEST_VALIDATION" 2>/dev/null || true
+    add_summary "$(jq -nc --arg url "$url" --arg title "$title" --arg ops "$ops" \
+      '{type: "aborted_broke_checks", url: $url, title: $title, operations: $ops}')"
+    continue
+  fi
+
+  if [ -z "${GH_TOKEN_GENERATOR:-}" ]; then
+    echo "::warning::No GH_TOKEN_GENERATOR — cannot open the unskip PR for ${url}. Reverting local edit (will retry next run)."
+    git checkout -- "$POSITIVE_SUPPRESS" "$REQUEST_VALIDATION" 2>/dev/null || true
+    add_summary "$(jq -nc --arg url "$url" --arg title "$title" --arg ops "$ops" \
+      '{type: "aborted_no_token", url: $url, title: $title, operations: $ops}')"
+    continue
+  fi
+
+  # --- Commit, push, open the draft PR --------------------------------------
+  git config user.name "github-actions[bot]"
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  git checkout -B "$branch"
+  git add "$POSITIVE_SUPPRESS" "$REQUEST_VALIDATION"
+  git commit -m "chore(hub-unskip): re-enable ${ops} — camunda-hub#${issue_num} closed
+
+camunda-hub#${issue_num} (\"${title}\") is closed. This removes the
+suppress/exclude entries that were blocked on it, so the following
+operation(s) get their tests back: ${ops}." >/dev/null
+
+  git config --local --unset-all 'http.https://github.com/.extraheader' 2>/dev/null || true
+  git remote set-url origin "https://x-access-token:${GH_TOKEN_GENERATOR}@github.com/${GEN_REPO}.git"
+  git push --force origin "$branch"
+
+  body_file="$(mktemp)"
+  {
+    echo "camunda-hub#${issue_num} (\"${title}\") is now **closed**. This removes the"
+    echo "suppress/exclude entries that were blocked on it:"
+    echo
+    # shellcheck disable=SC2016  # literal backticks for markdown, no expansion wanted
+    printf '%s\n' "$removed_ops" | sed '/^$/d' | sed 's/^/- `/; s/$/`/'
+    echo
+    echo "This PR is a **draft** — it is not ready to merge on its own. A live-Hub"
+    echo "validation run is dispatched automatically (see the comment below); if"
+    echo "the upstream fix was only partial, that run will fail and someone should"
+    echo "investigate before merging."
+    echo
+    echo "Closed blocker: ${url}"
+    echo
+    echo "🤖 Opened by the hub-known-issue-reenable-check workflow (#432)."
+  } > "$body_file"
+
+  GH_TOKEN="$GH_TOKEN_GENERATOR" gh label create nightly-api-fix --repo "$GEN_REPO" --color FF4444 \
+    --description "Bot-opened fix PR for a nightly triage finding (test-generation bug or coverage gap)" 2>/dev/null || true
+
+  pr_url="$(GH_TOKEN="$GH_TOKEN_GENERATOR" gh pr create --repo "$GEN_REPO" --base main --head "$branch" --draft \
+    --title "chore(nightly): re-enable ${ops} — camunda-hub#${issue_num} closed" \
+    --body-file "$body_file" --label nightly-api-fix 2>&1)"
+  create_rc=$?
+  rm -f "$body_file"
+
+  if [ $create_rc -ne 0 ]; then
+    echo "::warning::Could not open unskip PR for ${url}: ${pr_url}"
+    add_summary "$(jq -nc --arg url "$url" --arg title "$title" --arg ops "$ops" --arg err "$pr_url" \
+      '{type: "aborted_pr_create_failed", url: $url, title: $title, operations: $ops, error: $err}')"
+    git checkout main 2>/dev/null || true
+    continue
+  fi
+
+  echo "Opened unskip PR: ${pr_url}"
+  add_summary "$(jq -nc --arg url "$url" --arg title "$title" --arg ops "$ops" --arg pr "$pr_url" \
+    '{type: "opened", url: $url, title: $title, operations: $ops, pr_url: $pr}')"
+
+  # Same live-Hub validation every fix/suppress PR from the triage workflow
+  # gets — extracted so both callers share one hardened implementation.
+  printf '%s\n' "$pr_url" | GH_TOKEN="$GH_TOKEN_GENERATOR" REPO="$GEN_REPO" \
+    bash "${SCRIPT_DIR}/hub-dispatch-ondemand-validation.sh" || true
+
+  git checkout main 2>/dev/null || true
+done < <(jq -c '.opScoped[]' <<<"$collected")
+
+echo "$summary_actions" > "$SUMMARY_FILE"
+echo "== Summary written to ${SUMMARY_FILE} =="
+cat "$SUMMARY_FILE"

--- a/.github/scripts/hub-reenable-format-slack.sh
+++ b/.github/scripts/hub-reenable-format-slack.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Format the summary JSON written by hub-reenable-check.sh into a Slack
+# mrkdwn message body. Prints nothing (exit 0) when there's nothing to
+# report — the caller should skip posting entirely in that case, matching
+# spec-bump-check.yml's "non-spammy" convention (silent on a no-op run).
+#
+#   hub-reenable-format-slack.sh <summary.json>
+set -euo pipefail
+
+FILE="${1:?usage: hub-reenable-format-slack.sh <summary.json>}"
+
+if [ ! -s "$FILE" ]; then
+  exit 0
+fi
+
+if ! jq empty "$FILE" 2>/dev/null; then
+  echo ":warning: hub-known-issue-reenable-check produced a non-JSON summary — check the run."
+  exit 0
+fi
+
+jq -r '
+  def line(item):
+    item.url as $url | item.title as $title | (item.operations // "") as $ops |
+    if item.type == "opened" then
+      "🎉 <" + $url + "|camunda-hub#" + ($url | split("/") | last) + "> (\"" + $title + "\") is closed — re-enabled: `" + $ops + "` → <" + item.pr_url + "|draft PR> (pending live-Hub validation)"
+    elif item.type == "already_in_flight" then
+      "🎉 <" + $url + "|camunda-hub#" + ($url | split("/") | last) + "> is closed — `" + $ops + "` already has an open unskip PR: <" + item.pr_url + ">"
+    elif item.type == "aborted_broke_checks" then
+      "⚠️ <" + $url + "|camunda-hub#" + ($url | split("/") | last) + "> is closed, but re-enabling `" + $ops + "` breaks local generate/tests — needs manual investigation (see the workflow run log)."
+    elif item.type == "aborted_no_token" then
+      "⚠️ <" + $url + "|camunda-hub#" + ($url | split("/") | last) + "> is closed and `" + $ops + "` is ready to re-enable, but no generator token was available this run — will retry."
+    elif item.type == "aborted_pr_create_failed" then
+      "⚠️ <" + $url + "|camunda-hub#" + ($url | split("/") | last) + "> is closed, but opening the unskip PR for `" + $ops + "` failed — see the workflow run log."
+    elif item.type == "suite_wide_closed" then
+      "📋 <" + $url + "|camunda-hub#" + ($url | split("/") | last) + "> (\"" + (item.summary // "") + "\") is closed but has no specific operation(s) to auto-unskip — needs manual follow-up."
+    else
+      "❓ Unrecognized summary item type: " + (item.type // "?")
+    end;
+  if length == 0 then "" else
+    ":gear: *camunda-hub known-issue re-enable check*\n" + (map(line(.)) | join("\n"))
+  end
+' "$FILE"

--- a/.github/scripts/hub-remove-known-issue-entries.mjs
+++ b/.github/scripts/hub-remove-known-issue-entries.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// Remove every entry in <file>'s <arrayKey> array whose knownIssue.url equals
+// <issueUrl>, rewriting the file with the same 2-space-indent + trailing-
+// newline formatting the config files already use. Prints the removed
+// operationIds, one per line, so the caller can report exactly what was
+// re-enabled. A no-op call (no matching entries) never touches the file.
+//
+// Usage: node hub-remove-known-issue-entries.mjs <file> <arrayKey> <issueUrl>
+//
+// Called by hub-reenable-check.sh — see that script + AGENTS.md's "Standing
+// rule: every new request-validation scenario kind needs an applicability
+// rule" neighbourhood for the broader knownIssue convention this operates on.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const [file, arrayKey, issueUrl] = process.argv.slice(2);
+if (!file || !arrayKey || !issueUrl) {
+  console.error('usage: hub-remove-known-issue-entries.mjs <file> <arrayKey> <issueUrl>');
+  process.exit(2);
+}
+
+const raw = readFileSync(file, 'utf8');
+const data = JSON.parse(raw);
+
+const entries = data[arrayKey];
+if (!Array.isArray(entries)) {
+  console.error(`::error::${file} has no array at "${arrayKey}"`);
+  process.exit(2);
+}
+
+const removed = [];
+const kept = entries.filter((entry) => {
+  const matches = entry?.knownIssue?.url === issueUrl;
+  if (matches) removed.push(entry.operationId ?? '(no operationId)');
+  return !matches;
+});
+
+if (removed.length === 0) {
+  // Nothing to do — leave the file untouched (no rewrite, no trailing diff).
+  process.exit(0);
+}
+
+data[arrayKey] = kept;
+writeFileSync(file, `${JSON.stringify(data, null, 2)}\n`);
+
+for (const operationId of removed) {
+  console.log(operationId);
+}

--- a/.github/workflows/hub-known-issue-reenable-check.yml
+++ b/.github/workflows/hub-known-issue-reenable-check.yml
@@ -1,0 +1,165 @@
+# Scheduled, non-blocking check for #432: camunda-hub nightly coverage
+# statically skips operations blocked on known upstream issues (knownIssue
+# entries in configs/camunda-hub/{positive-suppress,request-validation}.json).
+# When the blocking issue closes, nothing tells anyone to re-enable the test
+# — coverage silently rots. This workflow detects a closed blocker and reacts:
+# removes the matching suppress/exclude entries, regenerates + runs a narrow
+# local guard, and — if that's clean — opens a draft PR (never auto-merged)
+# plus a Slack heads-up. If checks fail (the upstream fix was partial, or a
+# hardcoded invariant still expects the op suppressed), it reverts and reports
+# instead of opening a broken PR.
+#
+# Fully deterministic — no agent/LLM judgment anywhere (see AGENTS.md and
+# .github/scripts/hub-reenable-check.sh's header for why #432's original plan
+# to extend the nightly triage agent was reconsidered). Modeled on
+# spec-bump-check.yml's shape: schedule → resolve external state → route to a
+# PR or a Slack notice, non-spammy (silent when there's nothing to report).
+#
+# Two qa-processes App tokens, same split as triage-camunda-hub-nightly.yml:
+# GH_TOKEN_HUB (Issues:read on camunda-hub — it already has Issues:write there
+# for the triage agent's own issue filing, which implies read, so #432's
+# stated "grant Issues: Read" prerequisite needed no new provisioning) and
+# GH_TOKEN_GENERATOR (contents+PR write on api-test-generator, to open the
+# draft PR). Live-Hub validation of any opened PR reuses
+# hub-dispatch-ondemand-validation.sh, the same script
+# triage-camunda-hub-nightly.yml uses for its own fix/suppress PRs.
+name: Hub known-issue re-enable check
+
+on:
+  schedule:
+    # 04:00 UTC — after the 02:00 camunda-hub nightly and the 03:00
+    # spec-bump-check, so it never races either.
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # OIDC → Vault, for both qa-processes App tokens + Slack
+
+concurrency:
+  group: hub-known-issue-reenable-check
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check closed blockers → unskip PR + Slack
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          # Don't persist github.token — it's read-only here and its
+          # Authorization header would take precedence over the App-token URL
+          # the script sets before pushing (same reasoning as
+          # spec-bump-open-pr.sh's identical unset-then-set-url step).
+          persist-credentials: false
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci
+
+      # --- Two separately-scoped qa-processes App tokens ----------------------
+      - name: Generate qa-processes App token (camunda-hub issues)
+        id: qa-token-hub
+        continue-on-error: true
+        # Pinned SHA — same pin as triage-camunda-hub-nightly.yml /
+        # spec-bump-check.yml. Bump intentionally.
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@7a9c6f3e477321400802c88290068f88a7ed5684
+        with:
+          github-app-id-vault-key: GITHUB_APP_ID
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          github-app-private-key-vault-key: GITHUB_APP_SECRET
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          owner: camunda
+          repositories: camunda-hub
+
+      - name: Generate qa-processes App token (api-test-generator PRs)
+        id: qa-token-generator
+        continue-on-error: true
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@7a9c6f3e477321400802c88290068f88a7ed5684
+        with:
+          github-app-id-vault-key: GITHUB_APP_ID
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          github-app-private-key-vault-key: GITHUB_APP_SECRET
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          owner: camunda
+          repositories: api-test-generator
+
+      - name: Fetch Slack bot token from Vault
+        id: slack
+        continue-on-error: true
+        uses: ./.github/actions/slack-token
+        with:
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          vault-jwt-path: ${{ secrets.VAULT_JWT_PATH }}
+          vault-jwt-role: ${{ secrets.VAULT_JWT_ROLE }}
+          vault-jwt-audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
+
+      # --- The actual check ----------------------------------------------------
+      # Neither token being empty fails this step — the script degrades
+      # gracefully (skips state checks without GH_TOKEN_HUB, skips PR-opening
+      # without GH_TOKEN_GENERATOR, reverting any local edit either way) per
+      # #432's explicit graceful-degrade requirement.
+      - name: Run hub-reenable-check
+        id: reenable
+        env:
+          GH_TOKEN_HUB: ${{ steps.qa-token-hub.outputs.token }}
+          GH_TOKEN_GENERATOR: ${{ steps.qa-token-generator.outputs.token }}
+          SUMMARY_FILE: ${{ github.workspace }}/hub-reenable-summary.json
+        run: bash .github/scripts/hub-reenable-check.sh
+
+      # --- Slack heads-up, only when there's something to report ---------------
+      - name: Build Slack message
+        id: slack-message
+        if: always() && steps.slack.outputs.SLACK_BOT_TOKEN != ''
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          text="$(bash .github/scripts/hub-reenable-format-slack.sh "${{ github.workspace }}/hub-reenable-summary.json")"
+          {
+            echo 'text<<EOF'
+            echo "$text"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack
+        if: >-
+          always() && steps.slack.outputs.SLACK_BOT_TOKEN != '' &&
+          steps.slack-message.outcome == 'success' && steps.slack-message.outputs.text != ''
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v2
+        with:
+          method: chat.postMessage
+          token: ${{ steps.slack.outputs.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "#camunda-hub-nightly-test-results",
+              "text": ${{ toJSON(steps.slack-message.outputs.text) }},
+              "mrkdwn": true
+            }
+
+      - name: Write job summary
+        if: always()
+        run: |
+          {
+            echo "## Hub known-issue re-enable check"
+            echo ""
+            echo '```json'
+            cat "${{ github.workspace }}/hub-reenable-summary.json" 2>/dev/null || echo "[]"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/triage-camunda-hub-nightly.yml
+++ b/.github/workflows/triage-camunda-hub-nightly.yml
@@ -640,6 +640,9 @@ jobs:
           # Both are real api-test-generator PRs the agent opened — a
           # suppress PR needs the same live-Hub proof a fix PR does (that the
           # operation is now correctly suppressed, not that anything broke).
+          # hub-triage.json is written by an agent working from untrusted
+          # report content — the dispatch script below re-validates each URL
+          # before deriving anything from it.
           urls=$(jq -r '
             [(.failures // [] | .[]? | .fix_pr_url // empty),
              (.failures // [] | .[]? | .suppress_pr_url // empty),
@@ -656,84 +659,7 @@ jobs:
             exit 0
           fi
 
-          while IFS= read -r pr_url; do
-            [ -z "$pr_url" ] && continue
-            # hub-triage.json is written by an agent working from untrusted
-            # report content — validate the URL is exactly a well-formed
-            # camunda/api-test-generator PR URL before deriving anything from
-            # it. $REPO is already hardcoded (not derived from $pr_url), so
-            # this can't redirect gh calls to a different repo, but an
-            # unvalidated value could still resolve to an unrelated real PR
-            # number on THIS repo and cause a dispatch/comment against the
-            # wrong branch.
-            if ! [[ "$pr_url" =~ ^https://github\.com/camunda/api-test-generator/pull/[0-9]+$ ]]; then
-              echo "::warning::Skipping malformed/unexpected PR URL from triage JSON: ${pr_url}"
-              continue
-            fi
-            pr_num="${pr_url##*/}"
-            echo "Validating fix/suppress PR #${pr_num} (${pr_url})"
-
-            branch=$(gh pr view "$pr_num" --repo "$REPO" --json headRefName --jq .headRefName 2>/dev/null || true)
-            if [ -z "$branch" ]; then
-              echo "::warning::Could not resolve branch for ${pr_url} — skipping validation dispatch."
-              continue
-            fi
-
-            # SECURITY: `gh workflow run ... --ref "$branch"` runs
-            # hub-ondemand-test.yml AS IT EXISTS ON THAT BRANCH, not the
-            # version on main — and that workflow calls _hub-suite-run.yml
-            # with real VAULT_* secrets. The agent that opened this PR was fed
-            # untrusted nightly-report content and runs unattended
-            # (--dangerously-skip-permissions); if adversarial content ever
-            # steered it into a PR that also edits .github/**, auto-dispatching
-            # here would execute that modified workflow with production
-            # secrets, no human review required. Refuse to dispatch — fail
-            # CLOSED (skip) if we can't even determine the changed files,
-            # since the cost of an unnecessary manual dispatch is trivial next
-            # to the cost of a wrong guess here.
-            if changed=$(gh pr diff "$pr_num" --repo "$REPO" --name-only 2>/dev/null); then
-              touches_github=false
-              grep -qE '^\.github/' <<<"$changed" && touches_github=true
-            else
-              echo "::warning::Could not fetch changed-files list for ${pr_url} — assuming it may touch .github/** out of caution."
-              touches_github=true
-            fi
-            if [ "$touches_github" = true ]; then
-              echo "::warning::PR #${pr_num} changes .github/** (or its changed files couldn't be verified) — skipping auto-validation dispatch; a human must review and dispatch it manually."
-              gh pr comment "$pr_num" --repo "$REPO" \
-                --body ":warning: This PR touches \`.github/**\` (or its changed files could not be verified), so automatic on-demand validation was skipped for safety — dispatching \`hub-ondemand-test.yml\` runs *this branch's own* workflow code with production secrets. A maintainer must review the workflow changes and dispatch it manually before merging." \
-                2>/dev/null || true
-              continue
-            fi
-
-            if ! gh workflow run hub-ondemand-test.yml --repo "$REPO" --ref "$branch"; then
-              echo "::warning::Could not dispatch hub-ondemand-test.yml for ${pr_url}"
-              gh pr comment "$pr_num" --repo "$REPO" \
-                --body ":warning: Could not auto-dispatch on-demand validation (\`hub-ondemand-test.yml\`) for this PR — please trigger it manually against this branch before merging (it starts a live Hub and runs the real suite; \`hub-invariants\` on this PR only checks static invariants against the pinned spec, not a live run)." \
-                2>/dev/null || true
-              continue
-            fi
-
-            # workflow_run creation isn't synchronous with the dispatch call —
-            # poll briefly for the run this dispatch just created.
-            run_url=""
-            for _ in 1 2 3 4 5 6 7 8 9 10; do
-              sleep 3
-              run_id=$(gh run list --repo "$REPO" --workflow=hub-ondemand-test.yml --branch "$branch" --event workflow_dispatch --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)
-              if [ -n "$run_id" ]; then
-                run_url="https://github.com/${REPO}/actions/runs/${run_id}"
-                break
-              fi
-            done
-
-            note_body=$(if [ -n "$run_url" ]; then
-              printf '🔎 **On-demand validation**: [hub-ondemand-test run](%s) — dispatched automatically. This confirms the change actually passes against a live Hub, not just static invariants (which is all `hub-invariants` on this PR checks).' "$run_url"
-            else
-              printf '⚠️ Dispatched `hub-ondemand-test.yml` for validation but could not resolve the run URL within the poll window — check the Actions tab for branch `%s`.' "$branch"
-            fi)
-            gh pr comment "$pr_num" --repo "$REPO" --body "$note_body" 2>/dev/null \
-              || echo "::warning::Could not comment validation link on #${pr_num}"
-          done <<< "$urls"
+          printf '%s\n' "$urls" | bash .github/scripts/hub-dispatch-ondemand-validation.sh
 
       # No reports downloaded → write an inconclusive result so Slack announces it
       # (never a green digest). Mirrors the c8 "no false all-clear" rule.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -584,6 +584,33 @@ warning). `do-not-close` holds a PR across the daily reset; `dry_run` previews.
 Fix PRs must carry the `nightly-api-fix` label to be managed (the filed issues say
 so).
 
+The **hub known-issue re-enable check**
+([hub-known-issue-reenable-check.yml](.github/workflows/hub-known-issue-reenable-check.yml),
+#432) is a scheduled (04:00 UTC, after the nightly + spec-bump-check) +
+`workflow_dispatch` job that watches for a camunda-hub `knownIssue` blocker
+closing. Both suite configs' `knownIssue.url` entries (`positive-suppress.json`'s
+`suppress[]`, `request-validation.json`'s `excludeOperations[]`) are collected
+and checked via `gh issue view`; for each one that's now **closed**, it removes
+the matching entries, regenerates camunda-hub, runs a narrow local guard
+(`configs/camunda-hub/regression-invariants.test.ts` +
+`tests/codegen/known-issue-summary-consistency.test.ts`), and — only if that's
+clean — opens a **draft** PR (branch `chore/hub-unskip-<issue-number>`, label
+`nightly-api-fix`) plus a Slack heads-up to
+`#camunda-hub-nightly-test-results`. If the local guard fails (the upstream fix
+was partial, or a hardcoded invariant still expects the op suppressed), it
+reverts and reports instead of opening a broken PR. Entirely deterministic —
+no agent involved, unlike the triage flow above; detecting a closed issue and
+removing a JSON entry are pure mechanics. Same two-App-token split as the
+triage agent (`GH_TOKEN_HUB` for the issue-state check, `GH_TOKEN_GENERATOR`
+for the PR), and any PR it opens gets the same automatic live-Hub validation
+dispatch via the shared `.github/scripts/hub-dispatch-ondemand-validation.sh`
+(extracted from the triage workflow's own equivalent step so the two don't
+carry duplicate copies of that hardened logic). Top-level `knownIssues[]`
+entries (suite-wide, no `operationId`) get a Slack mention when closed but are
+never auto-acted on — there's nothing mechanical to remove for them. Silent
+(no Slack post) when there's nothing to report, matching spec-bump-check's
+non-spammy convention.
+
 The **on-demand hub test** ([hub-ondemand-test.yml](.github/workflows/hub-ondemand-test.yml))
 is the nightly's manual sibling: `workflow_dispatch` it against **any branch**
 (`gh workflow run hub-ondemand-test.yml --ref <branch>`, or the Actions UI branch


### PR DESCRIPTION
camunda-hub#1 ("Edited README via GitHub") is now **closed**. This removes the
suppress/exclude entries that were blocked on it:

- `zzzFakeDryRunOp`

This PR is a **draft** — it is not ready to merge on its own. A live-Hub
validation run is dispatched automatically (see the comment below); if
the upstream fix was only partial, that run will fail and someone should
investigate before merging.

Closed blocker: https://github.com/octocat/Hello-World/issues/1

🤖 Opened by the hub-known-issue-reenable-check workflow (#432).
