### PR TITLE
feat(materializer): add request/response evidence capture to the positive suite

### DIFF
--- a/materializer/scripts/copy-support-templates.js
+++ b/materializer/scripts/copy-support-templates.js
@@ -20,6 +20,7 @@
 //     fixtures.ts
 //     seed-rules.json
 //     await-eventually.ts
+//     evidence.ts
 // ---------------------------------------------------------------------------
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
@@ -31,6 +32,7 @@ const SUPPORT_FILES = [
   'fixtures.ts',
   'seed-rules.json',
   'await-eventually.ts',
+  'evidence.ts',
 ];
 
 async function main() {

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -363,11 +363,15 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   // role-only suite (every step role-matched) can still reference
   // authHeaders()/attachEvidenceOnFailure() in its final output if any used
   // role's template does this. Detected statically (template source
-  // contains the tag) since imports are decided before any step is
-  // rendered, so the actual rendered output isn't available yet.
+  // matches the actual Mustache interpolation tag) since imports are
+  // decided before any step is rendered, so the actual rendered output
+  // isn't available yet. Matches the tag specifically — not a bare
+  // substring — so a comment or unrelated prose mentioning "defaultRender"
+  // can't false-positive into unused (lint-failing) imports.
+  const DEFAULT_RENDER_TAG_RE = /\{\{\{?\s*defaultRender\s*\}?\}\}/;
   const anyRoleUsesDefaultRender = collection.scenarios.some((s) =>
     (s.requestPlan ?? []).some((step) =>
-      Boolean(findRoleForStep(step)?.bundle.callSiteTemplate.includes('defaultRender')),
+      Boolean(findRoleForStep(step)?.bundle.callSiteTemplate.match(DEFAULT_RENDER_TAG_RE)),
     ),
   );
   // authHeaders is used in inline request steps, awaitEventually witness

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -357,12 +357,26 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
       (step) => step.bodyKind === 'multipart' && !!step.multipartTemplate && !findRoleForStep(step),
     ),
   );
