### PR TITLE
fix(ci): decouple the "Live Hub suite" required check from its reusable job name

### DIFF
--- a/.github/workflows/hub-pr-live-check.yml
+++ b/.github/workflows/hub-pr-live-check.yml
@@ -76,7 +76,19 @@ jobs:
           fi
 
   run:
-    name: Live Hub suite
+    # NOT named "Live Hub suite" — a job that calls a reusable workflow via
+    # `uses:` gets its check-run reported under the COMPOSITE name
+    # "<this job's name> / <reusable workflow's own job name>" (here,
+    # _hub-suite-run.yml's job is named "Generate + run hub suites
+    # (${{ inputs.hub_ref }})"), never the bare name alone. Branch
+    # protection's required status check is the exact string "Live Hub
+    # suite" — if this job carried that name directly, the composite name
+    # it actually reports under would never match, permanently blocking
+    # merge on every PR that reaches this job (rather than being skipped
+    # by the guard above). The `live-hub-suite` job below is the one that
+    # actually carries the required name, decoupled from whatever this job
+    # (or the reusable workflow it calls) is internally called.
+    name: Run hub suite (internal)
     needs: guard
     if: needs.guard.outputs.proceed == 'true'
     permissions:
@@ -97,3 +109,24 @@ jobs:
       summary_heading: |
         ## Hub PR live check — #${{ github.event.pull_request.number }}
         `${{ github.event.pull_request.head.sha }}` against camunda-hub main / camunda/hub:SNAPSHOT
+
+  # The actual required-status-check job. Always runs (even if `run` was
+  # skipped by the guard, e.g. a PR touching .github/**) and just reports
+  # `run`'s result under a name stable regardless of the reusable
+  # workflow's own internal job name. `skipped` counts as passing — same
+  # semantics the guard's own skip path already relied on before this job
+  # existed (see every prior PR's "Live Hub suite | skipped" check-run).
+  live-hub-suite:
+    name: Live Hub suite
+    needs: run
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report aggregate result
+        run: |
+          result="${{ needs.run.result }}"
+          echo "Underlying hub-suite job result: $result"
+          case "$result" in
+            success|skipped) exit 0 ;;
+            *) exit 1 ;;
+          esac

--- a/.github/workflows/hub-pr-live-check.yml
+++ b/.github/workflows/hub-pr-live-check.yml
@@ -110,23 +110,23 @@ jobs:
         ## Hub PR live check — #${{ github.event.pull_request.number }}
         `${{ github.event.pull_request.head.sha }}` against camunda-hub main / camunda/hub:SNAPSHOT
 
-  # The actual required-status-check job. Always runs (even if `run` was
-  # skipped by the guard, e.g. a PR touching .github/**) and just reports
-  # `run`'s result under a name stable regardless of the reusable
-  # workflow's own internal job name. `skipped` counts as passing — same
-  # semantics the guard's own skip path already relied on before this job
-  # existed (see every prior PR's "Live Hub suite | skipped" check-run).
+  # The actual required-status-check job. Reports `run`'s result under a
+  # name stable regardless of the reusable workflow's own internal job
+  # name. Deliberately SKIPS ITSELF (rather than running and exiting 0)
+  # when `run` was itself skipped by the guard (e.g. a PR touching
+  # .github/**) — this job's own check-run conclusion then shows
+  # `skipped`, preserving the exact same UI-visible distinction every
+  # prior PR's "Live Hub suite | skipped" already relied on, instead of
+  # collapsing "guarded/never ran" and "ran for real" into the same
+  # `success` conclusion.
   live-hub-suite:
     name: Live Hub suite
     needs: run
-    if: always()
+    if: always() && needs.run.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
-      - name: Report aggregate result
+      - name: Fail if the underlying hub-suite job didn't succeed
         run: |
           result="${{ needs.run.result }}"
           echo "Underlying hub-suite job result: $result"
-          case "$result" in
-            success|skipped) exit 0 ;;
-            *) exit 1 ;;
-          esac
+          [ "$result" = "success" ]


### PR DESCRIPTION
## Summary

The "Live Hub suite" required status check has been permanently unsatisfiable for any PR that doesn't touch `.github/**` — including PR #528, which is where this was noticed (stuck on the exact symptom in the screenshot: `Live Hub suite | Expected — Waiting for status to be reported | Required`).

## Root cause

Branch protection on `main` requires the exact status context `"Live Hub suite"`. The job that carried that name (`hub-pr-live-check.yml`'s `run:` job) calls `_hub-suite-run.yml` via `uses:` — and GitHub Actions reports a reusable-workflow-calling job's check-run under the **composite** name `"<caller job name> / <called job's own name>"`, never the bare caller name alone. `_hub-suite-run.yml`'s single job is named `Generate + run hub suites (${{ inputs.hub_ref }})`, so the actual reported name was:

```
Live Hub suite / Generate + run hub suites (main)
```

— which never matches the required `"Live Hub suite"` exactly, no matter how many times the underlying job passes.

**Why this hasn't been noticed before:** the guard job (`.github/**`-diff check) bails *before* calling the reusable workflow for any PR touching `.github/**`, so the outer job's own bare name reports directly as `Live Hub suite | skipped`, which *does* satisfy the requirement. I checked #524, #521, #517 — every one shows `Live Hub suite | skipped`, meaning every recent merge got past this check purely by skipping it, never by it actually running successfully under the matching name. #528 is one of the first PRs in a while that doesn't touch `.github/**`, so it's the first to hit the real composite-name mismatch — and it will keep happening to every future PR that doesn't touch `.github/**`.

## Fix

Renamed the reusable-workflow-calling job to an internal name (`Run hub suite (internal)`) and added a new terminal job, literally named `Live Hub suite`, that reports the aggregate result of the internal job (`success`/`skipped` both count as passing, matching the existing skip semantics every merged PR already relied on). This decouples the required check's reported name from whatever the reusable workflow's own job happens to be called — no branch-protection setting needs to change.

## Verification

- `actionlint .github/workflows/hub-pr-live-check.yml` — clean.
- `python3 -c "import yaml; yaml.safe_load(...)"` — parses cleanly.
- Real end-to-end proof can only come from this very PR's own run — since it touches `.github/**`, the guard here will (correctly, by design) skip the live-Hub run and report `Live Hub suite | skipped`. A maintainer should manually run `hub-ondemand-test.yml` against this branch, or trust that the next non-`.github/**` PR (e.g. #528, once this merges) reports `Live Hub suite | success` for real instead of getting stuck pending.

## Test plan

- [x] `actionlint` clean
- [x] YAML syntax valid
- [ ] Manual `hub-ondemand-test.yml` dispatch against this branch (recommended before merging, since the guard skips this PR's own live-Hub run)
- [ ] Confirm the next non-`.github/**` PR reports `Live Hub suite | success` instead of stuck-pending
