### PR TITLE
feat(oca): model message subscription lifecycle — MessageName, CorrelationKey, correlateMessage chain (#305)

### DIFF
--- a/configs/camunda-oca/fixtures/bpmn/message-catch-event.bpmn
+++ b/configs/camunda-oca/fixtures/bpmn/message-catch-event.bpmn
@@ -16,11 +16,6 @@
       <bpmn:incoming>Flow_to_end</bpmn:incoming>
     </bpmn:endEvent>
   </bpmn:process>
-  <bpmn:message id="Message_1" name="sampleMessage">
-    <bpmn:extensionElements>
-      <zeebe:subscription correlationKey="=12312" />
-    </bpmn:extensionElements>
-  </bpmn:message>
   <bpmn:message id="Message_1j9t80c" name="Message_1j9t80c">
     <bpmn:extensionElements>
       <zeebe:subscription correlationKey="=12312" />

--- a/configs/camunda-oca/fixtures/bpmn/message-catch-event.bpmn
+++ b/configs/camunda-oca/fixtures/bpmn/message-catch-event.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_message_catch_event" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="b876cbe" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="Process_message_catch_event" name="Message Catch Event Process" isExecutable="true">
+    <bpmn:extensionElements />
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_to_catchEvent</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_to_catchEvent" sourceRef="StartEvent_1" targetRef="CatchEvent_1" />
+    <bpmn:intermediateCatchEvent id="CatchEvent_1" name="Wait for Message">
+      <bpmn:incoming>Flow_to_catchEvent</bpmn:incoming>
+      <bpmn:outgoing>Flow_to_end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_1j9t80c" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_to_end" sourceRef="CatchEvent_1" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1" name="End">
+      <bpmn:incoming>Flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_1" name="sampleMessage">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=12312" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_1j9t80c" name="Message_1j9t80c">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=12312" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_message_catch_event">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CatchEvent_1_di" bpmnElement="CatchEvent_1">
+        <dc:Bounds x="282" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="382" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_to_catchEvent_di" bpmnElement="Flow_to_catchEvent">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="282" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_to_end_di" bpmnElement="Flow_to_end">
+        <di:waypoint x="318" y="120" />
+        <di:waypoint x="382" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/configs/camunda-oca/fixtures/bpmn/service-message-catch.bpmn
+++ b/configs/camunda-oca/fixtures/bpmn/service-message-catch.bpmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="3daf969" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="Process_task_boundary_message_catch" name="service-message-catch" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0pwexhj</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_04lr7k1" name="Simple Service Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="sampleJobWithMessage" retries="3" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0pwexhj</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ezrv14</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="Event_1aoilzw" attachedToRef="Activity_04lr7k1">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0om1mz6" messageRef="Message_2jcp7c1" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_0pwexhj" sourceRef="StartEvent_1" targetRef="Activity_04lr7k1" />
+    <bpmn:endEvent id="Event_0jglhm1">
+      <bpmn:incoming>Flow_0ezrv14</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0ezrv14" sourceRef="Activity_04lr7k1" targetRef="Event_0jglhm1" />
+  </bpmn:process>
+  <bpmn:message id="Message_2jcp7c1" name="Message_2jcp7c1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=45646" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_task_boundary_message_catch">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_13jkm80_di" bpmnElement="Activity_04lr7k1">
+        <dc:Bounds x="280" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0jglhm1_di" bpmnElement="Event_0jglhm1">
+        <dc:Bounds x="482" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1oofnxk_di" bpmnElement="Event_1aoilzw">
+        <dc:Bounds x="362" y="140" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0pwexhj_di" bpmnElement="Flow_0pwexhj">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="280" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ezrv14_di" bpmnElement="Flow_0ezrv14">
+        <di:waypoint x="380" y="118" />
+        <di:waypoint x="482" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/configs/camunda-oca/fixtures/bpmn/service-message-catch.bpmn
+++ b/configs/camunda-oca/fixtures/bpmn/service-message-catch.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="3daf969" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="0a9b4c5" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
   <bpmn:process id="Process_task_boundary_message_catch" name="service-message-catch" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0pwexhj</bpmn:outgoing>
@@ -11,7 +11,8 @@
       <bpmn:incoming>Flow_0pwexhj</bpmn:incoming>
       <bpmn:outgoing>Flow_0ezrv14</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:boundaryEvent id="Event_1aoilzw" attachedToRef="Activity_04lr7k1">
+    <bpmn:boundaryEvent id="Event_1aoilzw" cancelActivity="false" attachedToRef="Activity_04lr7k1">
+      <bpmn:outgoing>Flow_097o97l</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_0om1mz6" messageRef="Message_2jcp7c1" />
     </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="Flow_0pwexhj" sourceRef="StartEvent_1" targetRef="Activity_04lr7k1" />
@@ -19,6 +20,10 @@
       <bpmn:incoming>Flow_0ezrv14</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_0ezrv14" sourceRef="Activity_04lr7k1" targetRef="Event_0jglhm1" />
+    <bpmn:endEvent id="Event_05fcrmd">
+      <bpmn:incoming>Flow_097o97l</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_097o97l" sourceRef="Event_1aoilzw" targetRef="Event_05fcrmd" />
   </bpmn:process>
   <bpmn:message id="Message_2jcp7c1" name="Message_2jcp7c1">
     <bpmn:extensionElements>
@@ -37,6 +42,9 @@
       <bpmndi:BPMNShape id="Event_0jglhm1_di" bpmnElement="Event_0jglhm1">
         <dc:Bounds x="482" y="100" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05fcrmd_di" bpmnElement="Event_05fcrmd">
+        <dc:Bounds x="452" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1oofnxk_di" bpmnElement="Event_1aoilzw">
         <dc:Bounds x="362" y="140" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -47,6 +55,11 @@
       <bpmndi:BPMNEdge id="Flow_0ezrv14_di" bpmnElement="Flow_0ezrv14">
         <di:waypoint x="380" y="118" />
         <di:waypoint x="482" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_097o97l_di" bpmnElement="Flow_097o97l">
+        <di:waypoint x="380" y="176" />
+        <di:waypoint x="380" y="240" />
+        <di:waypoint x="452" y="240" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/configs/camunda-oca/fixtures/deployment-artifacts.json
+++ b/configs/camunda-oca/fixtures/deployment-artifacts.json
@@ -62,6 +62,32 @@
       ]
     },
     {
+      "kind": "bpmnProcess",
+      "path": "bpmn/service-message-catch.bpmn",
+      "description": "BPMN process with a service task (zeebe:taskDefinition type sampleJobWithMessage) and a boundary message catch event. Provides both ModelHasServiceTaskType and ModelEmitsMessageSubscription. Selected for chains that require both job activation and message subscription data (e.g. activateJobs + searchMessageSubscriptions). See #305.",
+      "providesStates": ["ModelHasServiceTaskType", "ModelEmitsMessageSubscription"],
+      "providesValues": {
+        "JobType": ["sampleJobWithMessage"]
+      },
+      "providesElements": [
+        { "id": "StartEvent_1", "type": "startEvent" },
+        { "id": "Activity_04lr7k1", "type": "serviceTask" },
+        { "id": "Event_1aoilzw", "type": "boundaryEvent" },
+        { "id": "Event_0jglhm1", "type": "endEvent" }
+      ]
+    },
+    {
+      "kind": "bpmnProcess",
+      "path": "bpmn/message-catch-event.bpmn",
+      "description": "BPMN process with an intermediate message catch event referencing a named message (Message_1j9t80c). When a process instance is created, the token reaches the catch event and the engine creates a message subscription deterministically (the instance blocks waiting for the message). Selected for chains whose consumer ops require ModelEmitsMessageSubscription (e.g. searchMessageSubscriptions discovered via processInstanceKey). See #305.",
+      "providesStates": ["ModelEmitsMessageSubscription"],
+      "providesElements": [
+        { "id": "StartEvent_1", "type": "startEvent" },
+        { "id": "CatchEvent_1", "type": "intermediateCatchEvent" },
+        { "id": "EndEvent_1", "type": "endEvent" }
+      ]
+    },
+    {
       "kind": "form",
       "path": "forms/simple.form",
       "description": "Minimal Camunda form JSON"

--- a/configs/camunda-oca/fixtures/deployment-artifacts.json
+++ b/configs/camunda-oca/fixtures/deployment-artifacts.json
@@ -64,7 +64,7 @@
     {
       "kind": "bpmnProcess",
       "path": "bpmn/service-message-catch.bpmn",
-      "description": "BPMN process with a service task (zeebe:taskDefinition type sampleJobWithMessage) and a boundary message catch event. Provides both ModelHasServiceTaskType and ModelEmitsMessageSubscription. Selected for chains that require both job activation and message subscription data (e.g. activateJobs + searchMessageSubscriptions). See #305.",
+      "description": "BPMN process with a service task (zeebe:taskDefinition type sampleJobWithMessage) and a NON-INTERRUPTING boundary message catch event (cancelActivity=\"false\"). Provides both ModelHasServiceTaskType and ModelEmitsMessageSubscription. Selected for chains that require both job activation and message subscription data (e.g. activateJobs + searchMessageSubscriptions). The boundary event must stay non-interrupting: chains exist that correlate the message and THEN act on the job (completeJob's variant chain runs activateJobs -> correlateMessage -> searchCorrelatedMessageSubscriptions -> completeJob), and an interrupting boundary event cancels the service task on correlation, terminating the job so completeJob returns 404. See #305.",
       "providesStates": ["ModelHasServiceTaskType", "ModelEmitsMessageSubscription"],
       "providesValues": {
         "JobType": ["sampleJobWithMessage"],

--- a/configs/camunda-oca/fixtures/deployment-artifacts.json
+++ b/configs/camunda-oca/fixtures/deployment-artifacts.json
@@ -67,7 +67,9 @@
       "description": "BPMN process with a service task (zeebe:taskDefinition type sampleJobWithMessage) and a boundary message catch event. Provides both ModelHasServiceTaskType and ModelEmitsMessageSubscription. Selected for chains that require both job activation and message subscription data (e.g. activateJobs + searchMessageSubscriptions). See #305.",
       "providesStates": ["ModelHasServiceTaskType", "ModelEmitsMessageSubscription"],
       "providesValues": {
-        "JobType": ["sampleJobWithMessage"]
+        "JobType": ["sampleJobWithMessage"],
+        "MessageName": ["Message_2jcp7c1"],
+        "CorrelationKey": ["45646"]
       },
       "providesElements": [
         { "id": "StartEvent_1", "type": "startEvent" },
@@ -81,6 +83,10 @@
       "path": "bpmn/message-catch-event.bpmn",
       "description": "BPMN process with an intermediate message catch event referencing a named message (Message_1j9t80c). When a process instance is created, the token reaches the catch event and the engine creates a message subscription deterministically (the instance blocks waiting for the message). Selected for chains whose consumer ops require ModelEmitsMessageSubscription (e.g. searchMessageSubscriptions discovered via processInstanceKey). See #305.",
       "providesStates": ["ModelEmitsMessageSubscription"],
+      "providesValues": {
+        "MessageName": ["Message_1j9t80c"],
+        "CorrelationKey": ["12312"]
+      },
       "providesElements": [
         { "id": "StartEvent_1", "type": "startEvent" },
         { "id": "CatchEvent_1", "type": "intermediateCatchEvent" },

--- a/configs/camunda-oca/ontology/artifact-kinds.json
+++ b/configs/camunda-oca/ontology/artifact-kinds.json
@@ -8,7 +8,7 @@
       "name": "bpmnProcess",
       "identifierType": "ProcessDefinitionId",
       "producesStates": ["ProcessDefinitionDeployed"],
-      "producibleStates": ["ModelHasServiceTaskType", "ModelHasUserTask", "ModelEmitsIncident", "ModelHasCancellationBlocker", "ProcessInstanceCompleted"],
+      "producibleStates": ["ModelHasServiceTaskType", "ModelHasUserTask", "ModelEmitsIncident", "ModelHasCancellationBlocker", "ModelEmitsMessageSubscription", "ProcessInstanceCompleted"],
       "producesSemantics": ["ProcessDefinitionKey"],
       "deploymentSlices": ["processDefinition"],
       "modelKind": "bpmn",

--- a/configs/camunda-oca/ontology/runtime-states.json
+++ b/configs/camunda-oca/ontology/runtime-states.json
@@ -148,6 +148,12 @@
       "requires": [
         "ProcessDefinitionDeployed"
       ]
+    },
+    {
+      "operationId": "searchMessageSubscriptions",
+      "requires": [
+        "ModelEmitsMessageSubscription"
+      ]
     }
   ]
 }

--- a/configs/camunda-oca/ontology/runtime-states.json
+++ b/configs/camunda-oca/ontology/runtime-states.json
@@ -72,6 +72,17 @@
       "producedBy": [
         "createDeployment"
       ]
+    },
+    {
+      "name": "MessageCorrelationExists",
+      "parameter": "messageKey",
+      "producedBy": [
+        "correlateMessage"
+      ],
+      "requires": [
+        "ProcessInstanceExists",
+        "ModelEmitsMessageSubscription"
+      ]
     }
   ],
   "operationRequirements": [
@@ -153,6 +164,26 @@
       "operationId": "searchMessageSubscriptions",
       "requires": [
         "ModelEmitsMessageSubscription"
+      ]
+    },
+    {
+      "operationId": "correlateMessage",
+      "requires": [
+        "ProcessInstanceExists",
+        "ModelEmitsMessageSubscription"
+      ],
+      "produces": [
+        "MessageCorrelationExists"
+      ],
+      "valueBindings": {
+        "request.name": "ModelEmitsMessageSubscription.messageName",
+        "request.correlationKey": "ModelEmitsMessageSubscription.correlationKey"
+      }
+    },
+    {
+      "operationId": "searchCorrelatedMessageSubscriptions",
+      "requires": [
+        "MessageCorrelationExists"
       ]
     }
   ]