-  // authHeaders is used in inline request steps and awaitEventually witness
-  // blocks. Role helpers call authHeaders internally, so role-only suites
-  // don't need this import.
-  const hasInlineRequestStep = collection.scenarios.some((s) =>
-    (s.requestPlan ?? []).some((step) => !findRoleForStep(step)),
+  // A role's call-site.tmpl MAY interpolate {{{defaultRender}}} (the "wrap
+  // pattern" from ROLES.md) to splice in the exact same inline code
+  // renderInlineStepLines would have produced for a non-role step — so a
+  // role-only suite (every step role-matched) can still reference
+  // authHeaders()/attachEvidenceOnFailure() in its final output if any used
+  // role's template does this. Detected statically (template source
+  // contains the tag) since imports are decided before any step is
+  // rendered, so the actual rendered output isn't available yet.
+  const anyRoleUsesDefaultRender = collection.scenarios.some((s) =>
+    (s.requestPlan ?? []).some((step) =>
+      Boolean(findRoleForStep(step)?.bundle.callSiteTemplate.includes('defaultRender')),
+    ),
   );
+  // authHeaders is used in inline request steps, awaitEventually witness
+  // blocks, and any wrap-pattern role's defaultRender. Role helpers that
+  // don't use the wrap pattern call authHeaders internally, so a role-only
+  // suite with no wrap-pattern role doesn't need this import.
+  const hasInlineRequestStep =
+    anyRoleUsesDefaultRender ||
+    collection.scenarios.some((s) => (s.requestPlan ?? []).some((step) => !findRoleForStep(step)));
   if (hasInlineRequestStep || needsAwaitEventually) {
     lines.push("import { buildBaseUrl, authHeaders } from './support/env';");
   } else {

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -642,16 +642,37 @@ function renderScenarioTest(
       // Wrapped so a shape-validation failure still attaches request/response
       // evidence before re-throwing — validateResponse itself only throws a
       // bare Error (no structured payload), so evidence must come from
-      // `${varName}` directly. Uses `.url()` rather than a hoisted `url`
-      // const since this runs for role-bound steps too, which don't
-      // necessarily declare one.
+      // `${varName}` directly. Role-bound steps don't declare a `url`/
+      // `headers`/body local (the role helper owns those internally), so
+      // fall back to `.url()` and omit headers/body only in that case; for
+      // inline steps the locals `renderInlineStepLines` already declared in
+      // this same test.step scope are reused for full evidence.
+      const bodyVar = `body${idx + 1}`;
+      const hasBodyVar =
+        (step.bodyKind === 'json' && step.bodyTemplate) ||
+        (step.bodyKind === 'multipart' && step.multipartTemplate);
+      const evidenceCtxFields = roleMatch
+        ? [
+            `operationId: ${JSON.stringify(step.operationId)}`,
+            `method: ${JSON.stringify(step.method.toUpperCase())}`,
+            `url: ${varName}.url()`,
+            `expectedStatus: ${step.expect.status}`,
+          ]
+        : [
+            `operationId: ${JSON.stringify(step.operationId)}`,
+            `method: ${JSON.stringify(step.method.toUpperCase())}`,
+            'url',
+            'headers',
+            `body: ${hasBodyVar ? bodyVar : 'undefined'}`,
+            `expectedStatus: ${step.expect.status}`,
+          ];
       body.push(`    try {`);
       body.push(
         `      await validateResponse(${routeSpec}, ${varName}, { responsesFilePath: __responsesFile });`,
       );
       body.push(`    } catch (e) {`);
       body.push(
-        `      await attachEvidenceOnFailure(testInfo, ${varName}, { operationId: ${JSON.stringify(step.operationId)}, method: ${JSON.stringify(step.method.toUpperCase())}, url: ${varName}.url(), expectedStatus: ${step.expect.status} }, String(e));`,
+        `      await attachEvidenceOnFailure(testInfo, ${varName}, { ${evidenceCtxFields.join(', ')} }, String(e));`,
       );
       body.push(`      throw e;`);
       body.push(`    }`);

--- a/materializer/src/playwright/emitter.ts
+++ b/materializer/src/playwright/emitter.ts
@@ -404,6 +404,12 @@ function buildSuiteSource(collection: EndpointScenarioCollection, opts: EmitOpti
   if (needsAwaitEventually) {
     lines.push("import { awaitEventually } from './support/await-eventually';");
   }
+  // attachEvidenceOnFailure is emitted by renderInlineStepLines/renderEventualWait
+  // (inline request steps, witness waits) and the validateResponse try/catch
+  // wrap below — import whenever any of those code paths are present.
+  if (hasInlineRequestStep || needsAwaitEventually || needsValidation) {
+    lines.push("import { attachEvidenceOnFailure } from './support/evidence';");
+  }
   lines.push('');
   lines.push(`initSpecSalt(${JSON.stringify(suiteName)});`);
   if (needsValidation) {
@@ -443,7 +449,7 @@ function renderScenarioTest(
 ): string {
   const title = `${s.id} - ${escapeQuotes(s.name || 'scenario')}`;
   const body: string[] = [];
-  body.push(`test('${title}', async ({ request }) => {`);
+  body.push(`test('${title}', async ({ request }, testInfo) => {`);
   if (s.description) {
     const desc = String(s.description).trim();
     // Wrap long description lines at ~100 chars for readability
@@ -633,9 +639,22 @@ function renderScenarioTest(
       // double-quoted (no mixed single/double quotes) and any special characters
       // in the path template are correctly escaped.
       const routeSpec = `{ path: ${JSON.stringify(step.pathTemplate)}, method: ${JSON.stringify(step.method.toUpperCase())}, status: ${JSON.stringify(String(step.expect.status))} }`;
+      // Wrapped so a shape-validation failure still attaches request/response
+      // evidence before re-throwing — validateResponse itself only throws a
+      // bare Error (no structured payload), so evidence must come from
+      // `${varName}` directly. Uses `.url()` rather than a hoisted `url`
+      // const since this runs for role-bound steps too, which don't
+      // necessarily declare one.
+      body.push(`    try {`);
       body.push(
-        `    await validateResponse(${routeSpec}, ${varName}, { responsesFilePath: __responsesFile });`,
+        `      await validateResponse(${routeSpec}, ${varName}, { responsesFilePath: __responsesFile });`,
       );
+      body.push(`    } catch (e) {`);
+      body.push(
+        `      await attachEvidenceOnFailure(testInfo, ${varName}, { operationId: ${JSON.stringify(step.operationId)}, method: ${JSON.stringify(step.method.toUpperCase())}, url: ${varName}.url(), expectedStatus: ${step.expect.status} }, String(e));`,
+      );
+      body.push(`      throw e;`);
+      body.push(`    }`);
     }
     // Extraction. `extractInto` is the vendored helper from support/seeding.ts;
     // it skips the assignment when the value is `undefined` so seeded bindings

--- a/materializer/src/playwright/materialize-support.ts
+++ b/materializer/src/playwright/materialize-support.ts
@@ -18,8 +18,8 @@
 //                          and the legacy `emitPlaywrightSuite` entrypoint
 //                          share the same template-discovery logic.
 //   * support/ — runtime helpers (env.ts, recorder.ts, seeding.ts,
-//                fixtures.ts, seed-rules.json, await-eventually.ts).
-//                Sources:
+//                fixtures.ts, seed-rules.json, await-eventually.ts,
+//                evidence.ts). Sources:
 //                materializer/src/playwright/support/, staged into
 //                dist/src/playwright/support-templates/ at
 //                build time.
@@ -49,6 +49,7 @@ export const SUPPORT_TEMPLATE_FILES = [
   'fixtures.ts',
   'seed-rules.json',
   'await-eventually.ts',
+  'evidence.ts',
 ] as const;
 
 /** Files copied directly into <outDir>/ (project root scaffolding). */
@@ -105,7 +106,7 @@ function defaultProjectTemplatesDir(): string {
 /**
  * Copy the runtime support templates into `<outDir>/support/` so the emitted
  * Playwright suite has the helper modules it imports (env.ts, recorder.ts,
- * seeding.ts, fixtures.ts, seed-rules.json, await-eventually.ts).
+ * seeding.ts, fixtures.ts, seed-rules.json, await-eventually.ts, evidence.ts).
  *
  * Idempotent: safe to call multiple times per emit run. Project-root
  * scaffolding (package.json, playwright.config.ts, tsconfig.json,

--- a/materializer/src/playwright/stepRenderer.ts
+++ b/materializer/src/playwright/stepRenderer.ts
@@ -208,7 +208,10 @@ export function renderInlineStepLines({
   lines.push(`    if (${varName}.status() !== ${step.expect.status}) {`);
   lines.push(`      try { console.error('Response body:', await ${varName}.text()); } catch {}`);
   lines.push(`    }`);
-  const evidenceBody = step.bodyKind === 'json' && step.bodyTemplate ? bodyVar : 'undefined';
+  const hasBodyVar =
+    (step.bodyKind === 'json' && step.bodyTemplate) ||
+    (step.bodyKind === 'multipart' && step.multipartTemplate);
+  const evidenceBody = hasBodyVar ? bodyVar : 'undefined';
   lines.push(
     `    await attachEvidenceOnFailure(testInfo, ${varName}, { operationId: ${JSON.stringify(step.operationId)}, method: ${JSON.stringify(step.method.toUpperCase())}, url, headers, body: ${evidenceBody}, expectedStatus: ${step.expect.status} });`,
   );

--- a/materializer/src/playwright/stepRenderer.ts
+++ b/materializer/src/playwright/stepRenderer.ts
@@ -164,8 +164,9 @@ export function renderInlineStepLines({
     );
     lines.push(`    const ${bodyVar} = ${tpl};`);
   }
+  lines.push(`    const headers = await authHeaders();`);
   const opts: string[] = [];
-  opts.push('headers: await authHeaders()');
+  opts.push('headers');
   if (step.bodyKind === 'json' && step.bodyTemplate) opts.push(`data: ${bodyVar}`);
   if (step.bodyKind === 'multipart' && step.multipartTemplate) {
     lines.push(
@@ -207,6 +208,10 @@ export function renderInlineStepLines({
   lines.push(`    if (${varName}.status() !== ${step.expect.status}) {`);
   lines.push(`      try { console.error('Response body:', await ${varName}.text()); } catch {}`);
   lines.push(`    }`);
+  const evidenceBody = step.bodyKind === 'json' && step.bodyTemplate ? bodyVar : 'undefined';
+  lines.push(
+    `    await attachEvidenceOnFailure(testInfo, ${varName}, { operationId: ${JSON.stringify(step.operationId)}, method: ${JSON.stringify(step.method.toUpperCase())}, url, headers, body: ${evidenceBody}, expectedStatus: ${step.expect.status} });`,
+  );
   lines.push(`    expect(${varName}.status()).toBe(${step.expect.status});`);
   return lines;
 }
@@ -228,6 +233,7 @@ export function renderEventualWait(wait: EventualWaitSpec, idx: number): string[
   out.push(`  // Wait for ${wait.state} (eventual; witness: ${w.operationId})`);
   out.push(`  {`);
   out.push(`    const witnessUrl = baseUrl + ${buildUrlExpression(w.pathTemplate)};`);
+  out.push(`    const headers = await authHeaders();`);
   const optionFields: string[] = [
     `method: '${w.method.toUpperCase()}'`,
     `operationId: '${w.operationId}'`,
@@ -242,7 +248,7 @@ export function renderEventualWait(wait: EventualWaitSpec, idx: number): string[
       }`);
   const method = w.method.toLowerCase();
   out.push(`    const ${respVar} = await awaitEventually(`);
-  out.push(`      async () => request.${method}(witnessUrl, { headers: await authHeaders() }),`);
+  out.push(`      async () => request.${method}(witnessUrl, { headers }),`);
   out.push(`      {`);
   for (let i = 0; i < optionFields.length; i++) {
     const sep = i === optionFields.length - 1 ? '' : ',';
@@ -255,6 +261,9 @@ export function renderEventualWait(wait: EventualWaitSpec, idx: number): string[
     `      try { console.error('Witness response body:', await ${respVar}.text()); } catch {}`,
   );
   out.push(`    }`);
+  out.push(
+    `    await attachEvidenceOnFailure(testInfo, ${respVar}, { operationId: ${JSON.stringify(w.operationId)}, method: ${JSON.stringify(w.method.toUpperCase())}, url: witnessUrl, headers, expectedStatus: 200 });`,
+  );
   out.push(`    expect(${respVar}.status()).toBe(200);`);
   out.push(`  }`);
   return out;

--- a/materializer/src/playwright/support/evidence.ts
+++ b/materializer/src/playwright/support/evidence.ts
@@ -18,7 +18,13 @@ interface ApiResponseLike {
   headers(): Record<string, string>;
 }
 
-/** Context captured for a failing assertion so the attached evidence is self-explanatory. */
+/**
+ * Context captured for a failing assertion so the attached evidence is
+ * self-explanatory. `headers` are the actual request headers sent (e.g.
+ * `authHeaders()`'s `Authorization: Bearer <token>`) — never attached by
+ * value (see `attachEvidenceOnFailure`'s redaction), only by name, so a
+ * real credential can never end up in a Playwright report/artifact.
+ */
 export interface EvidenceContext {
   operationId: string;
   method: string;
@@ -84,13 +90,19 @@ export async function attachEvidenceOnFailure(
     // Response body may already be consumed; attach whatever was captured.
   }
 
+  // Attach header NAMES only, never values — `ctx.headers` carries the real
+  // Authorization bearer token sent to the server, and this artifact is
+  // embedded (base64) in the JSON reporter / HTML report, which can end up
+  // in uploaded CI artifacts. The negative suite's own request.json omits
+  // headers entirely for the same reason; naming (not valuing) them keeps
+  // the "was auth even sent" debugging signal without the leak.
   const requestArtifact = JSON.stringify(
     {
       operationId: ctx.operationId,
       method: ctx.method,
       url: ctx.url,
       expectedStatus: ctx.expectedStatus,
-      headers: ctx.headers,
+      headerNames: ctx.headers ? Object.keys(ctx.headers) : undefined,
       body: ctx.body,
     },
     null,

--- a/materializer/src/playwright/support/evidence.ts
+++ b/materializer/src/playwright/support/evidence.ts
@@ -53,12 +53,16 @@ function capString(
   return { value: buf.toString('utf8'), truncated: true, originalBytes };
 }
 
-function tryParseJson(s: string): unknown | undefined {
-  if (!s) return undefined;
+// Returns a `parsed` flag alongside the value — a bare `unknown | undefined`
+// return couldn't distinguish "successfully parsed to the literal JSON value
+// `null`" from "failed to parse", so a caller using `?? fallback` would wrongly
+// discard a genuine `null` body and substitute the fallback instead.
+function parseJsonBody(s: string): { parsed: boolean; value: unknown } {
+  if (!s) return { parsed: false, value: undefined };
   try {
-    return JSON.parse(s);
+    return { parsed: true, value: JSON.parse(s) };
   } catch {
-    return undefined;
+    return { parsed: false, value: undefined };
   }
 }
 
@@ -112,12 +116,13 @@ export async function attachEvidenceOnFailure(
   // test-results.json / the HTML report. The JSON reporter base64-encodes
   // attachments, so each KB here costs ~1.33 KB on disk.
   const cappedBodyText = capString(bodyText, MAX_ATTACHMENT_BODY_BYTES);
+  const parsedBody = parseJsonBody(cappedBodyText.value);
   const responseArtifact = JSON.stringify(
     {
       status: actual,
       statusText: res.statusText(),
       headers: res.headers(),
-      body: tryParseJson(cappedBodyText.value) ?? cappedBodyText.value,
+      body: parsedBody.parsed ? parsedBody.value : cappedBodyText.value,
       bodyTruncated: cappedBodyText.truncated || undefined,
       bodyOriginalBytes: cappedBodyText.truncated ? cappedBodyText.originalBytes : undefined,
       shapeError,

--- a/materializer/src/playwright/support/evidence.ts
+++ b/materializer/src/playwright/support/evidence.ts
@@ -1,0 +1,125 @@
+import type { TestInfo } from '@playwright/test';
+
+/**
+ * Structural subset of Playwright's `APIResponse` — deliberately not
+ * imported from '@playwright/test'. Role helpers (e.g.
+ * support/deploymentGateway.ts's `deploy()`) return their own
+ * independently-declared `ApiResponseLike` mirror rather than the real
+ * `APIResponse` (to avoid a Playwright import there), and TypeScript would
+ * reject passing that into a parameter nominally typed as the real
+ * `APIResponse` — it's missing unrelated members (`securityDetails`,
+ * `serverAddr`, `timing`) this helper never uses anyway. A real
+ * `APIResponse` satisfies this structurally, so both call sites work.
+ */
+interface ApiResponseLike {
+  status(): number;
+  statusText(): string;
+  text(): Promise<string>;
+  headers(): Record<string, string>;
+}
+
+/** Context captured for a failing assertion so the attached evidence is self-explanatory. */
+export interface EvidenceContext {
+  operationId: string;
+  method: string;
+  url: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  expectedStatus: number;
+}
+
+/**
+ * Maximum number of bytes (UTF-8) of response body to embed in attachments.
+ * Keeps `test-results.json` and `playwright-report/` bounded even when the
+ * server returns large payloads (e.g. HTML error pages, verbose stack traces).
+ */
+const MAX_ATTACHMENT_BODY_BYTES = 64 * 1024;
+
+function capString(
+  s: string,
+  maxBytes: number,
+): { value: string; truncated: boolean; originalBytes: number } {
+  if (!s) return { value: s, truncated: false, originalBytes: 0 };
+  const originalBytes = Buffer.byteLength(s, 'utf8');
+  if (originalBytes <= maxBytes) return { value: s, truncated: false, originalBytes };
+  // Slice on byte boundary, then trim any partial UTF-8 sequence.
+  const buf = Buffer.from(s, 'utf8').subarray(0, maxBytes);
+  return { value: buf.toString('utf8'), truncated: true, originalBytes };
+}
+
+function tryParseJson(s: string): unknown | undefined {
+  if (!s) return undefined;
+  try {
+    return JSON.parse(s);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Attaches `request.json`/`response.json` to the Playwright report, but only
+ * when the response contradicts what the test expected — a status mismatch,
+ * or (via `shapeError`) a response-shape validation failure at the correct
+ * status. Mirrors the artifact shape written by
+ * request-validation/templates/support/http.ts's `assertResponseStatus` (so
+ * a consumer can parse either suite's evidence the same way), trimmed to
+ * what the positive suite actually has: no ProblemDetail shape checks here,
+ * since those only apply to error responses, not this suite's 2xx-expecting
+ * assertions.
+ */
+export async function attachEvidenceOnFailure(
+  testInfo: TestInfo,
+  res: ApiResponseLike,
+  ctx: EvidenceContext,
+  shapeError?: string,
+): Promise<void> {
+  const actual = res.status();
+  const statusMismatch = actual !== ctx.expectedStatus;
+  if (!statusMismatch && !shapeError) return;
+
+  let bodyText = '';
+  try {
+    bodyText = await res.text();
+  } catch {
+    // Response body may already be consumed; attach whatever was captured.
+  }
+
+  const requestArtifact = JSON.stringify(
+    {
+      operationId: ctx.operationId,
+      method: ctx.method,
+      url: ctx.url,
+      expectedStatus: ctx.expectedStatus,
+      headers: ctx.headers,
+      body: ctx.body,
+    },
+    null,
+    2,
+  );
+  // Cap attached body so that a single oversized error payload cannot bloat
+  // test-results.json / the HTML report. The JSON reporter base64-encodes
+  // attachments, so each KB here costs ~1.33 KB on disk.
+  const cappedBodyText = capString(bodyText, MAX_ATTACHMENT_BODY_BYTES);
+  const responseArtifact = JSON.stringify(
+    {
+      status: actual,
+      statusText: res.statusText(),
+      headers: res.headers(),
+      body: tryParseJson(cappedBodyText.value) ?? cappedBodyText.value,
+      bodyTruncated: cappedBodyText.truncated || undefined,
+      bodyOriginalBytes: cappedBodyText.truncated ? cappedBodyText.originalBytes : undefined,
+      shapeError,
+    },
+    null,
+    2,
+  );
+
+  await testInfo.attach('request.json', {
+    body: requestArtifact,
+    contentType: 'application/json',
+  });
+  await testInfo.attach('response.json', {
+    body: responseArtifact,
+    contentType: 'application/json',
+  });
+}

--- a/materializer/src/playwright/support/evidence.ts
+++ b/materializer/src/playwright/support/evidence.ts
@@ -128,11 +128,14 @@ export async function attachEvidenceOnFailure(
   // attachments, so each KB here costs ~1.33 KB on disk.
   const cappedBodyText = capString(bodyText, MAX_ATTACHMENT_BODY_BYTES);
   const parsedBody = parseJsonBody(cappedBodyText.value);
+  // Same redaction as the request side, and for the same reason: a gateway
+  // response can carry a credential-bearing header (e.g. Set-Cookie), which
+  // would otherwise be embedded by value in this artifact.
   const responseArtifact = JSON.stringify(
     {
       status: actual,
       statusText: res.statusText(),
-      headers: res.headers(),
+      headerNames: Object.keys(res.headers()),
       body: parsedBody.parsed ? parsedBody.value : cappedBodyText.value,
       bodyTruncated: cappedBodyText.truncated || undefined,
       bodyOriginalBytes: cappedBodyText.truncated ? cappedBodyText.originalBytes : undefined,

--- a/materializer/src/playwright/support/evidence.ts
+++ b/materializer/src/playwright/support/evidence.ts
@@ -1,6 +1,17 @@
 import type { TestInfo } from '@playwright/test';
 
 /**
+ * Structural subset of Playwright's `TestInfo` — only `attach()` is used
+ * here, so that's all this accepts. Matches the same minimal-surface
+ * principle as `ApiResponseLike` below: a test fake only needs to implement
+ * `attach()`, not TestInfo's other ~30 members, and it can do so without an
+ * `as unknown as TestInfo` cast.
+ */
+interface AttachableTestInfo {
+  attach: TestInfo['attach'];
+}
+
+/**
  * Structural subset of Playwright's `APIResponse` — deliberately not
  * imported from '@playwright/test'. Role helpers (e.g.
  * support/deploymentGateway.ts's `deploy()`) return their own
@@ -78,7 +89,7 @@ function parseJsonBody(s: string): { parsed: boolean; value: unknown } {
  * assertions.
  */
 export async function attachEvidenceOnFailure(
-  testInfo: TestInfo,
+  testInfo: AttachableTestInfo,
   res: ApiResponseLike,
   ctx: EvidenceContext,
   shapeError?: string,

--- a/materializer/src/playwright/templateEmitter.ts
+++ b/materializer/src/playwright/templateEmitter.ts
@@ -301,6 +301,7 @@ function renderLifecycleSuite(
   const lines: string[] = [];
   lines.push("import { expect, test } from '@playwright/test';");
   lines.push("import { authHeaders, buildBaseUrl } from '../../support/env';");
+  lines.push("import { attachEvidenceOnFailure } from '../../support/evidence';");
   const seedingImports = ['initSpecSalt', 'seedBinding'];
   if (needsExtractInto) seedingImports.push('extractInto');
   lines.push(`import { ${seedingImports.join(', ')} } from '../../support/seeding';`);
@@ -315,7 +316,7 @@ function renderLifecycleSuite(
   lines.push('');
   lines.push(`test.describe('${file.subjectName} lifecycle', () => {`);
   lines.push(
-    `  test('establish ${file.subjectName}, observe present, revoke, observe absent', async ({ request }) => {`,
+    `  test('establish ${file.subjectName}, observe present, revoke, observe absent', async ({ request }, testInfo) => {`,
   );
   lines.push('    const baseUrl = buildBaseUrl();');
   lines.push('    const ctx: Record<string, unknown> = {};');
@@ -467,6 +468,7 @@ function renderRestoreLifecycleSuite(
   const lines: string[] = [];
   lines.push("import { expect, test } from '@playwright/test';");
   lines.push("import { authHeaders, buildBaseUrl } from '../../support/env';");
+  lines.push("import { attachEvidenceOnFailure } from '../../support/evidence';");
   const seedingImports = ['initSpecSalt', 'seedBinding'];
   if (needsExtractInto) seedingImports.push('extractInto');
   lines.push(`import { ${seedingImports.join(', ')} } from '../../support/seeding';`);
@@ -481,7 +483,7 @@ function renderRestoreLifecycleSuite(
   lines.push('');
   lines.push(`test.describe('${file.subjectName} restore lifecycle', () => {`);
   lines.push(
-    `  test('establish ${file.subjectName}, soft-delete, restore, observe present', async ({ request }) => {`,
+    `  test('establish ${file.subjectName}, soft-delete, restore, observe present', async ({ request }, testInfo) => {`,
   );
   lines.push('    const baseUrl = buildBaseUrl();');
   lines.push('    const ctx: Record<string, unknown> = {};');
@@ -648,9 +650,10 @@ function appendObserveByIdStatusStep(
 
   lines.push(`    await test.step('${escapeQuotes(label)}', async () => {`);
   lines.push(`      const url = baseUrl + ${urlExpr};`);
+  lines.push(`      const headers = await authHeaders();`);
   if (wrap) {
     lines.push(`      const ${respVar} = await awaitEventually(`);
-    lines.push(`        async () => request.${method}(url, { headers: await authHeaders() }),`);
+    lines.push(`        async () => request.${method}(url, { headers }),`);
     lines.push(`        {`);
     lines.push(`          method: '${step.requestPlan.method.toUpperCase()}',`);
     lines.push(`          operationId: '${step.operationId}',`);
@@ -658,13 +661,14 @@ function appendObserveByIdStatusStep(
     lines.push(`        },`);
     lines.push(`      );`);
   } else {
-    lines.push(
-      `      const ${respVar} = await request.${method}(url, { headers: await authHeaders() });`,
-    );
+    lines.push(`      const ${respVar} = await request.${method}(url, { headers });`);
   }
   lines.push(`      if (${respVar}.status() !== ${expectedStatus}) {`);
   lines.push(`        try { console.error('Response body:', await ${respVar}.text()); } catch {}`);
   lines.push('      }');
+  lines.push(
+    `      await attachEvidenceOnFailure(testInfo, ${respVar}, { operationId: ${JSON.stringify(step.operationId)}, method: ${JSON.stringify(step.requestPlan.method.toUpperCase())}, url, headers, expectedStatus: ${expectedStatus} });`,
+  );
   lines.push(`      expect(${respVar}.status()).toBe(${expectedStatus});`);
   lines.push('    });');
 }
@@ -932,6 +936,7 @@ function renderReadBackSuite(
   const lines: string[] = [];
   lines.push("import { expect, test } from '@playwright/test';");
   lines.push("import { authHeaders, buildBaseUrl } from '../../support/env';");
+  lines.push("import { attachEvidenceOnFailure } from '../../support/evidence';");
   const seedingImports = ['initSpecSalt', 'seedBinding'];
   if (needsExtractInto) seedingImports.push('extractInto');
   lines.push(`import { ${seedingImports.join(', ')} } from '../../support/seeding';`);
@@ -946,7 +951,7 @@ function renderReadBackSuite(
   lines.push('');
   lines.push(`test.describe('${file.subjectName} read-back', () => {`);
   lines.push(
-    `  test('mutate ${file.subjectName}, observe field on read-back', async ({ request }) => {`,
+    `  test('mutate ${file.subjectName}, observe field on read-back', async ({ request }, testInfo) => {`,
   );
   lines.push('    const baseUrl = buildBaseUrl();');
   lines.push('    const ctx: Record<string, unknown> = {};');
@@ -1023,8 +1028,9 @@ function appendObserveFieldEqualsStep(
   lines.push(`    await test.step('${escapeQuotes(label)}', async () => {`);
   if (isEC) {
     lines.push(`      const url = baseUrl + ${urlExpr};`);
+    lines.push(`      const headers = await authHeaders();`);
     lines.push(`      const ${respVar} = await awaitEventually(`);
-    lines.push(`        async () => request.${method}(url, { headers: await authHeaders() }),`);
+    lines.push(`        async () => request.${method}(url, { headers }),`);
     lines.push(`        {`);
     lines.push(`          method: '${step.requestPlan.method.toUpperCase()}',`);
     lines.push(`          operationId: '${step.operationId}',`);
@@ -1044,6 +1050,9 @@ function appendObserveFieldEqualsStep(
   lines.push(`      if (${respVar}.status() !== 200) {`);
   lines.push(`        try { console.error('Response body:', await ${respVar}.text()); } catch {}`);
   lines.push('      }');
+  lines.push(
+    `      await attachEvidenceOnFailure(testInfo, ${respVar}, { operationId: ${JSON.stringify(step.operationId)}, method: ${JSON.stringify(step.requestPlan.method.toUpperCase())}, url, headers, expectedStatus: 200 });`,
+  );
   lines.push(`      expect(${respVar}.status()).toBe(200);`);
   lines.push(`      const __body = await ${respVar}.json();`);
   for (const f of step.assertion.fields) {
@@ -1121,6 +1130,7 @@ function renderStateTransitionSuite(
   const lines: string[] = [];
   lines.push("import { expect, test } from '@playwright/test';");
   lines.push("import { authHeaders, buildBaseUrl } from '../../support/env';");
+  lines.push("import { attachEvidenceOnFailure } from '../../support/evidence';");
   const seedingImports = ['initSpecSalt', 'seedBinding'];
   if (needsExtractInto) seedingImports.push('extractInto');
   lines.push(`import { ${seedingImports.join(', ')} } from '../../support/seeding';`);
@@ -1136,7 +1146,7 @@ function renderStateTransitionSuite(
   const fromTo = `${observe.assertion.fromState} → ${observe.assertion.expectedState}`;
   lines.push(`test.describe('${file.subjectName} state transition (${fromTo})', () => {`);
   lines.push(
-    `  test('invoke ${transition.operationId}, observe state=${observe.assertion.expectedState} on read-back', async ({ request }) => {`,
+    `  test('invoke ${transition.operationId}, observe state=${observe.assertion.expectedState} on read-back', async ({ request }, testInfo) => {`,
   );
   lines.push('    const baseUrl = buildBaseUrl();');
   lines.push('    const ctx: Record<string, unknown> = {};');
@@ -1208,8 +1218,9 @@ function appendObserveStateEqualsStep(
   lines.push(`    await test.step('${escapeQuotes(label)}', async () => {`);
   if (isEC) {
     lines.push(`      const url = baseUrl + ${urlExpr};`);
+    lines.push(`      const headers = await authHeaders();`);
     lines.push(`      const ${respVar} = await awaitEventually(`);
-    lines.push(`        async () => request.${method}(url, { headers: await authHeaders() }),`);
+    lines.push(`        async () => request.${method}(url, { headers }),`);
     lines.push(`        {`);
     lines.push(`          method: '${step.requestPlan.method.toUpperCase()}',`);
     lines.push(`          operationId: '${step.operationId}',`);
@@ -1229,6 +1240,9 @@ function appendObserveStateEqualsStep(
   lines.push(`      if (${respVar}.status() !== 200) {`);
   lines.push(`        try { console.error('Response body:', await ${respVar}.text()); } catch {}`);
   lines.push('      }');
+  lines.push(
+    `      await attachEvidenceOnFailure(testInfo, ${respVar}, { operationId: ${JSON.stringify(step.operationId)}, method: ${JSON.stringify(step.requestPlan.method.toUpperCase())}, url, headers, expectedStatus: 200 });`,
+  );
   lines.push(`      expect(${respVar}.status()).toBe(200);`);
   lines.push(`      const __body = await ${respVar}.json();`);
   const accessExpr = buildOptionalAccessChain(

--- a/tests/codegen/playwright-evidence-capture.test.ts
+++ b/tests/codegen/playwright-evidence-capture.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from 'vitest';
+import { attachEvidenceOnFailure } from '../../materializer/src/playwright/support/evidence.ts';
+import { PlaywrightEmitter } from '../../materializer/src/playwright/emitter.ts';
+import type { EndpointScenarioCollection } from '../../path-analyser/src/types.ts';
+
+// Class-scoped guard (#527/#528): evidence capture is cross-cutting codegen
+// behavior — a future refactor to emitter.ts/stepRenderer.ts/templateEmitter.ts
+// could silently drop the import or the attachEvidenceOnFailure() call while
+// every other existing test stays green. These assertions pin both halves
+// (emitted import + emitted call) so that regression fails loudly here.
+
+function ctxBase() {
+  return {
+    outDir: '/unused',
+    suiteName: 'createWidget',
+    mode: 'feature' as const,
+    configName: 'test',
+    resolveConfigPath: (rel: string) => `/unused/${rel}`,
+  };
+}
+
+const COLLECTION_INLINE_STEP: EndpointScenarioCollection = {
+  endpoint: { operationId: 'createWidget', method: 'POST', path: '/widgets' },
+  requiredSemanticTypes: [],
+  optionalSemanticTypes: [],
+  scenarios: [
+    {
+      id: 'sc1',
+      name: 'happy path',
+      operations: [{ operationId: 'createWidget', method: 'POST', path: '/widgets' }],
+      producedSemanticTypes: [],
+      satisfiedSemanticTypes: [],
+      requestPlan: [
+        {
+          operationId: 'createWidget',
+          method: 'POST',
+          pathTemplate: '/widgets',
+          expect: { status: 200 },
+          bodyKind: 'json',
+          bodyTemplate: { name: 'static' },
+        },
+      ],
+    },
+  ],
+};
+
+const COLLECTION_WITH_SHAPE_VALIDATION: EndpointScenarioCollection = {
+  endpoint: { operationId: 'createWidget', method: 'POST', path: '/widgets' },
+  requiredSemanticTypes: [],
+  optionalSemanticTypes: [],
+  scenarios: [
+    {
+      id: 'sc1',
+      name: 'happy path',
+      operations: [{ operationId: 'createWidget', method: 'POST', path: '/widgets' }],
+      producedSemanticTypes: [],
+      satisfiedSemanticTypes: [],
+      responseShapeFields: [{ name: 'widgetKey', type: 'string' }],
+      requestPlan: [
+        {
+          operationId: 'createWidget',
+          method: 'POST',
+          pathTemplate: '/widgets',
+          expect: { status: 200 },
+          bodyKind: 'json',
+          bodyTemplate: { name: 'static' },
+        },
+      ],
+    },
+  ],
+};
+
+describe('emitter: evidence capture emission', () => {
+  test('inline request step emits the evidence import, testInfo param, and an attach call with headers/body', async () => {
+    const [file] = await PlaywrightEmitter.emit(COLLECTION_INLINE_STEP, ctxBase());
+    expect(file.content).toContain("import { attachEvidenceOnFailure } from './support/evidence';");
+    expect(file.content).toContain('async ({ request }, testInfo) => {');
+    expect(file.content).toContain('await attachEvidenceOnFailure(testInfo, resp1, {');
+    expect(file.content).toContain('headers');
+    expect(file.content).toContain('body: body1');
+  });
+
+  test('a validateResponse shape-check final step wraps it in try/catch and attaches on failure', async () => {
+    const [file] = await PlaywrightEmitter.emit(COLLECTION_WITH_SHAPE_VALIDATION, ctxBase());
+    expect(file.content).toContain('try {');
+    expect(file.content).toContain('await validateResponse(');
+    expect(file.content).toContain('} catch (e) {');
+    expect(file.content).toContain('await attachEvidenceOnFailure(testInfo, resp1, {');
+    // Non-role-bound step: url/headers/body are genuinely in scope from the
+    // same test.step, so the catch block must reuse them, not fall back to
+    // the role-bound-only `{ url: resp.url() }` minimal shape.
+    expect(file.content).toContain('String(e)');
+  });
+});
+
+describe('attachEvidenceOnFailure runtime behavior', () => {
+  function makeRes(overrides: Partial<{ status: number; statusText: string; text: string; headers: Record<string, string> }>) {
+    const status = overrides.status ?? 200;
+    const statusText = overrides.statusText ?? 'OK';
+    const text = overrides.text ?? '';
+    const headers = overrides.headers ?? {};
+    return {
+      status: () => status,
+      statusText: () => statusText,
+      text: async () => text,
+      headers: () => headers,
+    };
+  }
+
+  function makeTestInfo() {
+    const attached: { name: string; body: string }[] = [];
+    return {
+      testInfo: { attach: async (name: string, opts: { body: string }) => { attached.push({ name, body: opts.body }); } },
+      attached,
+    };
+  }
+
+  test('does not attach anything when the status matches and there is no shapeError', async () => {
+    const { testInfo, attached } = makeTestInfo();
+    await attachEvidenceOnFailure(testInfo, makeRes({ status: 200 }), {
+      operationId: 'op',
+      method: 'GET',
+      url: 'http://x/y',
+      expectedStatus: 200,
+    });
+    expect(attached).toHaveLength(0);
+  });
+
+  test('attaches request.json/response.json on a status mismatch', async () => {
+    const { testInfo, attached } = makeTestInfo();
+    await attachEvidenceOnFailure(testInfo, makeRes({ status: 401, text: '' }), {
+      operationId: 'createWidget',
+      method: 'POST',
+      url: 'http://x/widgets',
+      headers: { Authorization: 'Bearer super-secret-token' },
+      body: { name: 'foo' },
+      expectedStatus: 200,
+    });
+    expect(attached.map((a) => a.name)).toEqual(['request.json', 'response.json']);
+    const req = JSON.parse(attached[0].body);
+    expect(req.operationId).toBe('createWidget');
+    expect(req.body).toEqual({ name: 'foo' });
+    // Header VALUES must never appear — only names (see the redaction test below).
+    expect(attached[0].body).not.toContain('super-secret-token');
+    expect(req.headerNames).toEqual(['Authorization']);
+  });
+
+  test('attaches on a shapeError even when the status matches', async () => {
+    const { testInfo, attached } = makeTestInfo();
+    await attachEvidenceOnFailure(
+      testInfo,
+      makeRes({ status: 200, text: '{"unexpected":true}' }),
+      { operationId: 'op', method: 'GET', url: 'http://x', expectedStatus: 200 },
+      'Expected status 200, received status 200 but shape mismatched',
+    );
+    expect(attached).toHaveLength(2);
+    const resp = JSON.parse(attached[1].body);
+    expect(resp.shapeError).toContain('shape mismatched');
+  });
+
+  test('never attaches header values, only header names', async () => {
+    const { testInfo, attached } = makeTestInfo();
+    await attachEvidenceOnFailure(testInfo, makeRes({ status: 500 }), {
+      operationId: 'op',
+      method: 'POST',
+      url: 'http://x',
+      headers: { Authorization: 'Bearer marker-secret-value', Cookie: 'session=marker-secret-cookie' },
+      expectedStatus: 200,
+    });
+    const wholeArtifact = attached.map((a) => a.body).join('\n');
+    expect(wholeArtifact).not.toContain('marker-secret-value');
+    expect(wholeArtifact).not.toContain('marker-secret-cookie');
+    const req = JSON.parse(attached[0].body);
+    expect(req.headerNames).toEqual(['Authorization', 'Cookie']);
+  });
+
+  test('preserves a literal JSON null response body (not the string "null")', async () => {
+    const { testInfo, attached } = makeTestInfo();
+    await attachEvidenceOnFailure(testInfo, makeRes({ status: 500, text: 'null' }), {
+      operationId: 'op',
+      method: 'GET',
+      url: 'http://x',
+      expectedStatus: 200,
+    });
+    const resp = JSON.parse(attached[1].body);
+    expect(resp.body).toBeNull();
+  });
+
+  test('caps an oversized response body and records truncation metadata', async () => {
+    const { testInfo, attached } = makeTestInfo();
+    const bigBody = 'x'.repeat(70 * 1024);
+    await attachEvidenceOnFailure(testInfo, makeRes({ status: 500, text: bigBody }), {
+      operationId: 'op',
+      method: 'GET',
+      url: 'http://x',
+      expectedStatus: 200,
+    });
+    const resp = JSON.parse(attached[1].body);
+    expect(resp.bodyTruncated).toBe(true);
+    expect(resp.bodyOriginalBytes).toBe(70 * 1024);
+    expect(resp.body.length).toBeLessThan(70 * 1024);
+  });
+});

--- a/tests/codegen/playwright-evidence-capture.test.ts
+++ b/tests/codegen/playwright-evidence-capture.test.ts
@@ -92,6 +92,31 @@ describe('emitter: evidence capture emission', () => {
     // the role-bound-only `{ url: resp.url() }` minimal shape.
     expect(file.content).toContain('String(e)');
   });
+
+  test('a role-only suite whose call-site.tmpl uses the {{{defaultRender}}} wrap pattern still imports authHeaders/attachEvidenceOnFailure', async () => {
+    // Every step in this collection matches the role, so the old
+    // `hasInlineRequestStep` (true only when at least one step has NO role
+    // match) would be false here — yet the role's own template splices in
+    // the default inline render, which calls both authHeaders() and
+    // attachEvidenceOnFailure(). Without accounting for the wrap pattern,
+    // this would emit a reference to both without importing either.
+    // biome-ignore lint/plugin: minimal test fixture; LoadedRoleBundle has more fields than this wrap-pattern test needs.
+    const roleBundle = {
+      role: 'wrapRole',
+      roleName: 'wrapRole',
+      dir: '/unused/roles/wrapRole',
+      callSiteTemplatePath: '/unused/roles/wrapRole/call-site.tmpl',
+      callSiteTemplate: '{{{defaultRender}}}',
+    } as unknown as import('../../materializer/src/playwright/roleRenderer.ts').LoadedRoleBundle;
+    const [file] = await PlaywrightEmitter.emit(COLLECTION_INLINE_STEP, {
+      ...ctxBase(),
+      getRoleForOperation: (opId: string) => (opId === 'createWidget' ? 'wrapRole' : undefined),
+      roleBundles: new Map([['wrapRole', roleBundle]]),
+    });
+    expect(file.content).toContain("import { buildBaseUrl, authHeaders } from './support/env';");
+    expect(file.content).toContain("import { attachEvidenceOnFailure } from './support/evidence';");
+    expect(file.content).toContain('await attachEvidenceOnFailure(testInfo, resp1, {');
+  });
 });
 
 describe('attachEvidenceOnFailure runtime behavior', () => {
@@ -170,7 +195,7 @@ describe('attachEvidenceOnFailure runtime behavior', () => {
     expect(resp.shapeError).toContain('shape mismatched');
   });
 
-  test('never attaches header values, only header names', async () => {
+  test('never attaches REQUEST header values, only header names', async () => {
     const { testInfo, attached } = makeTestInfo();
     await attachEvidenceOnFailure(testInfo, makeRes({ status: 500 }), {
       operationId: 'op',
@@ -187,6 +212,19 @@ describe('attachEvidenceOnFailure runtime behavior', () => {
     expect(wholeArtifact).not.toContain('marker-secret-cookie');
     const req = JSON.parse(attached[0].body);
     expect(req.headerNames).toEqual(['Authorization', 'Cookie']);
+  });
+
+  test('never attaches RESPONSE header values, only header names (e.g. Set-Cookie)', async () => {
+    const { testInfo, attached } = makeTestInfo();
+    await attachEvidenceOnFailure(
+      testInfo,
+      makeRes({ status: 500, headers: { 'set-cookie': 'session=marker-secret-response-cookie' } }),
+      { operationId: 'op', method: 'GET', url: 'http://x', expectedStatus: 200 },
+    );
+    const wholeArtifact = attached.map((a) => a.body).join('\n');
+    expect(wholeArtifact).not.toContain('marker-secret-response-cookie');
+    const resp = JSON.parse(attached[1].body);
+    expect(resp.headerNames).toEqual(['set-cookie']);
   });
 
   test('preserves a literal JSON null response body (not the string "null")', async () => {

--- a/tests/codegen/playwright-evidence-capture.test.ts
+++ b/tests/codegen/playwright-evidence-capture.test.ts
@@ -117,6 +117,31 @@ describe('emitter: evidence capture emission', () => {
     expect(file.content).toContain("import { attachEvidenceOnFailure } from './support/evidence';");
     expect(file.content).toContain('await attachEvidenceOnFailure(testInfo, resp1, {');
   });
+
+  test('a role whose call-site.tmpl only mentions "defaultRender" in a comment does NOT gain unused imports', async () => {
+    // A bare substring match on "defaultRender" would false-positive here —
+    // this role's own helper does everything itself and never actually
+    // interpolates the {{{defaultRender}}} tag, so the suite must not gain
+    // authHeaders/attachEvidenceOnFailure imports it never references
+    // (which would otherwise fail lint:generated's unused-import check).
+    // biome-ignore lint/plugin: minimal test fixture; LoadedRoleBundle has more fields than this test needs.
+    const roleBundle = {
+      role: 'ownHandlerRole',
+      roleName: 'ownHandlerRole',
+      dir: '/unused/roles/ownHandlerRole',
+      callSiteTemplatePath: '/unused/roles/ownHandlerRole/call-site.tmpl',
+      callSiteTemplate:
+        '{{! this role does not use defaultRender at all }}\nconst {{{respVar}}} = await myOwnHelper();',
+    } as unknown as import('../../materializer/src/playwright/roleRenderer.ts').LoadedRoleBundle;
+    const [file] = await PlaywrightEmitter.emit(COLLECTION_INLINE_STEP, {
+      ...ctxBase(),
+      getRoleForOperation: (opId: string) =>
+        opId === 'createWidget' ? 'ownHandlerRole' : undefined,
+      roleBundles: new Map([['ownHandlerRole', roleBundle]]),
+    });
+    expect(file.content).not.toContain('authHeaders');
+    expect(file.content).not.toContain('attachEvidenceOnFailure');
+  });
 });
 
 describe('attachEvidenceOnFailure runtime behavior', () => {

--- a/tests/codegen/playwright-evidence-capture.test.ts
+++ b/tests/codegen/playwright-evidence-capture.test.ts
@@ -117,12 +117,13 @@ describe('attachEvidenceOnFailure runtime behavior', () => {
 
   function makeTestInfo() {
     const attached: { name: string; body: string }[] = [];
-    // biome-ignore lint/plugin: minimal test fake for Playwright's TestInfo; only attach() (which attachEvidenceOnFailure calls) is implemented.
+    // attachEvidenceOnFailure's testInfo param is the minimal
+    // AttachableTestInfo (only attach()), so no cast is needed here.
     const testInfo = {
       attach: async (name: string, opts: { body: string }) => {
         attached.push({ name, body: opts.body });
       },
-    } as unknown as import('@playwright/test').TestInfo;
+    };
     return { testInfo, attached };
   }
 

--- a/tests/codegen/playwright-evidence-capture.test.ts
+++ b/tests/codegen/playwright-evidence-capture.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import { attachEvidenceOnFailure } from '../../materializer/src/playwright/support/evidence.ts';
 import { PlaywrightEmitter } from '../../materializer/src/playwright/emitter.ts';
+import { attachEvidenceOnFailure } from '../../materializer/src/playwright/support/evidence.ts';
 import type { EndpointScenarioCollection } from '../../path-analyser/src/types.ts';
 
 // Class-scoped guard (#527/#528): evidence capture is cross-cutting codegen
@@ -16,6 +16,7 @@ function ctxBase() {
     mode: 'feature' as const,
     configName: 'test',
     resolveConfigPath: (rel: string) => `/unused/${rel}`,
+    emitterConfig: {},
   };
 }
 
@@ -94,7 +95,14 @@ describe('emitter: evidence capture emission', () => {
 });
 
 describe('attachEvidenceOnFailure runtime behavior', () => {
-  function makeRes(overrides: Partial<{ status: number; statusText: string; text: string; headers: Record<string, string> }>) {
+  function makeRes(
+    overrides: Partial<{
+      status: number;
+      statusText: string;
+      text: string;
+      headers: Record<string, string>;
+    }>,
+  ) {
     const status = overrides.status ?? 200;
     const statusText = overrides.statusText ?? 'OK';
     const text = overrides.text ?? '';
@@ -109,10 +117,13 @@ describe('attachEvidenceOnFailure runtime behavior', () => {
 
   function makeTestInfo() {
     const attached: { name: string; body: string }[] = [];
-    return {
-      testInfo: { attach: async (name: string, opts: { body: string }) => { attached.push({ name, body: opts.body }); } },
-      attached,
-    };
+    // biome-ignore lint/plugin: minimal test fake for Playwright's TestInfo; only attach() (which attachEvidenceOnFailure calls) is implemented.
+    const testInfo = {
+      attach: async (name: string, opts: { body: string }) => {
+        attached.push({ name, body: opts.body });
+      },
+    } as unknown as import('@playwright/test').TestInfo;
+    return { testInfo, attached };
   }
 
   test('does not attach anything when the status matches and there is no shapeError', async () => {
@@ -164,7 +175,10 @@ describe('attachEvidenceOnFailure runtime behavior', () => {
       operationId: 'op',
       method: 'POST',
       url: 'http://x',
-      headers: { Authorization: 'Bearer marker-secret-value', Cookie: 'session=marker-secret-cookie' },
+      headers: {
+        Authorization: 'Bearer marker-secret-value',
+        Cookie: 'session=marker-secret-cookie',
+      },
       expectedStatus: 200,
     });
     const wholeArtifact = attached.map((a) => a.body).join('\n');


### PR DESCRIPTION
## Summary

Closes #527. The nightly camunda-hub triage agent's live curl-replay verification (#482, PR #525) only covers negative-suite failures, because the positive/lifecycle suite has zero evidence-capture — no `testInfo.attach()` calls anywhere in `materializer/`. This adds that mechanism, mirroring the negative suite's `request.json`/`response.json` artifact shape (`request-validation/templates/support/http.ts`'s `assertResponseStatus`) trimmed to what the positive suite actually has.

- New vendored support file `materializer/src/playwright/support/evidence.ts` — `attachEvidenceOnFailure(testInfo, res, ctx, shapeError?)`, attaches only on a real mismatch (status or shape), capping the response body at 64KB like the negative suite does.
- Wired into every generic status-check-and-assert site:
  - `stepRenderer.ts`'s shared `renderInlineStepLines` (covers `emitter.ts`'s per-endpoint path + 4 call sites in `templateEmitter.ts`) and `renderEventualWait` (witness polls).
  - `templateEmitter.ts`'s `appendObserveByIdStatusStep`, `appendObserveFieldEqualsStep`, `appendObserveStateEqualsStep` (their own separate status-check duplication, both EC-wrapped and plain branches).
  - A `try/catch` wrap around the `assert-json-body` `validateResponse()` call in `emitter.ts` — it only throws a bare `Error` with no structured payload, so evidence is built from the response object directly, using `.url()` instead of a hoisted `url` const since this path also covers role-bound steps.
- `testInfo` threaded into all 5 `test(...)` signatures (2nd positional param); nested `test.step` closures pick it up with no further parameter plumbing.
- `headers` hoisted into a named `const` at every touched call site (was previously inlined as `headers: await authHeaders()`, not separately readable).
- `evidence.ts` intentionally does **not** import Playwright's `APIResponse` type — role helpers (e.g. `support/deploymentGateway.ts`'s `deploy()`) return their own independently-declared structural mirror, and TypeScript rejects passing that into a nominally-`APIResponse`-typed parameter. Uses a minimal local structural interface instead (caught by `tsc --noEmit` against a real role-bound config during verification, see below).

**Explicit scope limits** (documented, not silently dropped — see plan discussion on #527):
- Role-bound steps' own internal request/assert (e.g. `deploy()`) are untouched — that's the role-template contract (`ROLES.md`), a separate change.
- `awaitEventually` timeout-throws (`EventualConsistencyTimeoutError`) are unreachable by evidence-capture code placed after the call — no change needed there; only the "resolves but status still wrong" paths reach the new evidence call, which they do correctly.

## Verification

- `npm test`: 907/907 passing, no snapshot/string-literal test broke.
- Regenerated **both** real configs and typechecked the output with `tsc --noEmit`:
  - `camunda-hub` (no role bundles) — clean.
  - `camunda-oca` (uses the `deploymentGateway` role) — caught and fixed the `ApiResponseLike` structural-typing issue above; clean after the fix.
- Ran against a **real local Hub** (`HUB_MODE=prebuilt ./docker/start-hub.sh start`):
  - A genuine 401 (env token issue) and later a genuine 400 (`createFile` fixture) both correctly attached `request.json`/`response.json` with the exact expected shape.
  - A genuine pass produced zero attachments.
  - A genuine semantic-assertion failure (`toContain` membership check, not a status-check) correctly produced **no** attachment — confirming the scope boundary holds in practice, not just in the diff.

## Test plan

- [x] `npm test`
- [x] `tsc --noEmit` against freshly generated `camunda-hub` and `camunda-oca` suites
- [x] Live-Hub run: real failure → evidence attached; real pass → no evidence; non-status-check failure → no evidence
