### PR TITLE
ci: retry the Hub registry login and gate the coverage check on generate running

### DIFF
--- a/.github/workflows/_hub-suite-run.yml
+++ b/.github/workflows/_hub-suite-run.yml
@@ -169,7 +169,23 @@ jobs:
             echo "::error::hub_registry=$REGISTRY set but REGISTRY_USERNAME/PASSWORD not provided."
             exit 1
           fi
-          printf '%s' "$REGISTRY_PASSWORD" | docker login "$REGISTRY" -u "$REGISTRY_USERNAME" --password-stdin
+          # Retry to absorb a transient registry blip ("Get https://…/v2/:
+          # net/http: request canceled while waiting for connection") — same
+          # reason the compose pull in docker/start-hub.sh retries. `timeout`
+          # bounds an attempt that hangs past docker's own client timeout.
+          # A credential/permission error is not retry-fixable, but it fails
+          # identically on every attempt, so the job still goes red.
+          login_attempts=0
+          until printf '%s' "$REGISTRY_PASSWORD" \
+            | timeout 60 docker login "$REGISTRY" -u "$REGISTRY_USERNAME" --password-stdin; do
+            login_attempts=$((login_attempts + 1))
+            if [ "$login_attempts" -ge 3 ]; then
+              echo "::error::docker login to '$REGISTRY' failed after ${login_attempts} attempts."
+              exit 1
+            fi
+            echo "docker login failed — retry ${login_attempts}/3 in $((login_attempts * 10))s..."
+            sleep $((login_attempts * 10))
+          done
 
       - name: Start Hub (prebuilt image)
         env:
@@ -187,6 +203,7 @@ jobs:
       # hub_ref (SKIP_BUNDLE unset), so the generated suite matches the ref under
       # test — no separate bundle step needed.
       - name: Generate + run positive + negative suites
+        id: suites
         env:
           STEPS: generate run
           RV_PROFILES: secured rbac
@@ -205,9 +222,13 @@ jobs:
       # later via the separate spec-bump tracking issue. `if: always()`: run
       # this even if the suite run above already failed for an unrelated
       # reason, so both signals surface together instead of one hiding the other.
+      # Gated on the suite step not being SKIPPED, though: if the job died before
+      # generate ever ran (registry login, Hub startup), coverage.json cannot
+      # exist and this would add a spurious second ::error:: that buries the real
+      # cause in the summary and misleads hub-pr-check's classify step.
       - name: Fail if any operation has no generated test coverage
         id: unmapped
-        if: always()
+        if: always() && steps.suites.conclusion != 'skipped'
         run: |
           set -euo pipefail
           # A read/parse failure (missing file, corrupt JSON) is NOT the same


### PR DESCRIPTION
## What failed

[Hub PR check run 31081428756](https://github.com/camunda/api-test-generator/actions/runs/31081428756/job/92550938638) (triggered by [camunda-hub#26988](https://github.com/camunda/camunda-hub/pull/26988)) went red in **Log in to the Hub image registry**:

```
Error response from daemon: Get "https://registry.camunda.cloud/v2/": net/http:
request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```

A transient registry/network blip, ~15s in. The step is a single-shot `docker login` with no retry, so the job aborted before the image was ever pulled — every downstream step (Start Hub, Wait for Hub, generate + run) was skipped. Nothing about the Hub PR under test was actually exercised.

Notably, `docker/start-hub.sh` already retries the compose pull 3× for *exactly* this failure mode ("transient registry pull error"). The login step was the one registry-touching step that didn't.

## Changes

**1. Retry the login (the actual fix).** 3 attempts with 10s/20s backoff, mirroring the existing `start-hub.sh` pattern, plus an explicit `timeout 60` per attempt so a hang past docker's own client timeout can't eat the job budget.

This does not mask anything: a genuine credential or permission error fails identically on all three attempts and the job still goes red. Only a blip self-heals.

**2. Stop the coverage check from firing when generate never ran.** The same run also emitted a second, misleading error:

```
::error::Could not read/parse generated/camunda-hub/playwright/coverage.json
```

`coverage.json` obviously cannot exist when the job died before `generate` — the step's `if: always()` fired anyway, which buried the real cause in the run summary and gave `hub-pr-check.yml`'s classify step a bogus signal to reason about. It's now gated on the suite step not having been *skipped*, so it still runs when generate itself fails (both signals surfacing together, which is the step's stated intent) but not when generate never got the chance.

## Validation

- `actionlint .github/workflows/_hub-suite-run.yml` — clean
- `bash -n` on the extracted login step — clean
- YAML parses; step gate resolves to `always() && steps.suites.conclusion != 'skipped'`

The registry blip is not locally reproducible; the retry logic is a direct port of the pattern already proven in `docker/start-hub.sh`. The next Hub PR dispatch exercises this path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)