--- a/configs/camunda-oca/ontology/runtime-states.json
+++ b/configs/camunda-oca/ontology/runtime-states.json
@@ -163,6 +163,7 @@
     {
       "operationId": "searchMessageSubscriptions",
       "requires": [
+        "ProcessInstanceExists",
         "ModelEmitsMessageSubscription"
       ]
     },

--- a/configs/camunda-oca/ontology/runtime-states.json
+++ b/configs/camunda-oca/ontology/runtime-states.json
@@ -178,7 +178,7 @@
       ],
       "valueBindings": {
         "request.name": "ModelEmitsMessageSubscription.messageName",
-        "request.correlationKey": "ModelEmitsMessageSubscription.correlationKey"
+        "request.correlationKey": "semantic:CorrelationKey"
       }
     },
     {

--- a/configs/camunda-oca/ontology/semantics.json
+++ b/configs/camunda-oca/ontology/semantics.json
@@ -231,7 +231,7 @@
     },
     {
       "name": "ModelEmitsMessageSubscription",
-      "parameter": "messageSubscriptionElementId",
+      "parameter": "messageName",
       "producedBy": [
         "createDeployment"
       ],

--- a/configs/camunda-oca/ontology/semantics.json
+++ b/configs/camunda-oca/ontology/semantics.json
@@ -113,8 +113,20 @@
     },
     {
       "name": "MessageSubscriptionKey",
-      "kind": "serverEmergent",
-      "$comment": "Server-minted lifecycle key for a message subscription. Subscriptions emerge when a deployed process reaches a message catch event \u2014 no direct create API. Search-filter input only; planner mints a deterministic placeholder. See #162 PR 5."
+      "kind": "runtimeEmission",
+      "emittedBy": {
+        "predecessor": "ProcessInstanceExists",
+        "guardedBy": [
+          "ModelEmitsMessageSubscription"
+        ]
+      },
+      "discoveredVia": {
+        "operationId": "searchMessageSubscriptions",
+        "filterBy": "processInstanceKey",
+        "extractKey": "messageSubscriptionKey",
+        "consistency": "eventual"
+      },
+      "$comment": "Server-minted lifecycle key for a message subscription. Emitted after a deployment whose BPMN contains an intermediate message catch event (ModelEmitsMessageSubscription) reaches that element during a process instance run. Discovered via searchMessageSubscriptions filtered by processInstanceKey; eventually consistent (await-eventually). Promoted from serverEmergent per #305."
     },
     {
       "name": "IncidentKey",
@@ -200,6 +212,16 @@
     {
       "name": "ModelHasCancellationBlocker",
       "parameter": "cancellationBlockerJobType",
+      "producedBy": [
+        "createDeployment"
+      ],
+      "dependsOn": [
+        "ProcessDefinitionDeployed"
+      ]
+    },
+    {
+      "name": "ModelEmitsMessageSubscription",
+      "parameter": "messageSubscriptionElementId",
       "producedBy": [
         "createDeployment"
       ],

--- a/configs/camunda-oca/ontology/semantics.json
+++ b/configs/camunda-oca/ontology/semantics.json
@@ -85,6 +85,16 @@
       "$comment": "zeebe:taskDefinition type is encoded in the BPMN model on each service-task element. Read out-of-band from the chosen fixture's providesValues. Subsumes the pre-#162 ad-hoc `parameters.jobType` handling in the registry."
     },
     {
+      "name": "MessageName",
+      "kind": "modelDerived",
+      "$comment": "The bpmn:message/@name value from the deployed BPMN model. Used by correlateMessage and publishMessage to target the correct message subscription. Resolved from the fixture's providesValues.MessageName at plan time. See #305."
+    },
+    {
+      "name": "CorrelationKey",
+      "kind": "modelDerived",
+      "$comment": "The zeebe:subscription/@correlationKey result from the deployed BPMN model. Used by correlateMessage to match the correct message subscription. Resolved from the fixture's providesValues.CorrelationKey at plan time. See #305."
+    },
+    {
       "name": "Tag",
       "kind": "attribute",
       "clientMinted": true,

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -7697,18 +7697,6 @@ describeForThisConfig(
 describeForThisConfig(
   'bundled-spec invariants: optional semantic-typed body fields are variant-suite-only (#247)',
   () => {
-    interface BodySemanticLeaf {
-      semanticType: string;
-      fieldPath: string;
-      required: boolean;
-    }
-    interface GraphOpEntry {
-      operationId: string;
-      requestBodySemanticTypes?: BodySemanticLeaf[];
-    }
-    interface GraphDoc {
-      operations: GraphOpEntry[];
-    }
     interface PlanStep {
       operationId: string;
       bodyKind?: string;
@@ -7745,8 +7733,7 @@ describeForThisConfig(
     // annotation is OPTIONAL. Mirrors the planner's own grouping: strip a
     // trailing `[]`, skip nested paths and `$`-prefixed operator pseudo-fields,
     // and treat a single required annotation at the path as justification.
-    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
-    const graph = JSON.parse(readFileSync(GRAPH_PATH, 'utf8')) as GraphDoc;
+    const graph = loadGraph();
     const optionalOnlyByOp = new Map<string, Set<string>>();
     for (const op of graph.operations) {
       const anyRequiredByField = new Map<string, boolean>();
@@ -7785,6 +7772,16 @@ describeForThisConfig(
     // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
     const requestDefaults = JSON.parse(readFileSync(defaultsPath, 'utf8')) as RequestDefaultsFile;
     const globalDefaultKeys = new Set(Object.keys(requestDefaults.global ?? {}));
+    // Pre-indexed per-operation default keys. Built once here rather than
+    // re-derived per body field: the scan below is a triple-nested loop over
+    // every scenario in all three output dirs, so an `Object.keys()` inside it
+    // allocates an array per field for no benefit.
+    const opDefaultKeysByOp = new Map<string, Set<string>>(
+      Object.entries(requestDefaults.operations ?? {}).map(([opId, defaults]) => [
+        opId,
+        new Set(Object.keys(defaults ?? {})),
+      ]),
+    );
 
     interface Offender {
       dir: string;
@@ -7820,6 +7817,9 @@ describeForThisConfig(
             const optionalOnly = optionalOnlyByOp.get(step.operationId);
             if (!optionalOnly?.size) continue;
             const isFinal = i === steps.length - 1;
+            // Resolved once per step — both are per-operation, not per-field.
+            const declaredFields = declaredFieldsByOp.get(step.operationId);
+            const opDefaultKeys = opDefaultKeysByOp.get(step.operationId);
             for (const [field, value] of Object.entries(body)) {
               if (!optionalOnly.has(field)) continue;
               if (typeof value !== 'string' || !PLACEHOLDER_RE.test(value)) continue;
@@ -7829,12 +7829,9 @@ describeForThisConfig(
                 continue;
               }
               // 2 — explicit ABox operator intent.
-              if (declaredFieldsByOp.get(step.operationId)?.has(field)) continue;
+              if (declaredFields?.has(field)) continue;
               // 3 — explicit per-config request defaults.
-              const opDefaultKeys = Object.keys(
-                requestDefaults.operations?.[step.operationId] ?? {},
-              );
-              if (globalDefaultKeys.has(field) || opDefaultKeys.includes(field)) continue;
+              if (globalDefaultKeys.has(field) || opDefaultKeys?.has(field)) continue;
               offenders.push({
                 dir: dirLabel,
                 file: f,

--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -7667,6 +7667,222 @@ describeForThisConfig(
   },
 );
 
+// ---------------------------------------------------------------------------
+// Optional semantic-typed body fields are variant-suite-only (#247)
+// ---------------------------------------------------------------------------
+//
+// Companion to the feature-base guard above, which only inspects the FINAL
+// step of `variantKey: "base"` feature scenarios. The defect class is wider
+// than that window: `buildRequestBodyFromCanonical`'s optional-fill pass
+// derives its binding from the field's own leaf name (`tenantId` →
+// `tenantIdVar`), so ANY step — prerequisite or endpoint, in any suite —
+// picks up an optional field the moment some unrelated step in the chain
+// mints a same-named binding. That is how createDeployment's multipart
+// `globalContextSeeds` binding leaked `tenantId` into correlateMessage's
+// body across the feature, variant, and planner outputs at once.
+//
+// Post-fix contract: a top-level field whose only `requestBodySemanticTypes`
+// annotations are OPTIONAL may carry a `${binding}` placeholder only when
+//   1. the step is the scenario's FINAL step and the field is one of the
+//      scenario's `populatesSubShape` subject leaves (the variant suite's own
+//      coverage, injected by `mergePopulatesSubShapeIntoFinalBody`), or
+//   2. the operation declares an explicit `valueBindings["request.<field>"]`
+//      entry in the runtime-states ABox (operator intent), or
+//   3. the field has a `request-defaults.json` entry (explicit config).
+// Anything else is an opportunistic name-collision fill.
+//
+// The assertion targets `${…}` placeholders specifically because that is the
+// exact shape the gated code path emits — `request-defaults` values are
+// literals and never match.
+describeForThisConfig(
+  'bundled-spec invariants: optional semantic-typed body fields are variant-suite-only (#247)',
+  () => {
+    interface BodySemanticLeaf {
+      semanticType: string;
+      fieldPath: string;
+      required: boolean;
+    }
+    interface GraphOpEntry {
+      operationId: string;
+      requestBodySemanticTypes?: BodySemanticLeaf[];
+    }
+    interface GraphDoc {
+      operations: GraphOpEntry[];
+    }
+    interface PlanStep {
+      operationId: string;
+      bodyKind?: string;
+      bodyTemplate?: unknown;
+    }
+    interface WalkedScenario {
+      id: string;
+      variantKey?: string;
+      populatesSubShape?: { leafPaths?: string[] };
+      requestPlan?: PlanStep[];
+    }
+    interface WalkedScenarioFile {
+      scenarios?: WalkedScenario[];
+    }
+    interface RuntimeStatesAbox {
+      operationRequirements?: { operationId?: string; valueBindings?: Record<string, string> }[];
+    }
+    interface RequestDefaultsFile {
+      global?: Record<string, unknown>;
+      operations?: Record<string, Record<string, unknown>>;
+    }
+
+    const PLACEHOLDER_RE = /^\$\{[A-Za-z_$][\w$]*\}$/;
+
+    for (const dir of [SCENARIOS_DIR, FEATURE_SCENARIOS_DIR, VARIANT_SCENARIOS_DIR]) {
+      if (!existsSync(dir)) {
+        throw new Error(
+          `Scenario output directory not found at ${dir}. Run 'npm run pipeline' first.`,
+        );
+      }
+    }
+
+    // Per-operation set of top-level body fields whose every semantic-type
+    // annotation is OPTIONAL. Mirrors the planner's own grouping: strip a
+    // trailing `[]`, skip nested paths and `$`-prefixed operator pseudo-fields,
+    // and treat a single required annotation at the path as justification.
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const graph = JSON.parse(readFileSync(GRAPH_PATH, 'utf8')) as GraphDoc;
+    const optionalOnlyByOp = new Map<string, Set<string>>();
+    for (const op of graph.operations) {
+      const anyRequiredByField = new Map<string, boolean>();
+      for (const leaf of op.requestBodySemanticTypes ?? []) {
+        if (typeof leaf.fieldPath !== 'string') continue;
+        const fieldPath = leaf.fieldPath.replace(/\[\]$/, '');
+        if (fieldPath.includes('.') || fieldPath.startsWith('$')) continue;
+        anyRequiredByField.set(
+          fieldPath,
+          (anyRequiredByField.get(fieldPath) ?? false) || leaf.required === true,
+        );
+      }
+      const optionalOnly = new Set<string>();
+      for (const [fieldPath, anyRequired] of anyRequiredByField) {
+        if (!anyRequired) optionalOnly.add(fieldPath);
+      }
+      if (optionalOnly.size) optionalOnlyByOp.set(op.operationId, optionalOnly);
+    }
+
+    // Allow-rule 2: explicit ABox `request.<field>` valueBindings.
+    const aboxPath = join(REPO_ROOT, 'configs', CONFIG_NAME, 'ontology', 'runtime-states.json');
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const abox = JSON.parse(readFileSync(aboxPath, 'utf8')) as RuntimeStatesAbox;
+    const declaredFieldsByOp = new Map<string, Set<string>>();
+    for (const entry of abox.operationRequirements ?? []) {
+      if (!entry.operationId) continue;
+      const fields = declaredFieldsByOp.get(entry.operationId) ?? new Set<string>();
+      for (const key of Object.keys(entry.valueBindings ?? {})) {
+        if (key.startsWith('request.')) fields.add(key.slice('request.'.length));
+      }
+      declaredFieldsByOp.set(entry.operationId, fields);
+    }
+
+    // Allow-rule 3: explicit request-defaults entries (global or per-operation).
+    const defaultsPath = join(REPO_ROOT, 'configs', CONFIG_NAME, 'request-defaults.json');
+    // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+    const requestDefaults = JSON.parse(readFileSync(defaultsPath, 'utf8')) as RequestDefaultsFile;
+    const globalDefaultKeys = new Set(Object.keys(requestDefaults.global ?? {}));
+
+    interface Offender {
+      dir: string;
+      file: string;
+      scenarioId: string;
+      operationId: string;
+      field: string;
+    }
+    const offenders: Offender[] = [];
+    // Non-vacuity counter: legitimate allow-rule-1 occurrences (a variant
+    // populating its OWN optional semantic leaf).
+    let subjectLeafHits = 0;
+
+    for (const [dirLabel, dir] of [
+      ['scenarios', SCENARIOS_DIR],
+      ['feature-output', FEATURE_SCENARIOS_DIR],
+      ['variant-output', VARIANT_SCENARIOS_DIR],
+    ] as const) {
+      for (const f of readdirSync(dir)) {
+        if (!f.endsWith('-scenarios.json')) continue;
+        // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+        const parsed = JSON.parse(readFileSync(join(dir, f), 'utf8')) as WalkedScenarioFile;
+        for (const scenario of parsed.scenarios ?? []) {
+          const steps = scenario.requestPlan ?? [];
+          const subjectLeaves = new Set(
+            (scenario.populatesSubShape?.leafPaths ?? []).map((p) => p.replace(/\[\]$/, '')),
+          );
+          for (let i = 0; i < steps.length; i++) {
+            const step = steps[i];
+            if (step.bodyKind !== 'json') continue;
+            const body = step.bodyTemplate;
+            if (!body || typeof body !== 'object' || Array.isArray(body)) continue;
+            const optionalOnly = optionalOnlyByOp.get(step.operationId);
+            if (!optionalOnly?.size) continue;
+            const isFinal = i === steps.length - 1;
+            for (const [field, value] of Object.entries(body)) {
+              if (!optionalOnly.has(field)) continue;
+              if (typeof value !== 'string' || !PLACEHOLDER_RE.test(value)) continue;
+              // 1 — the variant suite's own subject leaf on the endpoint step.
+              if (isFinal && subjectLeaves.has(field)) {
+                subjectLeafHits++;
+                continue;
+              }
+              // 2 — explicit ABox operator intent.
+              if (declaredFieldsByOp.get(step.operationId)?.has(field)) continue;
+              // 3 — explicit per-config request defaults.
+              const opDefaultKeys = Object.keys(
+                requestDefaults.operations?.[step.operationId] ?? {},
+              );
+              if (globalDefaultKeys.has(field) || opDefaultKeys.includes(field)) continue;
+              offenders.push({
+                dir: dirLabel,
+                file: f,
+                scenarioId: scenario.id,
+                operationId: step.operationId,
+                field,
+              });
+            }
+          }
+        }
+      }
+    }
+
+    it('no scenario step fills an optional semantic-typed top-level field from a same-named chain binding', () => {
+      expect(
+        offenders,
+        `Found ${offenders.length} scenario steps whose bodyTemplate carries a \`\${binding}\` ` +
+          `in a top-level field backed only by OPTIONAL semantic-typed leaves. Optional ` +
+          `semantic population is owned by the variant suite ` +
+          `(\`generateOptionalSubShapeVariants\` + \`mergePopulatesSubShapeIntoFinalBody\`); a ` +
+          `fill here means \`buildRequestBodyFromCanonical\`'s optional-fill pass matched the ` +
+          `field's leaf name against a binding minted by an unrelated step in the chain. ` +
+          `Declare an ABox \`valueBindings["request.<field>"]\` entry if the population is ` +
+          `intentional. Offenders:\n${offenders
+            .map(
+              (o) =>
+                `  - ${o.dir}/${o.file} :: ${o.scenarioId} (${o.operationId}) :: field "${o.field}"`,
+            )
+            .join('\n')}`,
+      ).toEqual([]);
+    });
+
+    it('the walk actually reaches optional semantic-typed fields (non-vacuity floor)', () => {
+      // Mirrors the `multipartFieldHits` floor of the #342 suite: the guard
+      // above passes trivially if the walk never sees an optional semantic
+      // field at all (renamed output dirs, a changed `populatesSubShape`
+      // shape, or a spec that dropped every optional annotation). At least one
+      // variant must be exercising its own optional semantic leaf.
+      expect(
+        subjectLeafHits,
+        'expected ≥1 variant scenario whose FINAL step populates its own optional ' +
+          'semantic-typed top-level leaf (allow-rule 1). Zero matches means the scan never ' +
+          'reached the fields this invariant governs, so the offender check is vacuous.',
+      ).toBeGreaterThan(0);
+    });
+  },
+);
+
 describeForThisConfig(
   'bundled-spec invariants: response extract autoderivation parity (#251)',
   () => {

--- a/configs/camunda-oca/spec-pin.json
+++ b/configs/camunda-oca/spec-pin.json
@@ -1,5 +1,5 @@
 {
   "$comment": "Spec pin for the bundled-spec invariants regression layer. The invariants in configs/camunda-oca/regression-invariants.test.ts assert named properties of the upstream spec content fingerprinted by `expectedSpecHash`. `specRef` MUST be a full 40-char commit SHA on camunda/camunda (not a branch like `main`) so the baseline does not drift on every upstream merge. CI fetches the spec at `specRef` (requires camunda-schema-bundler >= 2.1.0 for SHA support) and aborts early via tests/regression/spec-pin.setup.ts if its hash drifts, so reviewers see a clear 'spec changed upstream — re-pin' signal instead of confusing invariant failures. To bump: pick a newer SHA, run `SPEC_REF=<sha> npm run fetch-spec:ref`, regenerate the pipeline, update any invariants whose values legitimately changed, then update both fields below in the same PR.",
-  "specRef": "ef1ec46c65fe05e2f07d84508400c3b2db392558",
-  "expectedSpecHash": "sha256:2d638fa54edfff38ce1e05e76f1b26575927ac261d240dc8e35843dfe5326846"
+  "specRef": "6859c3ccb4e1dab2cbb28ce635ca7cc73d4c9508",
+  "expectedSpecHash": "sha256:a58ebf3da860def6f73999c93218336bcbaa90d2674dcf2e30b8e3b3b35d2b01"
 }

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1588,6 +1588,34 @@ export function buildRequestBodyFromCanonical(
             ),
           )
         : undefined;
+    // #247 — a top-level field whose ONLY semantic-type annotations are OPTIONAL
+    // is owned by the variant suite (`generateOptionalSubShapeVariants`, injected
+    // into the final body by `mergePopulatesSubShapeIntoFinalBody` AFTER this
+    // pass). The fill binding below is derived from the field's own leaf name
+    // (`tenantId` → `tenantIdVar`), so populating it here merely because some
+    // OTHER step in the chain minted a same-named binding couples an operation's
+    // body shape to unrelated prerequisites: once the ABox gave correlateMessage a
+    // chain, createDeployment's multipart `globalContextSeeds` binding leaked
+    // `tenantId` into correlateMessage's feature-BASE body. Mirrors the
+    // clientMintedAttribute exclusion in `semanticFallback` above, which drops the
+    // same class of optional population for the same reason.
+    const optionalOnlySemanticTopLevel = new Set<string>();
+    {
+      const anyRequiredByField = new Map<string, boolean>();
+      for (const entry of graph.operations[opId]?.requestBodySemantics ?? []) {
+        const fieldPath = entry.fieldPath.replace(/\[\]$/, '');
+        // Nested paths are already out of this loop's scope; `$`-prefixed
+        // segments are filter operator pseudo-fields, not real body leaves.
+        if (fieldPath.includes('.') || fieldPath.startsWith('$')) continue;
+        anyRequiredByField.set(
+          fieldPath,
+          (anyRequiredByField.get(fieldPath) ?? false) || entry.required,
+        );
+      }
+      for (const [fieldPath, anyRequired] of anyRequiredByField) {
+        if (!anyRequired) optionalOnlySemanticTopLevel.add(fieldPath);
+      }
+    }
     for (const f of nodes.filter(
       (n) => !n.required && !n.path.includes('[]') && !n.path.includes('.'),
     )) {
@@ -1596,7 +1624,13 @@ export function buildRequestBodyFromCanonical(
       if (variantLeafNames?.has(leaf)) continue;
       const varBase = `${camelCase(bindingMap[f.path] || leaf || 'value')}Var`;
       if (!template[leaf]) {
-        if (scenario.bindings?.[varBase]) {
+        // An explicit ABox `request.<field>` valueBinding is operator intent, not
+        // a name collision, so it keeps its fill (and is re-applied by the
+        // "ensure all domain request.* bindings are present" pass below).
+        // `defaults` stays reachable either way — request-defaults.json is
+        // explicit per-config configuration.
+        const suppressBindingFill = !bindingMap[f.path] && optionalOnlySemanticTopLevel.has(leaf);
+        if (!suppressBindingFill && scenario.bindings?.[varBase]) {
           template[leaf] = `${'${'}${varBase}}`;
         } else if (defaults && Object.hasOwn(defaults, leaf)) {
           template[leaf] = defaults[leaf];

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -1763,23 +1763,26 @@ export function buildRequestBodyFromCanonical(
         );
       }
       const fileRef = regHit.ref;
-      // Bind jobType from the chosen fixture for later use in the request
-      // body (`activateJobs.type`, `completeJob`/`failJob`/`throwJobError`
-      // path params, etc.). After #164 the SOLE source is
-      // `providesValues.JobType[0]` (declared on the bpmnProcess fixture
-      // alongside ElementId). The legacy `parameters.jobType` field and
-      // its `??`-fallback reader are gone.
+      // Seed scenario bindings from the chosen fixture's providesValues.
+      // Each entry maps a semantic-type name (e.g. "JobType", "MessageName")
+      // to its concrete model-derived value(s); we select index-0 and bind
+      // as `<camelCase(type)>Var`. Generalises the former JobType-only block
+      // to cover MessageName, CorrelationKey, and any future modelDerived
+      // semantic whose value is baked into the fixture. See #305.
       //
       // The `jobType` → `type` mapping special-case elsewhere in
       // `buildRequestBodyFromCanonical` (pairing the semantically-named
       // `jobType` binding with the spec-named `type` field) is
       // intentionally left in place — that's a separate architectural
       // cleanup tracked by #162 PR 3 (unified dispatch).
-      const jobTypeValue = regHit?.providesValues?.JobType?.[0];
-      if (jobTypeValue !== undefined) {
-        const varName = 'jobTypeVar';
-        scenario.bindings ||= {};
-        if (!scenario.bindings[varName]) scenario.bindings[varName] = jobTypeValue;
+      if (regHit?.providesValues) {
+        for (const [semanticType, values] of Object.entries(regHit.providesValues)) {
+          if (values?.[0] !== undefined) {
+            const varName = `${camelCase(semanticType)}Var`;
+            scenario.bindings ||= {};
+            if (!scenario.bindings[varName]) scenario.bindings[varName] = values[0];
+          }
+        }
       }
       // #172: fulfill modelDerived variant placeholders from the chosen
       // deploy fixture. The variant generator installs a synthetic

--- a/tests/fixtures/planner/optional-semantic-no-opportunistic-fill.test.ts
+++ b/tests/fixtures/planner/optional-semantic-no-opportunistic-fill.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Body-synthesis contract (#247) — an OPTIONAL semantic-typed top-level field is
+ * owned by the variant suite and must never be filled just because a same-named
+ * binding happens to exist in the scenario.
+ *
+ * `buildRequestBodyFromCanonical` derives its fill binding from the field's own
+ * leaf name (`tenantId` → `tenantIdVar`). Any prerequisite that mints a binding
+ * of that name therefore silently changes an unrelated operation's body shape.
+ *
+ * Reproduces correlateMessage: once the ABox gave it a prerequisite chain
+ * (createDeployment → createProcessInstance → correlateMessage), the multipart
+ * `globalContextSeeds` wiring stamped `tenantIdVar` for createDeployment's
+ * `fields.tenantId`, and the optional-fill pass then injected
+ * `tenantId: '${tenantIdVar}'` into correlateMessage's feature-BASE body —
+ * exactly the optional population the #162 PR 4 suite-partition cut moved into
+ * `generateOptionalSubShapeVariants`.
+ *
+ * The two boundary cases below keep the guard scoped: it must key on the
+ * semantic-type annotation (non-annotated optionals like `updateUser.password`
+ * still fill) and it must not override explicit ABox operator intent.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  buildRequestBodyFromCanonical,
+  type CanonicalShape,
+} from '../../../path-analyser/src/index.ts';
+import type { EndpointScenario, OperationGraph } from '../../../path-analyser/src/types.ts';
+
+// correlateMessage-like body: required `name`, optional semantic-typed
+// `tenantId`, optional NON-annotated `password`.
+const canonical: Record<string, CanonicalShape> = {
+  correlateMessageL2: {
+    requestByMediaType: {
+      'application/json': [
+        { path: 'name', type: 'string', required: true },
+        { path: 'tenantId', type: 'string', required: false },
+        { path: 'password', type: 'string', required: false },
+      ],
+    },
+  },
+};
+
+function graphWith(valueBindings?: Record<string, string>): OperationGraph {
+  const graph: OperationGraph = {
+    operations: {
+      correlateMessageL2: {
+        operationId: 'correlateMessageL2',
+        method: 'POST',
+        path: '/messages/correlation',
+        requires: { required: [], optional: ['TenantId'] },
+        produces: [],
+        // Only `tenantId` carries a semantic-type annotation, and it is
+        // OPTIONAL. `password` is deliberately unannotated.
+        requestBodySemantics: [{ semantic: 'TenantId', fieldPath: 'tenantId', required: false }],
+      },
+    },
+    producersByType: {},
+    producersByState: {},
+    responseProducersByType: {},
+  };
+  if (valueBindings) {
+    graph.domain = {
+      version: 1,
+      operationRequirements: { correlateMessageL2: { valueBindings } },
+    };
+  }
+  return graph;
+}
+
+// A chain prerequisite (createDeployment's multipart `fields.tenantId`) already
+// minted `tenantIdVar`; `passwordVar` stands in for any ordinary chain binding.
+function chainScenario(): EndpointScenario {
+  return {
+    id: 'feature-1',
+    operations: [],
+    producedSemanticTypes: [],
+    satisfiedSemanticTypes: [],
+    strategy: 'featureCoverage',
+    variantKey: 'base',
+    bindings: { tenantIdVar: '__PENDING__', passwordVar: '__PENDING__' },
+  };
+}
+
+function templateFor(graph: OperationGraph): Record<string, unknown> {
+  const plan = buildRequestBodyFromCanonical(
+    'correlateMessageL2',
+    chainScenario(),
+    graph,
+    canonical,
+    {},
+    /* isEndpoint */ true,
+  );
+  expect(plan?.kind).toBe('json');
+  return plan?.kind === 'json' ? plan.template : {};
+}
+
+describe('optional semantic-typed body fields are variant-suite-only (#247)', () => {
+  it('does NOT fill an optional semantic-typed field from a same-named chain binding', () => {
+    const template = templateFor(graphWith());
+    expect(template).toHaveProperty('name'); // required field still synthesised
+    expect(template).not.toHaveProperty('tenantId'); // optional semantic → variant suite only
+  });
+
+  it('still fills an optional field that carries NO semantic-type annotation', () => {
+    // Scope guard: the suppression keys on the semantic-type annotation, not on
+    // optionality. `updateUser`'s base body is `{ password: "${passwordVar}" }`
+    // and must not collapse to `{}`.
+    const template = templateFor(graphWith());
+    expect(template.password).toBe('${passwordVar}');
+  });
+
+  it('still fills an optional semantic-typed field declared by an ABox valueBinding', () => {
+    // Scope guard: an explicit `request.<field>` entry in the ABox is operator
+    // intent, not a name collision, and stays honoured.
+    const template = templateFor(graphWith({ 'request.tenantId': 'TenantExists.tenantId' }));
+    expect(template.tenantId).toBe('${tenantIdVar}');
+  });
+});


### PR DESCRIPTION
## Make message-subscription and correlation endpoints testable (#305)

### Why

`MessageSubscriptionKey` was modelled as `serverEmergent`, which tells the planner "this key cannot be obtained — mint a deterministic placeholder" (`fc:sem:messageSubscriptionKey:<suffix>`). That was the wrong model. Message subscriptions genuinely have no create API, but they *do* emerge deterministically at runtime: deploy a BPMN containing a message catch event, start an instance, and the engine creates a subscription when the token reaches that element.

Because the model said "unobtainable", every message endpoint ran as a bare single-step call against a cluster where nothing existed. On `main`, `searchMessageSubscriptions`, `searchCorrelatedMessageSubscriptions`, `correlateMessage` and `publishMessage` all searched or correlated into the void and failed.

Sections 1–4 model the real mechanism. Sections 5–7 cover the spec-pin bumps and the fixes that came out of review.

### 1. Promote `MessageSubscriptionKey` to `runtimeEmission` (`7786166`)

`runtimeEmission` already exists for exactly this shape — "not directly creatable, but reachable by doing X then discovering it". Switching the kind lets the existing `expandRuntimeEmission` BFS branch ([scenarioGenerator.ts:1454](path-analyser/src/scenarioGenerator.ts:1454)) take over: it defers until the gates surface, appends a discovery step, and mints a `PENDING_BINDING` for the server-extracted value.

The declaration in `semantics.json` now carries:

```json
"emittedBy":     { "predecessor": "ProcessInstanceExists",
                   "guardedBy": ["ModelEmitsMessageSubscription"] },
"discoveredVia": { "operationId": "searchMessageSubscriptions",
                   "filterBy": "processInstanceKey",
                   "extractKey": "messageSubscriptionKey",
                   "consistency": "eventual" }
```

`consistency: eventual` routes the discovery through `awaitEventually`, since the subscription is not immediately visible to the search index.

Supporting changes:
- New capability **`ModelEmitsMessageSubscription`** (produced by `createDeployment`, depends on `ProcessDefinitionDeployed`) — the model must actually contain a catch event, which is a property of the *chosen fixture*, not of deployment in general. Added to `bpmnProcess.producibleStates` in `artifact-kinds.json` so BFS knows a deployment *can* satisfy it.
- Two committed BPMN fixtures:
  - `message-catch-event.bpmn` — intermediate catch event; the instance blocks waiting, so the subscription is created deterministically.
  - `service-message-catch.bpmn` — service task **plus** boundary message catch, so one deployment satisfies `ModelHasServiceTaskType` *and* `ModelEmitsMessageSubscription` for chains needing both (e.g. `activateJobs` + `searchMessageSubscriptions`). See section 6 — this fixture needed two follow-up corrections.

### 2. Model the `correlateMessage` prerequisite chain (`ecd4a57`)

Correlation needs two things the planner could not previously express: a live subscription to correlate *to*, and `name`/`correlationKey` values that **match the deployed model** — random seeds can never correlate.

- Two new `modelDerived` semantics, **`MessageName`** and **`CorrelationKey`**; the fixtures declare their concrete values via `providesValues` (`Message_1j9t80c`/`12312`, `Message_2jcp7c1`/`45646`).
- `operationRequirements[correlateMessage]` requires `ProcessInstanceExists` + `ModelEmitsMessageSubscription`, produces a new state **`MessageCorrelationExists`**, and maps the body fields via `valueBindings`. Final form after section 7:
  ```json
  "request.name": "ModelEmitsMessageSubscription.messageName",
  "request.correlationKey": "semantic:CorrelationKey"
  ```
- `searchCorrelatedMessageSubscriptions` requires `MessageCorrelationExists`, so it only runs after a correlation has actually happened.

### 3. Generalise fixture-value seeding (`de0919a`)

The reader that pulls values out of the chosen fixture was hardcoded to `providesValues.JobType` — a leftover from #164. The `MessageName`/`CorrelationKey` values declared in step 2 would have been silently dropped.

Replaced the single lookup with a loop over every `providesValues` entry, binding `<camelCase(semanticType)>Var`. This covers `MessageName`, `CorrelationKey`, and any future `modelDerived` semantic baked into a fixture, with no further code changes. The `jobType → type` field-name special case is deliberately left alone (tracked separately by #162 PR 3).

Also added `searchMessageSubscriptions` requires `ProcessInstanceExists` + `ModelEmitsMessageSubscription` — a subscription exists only once an instance reaches the catch event.

Without this commit the branch would not work: `correlateMessage` would send randomly seeded values and the engine would answer `404 NOT_FOUND — Expected to find subscription for message with name '<random>' … but none was found`, taking down every chain containing a correlate step. Notably, **no vitest assertion covers that** — the only `providesValues` guard is hardcoded to `jobTypeVar`, so the regression would have been live-only.

### 4. Fix the #247 regression the new chain exposed (`26f85b8`, `77c71da`)

Giving `correlateMessage` a chain surfaced a latent planner defect. The optional-fill pass in `buildRequestBodyFromCanonical` derives its fill binding from the field's own **leaf name** (`tenantId` → `tenantIdVar`). Once the chain included `createDeployment`, whose multipart `globalContextSeeds` wiring mints `tenantIdVar` for `fields.tenantId`, the pass injected `tenantId: "${tenantIdVar}"` into `correlateMessage`'s **feature-base** body — purely because an unrelated step happened to mint a same-named binding. That broke the #247 invariant: a feature base must carry only required-leaf top-level fields; optional population belongs to the variant suite.

Fix: suppress the fill for any top-level field whose *only* semantic-type annotations are OPTIONAL. Two escape hatches are deliberate — an explicit ABox `request.<field>` valueBinding (operator intent, not a name collision) and `request-defaults.json` (explicit config) both still fill.

Blast radius measured against the generated artifacts: **21 occurrences, all collateral**. No variant loses its own subject leaf, since `mergePopulatesSubShapeIntoFinalBody` runs after this pass and re-injects those 16.

Tests: a red-first L2 planner fixture (`tests/fixtures/planner/optional-semantic-no-opportunistic-fill.test.ts`) with two boundary cases pinning the scope, plus a new class-scoped L3 invariant spanning all three output dirs with a non-vacuity floor. The invariant reported exactly those 21 offenders before the fix and zero after.

`77c71da` is review cleanup on that invariant: reuse the file's cached `loadGraph()` instead of re-parsing `GRAPH_PATH` (which also removed three redundant local interfaces and a `biome-ignore`), and pre-index the per-operation `request-defaults` keys instead of calling `Object.keys()` once per body field inside the triple-nested scan. Verified non-neutering by re-injecting the original offender into a generated artifact and confirming the guard still reports it with the correct file, scenario, operation and field.

### 5. Bump the OCA spec pin (`f051961`, `bc5ac24`, `920a78c`)

Three bumps landed while the branch was open. Net movement:

| | from | to |
|---|---|---|
| `specRef` | `ef1ec46c6` | `6859c3ccb` |
| `expectedSpecHash` | `sha256:2d638fa5…` | `sha256:a58ebf3d…` |

That spans `camunda/camunda` main from 2026-08-13 10:15Z to 2026-08-14 11:11Z, tip commit *"feat: physical-tenant-aware exporters actuator endpoint (#60145)"*.

- **Why it's here rather than standalone:** the generated output in this PR was produced against the new bundle, so the pin and the regenerated artefacts have to move together. Splitting them would leave the branch's invariants asserting against a spec the pin doesn't name.
- **No invariant values needed changing.** The pin file's own procedure calls for updating any invariants whose values legitimately shifted; none did. `tests/regression/spec-pin.setup.ts` aborts the whole suite on hash drift, so a green regression leg is positive confirmation that pin and bundle agree.

Side effect worth knowing: the newer spec grew the planned-endpoint count from 225 to 227, which is why the live figures in Verification below no longer match the current tree.

### 6. Correct the `service-message-catch` fixture (`f961c41`, `ed5bf77`, `406fb41`)

Three follow-ups on the fixture added in section 1, two of them from review:

- **`f961c41`** — the boundary message event had no outgoing sequence flow. Added one to a new end event (`Flow_097o97l` → `Event_05fcrmd`), making the model unambiguously valid.
- **`ed5bf77`** — removed an unused `<bpmn:message id="Message_1" name="sampleMessage">` that no `messageRef` pointed at, so the fixture no longer implies a second message name.
- **`406fb41`** — set `cancelActivity="false"`. The event defaulted to *interrupting*, so correlating `Message_2jcp7c1` cancelled the attached service task and terminated its job. `completeJob`'s variant chain runs `activateJobs → correlateMessage → searchCorrelatedMessageSubscriptions → completeJob`, so the job was already gone by the final step and it returned **404 instead of 204**. Making the event non-interrupting lets the job survive correlation; the boundary subscription is still opened when the activity activates, so `ModelEmitsMessageSubscription` continues to hold and no ABox change was needed.

The non-interrupting property is load-bearing and silently reversible, so the reasoning is recorded on the fixture's registry entry in `deployment-artifacts.json` rather than only in this description.

### 7. Make the `correlateMessage` `valueBindings` conformant (`8f8a555`)

Raised twice by Copilot as a suppressed comment. The `valueBindings` RHS grammar is documented as either `<StateName>.<parameter>` or `semantic:<SemanticTypeName>`, but both `correlateMessage` bindings named parameters `ModelEmitsMessageSubscription` did not declare — it declared only `parameter: "messageSubscriptionElementId"`. They worked anyway because the consumer string-splits the RHS and uses the leaf as a variable name, never resolving the parameter, so the two halves met only by spelling coincidence.

The anomaly turned out to be the capability's parameter name, not the bindings. Surveying all five capabilities: when a capability's value is bound into a request, its `parameter` names *that value* (`ModelHasServiceTaskType` → `jobType`, matching `providesValues.JobType`); element-id names appear only on capabilities nothing binds. `ModelEmitsMessageSubscription` was in the first group but named as if in the second. Two one-line edits:

- `semantics.json` — `parameter: "messageSubscriptionElementId"` → `"messageName"`, restoring the same four-name agreement `jobType` has (capability parameter = binding leaf = `providesValues` key = seeded variable).
- `runtime-states.json` — `request.correlationKey` → `"semantic:CorrelationKey"`. `parameter` is singular so it can only legitimise one binding; the second moves to the other documented grammar, which is strictly better here because `CorrelationKey` is a declared `semanticType` and the binding therefore gains real enforcement from `checkSemanticBindingTargetResolves`.

`request.name` cannot make the same move — its LHS leaf `name` would derive `nameVar` and miss the seeded `messageNameVar`, the same spec-field-vs-semantic-name mismatch as the `jobType → type` special case. That asymmetry is why the parameter rename was needed.

All four `valueBindings` in the OCA ABox now conform, down from two violations. No TBox change, no vocabulary regeneration, and the change is inert: with the edits reverted and re-applied, `scenarios/index.json`'s endpoint array is byte-identical, and `correlateMessage`'s body still resolves to the fixture values (`messageNameVar: Message_1j9t80c`, `correlationKeyVar: 12312`).

### Verification

**Unit / invariants** — current tree (`8f8a555`)
- `npm test` — 933 passed, 12 skipped, 0 failed
- `configs/camunda-oca/regression-invariants.test.ts` — 203 passed, 4 skipped (207 total, up from 205)
- `npm run lint` — 0 errors
- CI — 7/7 checks pass, including both `camunda-hub` legs

**Live Playwright suite, branch vs main** — ⚠️ measured at `26f85b8`, **not** the current tree

This comparison predates `f961c41`, `ed5bf77`, `406fb41`, `8f8a555` and two of the three spec-pin bumps. It is kept because it is the only end-to-end evidence available, but the numbers are not current: the endpoint count has since moved 225 → 227, so the scenario inventory differs.

591 scenarios, identical inventory on both sides at the time of measurement:

| | main | branch |
|---|---|---|
| Passed | 210 (35.5%) | **224 (37.9%)** |
| Failed | 381 | **367** |

**15 fixed, 1 flipped (+14).** 11 of the 15 are structural — the chain genuinely changed:

| Scenario | main → branch |
|---|---|
| `correlateMessage` feature-1 | `correlateMessage` → `createDeployment → createProcessInstance → correlateMessage` |
| `searchCorrelatedMessageSubscriptions` feature-1 | 1 step → 4 steps |
| `searchMessageSubscriptions` feature-1 | 1 step → 3 steps |
| `publishMessage` variant-2 | 1 step → 5 steps |
| + 7 more subscription variants | gain `correlateMessage` / `createProcessInstance` prerequisites |

The other 4 had identical chains and had failed on main with `EventualConsistencyTimeoutError`. The single flip — `searchProcessInstanceIncidents` variant-2 — is also an EC timeout: byte-identical chain on both sides, touching none of the operations whose bodies changed, and its sibling variant-3 times out on *both* runs. The EC-timeout class dropped 99 → 83 overall; the standing 404/400 failure population is flat (135→137, 106→105).

**Expected to change on a re-run:** `406fb41` should flip `completeJob` variant-2 from 404 to 204, which was the one unexplained new failure in the table above. If it does, the headline becomes **16 fixed, 0 new**, leaving the `searchProcessInstanceIncidents` EC-timeout flake as the only anomaly. That is reasoned, not measured — the OCA live suite is not part of PR checks, so it needs a run against a cluster to confirm.

### Risks and follow-ups

- **Multi-tenancy.** The `correlateMessage` feature base is now tenant-implicit (omitted `tenantId` resolves to `<default>`), which is correct here because the whole base chain already lives in `<default>`. Real cross-tenant correlation is covered by variant-1, which mints a tenant via `createTenant` and propagates it through all four steps. If this suite is ever pointed at a multi-tenancy-enabled cluster whose chains deploy outside `<default>`, the base scenario would correlate against the wrong tenant.
- The ABox escape hatch is **not** a tenant-propagation switch — the #247 invariant is provenance-blind, so declaring `request.tenantId` would restore the field *and* re-trip the guard.
- Both eventual-consistency observations rest on single runs against a shared live cluster.
- `camunda-hub` is covered: the `hub invariants` and `Run hub suite (internal)` CI legs both pass on this branch, so the config-agnostic planner change is confirmed not to disturb Hub output.
- **Follow-up — the `<StateName>.<parameter>` grammar is still unvalidated.** `checkSemanticBindingTargetResolves` only checks the `semantic:` half; nothing verifies that a legacy-form RHS names a declared state or capability, let alone a parameter it declares. Section 7 fixed the data but nothing prevents recurrence. The fix is a companion cross-ref check in `runtimeStatesCrossRef.ts` (load-time, so it covers every config including Hub, and fails at generation rather than only under `npm test`).
- **Residual fragility.** Section 7 fixed the declaration, not the underlying coupling: `request.name` still resolves by leaf-name coincidence between the `providesValues` key, the RHS leaf and the derived variable. A *consistent* rename of the key and the leaf would pass validation while breaking the runtime match. Fully removing that needs the `semantic:`-resolves-by-type work tracked by #162 PR 3.
- **Not addressed here**, spotted in the same live reports: `getProcessDefinitionStatistics` variants 3/7 send a non-numeric `parentElementInstanceKey` (`elementInstanceKey_19jg`) and get `400 INVALID_ARGUMENT — not a valid key, expected a numeric value`. A separate seeded-key defect, unrelated to this branch's changes.
- **Open review note.** Copilot flagged (suppressed) that the optional-fill pass guards with `if (!template[leaf])`, a truthiness test, so a field legitimately set to `false`, `0` or `null` by an earlier pass would be treated as absent and overwritten. The guard is pre-existing rather than introduced here, but it sits on the line section 4 touches and is worth confirming against real operations.


🤖 Generated with [Claude Code](https://claude.com/claude-code)