### PR TITLE
feat(ci): live curl-replay verification before filing a new camunda-hub product bug (#482)

### DIFF
--- a/.github/workflows/triage-camunda-hub-nightly.yml
+++ b/.github/workflows/triage-camunda-hub-nightly.yml
@@ -191,35 +191,14 @@ jobs:
             echo "has_negative_failures=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Same App + Vault wiring as the "Mint camunda-hub clone token" step
-      # below (for the agent's own workspace) — a separate token/clone
-      # because this one starts a real Hub Docker container from it, an
-      # entirely different purpose from the agent's read-only source clone.
-      # continue-on-error: a failure anywhere in this verification chain
+      # No camunda-hub clone needed here: HUB_MODE=prebuilt (the "Start Hub"
+      # step below) runs a published DOCKER IMAGE, not a source build —
+      # docker/start-hub.sh's own source-build path is the only one that
+      # touches the ../camunda-hub sibling (for `make`/a JDK/the local-bundle
+      # spec source), and that path is never taken here. continue-on-error
+      # on every step below: a failure anywhere in this verification chain
       # must degrade to "no verification data" (handled by the guidance doc
       # below), never fail the whole triage run.
-      - name: Mint camunda-hub clone token (live verification)
-        id: verify-hub-token
-        if: ${{ steps.reports.outputs.has_reports == 'true' && steps.neg-failures.outputs.has_negative_failures == 'true' }}
-        continue-on-error: true
-        uses: ./.github/actions/hub-clone-token
-        with:
-          vault-url: ${{ secrets.VAULT_ADDR }}
-          vault-jwt-path: ${{ secrets.VAULT_JWT_PATH }}
-          vault-jwt-role: ${{ secrets.VAULT_JWT_ROLE }}
-          vault-jwt-audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
-
-      # main, unpinned — matches the nightly's own "clones camunda-hub@main
-      # unpinned" convention (this is re-verifying against CURRENT hub, not
-      # whatever SHA the nightly happened to test against hours ago).
-      - name: Clone camunda-hub main (sibling, for live verification)
-        if: ${{ steps.reports.outputs.has_reports == 'true' && steps.neg-failures.outputs.has_negative_failures == 'true' && steps.verify-hub-token.outputs.token != '' }}
-        continue-on-error: true
-        uses: ./.github/actions/clone-hub-sibling
-        with:
-          token: ${{ steps.verify-hub-token.outputs.token }}
-          ref: main
-
       - name: Setup Python (for live verification)
         if: ${{ steps.reports.outputs.has_reports == 'true' && steps.neg-failures.outputs.has_negative_failures == 'true' }}
         uses: actions/setup-python@v6

--- a/.github/workflows/triage-camunda-hub-nightly.yml
+++ b/.github/workflows/triage-camunda-hub-nightly.yml
@@ -65,7 +65,11 @@ jobs:
   triage:
     name: Download reports → workspace → Claude triage → Slack
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 30 -> 45: #482's live curl-replay verification adds a full Hub pull +
+    # boot (up to 10 min per wait-for-hub's own default timeout) on any
+    # night with negative-suite failures, on top of everything this job
+    # already does.
+    timeout-minutes: 45
     # workflow_run has no branch/origin filter by itself — it fires after ANY
     # completed run of a workflow with this name, including one dispatched
     # (nightly-camunda-hub.yml has workflow_dispatch: {}, unrestricted) against
@@ -153,6 +157,115 @@ jobs:
             echo "has_reports=false" >> "$GITHUB_OUTPUT"
             echo "::warning::No pw-*.json or pw-*.junit.xml reports found (download outcome: ${{ steps.download.outcome }}). Reporting as inconclusive."
           fi
+
+      # --- #482: live curl-replay verification of negative-suite failures ----
+      # Before the agent ever classifies a failure as a genuine product bug,
+      # give it one more piece of evidence: does the exact same request still
+      # get the same (wrong) response RIGHT NOW, against a fresh Hub — or has
+      # it since been fixed / was it flaky? Runs for EVERY negative-suite
+      # failure (not just eventual "looks like a product bug" candidates —
+      # nothing here knows which ones look like bugs yet, that's the agent's
+      # job), against ONE freshly-started Hub, so the live-Hub cost is
+      # bounded to once per night regardless of how many candidates appear.
+      #
+      # Positive-suite failures aren't covered — materializer/templates has
+      # no evidence-capture mechanism at all (unlike request-validation's
+      # request.json/response.json testInfo.attach()ments), so there is
+      # nothing to reconstruct a request from there yet. Tracked as a
+      # follow-up once that instrumentation exists.
+      - name: Check for negative-suite failures worth verifying
+        id: neg-failures
+        if: ${{ steps.reports.outputs.has_reports == 'true' }}
+        run: |
+          set -euo pipefail
+          count=0
+          for f in "${REPORTS_DIR}/pw-secured.json" "${REPORTS_DIR}/pw-rbac.json"; do
+            [ -f "$f" ] || continue
+            n=$(jq -r '.stats.unexpected // 0' "$f" 2>/dev/null || echo 0)
+            count=$((count + n))
+          done
+          echo "Negative-suite unexpected-result count: ${count}"
+          if [ "$count" -gt 0 ]; then
+            echo "has_negative_failures=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_negative_failures=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Same App + Vault wiring as the "Mint camunda-hub clone token" step
+      # below (for the agent's own workspace) — a separate token/clone
+      # because this one starts a real Hub Docker container from it, an
+      # entirely different purpose from the agent's read-only source clone.
+      # continue-on-error: a failure anywhere in this verification chain
+      # must degrade to "no verification data" (handled by the guidance doc
+      # below), never fail the whole triage run.
+      - name: Mint camunda-hub clone token (live verification)
+        id: verify-hub-token
+        if: ${{ steps.reports.outputs.has_reports == 'true' && steps.neg-failures.outputs.has_negative_failures == 'true' }}
+        continue-on-error: true
+        uses: ./.github/actions/hub-clone-token
+        with:
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          vault-jwt-path: ${{ secrets.VAULT_JWT_PATH }}
+          vault-jwt-role: ${{ secrets.VAULT_JWT_ROLE }}
+          vault-jwt-audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
+
+      # main, unpinned — matches the nightly's own "clones camunda-hub@main
+      # unpinned" convention (this is re-verifying against CURRENT hub, not
+      # whatever SHA the nightly happened to test against hours ago).
+      - name: Clone camunda-hub main (sibling, for live verification)
+        if: ${{ steps.reports.outputs.has_reports == 'true' && steps.neg-failures.outputs.has_negative_failures == 'true' && steps.verify-hub-token.outputs.token != '' }}
+        continue-on-error: true
+        uses: ./.github/actions/clone-hub-sibling
+        with:
+          token: ${{ steps.verify-hub-token.outputs.token }}
+          ref: main
+
+      - name: Setup Python (for live verification)
+        if: ${{ steps.reports.outputs.has_reports == 'true' && steps.neg-failures.outputs.has_negative_failures == 'true' }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      # Public image, no registry login needed (unlike hub-pr-check.yml's
+      # private pr-<sha> image) — same defaults hub-ondemand-test.yml uses.
+      - name: Start Hub (prebuilt image, for live verification)
+        id: verify-hub-start
+        if: ${{ steps.reports.outputs.has_reports == 'true' && steps.neg-failures.outputs.has_negative_failures == 'true' }}
+        continue-on-error: true
+        env:
+          HUB_MODE: prebuilt
+          HUB_IMAGE: camunda/hub:SNAPSHOT
+        run: ./docker/start-hub.sh start
+
+      - name: Wait for Hub to be ready (live verification)
+        if: ${{ steps.reports.outputs.has_reports == 'true' && steps.neg-failures.outputs.has_negative_failures == 'true' && steps.verify-hub-start.outcome == 'success' }}
+        continue-on-error: true
+        uses: ./.github/actions/wait-for-hub
+        with:
+          url: http://localhost:8088/api/v2/
+
+      - name: Run curl-replay verification
+        if: ${{ steps.reports.outputs.has_reports == 'true' && steps.neg-failures.outputs.has_negative_failures == 'true' }}
+        continue-on-error: true
+        run: |
+          python3 scripts/e2e/verify-negative-failures.py \
+            --reports-dir "${REPORTS_DIR}" \
+            --base-url http://localhost:8088/api \
+            --kc-url http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token \
+            --out "${GITHUB_WORKSPACE}/curl-verification.json"
+
+      # Runs regardless of which prior step failed/was skipped — the agent's
+      # guidance treats a missing/empty file as "verification unavailable,"
+      # so this just guarantees the path always exists to read.
+      - name: Ensure curl-verification.json exists
+        if: always()
+        run: |
+          f="${GITHUB_WORKSPACE}/curl-verification.json"
+          [ -s "$f" ] || echo '{}' > "$f"
+
+      - name: Stop Hub (live verification)
+        if: ${{ always() && steps.verify-hub-start.outcome == 'success' }}
+        run: ./docker/start-hub.sh stop || true
 
       # --- Secrets from Vault (GitHub OIDC/JWT) -------------------------------
       # Anthropic key + a GitHub PAT, from the SAME Vault KV path this repo's
@@ -509,6 +622,13 @@ jobs:
         if: ${{ steps.reports.outputs.has_reports == 'true' }}
         env:
           OPEN_FIX_PRS_FILE: ${{ github.workspace }}/open-fix-prs.json
+          # #482 — always exists (the "Ensure curl-verification.json exists"
+          # step above guarantees it), but may be "{}" if there were no
+          # negative-suite failures, the Hub never came up, or the script
+          # itself errored. Treat a missing key the same as an empty file:
+          # verification unavailable for that test, fall back to
+          # single-observation judgment (see the guidance's own section).
+          CURL_VERIFICATION_FILE: ${{ github.workspace }}/curl-verification.json
           ANTHROPIC_API_KEY: ${{ steps.vault.outputs.ANTHROPIC_API_KEY }}
           # Two separately-scoped tokens — see "Configure git credentials" above
           # and the guidance's Role section for which one is valid where.
@@ -541,9 +661,12 @@ jobs:
 
           Inputs:
           - The downloaded nightly reports are at: ${REPORTS_DIR}
-            (pw-positive.{json,junit.xml}, pw-secured.*, pw-rbac.*, pw-*/index.html HTML reports with
-            traces/screenshots for failing tests, and coverage.json — check its
-            summary.unmappedOperations EVERY run, independent of suite pass/fail, per the guidance).
+            (pw-positive.{json,junit.xml}, pw-secured.*, pw-rbac.*, pw-*/index.html HTML reports, and
+            coverage.json — check its summary.unmappedOperations EVERY run, independent of suite
+            pass/fail, per the guidance). NOTE: there is no Playwright trace (trace capture is off in
+            both suite configs) — the request/response evidence for a negative-suite failure is its
+            request.json/response.json attachment; a positive-suite failure has no such attachment,
+            recover what you can from the HTML report's own error message instead.
           - OpenAPI spec: ${ws_dir}/camunda-hub/restapi/public-api/src/main/resources/openapi/v2/*.yaml
           - Suite configs (known issues): ${ws_dir}/api-test-generator/configs/camunda-hub/positive-suppress.json
             and request-validation.json
@@ -553,6 +676,17 @@ jobs:
             anywhere in one of these diffs (a substring match, e.g. as a JSON key in
             positive-suppress.json or a comment); if so, that operation is already being
             fixed elsewhere.
+          - Live curl-replay verification results (#482), negative-suite failures only, may be "{}"
+            (no negative-suite failures, or verification itself was unavailable that night):
+            ${CURL_VERIFICATION_FILE} — keyed by "<operationId>::<scenarioKind>::<test title>", each
+            entry \`{ confirmed: true|false|null, curlStatus, expectedStatus, curlBody, error }\`.
+            confirmed:true means the exact same request STILL gets the wrong response right now
+            against a fresh Hub; confirmed:false means it no longer reproduces (treat as unconfirmed/
+            flaky, per the guidance's "when in doubt, report-only" rule — do not file); confirmed:null
+            means it could not be checked (see its error field — e.g. a body-shape-only failure this
+            tool doesn't re-verify, or no deny token available) — fall back to your own single-
+            observation judgment as before. See the guidance's "Filing a product-bug issue" section
+            for exactly where this plugs in.
           - NOTE: the generated *.spec.ts files are gitignored and NOT present here — recover what
             each test asserted from the report's request/response attachment + assertion error, not
             from source.
@@ -561,7 +695,8 @@ jobs:
           1. Parse both suites' JSON/JUnit and enumerate every failing test (positive + negative).
           2. Check coverage.json's summary.unmappedOperations regardless of suite results — these
              never show up as failing tests, so they're easy to miss on an all-green night.
-          3. For each test failure: read its trace/screenshot/response in the HTML report to see the
+          3. For each test failure: read its request/response attachment (negative suite) or the HTML
+             report's own error message (positive suite — no attachment exists there) to see the
              actual request+response+assertion, then resolve the operation in the OpenAPI v2 spec.
           4. Classify each as product / infrastructure / flakiness with evidence. A "product" bug
              REQUIRES the response to CONTRADICT the spec (mind the 400→404→403 precedence quirk
@@ -571,7 +706,19 @@ jobs:
           5. Reconcile against the knownIssue entries before calling anything a NEW bug.
           6. For each PRODUCT bug (response contradicts spec) that is NOT already-known: search recent
              camunda-hub main commits for a related change. If a related commit explains it → action
-             "skip" (record the commit). If not → compute the fingerprint, dedup by the
+             "skip" (record the commit). If not, and this is a NEGATIVE-suite failure, look up its
+             entry in ${CURL_VERIFICATION_FILE} (#482) BEFORE filing — key
+             "<operationId>::<scenarioKind>::<test title>":
+               - confirmed:true → proceed to file, and include the curl exchange (status + body) from
+                 curlStatus/curlBody as extra evidence in the issue body.
+               - confirmed:false → do NOT file. It no longer reproduces against a fresh Hub right now —
+                 treat as unconfirmed/flaky (category unchanged, action "report-only", note in your
+                 reasoning that a live re-check no longer reproduced it).
+               - confirmed:null, or no entry at all (positive-suite failure, or verification was
+                 unavailable that night) → fall back to filing on your own single-observation judgment
+                 as before, and say so explicitly in the issue/summary (so it's visible that live
+                 re-verification was attempted but inconclusive, not silently skipped).
+             Once past that check: compute the fingerprint, dedup by the
              \`nightly-api-triage fp=<fp>\` marker (then by symptom), and either link the existing issue
              or file a new one with \`gh issue create --repo camunda/camunda-hub\` using GH_TOKEN_HUB
              (labels kind/bug + nightly-detected, already pre-created; fingerprint marker in the body).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -592,7 +592,10 @@ The **nightly triage agent**
 ([triage-camunda-hub-nightly.yml](.github/workflows/triage-camunda-hub-nightly.yml))
 is the nightly's downstream companion: a `workflow_run` job that fires when the
 nightly completes, downloads its `camunda-hub-nightly-reports` artifact
-(JSON/JUnit + HTML report + traces/screenshots + `coverage.json`), and runs a
+(JSON/JUnit + HTML report + `coverage.json` — no trace/screenshots, capture
+is off in both suite configs; the negative suite's `request.json`/
+`response.json` `testInfo.attach()`ments are the real evidence, embedded
+inline in the JSON reporter's own output), and runs a
 **Claude Code** triage agent inside a 3-repo
 [`workspace-cli`](https://github.com/camunda/workspace-cli) workspace
 (`api-test-generator`, `camunda-docs`, `camunda-hub` @ `main` — manifest +
@@ -631,7 +634,22 @@ the pinned spec, so this is genuinely additional signal, not a duplicate). An
 earlier version of this workflow manually dispatched
 [hub-ondemand-test.yml](.github/workflows/hub-ondemand-test.yml) and
 commented the run link for the same purpose; that became redundant once
-hub-pr-live-check.yml shipped (#513) and has been removed. It posts a
+hub-pr-live-check.yml shipped (#513) and has been removed.
+
+Before filing a genuinely NEW (not already-known) product bug, #482 adds a
+live re-check: a step earlier in the same job spins up ONE fresh, separate
+Hub (only when there's at least one negative-suite failure — no cost
+otherwise) and replays every negative-suite failure's exact request via curl
+([scripts/e2e/verify-negative-failures.py](scripts/e2e/verify-negative-failures.py),
+reusing [curl_compare.py](scripts/e2e/curl_compare.py)'s `run_curl` and
+reconstructing auth headers from a closed mapping keyed on `scenarioKind`
+that mirrors `request-validation/src/emit/qaEmitter.ts`'s own header-builder
+selection — no source/emitter change needed), writing `curl-verification.json`
+for the agent to read as one more input. A candidate that no longer
+reproduces (`confirmed: false`) is never filed — treated as flakiness
+instead; one that still does (`confirmed: true`) gets filed with the fresh
+curl exchange as extra evidence. Positive-suite failures aren't covered —
+there's no evidence-capture mechanism there yet to replay from. It posts a
 triaged digest to
 `#camunda-hub-nightly-test-results` via the same Slack bot. Auth: `CLAUDE_API_KEY`
 at `secret/data/products/qa/ci/common`

--- a/resources/workspace-templates/camunda-hub-nightlies/camunda-hub-nightlies.guidance.md
+++ b/resources/workspace-templates/camunda-hub-nightlies/camunda-hub-nightlies.guidance.md
@@ -10,13 +10,13 @@ You are a QA **triage** engineer for the **camunda-hub Public API v2** nightly t
 
 Your job is to:
 
-1. **Debug** each failing test from the downloaded nightly reports (Playwright JSON/JUnit, HTML report, traces, screenshots, request/response attachments).
+1. **Debug** each failing test from the downloaded nightly reports (Playwright JSON/JUnit, HTML report, and — for the negative suite only — request/response attachments; see "Debug procedure" below for exactly what evidence exists and where).
 2. **Check for missing coverage** — spec operations with zero generated tests at all (see "Unmapped operations" below); these never appear as a failing test, so this is a separate, deliberate check, not something you'll stumble into while triaging failures.
 3. **Classify** every failure into exactly one of three categories: **product**, **infrastructure**, or **flakiness** (plus the `test-generation` subcategory carved out of `product` — see below).
 4. For a suspected **product** bug, **cross-check recent `camunda-hub` commits** and the **OpenAPI spec** to decide whether it is a *new* defect or *expected drift* from an intentional recent change.
 5. Produce a single machine-readable triage result (`/tmp/hub-triage.json`) that the workflow turns into a Slack digest. For confirmed new product bugs: file/link a `camunda-hub` issue AND suppress the affected test in api-test-generator (see "Suppressing a confirmed product bug"). For test-generation bugs or coverage gaps with a safe minimal fix: open an `api-test-generator` PR instead.
 
-Default posture: **evidence first**. Never conclude "transient — re-run" without pointing at the trace/response that proves it. Never label something a product bug without the spec + a response body that contradicts it. Never apply a fix you're not confident is minimal and correct — when in doubt, report-only and let a human decide (see the guardrails under "Fixing a test-generation / coverage bug").
+Default posture: **evidence first**. Never conclude "transient — re-run" without pointing at the response evidence that proves it. Never label something a product bug without the spec + a response body that contradicts it. Never apply a fix you're not confident is minimal and correct — when in doubt, report-only and let a human decide (see the guardrails under "Fixing a test-generation / coverage bug").
 
 ## The two suites you triage
 
@@ -40,6 +40,7 @@ For each entry in `unmappedOperations`: this is a generator/ontology gap, not a 
   - `configs/camunda-hub/request-validation.json` — negative-suite settings + `excludeOperations[]` (with `knownIssue`) + suite-wide `knownIssues[]`.
   - `scripts/e2e/run-hub.sh` — how the suites are run (fixtures, profiles, report layout). Reports land in `test-results/e2e-camunda-hub/`.
   - `coverage.json` (in `$REPORTS_DIR`, alongside the `pw-*` reports) — see "Unmapped operations" above.
+  - `curl-verification.json` (#482, path in `$CURL_VERIFICATION_FILE`) — see "Live curl-replay verification" below.
   - **Note:** the generated `*.spec.ts` files (`generated/camunda-hub/playwright/`) are a **gitignored build artifact** — they are **NOT present** in this triage workspace (no generate step runs here). Do not try to read them. What each test asserted is fully recoverable from the report attachments (the actual request + response + assertion error) — that plus the OpenAPI spec is all you need. If you ever need generator *logic*, read the emitter/materializer source, not generated output.
 - **`{{.WorkspacePath}}/camunda-hub/`** — the product under test at latest `main`. Two things you rely on:
   - **OpenAPI spec**: `restapi/public-api/src/main/resources/openapi/v2/*.yaml` (per-resource: `catalog.yaml`, `clusters.yaml`, `files.yaml`, `folders.yaml`, `members.yaml`, `common-responses.yaml`, `problem-detail.yaml`, …). This is the **authoritative** request/response contract.
@@ -49,8 +50,8 @@ For each entry in `unmappedOperations`: this is a generator/ontology gap, not a 
 ## Debug procedure (per failing test — do this BEFORE classifying)
 
 1. **Enumerate failures.** For each of `pw-positive.json`, `pw-secured.json`, `pw-rbac.json`, parse the Playwright JSON reporter: a test failed if any of its `results[]` has `status` not in `passed`/`skipped`, or if `stats.unexpected > 0`. Also confirm against the JUnit `<failure>`/`<error>` elements. Record `suite`, `profile`, `spec file`, `test title`, `expected vs actual status`, and the error message.
-2. **Read the trace + screenshots.** The HTML report (`pw-*/index.html`) and its `data/` / trace attachments hold, per failing test, the **actual HTTP request and response** (method, path, request body, response status + body). For API tests this response body is the single most important piece of evidence. Screenshots/trace exist only for failures (`retain-on-failure`). If a `trace.zip` is present, inspect its network entries.
-3. **Reconstruct what the test asserted — from the report, not source.** The generated `*.spec.ts` is gitignored and absent here; instead read the failing test's steps + request/response attachment + assertion error in the HTML report/trace to see the exact request built and the expected-vs-actual assertion.
+2. **Read the request/response evidence — negative suite only.** Both suite configs have Playwright trace capture **off** — there is no `trace.zip`, no screenshots, nothing to inspect there. What exists instead: `assertResponseStatus` (the negative suite's shared assertion helper) attaches `request.json` (`operationId`, `scenarioKind`, `method`, `url`, `body`/`multipart`, `expectedStatus`) and `response.json` (`status`, `headers`, `body`, `shapeErrors`) to any failing test — base64-encoded inline in the JSON reporter's own `results[].attachments[]`, not a separate file. **The positive (lifecycle) suite has no equivalent attachment mechanism at all** — for a positive-suite failure, the ONLY evidence is the HTML report's own error message (`pw-positive/index.html`) and the JUnit failure text; there is no structured request/response to read.
+3. **Reconstruct what the test asserted — from the report, not source.** The generated `*.spec.ts` is gitignored and absent here; instead read the failing test's request/response attachment (negative suite) or its error message (positive suite) to see the exact request built and the expected-vs-actual assertion.
 4. **Resolve the operation in the OpenAPI spec.** From the spec file's `operationId` / path, open the matching `camunda-hub/restapi/public-api/src/main/resources/openapi/v2/<resource>.yaml` and read the operation's request schema, required fields, and declared responses (`common-responses.yaml` / `problem-detail.yaml` hold shared 4xx shapes). Now you can judge: is the **test's expectation** wrong, or the **API's actual response** wrong?
 
 ## Classification — pick exactly one category per failure
@@ -92,7 +93,27 @@ For any failure you classify as **product** and that is **not** an already-known
 
 Only **product** failures whose response **contradicts** the spec get the commit-dedup + filing treatment. Infrastructure, flakiness, and test-generation (`subcategory: "test-generation"`) failures are reported in Slack but never filed as camunda-hub product issues.
 
+## Live curl-replay verification (#482 — check this before filing a NEW bug)
+
+A filed camunda-hub issue is a real, visible artifact — a false positive wastes the hub team's time and erodes trust in this whole pipeline. By the time you run, the nightly's own Hub is already stopped, so everything above is judged from **one static observation**. Before filing a genuinely new (not already-known) product bug, a separate workflow step already re-issued the exact same request via curl against a **freshly-started, separate** live Hub, and wrote the result to `$CURL_VERIFICATION_FILE` (may be `"{}"` — see below for when).
+
+**Scope: negative-suite failures only.** The positive suite has no request/response evidence to reconstruct a replay from in the first place (see "Debug procedure" above) — this file will never have an entry for a positive-suite failure. That's a known, explicit gap, not a bug in this step; extending it needs new evidence-capture instrumentation in `materializer/templates/` first (a tracked follow-up, not yours to build).
+
+**Format**: a flat object keyed `"<operationId>::<scenarioKind>::<test title>"` (build the same key to look yours up). Each entry:
+
+```json
+{ "confirmed": true, "curlStatus": 200, "expectedStatus": 400, "curlBody": "...", "error": null }
+```
+
+- **`confirmed: true`** — curl still gets the SAME wrong result right now, against a fresh Hub. Proceed to file, and quote `curlStatus`/`curlBody` in the issue body as extra, independent evidence.
+- **`confirmed: false`** — curl now gets the expected status; it no longer reproduces. Do **not** file. This is exactly what "flakiness" or "a Playwright-specific quirk in the original run" looks like — set `action: "report-only"` and say in your reasoning that a live re-check no longer reproduced it. (Do not silently drop the finding — it's still worth a Slack line.)
+- **`confirmed: null`** (with an `error` explaining why — e.g. the original failure was a response-*shape* violation this tool doesn't re-check, or no deny-probe token was available) — **or no entry at all** (this was a positive-suite failure, or the whole file is `"{}"` because there were zero negative-suite failures that night, the fresh Hub never came up, or the script itself errored) — verification is simply **not available** for this failure. Fall back to your own single-observation judgment exactly as before #482 existed, but say explicitly in the issue/summary that live re-verification was attempted and inconclusive, so that's visible rather than silently skipped.
+
+This only ever *stops* a filing (on `confirmed: false`) or *strengthens* one (on `confirmed: true`) — it never substitutes for the commit-dedup step above, and an already-known match (`known_issue: true`) never needs this at all (you're only re-linking, not deciding whether to file).
+
 ## Filing a product-bug issue (only when `action: "file"`)
+
+**For a negative-suite failure, check `$CURL_VERIFICATION_FILE` FIRST** (see "Live curl-replay verification" above) — before computing anything below, resolve `confirmed` for this failure and follow that section's rule (file only on `true`; `false` means do not file at all; `null`/no-entry falls back to everything below unchanged).
 
 **Compute a stable fingerprint** so the same bug is filed **once**, not re-filed every night:
 
@@ -118,7 +139,8 @@ gh issue list --repo camunda/camunda-hub --search "<operationId> in:title" --sta
 **Creating the issue** — `gh issue create --repo camunda/camunda-hub` with `GH_TOKEN_HUB` (the camunda-hub-scoped token the workflow exports — do NOT use `GH_TOKEN_GENERATOR` here, that one only has write access to api-test-generator). Title: `[nightly-api] <operationId> — <one-line contract violation>`. Labels: `--label kind/bug --label nightly-detected` — the workflow pre-creates both on camunda-hub (best-effort) before the agent runs, so this should never fail on a missing label; if it still does, retry once without labels rather than losing the issue. Body must contain:
 
 - suite/profile, spec file + test title;
-- **expected** (quote/pointer to the OpenAPI op) **vs actual** (the response body from the trace) — the proof the response contradicts the spec;
+- **expected** (quote/pointer to the OpenAPI op) **vs actual** (the response body from the report attachment) — the proof the response contradicts the spec;
+- if `confirmed: true` in `$CURL_VERIFICATION_FILE` (see "Live curl-replay verification" above): the curl exchange too (`curlStatus`/`curlBody`) — independent, freshly-observed evidence the response still contradicts the spec right now;
 - the nightly run URL;
 - a visible marker line: `Fingerprint: nightly-api-triage fp=<fp>` (this is what the dedup search above matches on);
 - a note that any PR fixing this should carry the **`nightly-api-fix`** label (the `close-stale-nightly-api-fix-prs` janitor reaps stale fix PRs with that label across both repos; `do-not-close` holds one);
@@ -165,7 +187,7 @@ A single isolated test-generation failure with no sibling in this run still foll
 **When to fix vs. report-only** — fix ONLY if all of these hold, otherwise fall back to `action: "report-only"` and explain what's missing:
 - It is NOT already covered by an open fix PR (see dedup check above).
 - It is NOT part of a systemic pattern shared with another failure in this same run (see above).
-- The root cause is fully understood from the evidence (trace/response + spec + generator source) — no guessing.
+- The root cause is fully understood from the evidence (response attachment + spec + generator source) — no guessing.
 - The fix is minimal and mechanical: a `positive-suppress.json` / `request-validation.json` entry (with a `knownIssue` pointing at this triage run), a small, obviously-correct ontology/entity-kind mapping fix, or a narrowly-scoped assertion/expected-status correction in generator source — NOT a refactor, NOT a change touching more than the one operation/test at fault.
 - You can articulate the fix in one sentence someone could verify by reading the diff alone.
 
@@ -212,7 +234,7 @@ either makes the digest unreadable.
       "confidence": "high|medium|low",
       "expected": "201 (spec: files.yaml createFile)",
       "actual": "500 — <response body snippet>",
-      "evidence": "trace/screenshot/report pointer",
+      "evidence": "response attachment / report pointer",
       "known_issue": false,
       "known_issue_url": null,
       "related_commit": null,
@@ -244,7 +266,7 @@ If there are **zero** failures across both suites **and** `unmappedOperations` i
 - `camunda-hub`: issues only, never code. Never edit camunda-hub source, never open a PR against it, never push to it. The only write action you may take there is `gh issue create`, per the rules above.
 - `api-test-generator`: read-only by default. The ONLY exceptions are (1) a confirmed test-generation bug or unmapped-operation with a minimal, obvious fix (see "Fixing a test-generation / coverage bug"), or (2) a confirmed camunda-hub product bug, suppressed with a reference to the issue (see "Suppressing a confirmed product bug") — and even then, always via a branch + PR, never a direct push to `main`.
 - `camunda-docs`: always read-only.
-- Never conclude "flaky/transient/re-run" without retry or trace evidence.
+- Never conclude "flaky/transient/re-run" without retry or response evidence (there is no trace — see "Debug procedure").
 - Never label a failure "product" without the OpenAPI op + the actual response body that contradicts it.
 - Every product failure must pass through the commit-dedup step before it is filed.
 - Respect `knownIssue` entries — never file a duplicate of an already-tracked issue.

--- a/scripts/e2e/verify-negative-failures.py
+++ b/scripts/e2e/verify-negative-failures.py
@@ -45,6 +45,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 # Same-directory import — curl_compare.py is a plain script, not a package,
 # but Python resolves this fine since both files live in scripts/e2e/. Reuses
@@ -121,6 +122,21 @@ def extract_context(result):
     return {"request": req, "response": resp}
 
 
+def rebase_url(original_url: str, base_url: str) -> str:
+    """Replace original_url's scheme+host with base_url's scheme+host,
+    keeping the captured path+query unchanged. buildUrl()'s own path
+    structure (/v2/...) is identical between the original nightly run and
+    this replay — same generator, same spec — but the ORIGINAL Hub is
+    already stopped by the time this runs, and this replay's freshly-
+    started Hub isn't guaranteed to land on the same host/port. Re-basing
+    only the host, never the path, is what lets --base-url actually matter
+    instead of silently trusting whatever host the original run happened to
+    use."""
+    new = urlsplit(base_url)
+    orig = urlsplit(original_url)
+    return urlunsplit((new.scheme, new.netloc, orig.path, orig.query, orig.fragment))
+
+
 AUTH_INVALID_HEADER = "Authorization: Bearer invalid-token"
 
 
@@ -195,10 +211,14 @@ def main():
         kind = req.get("scenarioKind", "?")
         key = f"{op}::{kind}::{f.get('title', '?')}"
         method = req.get("method")
-        url = req.get("url")
+        captured_url = req.get("url")
         expected = req.get("expectedStatus")
-        if not (method and url and expected is not None):
+        if not (method and captured_url and expected is not None):
             continue
+        # Re-host onto THIS run's fresh Hub — the nightly's own Hub (where
+        # captured_url's host/port came from) is already stopped, and this
+        # replay's Hub isn't guaranteed to share it.
+        url = rebase_url(captured_url, args.base_url)
 
         # This tool only re-verifies a STATUS-code contradiction. A body-
         # SHAPE-only failure (status already matched expected; the

--- a/scripts/e2e/verify-negative-failures.py
+++ b/scripts/e2e/verify-negative-failures.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""
+Live curl-replay verification for the camunda-hub nightly triage agent (#482).
+
+For every FAILING negative-suite test in the downloaded Playwright JSON
+report (pw-secured.json / pw-rbac.json), reconstructs the exact request the
+generated test built and replays it via curl against a freshly-started,
+separate live Hub — so the triage agent can tell a genuine, still-
+reproducing product-bug candidate apart from flakiness or a since-fixed
+regression, before filing a real issue on camunda-hub.
+
+Evidence comes entirely from the request.json/response.json testInfo
+attachments (request-validation/templates/support/http.ts) EMBEDDED INLINE
+(base64) in the JSON reporter's own output — confirmed against this repo's
+own request-validation/templates/scripts/summarize-failures.mjs, which reads
+attachments the exact same way. This script deliberately does NOT read
+generated *.spec.ts source (unlike curl_compare.py, its closest sibling) —
+the triage workspace never has it (a gitignored build artifact, absent
+there) — and does NOT rely on any Playwright trace: both suite configs set
+`trace: 'off'`, so there is none to read.
+
+Auth headers are reconstructed from a closed, verified mapping keyed on
+scenarioKind + JSON-body presence — traced directly from
+request-validation/src/emit/qaEmitter.ts's own header-builder selection
+(lines ~329-346), so it can't drift from what the generator actually emits.
+scenarioKind is a closed vocabulary the generator alone defines (see
+SCENARIO_KINDS in request-validation/src/model/types.ts), so this mapping
+only needs updating if that emitter logic itself changes.
+
+This tool only re-verifies a STATUS-code contradiction. A failure whose
+`response.json` shows a body-SHAPE violation (assertResponseStatus's
+ProblemDetail check) at the SAME status code as expected cannot be
+confirmed/refuted by re-checking the numeric status alone — those are
+flagged explicitly (confirmed: null) rather than silently misreporting a
+resolved-looking false negative.
+
+Usage:
+  verify-negative-failures.py --reports-dir <dir> --base-url <url> \
+    --kc-url <keycloak-token-endpoint> --out <curl-verification.json>
+"""
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Same-directory import — curl_compare.py is a plain script, not a package,
+# but Python resolves this fine since both files live in scripts/e2e/. Reuses
+# its run_curl() (the actual curl invocation + status/body extraction) rather
+# than re-implementing it a second time.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from curl_compare import run_curl  # noqa: E402
+
+
+def mint(kc_url: str, client_id: str, client_secret: str) -> str:
+    """Mints a Keycloak access token. Mirrors scripts/e2e/run-hub.sh's own
+    mint() bash function exactly (same client-credentials grant, same
+    --data-urlencode fields) — kept as a small, clearly-labeled port rather
+    than a cross-language import, since bash and Python can't share a
+    function directly."""
+    try:
+        proc = subprocess.run(
+            [
+                "curl", "-s", "-X", "POST", kc_url,
+                "--data-urlencode", f"client_id={client_id}",
+                "--data-urlencode", f"client_secret={client_secret}",
+                "--data-urlencode", "grant_type=client_credentials",
+            ],
+            capture_output=True, text=True, timeout=30,
+        )
+        return json.loads(proc.stdout).get("access_token", "")
+    except Exception:
+        return ""
+
+
+def walk_suites(suites, out, file_hint=None):
+    """Ported from summarize-failures.mjs's walkSuites() — same shape, same
+    "final attempt only" rule (a flaky test that eventually passed under
+    retries would otherwise leave a stale failed entry)."""
+    for suite in suites:
+        file = suite.get("file", file_hint)
+        for spec in suite.get("specs", []):
+            for test in spec.get("tests", []):
+                results = test.get("results") or []
+                if not results:
+                    continue
+                result = results[-1]
+                if result.get("status") in ("passed", "skipped"):
+                    continue
+                ctx = extract_context(result)
+                if ctx is not None:
+                    ctx["title"] = spec.get("title")
+                    ctx["file"] = file
+                    out.append(ctx)
+        if suite.get("suites"):
+            walk_suites(suite["suites"], out, file)
+
+
+def extract_context(result):
+    """Ported from summarize-failures.mjs's extractContext() — same
+    base64-decode + JSON-parse of the request.json/response.json
+    attachments. Returns None (skip) when there's no request.json (nothing
+    to replay — e.g. a failure with only a scraped error message)."""
+    req = None
+    resp = None
+    for att in result.get("attachments") or []:
+        if att.get("contentType") != "application/json" or not att.get("body"):
+            continue
+        try:
+            parsed = json.loads(base64.b64decode(att["body"]).decode("utf-8"))
+        except Exception:
+            continue
+        if att.get("name") == "request.json":
+            req = parsed
+        elif att.get("name") == "response.json":
+            resp = parsed
+    if req is None:
+        return None
+    return {"request": req, "response": resp}
+
+
+AUTH_INVALID_HEADER = "Authorization: Bearer invalid-token"
+
+
+def build_headers(scenario_kind, has_json_body, admin_header, deny_header):
+    """Mirrors request-validation/src/emit/qaEmitter.ts's own header-builder
+    selection (lines ~329-346) — kept in sync deliberately, not re-derived
+    independently, since scenarioKind is a closed, fixed vocabulary only the
+    generator defines. Returns None when the scenario needs a credential
+    this run doesn't have (auth-deny with no deny token available) — the
+    caller treats that as "cannot verify", not "no headers"."""
+    if scenario_kind == "auth-invalid":
+        return [AUTH_INVALID_HEADER]
+    if scenario_kind == "auth-deny":
+        return [deny_header] if deny_header else None
+    if scenario_kind == "auth-absent":
+        return []
+    # Every other kind: admin auth, +Content-Type when there's a JSON body.
+    # jsonHeaders()/authHeaders() both use the SAME admin token — the only
+    # difference is Content-Type, and a multipart request sets its own
+    # Content-Type via curl -F (handled by run_curl, not here).
+    headers = [admin_header] if admin_header else []
+    if has_json_body:
+        headers = ["Content-Type: application/json"] + headers
+    return headers
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--reports-dir", required=True,
+                     help="Directory containing pw-secured.json / pw-rbac.json")
+    ap.add_argument("--base-url", required=True,
+                     help="Hub core API base (buildUrl adds /v2), e.g. http://localhost:8088/api")
+    ap.add_argument("--kc-url", required=True, help="Keycloak token endpoint")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    failures = []
+    for name in ("pw-secured.json", "pw-rbac.json"):
+        p = Path(args.reports_dir) / name
+        if not p.exists():
+            continue
+        try:
+            report = json.loads(p.read_text(encoding="utf-8"))
+        except Exception as e:
+            print(f"::warning::Could not parse {p}: {e}", file=sys.stderr)
+            continue
+        walk_suites(report.get("suites", []), failures)
+
+    if not failures:
+        print("No failing negative-suite tests with request.json evidence — nothing to verify.")
+        Path(args.out).write_text("{}\n")
+        return
+
+    admin_tok = mint(args.kc_url, "c8-client", "c8-secret")
+    if not admin_tok:
+        print("::error::Could not mint admin token — is the fresh Hub/Keycloak actually up?",
+              file=sys.stderr)
+        Path(args.out).write_text("{}\n")
+        sys.exit(1)
+    admin_header = f"Authorization: Bearer {admin_tok}"
+    deny_tok = mint(args.kc_url, "c8-client-deny", "c8-deny-secret")
+    deny_header = f"Authorization: Bearer {deny_tok}" if deny_tok else None
+    if not deny_tok:
+        print("⚠ no c8-client-deny token — auth-deny candidates will be left unverified",
+              file=sys.stderr)
+
+    results = {}
+    for f in failures:
+        req = f["request"]
+        resp = f.get("response") or {}
+        op = req.get("operationId", "?")
+        kind = req.get("scenarioKind", "?")
+        key = f"{op}::{kind}::{f.get('title', '?')}"
+        method = req.get("method")
+        url = req.get("url")
+        expected = req.get("expectedStatus")
+        if not (method and url and expected is not None):
+            continue
+
+        # This tool only re-verifies a STATUS-code contradiction. A body-
+        # SHAPE-only failure (status already matched expected; the
+        # ProblemDetail shape check is what failed) can't be confirmed or
+        # refuted by re-checking the status alone — flag explicitly rather
+        # than silently reporting a misleading confirmed:false.
+        original_status = resp.get("status")
+        was_status_mismatch = original_status is not None and original_status != expected
+        if not was_status_mismatch and resp.get("shapeErrors"):
+            results[key] = {
+                "confirmed": None,
+                "error": "original failure was a response-shape violation at the expected "
+                         "status, not a status mismatch — this tool only re-verifies status "
+                         "codes, not response body shape",
+            }
+            continue
+
+        has_json_body = req.get("body") is not None and req.get("multipart") is None
+        headers = build_headers(kind, has_json_body, admin_header, deny_header)
+        if headers is None:
+            results[key] = {
+                "confirmed": None,
+                "error": "no deny token available — could not verify this auth-deny scenario",
+            }
+            continue
+
+        body_json = json.dumps(req["body"]) if req.get("body") is not None else None
+        multipart = req.get("multipart")
+        code, curl_body = run_curl(method, url, headers, body_json, multipart)
+        if code is None:
+            results[key] = {"confirmed": None, "error": f"curl could not reach the server: {curl_body}"}
+            continue
+
+        results[key] = {
+            # True = curl STILL contradicts the spec the same way the
+            # original failure did — a genuinely reproducing candidate.
+            # False = curl now gets the expected status — likely flaky or a
+            # since-fixed regression; don't file.
+            "confirmed": code != expected,
+            "curlStatus": code,
+            "expectedStatus": expected,
+            "curlBody": (curl_body or "")[:2000],
+        }
+
+    Path(args.out).write_text(json.dumps(results, indent=2) + "\n")
+    n_confirmed = sum(1 for r in results.values() if r.get("confirmed") is True)
+    n_unconfirmed = sum(1 for r in results.values() if r.get("confirmed") is False)
+    n_unverifiable = sum(1 for r in results.values() if r.get("confirmed") is None)
+    print(
+        f"Verified {len(results)} failing test(s): {n_confirmed} still reproduce, "
+        f"{n_unconfirmed} no longer reproduce, {n_unverifiable} could not be verified — "
+        f"wrote {args.out}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #482.

The nightly triage agent files a real, visible GitHub issue on camunda-hub the moment it classifies a failure as a genuine product bug — based on a single observation from one Playwright run, whose Hub instance is already stopped by the time triage runs. A false positive there wastes the hub team's time and erodes trust in the whole pipeline.

### Two things in #482's own framing didn't match reality

Found during research, corrected here rather than building on a wrong premise:

1. **There is no Playwright trace to reconstruct a request from** — both suite configs set `trace: 'off'`. The real evidence is the `request.json`/`response.json` `testInfo.attach()` pair already written on any negative-suite failure, embedded inline (base64) in the JSON reporter's own output — confirmed against this repo's own `request-validation/templates/scripts/summarize-failures.mjs`, which reads attachments the exact same way.
2. **The positive suite has zero evidence-capture mechanism at all** (no `testInfo.attach` calls anywhere in `materializer/templates/`) — this only applies to negative-suite failures for now. Extending it needs new instrumentation there first (a follow-up, not in scope here).

### Auth reconstruction needed no emitter change

The exact mapping `request-validation/src/emit/qaEmitter.ts` already uses to pick a header-builder call is a closed function of `scenarioKind` + JSON-body presence (both already in the evidence):

| `scenarioKind` | headers |
|---|---|
| `auth-invalid` | literal garbage bearer token |
| `auth-deny` | deny-probe token |
| `auth-absent` | none |
| everything else | admin token (+`Content-Type` if there's a JSON body) |

No new field needed, and it can't drift from what the generator emits since it mirrors that same logic.

### What's new

- **`scripts/e2e/verify-negative-failures.py`** — reuses `curl_compare.py`'s `run_curl()` rather than reimplementing it. Only re-verifies STATUS-code contradictions — a body-shape-only failure (status already matched expected) is explicitly flagged as unverifiable (`confirmed: null`) rather than silently misreporting a resolved-looking false negative.
- **New steps in `triage-camunda-hub-nightly.yml`** (same single job, before the agent runs): early-exit if there are zero negative-suite failures (no Hub spin-up, no cost); otherwise clone camunda-hub@main, start **one** fresh Hub (reusing the same `clone-hub-sibling`/`wait-for-hub` actions `_hub-suite-run.yml` already uses), run the new script against every negative-suite failure in a loop, write `curl-verification.json`, stop Hub. Bounded to one Hub spin-up per night regardless of how many candidates appear — the issue's own tradeoff section worried about cost "multiplying per candidate," which this design avoids. Every step from clone onward is `continue-on-error`: degrades to "no verification data" rather than failing the whole triage run.
- **Guidance/prompt updates**: a new evidence input (`curl-verification.json`), the filing procedure now checks `confirmed` (true/false/null) before filing a NEW candidate (already-known matches never needed this), and corrected several stale trace/screenshot references while touching this doc (`guidance.md`, `AGENTS.md`, and the prompt's own Inputs section all previously claimed a trace exists).

## Test plan

- [x] `actionlint .github/workflows/triage-camunda-hub-nightly.yml` — clean.
- [x] Script's parsing/header-mapping/main-flow logic exercised end-to-end against synthetic fixtures (mocked `mint`/`run_curl`) covering: all 4 auth kinds, a still-reproducing case, a since-fixed case, a shape-only-failure abstention, and a multipart request — all behaved exactly as designed.
- [x] `npm test` — 907/907 unaffected.
- [ ] Real end-to-end validation can only happen on an actual nightly run (or `workflow_dispatch` against a past `nightly_run_id`, which this workflow already supports) — a real live-Hub spin-up + agent invocation isn't something to trigger from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)