### PR TITLE
fix(path-analyser): plan chains for required clientMintedAttribute body fields

### DIFF
--- a/configs/camunda-oca/regression-invariants.test.ts
+++ b/configs/camunda-oca/regression-invariants.test.ts
@@ -4271,6 +4271,32 @@ describeForThisConfig(
     // meaningful (a setter step inserted before the filter step that
     // tags an entity, with the same minted value threaded through).
     // Tracked in #168 (the deferred follow-up to #162 PR 2).
+    //
+    // Suite partition by required-ness. A setter leaf's owning suite is
+    // decided by whether the body field is REQUIRED:
+    //
+    //   - OPTIONAL leaf → the VARIANT suite. The populated-vs-omitted
+    //     axis is exactly what a variant exercises, and the variant
+    //     contract is optional-only end to end:
+    //     `graphLoader.deriveOptionalSubShapes` skips `required === true`,
+    //     `path-analyser/src/index.ts` gates variant emission on
+    //     `op.optionalSubShapes?.length`, and
+    //     `generateOptionalSubShapeVariants` skips any leaf already in
+    //     `requires.required`. The sibling PR-4 invariant
+    //     ('variant suite covers every flat top-level optional...')
+    //     encodes the same filter with `if (e.required) continue`.
+    //
+    //   - REQUIRED leaf → the FEATURE (base) suite. A required field has
+    //     no populated-vs-omitted axis: omitting it is an invalid
+    //     request, so the base scenario must always populate it and the
+    //     planner mints the value at plan time (the missing-gate
+    //     exemption in `scenarioGenerator.generateScenariosForEndpoint`).
+    //     Demanding a variant here would ask the generator to emit a
+    //     near-duplicate of the base spec.
+    //
+    // The bundled camunda-oca spec's first required setter leaf is
+    // `assignProcessInstanceBusinessId.businessId` (`BusinessId`), added
+    // in spec version 8.10.
 
     interface SemanticTypeDecl {
       kind?: string;
@@ -4302,12 +4328,23 @@ describeForThisConfig(
       return !fieldPath.startsWith('filter.') && !fieldPath.startsWith('filter[');
     }
 
-    function setterOpsFor(semantic: string): OperationNode[] {
+    // Setter ops split by the required-ness of the setter leaf (see the
+    // suite-partition note above). An op that declares the semantic at
+    // BOTH a required and an optional non-filter path lands in both
+    // buckets — each leaf is owned by its own suite.
+    function setterOpsFor(semantic: string, required: boolean): OperationNode[] {
       const graph = loadGraph();
       const ops: OperationNode[] = [];
       for (const op of graph.operations) {
         const leaves = op.requestBodySemanticTypes ?? [];
-        if (leaves.some((l) => l.semanticType === semantic && isSetterPath(l.fieldPath))) {
+        if (
+          leaves.some(
+            (l) =>
+              l.semanticType === semantic &&
+              isSetterPath(l.fieldPath) &&
+              Boolean(l.required) === required,
+          )
+        ) {
           ops.push(op);
         }
       }
@@ -4333,18 +4370,18 @@ describeForThisConfig(
     });
 
     for (const semantic of ATTRIBUTE_SEMANTICS) {
-      const setterOps = setterOpsFor(semantic);
+      const optionalSetterOps = setterOpsFor(semantic, false);
+      const requiredSetterOps = setterOpsFor(semantic, true);
+      const varName = `${camelCase(semantic)}Var`;
 
       it(`${semantic}: at least one setter operation declares the semantic at a top-level body path`, () => {
         expect(
-          setterOps.length,
+          optionalSetterOps.length + requiredSetterOps.length,
           `expected at least one operation accepting ${semantic} at a non-filter body path`,
         ).toBeGreaterThan(0);
       });
 
-      for (const op of setterOps) {
-        const varName = `${camelCase(semantic)}Var`;
-
+      for (const op of optionalSetterOps) {
         it(`${semantic} :: ${op.operationId}: variant suite emits a ${semantic}-populating scenario binding ${varName} (#162 PR 4)`, () => {
           const variantFile = join(VARIANT_SCENARIOS_DIR, featureFileFor(op));
           if (!existsSync(variantFile)) {
@@ -4406,6 +4443,52 @@ describeForThisConfig(
           expect(
             src.includes(`ctx.${varName}`),
             `${op.operationId} variant spec: body must reference ctx.${varName}`,
+          ).toBe(true);
+        });
+      }
+
+      // Required setter leaves — owned by the FEATURE (base) suite. See
+      // the suite-partition note at the top of this block. These two
+      // assertions are the required-leaf mirror of the variant pair
+      // above, so coverage of a clientMintedAttribute setter site is
+      // asserted regardless of which suite owns it.
+      for (const op of requiredSetterOps) {
+        it(`${semantic} :: ${op.operationId}: feature suite binds ${varName} for the REQUIRED setter leaf (#162 PR 2)`, () => {
+          const featureFile = join(FEATURE_SCENARIOS_DIR, featureFileFor(op));
+          if (!existsSync(featureFile)) {
+            throw new Error(
+              `expected feature-output JSON not found: ${featureFileFor(op)} — run 'npm run testsuite:generate'`,
+            );
+          }
+          // biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+          const parsed = JSON.parse(readFileSync(featureFile, 'utf8')) as {
+            scenarios: Array<{ bindings?: Record<string, string> }>;
+          };
+          const scenario = parsed.scenarios.find((s) => s.bindings?.[varName] !== undefined);
+          expect(
+            scenario,
+            `${op.operationId}: expected a feature scenario binding ${varName} — a REQUIRED ${semantic} body leaf must be populated by the base scenario, not deferred to a variant`,
+          ).toBeDefined();
+          // The value is deliberately unasserted. The planner mints
+          // `fc:cma:<sem>:<suffix>` at plan time, but the materializer's
+          // #320 unique-seeding rule legitimately replaces a deterministic
+          // literal with `seedBinding(name, { unique: true })` when a step
+          // in the chain declares HTTP 409 — which every uniqueness-
+          // enforced setter (BusinessId) does. Asserting the literal would
+          // couple this invariant to that override.
+        });
+
+        it(`${semantic} :: ${op.operationId}: emitted feature spec references ctx.${varName} (#162 PR 2)`, () => {
+          const spec = join(GENERATED_TESTS_DIR, `${op.operationId}.feature.spec.ts`);
+          if (!existsSync(spec)) {
+            throw new Error(
+              `expected emitted spec not found: ${op.operationId}.feature.spec.ts — run 'npm run testsuite:generate'`,
+            );
+          }
+          const src = readFileSync(spec, 'utf8');
+          expect(
+            src.includes(`ctx.${varName}`),
+            `${op.operationId} feature spec: body must reference ctx.${varName}`,
           ).toBe(true);
         });
       }

--- a/configs/camunda-oca/spec-pin.json
+++ b/configs/camunda-oca/spec-pin.json
@@ -1,5 +1,5 @@
 {
   "$comment": "Spec pin for the bundled-spec invariants regression layer. The invariants in configs/camunda-oca/regression-invariants.test.ts assert named properties of the upstream spec content fingerprinted by `expectedSpecHash`. `specRef` MUST be a full 40-char commit SHA on camunda/camunda (not a branch like `main`) so the baseline does not drift on every upstream merge. CI fetches the spec at `specRef` (requires camunda-schema-bundler >= 2.1.0 for SHA support) and aborts early via tests/regression/spec-pin.setup.ts if its hash drifts, so reviewers see a clear 'spec changed upstream — re-pin' signal instead of confusing invariant failures. To bump: pick a newer SHA, run `SPEC_REF=<sha> npm run fetch-spec:ref`, regenerate the pipeline, update any invariants whose values legitimately changed, then update both fields below in the same PR.",
-  "specRef": "d21fa8e84c9be43a8f1368daf35ccbb86ad45f94",
-  "expectedSpecHash": "sha256:75896c815e2696b3505939ae50ad7a9a88b229541d461cb6e35545e8c5cd957c"
+  "specRef": "ef1ec46c65fe05e2f07d84508400c3b2db392558",
+  "expectedSpecHash": "sha256:2d638fa54edfff38ce1e05e76f1b26575927ac261d240dc8e35843dfe5326846"
 }

--- a/path-analyser/src/index.ts
+++ b/path-analyser/src/index.ts
@@ -2,6 +2,7 @@ import fsSync from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { classifySemantic } from './bindSemanticInput.js';
 import { buildCanonicalShapes } from './canonicalSchemas.js';
 import {
   getActiveConfigDir,
@@ -772,6 +773,33 @@ function buildRequestPlan(
         for (const entry of responseEntries) {
           const bind = `${camelCase(entry.semanticType)}Var`;
           if (existingBinds.has(bind)) continue;
+          // Never extract over a clientMintedAttribute binding the
+          // planner already pinned to a concrete value. The planner IS
+          // the authoritative source for that classification, and a
+          // producer step's echo of the same field is `nullable: true`
+          // whenever the producer did not itself set it. `extractInto`
+          // guards only `undefined`, so an echoed `null` would clobber
+          // the minted value and the consuming step would send `null`
+          // for a field the planner had already satisfied.
+          //
+          // Concrete case: `createProcessInstance` echoes a nullable
+          // `businessId` (null when creation set none) and
+          // `assignProcessInstanceBusinessId` REQUIRES `businessId` —
+          // extracting the echo turned a valid mint into a 400.
+          //
+          // Deliberately scoped to `clientMintedAttribute`, NOT to every
+          // literal binding: producer-bound synthetic fallbacks (e.g. a
+          // variant's `processDefinitionKey_<suffix>` placeholder) are
+          // literals that the real producer extract is SUPPOSED to
+          // overwrite. Suppressing those would strand a fake key.
+          const pinned = scenario.bindings?.[bind];
+          if (
+            pinned !== undefined &&
+            pinned !== PENDING_BINDING &&
+            classifySemantic(entry.semanticType, graph) === 'clientMintedAttribute'
+          ) {
+            continue;
+          }
           // semantic-graph-extractor emits array item paths with `[]`
           // markers (schema-analyzer.ts: `${fieldPath}[]`). The Playwright
           // emitter's accessor builder expects numeric indices, so

--- a/path-analyser/src/scenarioGenerator.ts
+++ b/path-analyser/src/scenarioGenerator.ts
@@ -216,9 +216,37 @@ export function generateScenariosForEndpoint(
   // chains it and this block is a no-op.
   const externalEntitySites: string[] = [];
   const externalBindings: Record<string, string> = {};
+  // #162: a `clientMintedAttribute` semantic (ABox `kind: 'attribute'` +
+  // `clientMinted: true`, e.g. Tag / BusinessId) has no producer and no
+  // establisher BY DESIGN — no endpoint returns it and no
+  // `x-semantic-establishes` annotation mints it. The planner IS the
+  // authoritative source: `bindSemanticInput` synthesises a deterministic
+  // `fc:cma:<sem>:<suffix>` token for it.
+  //
+  // Handled here rather than in the static-missing gate above because the
+  // satisfaction mechanism is a seeded binding (like `externalEntitySites`),
+  // not a BFS-scheduled op (like the `runtimeEmission` injection branch).
+  //
+  // This only fires for REQUIRED leaves — optional ones never enter
+  // `initialNeeded` and are owned by the variant suite
+  // (`generateOptionalSubShapeVariants`). The bundled camunda-oca spec's
+  // first required case is `assignProcessInstanceBusinessId.businessId`
+  // (`BusinessId`), added in spec version 8.10; before that every
+  // Tag/BusinessId body leaf was optional and this path was unexercised.
+  const clientMintedAttributeSites: string[] = [];
+  const clientMintedBindings: Record<string, string> = {};
   if (missing.length > 0) {
     const stillMissing: string[] = [];
     for (const st of missing) {
+      // Tier-1 ABox declarations beat the Tier-2 graph-index and
+      // external-entity checks below (see the precedence contract in
+      // `bindSemanticInput.classifySemantic`), so this branch runs first.
+      const bound = bindSemanticInput({ semantic: st, operationId: endpointOpId, graph });
+      if (bound.classification === 'clientMintedAttribute') {
+        clientMintedBindings[bound.varName] = bound.value;
+        clientMintedAttributeSites.push(st);
+        continue;
+      }
       // Per-tuple `acceptsExternal: true` only applies on edge
       // establishers. Look it up via the endpoint's own `establishes`.
       const isEdgeEstablisher =
@@ -260,23 +288,29 @@ export function generateScenariosForEndpoint(
       }
     }
     // Replace the missing list with whatever the fallback could not
-    // cover. If every missing semantic was external-mintable, the
-    // unsatisfied branch below MUST NOT fire.
+    // cover. If every missing semantic was external-mintable or
+    // client-minted, the unsatisfied branch below MUST NOT fire.
     missing.length = 0;
     missing.push(...stillMissing);
   }
 
-  // BFS planning state subtracts the external-mintable semantics from
+  // BFS planning state subtracts the planner-minted semantics from
   // `initialNeeded` because they are pre-satisfied by the seeded
   // bindings. `initialNeeded` itself stays immutable so downstream
   // reporting (`satisfiedSemanticTypes`) still reflects everything
   // the endpoint required — a scenario that satisfied a need via
   // external mint is not the same as a scenario that did not need
   // it. See PR #140 reviewer thread on initialNeeded mutation.
+  //
+  // Subtracting `clientMintedAttributeSites` is load-bearing, not
+  // cosmetic: nothing in the graph can ever produce such a semantic, so
+  // leaving it in the BFS `needed` set would mean no chain ever completes
+  // and the endpoint would silently degrade to `{ scenarios: [] }`.
+  const plannerMintedSites = [...externalEntitySites, ...clientMintedAttributeSites];
   const planningNeeded =
-    externalEntitySites.length === 0
+    plannerMintedSites.length === 0
       ? initialNeeded
-      : new Set([...initialNeeded].filter((s) => !externalEntitySites.includes(s)));
+      : new Set([...initialNeeded].filter((s) => !plannerMintedSites.includes(s)));
 
   const scenarios: EndpointScenario[] = [];
   const max = opts.maxChainAlternatives;
@@ -309,7 +343,7 @@ export function generateScenariosForEndpoint(
     // wrongly rejected. Externally-minted semantics are satisfied
     // by the seeded binding the same way establisher-minted
     // semantics are.
-    produced: new Set(externalEntitySites),
+    produced: new Set(plannerMintedSites),
     needed: new Set(planningNeeded),
     domainStates: new Set(),
     ops: [],
@@ -318,11 +352,15 @@ export function generateScenariosForEndpoint(
     providerList: {},
     artifactsApplied: [],
     // Issue #134: pre-seed bindingsDraft with the client-minted IDs
-    // synthesised for every bimodal `acceptsExternal` fallback above.
-    // The body builder and URL emitter look up by the same key
-    // (`${camelLower(name)}Var`), so the seeded value flows through
-    // without any per-step override.
-    bindingsDraft: Object.keys(externalBindings).length ? { ...externalBindings } : undefined,
+    // synthesised for every bimodal `acceptsExternal` fallback above,
+    // plus (#162) the `fc:cma:` tokens minted for required
+    // clientMintedAttribute body leaves. The body builder and URL
+    // emitter look up by the same key (`${camelLower(name)}Var`), so the
+    // seeded value flows through without any per-step override.
+    bindingsDraft:
+      Object.keys(externalBindings).length || Object.keys(clientMintedBindings).length
+        ? { ...externalBindings, ...clientMintedBindings }
+        : undefined,
   };
 
   const queue: State[] = [initial];

--- a/tests/fixtures/planner/planner-client-minted-attribute.test.ts
+++ b/tests/fixtures/planner/planner-client-minted-attribute.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Planner contract fixtures — REQUIRED clientMintedAttribute body leaves.
+ *
+ * A `clientMintedAttribute` semantic (`kind: 'attribute'` +
+ * `clientMinted: true` in the ABox) has no `producersByType` entry and no
+ * `establishersByType` entry *by design*: no endpoint returns it, and no
+ * `x-semantic-establishes` annotation mints it. The planner is the
+ * authoritative source of the value — `bindSemanticInput` synthesises a
+ * deterministic `fc:cma:<sem>:<suffix>` token for it.
+ *
+ * Until this fixture landed, the pre-BFS static-missing gate in
+ * `generateScenariosForEndpoint` only exempted `runtimeEmission`. A
+ * REQUIRED body leaf carrying a clientMintedAttribute semantic therefore
+ * fell through as "missing" and the planner returned `unsatisfied: true`
+ * before the BFS loop ever ran — so the endpoint's OTHER required
+ * semantics (path-parameter keys with real authoritative producers) never
+ * got a chain either.
+ *
+ * The bundled camunda-oca spec exercises this via
+ * `POST /process-instances/{processInstanceKey}/business-id-assignment`
+ * (`assignProcessInstanceBusinessId`), whose body requires `businessId`
+ * (`BusinessId`). Every other one of the 25 `Tag`/`BusinessId` body
+ * leaves in that spec is OPTIONAL, which is why the gate went unexercised
+ * until the 8.10 spec pin.
+ *
+ * Class-scoped invariant: a required request input whose semantic
+ * classifies as `clientMintedAttribute` must be satisfied by a planner-
+ * minted binding, never reported as missing — and must not suppress
+ * producer chaining for the endpoint's remaining required semantics.
+ */
+import { describe, expect, it } from 'vitest';
+import { generateScenariosForEndpoint } from '../../../path-analyser/src/scenarioGenerator.ts';
+import type {
+  OperationGraph,
+  OperationNode,
+  SemanticTypeSpec,
+} from '../../../path-analyser/src/types.ts';
+
+interface NodeOpts {
+  required?: string[];
+  produces?: string[];
+  providerMap?: Record<string, boolean>;
+  pathParameters?: OperationNode['pathParameters'];
+  requestBodySemantics?: OperationNode['requestBodySemantics'];
+}
+
+function makeOp(
+  operationId: string,
+  method: string,
+  path: string,
+  opts: NodeOpts = {},
+): OperationNode {
+  return {
+    operationId,
+    method,
+    path,
+    requires: { required: opts.required ?? [], optional: [] },
+    produces: opts.produces ?? [],
+    providerMap: opts.providerMap,
+    pathParameters: opts.pathParameters,
+    requestBodySemantics: opts.requestBodySemantics,
+  };
+}
+
+/**
+ * Mirrors graphLoader's indexing contract: only `provider: true` response
+ * leaves land in `producersByType` (#98). A clientMintedAttribute
+ * semantic appears in NEITHER `producersByType` nor `establishersByType`,
+ * which is exactly the state the missing-gate has to tolerate.
+ */
+function makeGraph(
+  nodes: OperationNode[],
+  semanticTypes: Record<string, SemanticTypeSpec>,
+): OperationGraph {
+  const operations: Record<string, OperationNode> = {};
+  const producersByType: Record<string, string[]> = {};
+  for (const node of nodes) {
+    operations[node.operationId] = node;
+    for (const sem of node.produces) {
+      if (node.providerMap?.[sem] !== true) continue;
+      const list = producersByType[sem] ?? [];
+      list.push(node.operationId);
+      producersByType[sem] = list;
+    }
+  }
+  return { operations, producersByType, domain: { version: 1, semanticTypes } };
+}
+
+function opIdsOf(scenario: { operations: { operationId: string }[] }): string[] {
+  return scenario.operations.map((o) => o.operationId);
+}
+
+/**
+ * Builds the `assignProcessInstanceBusinessId` shape with neutral names:
+ * a producer for the path-param semantic, plus a setter endpoint whose
+ * body REQUIRES an attribute semantic. `labelDecl` varies the ABox
+ * declaration so the fixtures can probe the classification boundary.
+ */
+function makeSetterGraph(labelDecl: SemanticTypeSpec | undefined): OperationGraph {
+  return makeGraph(
+    [
+      makeOp('createThing', 'POST', '/things', {
+        produces: ['ThingKey'],
+        providerMap: { ThingKey: true },
+      }),
+      makeOp('assignThingLabel', 'POST', '/things/{thingKey}/label-assignment', {
+        required: ['ThingKey', 'Label'],
+        pathParameters: [{ name: 'thingKey', semanticType: 'ThingKey' }],
+        requestBodySemantics: [{ semantic: 'Label', fieldPath: 'label', required: true }],
+      }),
+    ],
+    labelDecl ? { Label: labelDecl } : {},
+  );
+}
+
+const fixtureRequiredClientMintedAttribute = makeSetterGraph({
+  kind: 'attribute',
+  clientMinted: true,
+});
+
+// Negative control 1: `kind: 'attribute'` WITHOUT `clientMinted: true`.
+// Mirrors the `classifySemantic` precedence contract — only the explicit
+// flag promotes into the clientMintedAttribute branch — so this semantic
+// stays genuinely unreachable and must still be reported missing.
+const fixtureAttributeNotClientMinted = makeSetterGraph({ kind: 'attribute' });
+
+// Negative control 2: no ABox declaration at all (`unclassified`). The
+// exemption must be scoped to the classification, not a blanket bypass of
+// the missing-gate for every producer-less required body leaf.
+const fixtureUndeclaredSemantic = makeSetterGraph(undefined);
+
+describe('planner contracts: required clientMintedAttribute body leaf', () => {
+  describe('required clientMintedAttribute (Label) on a setter endpoint', () => {
+    it('plans a satisfied chain instead of returning unsatisfied', () => {
+      const result = generateScenariosForEndpoint(
+        fixtureRequiredClientMintedAttribute,
+        'assignThingLabel',
+        { maxChainAlternatives: 10 },
+      );
+      expect(result.unsatisfied).toBeFalsy();
+      expect(result.scenarios.length).toBeGreaterThan(0);
+      expect(result.scenarios[0].missingSemanticTypes ?? []).toEqual([]);
+    });
+
+    it('chains the authoritative producer for the endpoint’s other required semantic', () => {
+      // The regression this guards: a missing clientMintedAttribute
+      // short-circuited the whole BFS, so ThingKey — which HAS an
+      // authoritative producer — never got chained either. The emitted
+      // test then seeded a fake key into the URL.
+      const result = generateScenariosForEndpoint(
+        fixtureRequiredClientMintedAttribute,
+        'assignThingLabel',
+        { maxChainAlternatives: 10 },
+      );
+      expect(opIdsOf(result.scenarios[0])).toEqual(['createThing', 'assignThingLabel']);
+    });
+
+    it('binds the minted fc:cma: value for the attribute semantic', () => {
+      const result = generateScenariosForEndpoint(
+        fixtureRequiredClientMintedAttribute,
+        'assignThingLabel',
+        { maxChainAlternatives: 10 },
+      );
+      const bindings = result.scenarios[0].bindings ?? {};
+      // `bindSemanticInput` owns the value shape; assert the prefix
+      // rather than the full token so the deterministic suffix stays an
+      // implementation detail.
+      expect(bindings.labelVar).toMatch(/^fc:cma:label:/);
+    });
+
+    it('reports the attribute semantic as satisfied, not missing', () => {
+      const result = generateScenariosForEndpoint(
+        fixtureRequiredClientMintedAttribute,
+        'assignThingLabel',
+        { maxChainAlternatives: 10 },
+      );
+      expect(result.requiredSemanticTypes).toContain('Label');
+      expect(result.scenarios[0].satisfiedSemanticTypes).toContain('Label');
+    });
+  });
+
+  describe('classification boundary', () => {
+    it('kind:attribute WITHOUT clientMinted stays unsatisfied', () => {
+      const result = generateScenariosForEndpoint(
+        fixtureAttributeNotClientMinted,
+        'assignThingLabel',
+        { maxChainAlternatives: 10 },
+      );
+      expect(result.unsatisfied).toBe(true);
+      expect(result.scenarios[0].missingSemanticTypes).toEqual(['Label']);
+    });
+
+    it('an undeclared (unclassified) required body semantic stays unsatisfied', () => {
+      const result = generateScenariosForEndpoint(fixtureUndeclaredSemantic, 'assignThingLabel', {
+        maxChainAlternatives: 10,
+      });
+      expect(result.unsatisfied).toBe(true);
+      expect(result.scenarios[0].missingSemanticTypes).toEqual(['Label']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Three Layer-3 invariants in `configs/camunda-oca/regression-invariants.test.ts` were red on `main` after the spec-pin bump. This fixes the planner bug behind one of them and corrects an over-broad test contract behind the other two.

Failing before this PR:

| Invariant | Failure |
|---|---|
| `#54` planner output | `structuralViolations` contained `POST /process-instances/{processInstanceKey}/business-id-assignment` |
| `#162 PR 4` variant JSON | `expected variant-output JSON not found: post--process-instances--{processInstanceKey}--business-id-assignment-scenarios.json` |
| `#162 PR 4` variant spec | `expected emitted spec not found: assignProcessInstanceBusinessId.variant.spec.ts` |

---

## Root cause

The spec-pin bump (`11362f9`) introduced `POST /process-instances/{processInstanceKey}/business-id-assignment` (`assignProcessInstanceBusinessId`, `x-added-in-version: 8.10`). It is the **first and only** operation in the pinned spec with a **required** request-body field carrying a `clientMintedAttribute` semantic:

```json
// ProcessInstanceBusinessIdAssignmentInstruction
{ "properties": { "businessId": { "$ref": "#/components/schemas/BusinessId" } },
  "required": ["businessId"] }
```

`BusinessId` is declared in `configs/camunda-oca/ontology/semantics.json` as `kind: "attribute", clientMinted: true` — *"no producer endpoint … the planner mints a deterministic value at the setter site"*.

Verified blast radius across all 221 graph nodes: this is the **only** required `Tag`/`BusinessId` leaf, and the **only** planner file whose `missingSemanticTypes` contained a client-minted attribute. The other 24 such body leaves are all optional. That single `required: true` broke two subsystems that both assumed *client-minted ⇒ optional*.

### 1. Planner — a real generator bug (`#54`)

`path-analyser/src/scenarioGenerator.ts:184-201` — the pre-BFS static-missing gate asks only *"is there a `producersByType` entry, an `establishersByType` entry, or is this `runtimeEmission`?"*. A `clientMintedAttribute` semantic has none of those **by design**. So `BusinessId` landed in `missing` and `:284-302` returned `unsatisfied: true` **before the BFS loop at `:352` ever ran** — meaning `createProcessInstance` (the sole `provider:true` producer of `ProcessInstanceKey`) was never considered either.

The gate contradicted the repo's own classification chokepoint: `graphLoader.ts:712-726` validates that `BusinessId` classifies as `clientMintedAttribute`, and `bindSemanticInput.ts:145-150` can mint a value for it with no producer at all.

**Why the failure message was misleading.** The `#54` structural-cause check (`:1622-1644`) only inspects *path-placeholder* semantic types. It saw `ProcessInstanceKey` — which **is** authoritatively reachable — and concluded "the BFS dropped a chain it should have planned". The actual blocker, `BusinessId`, is a *body* type that never appears in the path. The verdict "investigate the BFS" was correct; the named type was not.

Runtime consequence, already on disk before this PR: the emitted spec seeded a fake `processInstanceKeyVar` and asserted `204`. A recorded run in `path-analyser/test-results/` shows `Expected: 204 / Received: 400`.

### 2. Variant contract — a test-contract gap, not a generator bug (`#162 PR 4`)

The variant suite is contractually **optional-only**, in three independent places:

- `graphLoader.deriveOptionalSubShapes` skips `required === true` (`graphLoader.ts:1386`)
- variant emission is gated on `op.optionalSubShapes?.length` (`index.ts:502`)
- `generateOptionalSubShapeVariants` skips leaves already in `requires.required` (`scenarioGenerator.ts:2125`)

A required field has no populated-vs-omitted axis, so the base/feature scenario owns it. The sibling PR-4 invariant already encodes exactly this with `if (e.required) continue;` (`:4802`). The PR-2 `setterOpsFor` derivation (`:4310`) simply omitted the same filter, so it demanded artifacts the generator will never emit for a required leaf. Forcing the generator to emit them would need three coordinated changes to the variant contract and would produce a variant spec that near-duplicates the base feature spec.

---

## Changes and rationale

### `path-analyser/src/scenarioGenerator.ts`

Client-minted semantics are pulled out of `missing`, subtracted from the BFS `needed` set, and seeded into `produced` + `bindingsDraft` — mirroring the existing `externalEntitySites` pattern rather than inventing a new mechanism.

This sits in the **fallback block**, not the missing-gate itself, because the satisfaction mechanism is a *seeded binding* (like `externalEntitySites`) rather than a *BFS-scheduled op* (like the `runtimeEmission` injection branch). That makes it the architecturally correct home and a smaller diff.

Subtracting from `planningNeeded` is **load-bearing, not cosmetic**: nothing in the graph can ever produce such a semantic, so leaving it in the BFS `needed` set would mean no chain ever completes and the endpoint would silently degrade to `{ scenarios: [] }`.

Result — the chain is now planned end to end:

```
createDeployment → createProcessInstance → assignProcessInstanceBusinessId
```

with `processInstanceKeyVar` **extracted** from the producer response instead of seeded with a fake key.

### `path-analyser/src/index.ts`

Producer-step extract auto-derivation now skips a `clientMintedAttribute` binding the planner already pinned.

This was **not** in the original plan — regeneration surfaced a bug the analysis hadn't predicted. `CreateProcessInstanceResult.businessId` is `nullable: true`, and `extractInto` guards only `undefined`, so step 2's echo clobbered the minted value with `null` → `{businessId: null}` → 400 on a required, `minLength: 1` field. Without this guard the fix would have produced a structurally-correct spec that still failed at runtime.

**The scoping matters.** A first attempt guarded *every* literal binding and suppressed **197** extracts across the generated tree — that would have stranded synthetic variant placeholders such as `processDefinitionKey_816j`, which the real producer extract is *supposed* to overwrite (verifiable in `searchProcessInstances.variant.spec.ts`, where the synthetic assignment is immediately followed by the real `extractInto`). Narrowed to the `clientMintedAttribute` classification, it suppresses exactly **1** — the intended case.

### `configs/camunda-oca/regression-invariants.test.ts`

`setterOpsFor` is split by required-ness, and the suite-partition rule is now documented in the block header:

- **optional** client-minted setter leaf → variant suite (the 4 existing ops keep their assertions unchanged)
- **required** setter leaf → feature/base suite (two new assertions: the feature scenario binds `<sem>Var`, and the emitted feature spec references `ctx.<sem>Var`)

Coverage is preserved, just asserted against the suite that actually owns it. The `#54` invariant itself is untouched — `assignProcessInstanceBusinessId` now drops out of its offender set naturally, leaving the three genuine upstream-gap endpoints (`getAgentDefinition`, `getAuditLog`, `getVariable`) and their documented tracking intact.

The new required-setter assertion deliberately does **not** assert the binding's value. The planner mints `fc:cma:<sem>:<suffix>`, but the materializer's `#320` unique-seeding rule legitimately replaces a deterministic literal with `seedBinding(name, { unique: true })` when a step declares HTTP 409 — which every uniqueness-enforced setter does, and which is the *correct* runtime value here (reusing a fixed business id across runs would 409). Asserting the literal would couple the invariant to that override.

### `tests/fixtures/planner/planner-client-minted-attribute.test.ts` (new)

Layer-2 fixture per the repo's red-fixture rule (red first: 4 failed / 2 passed, the 2 being negative controls). Covers the satisfied chain, the producer chaining, the `fc:cma:` binding, and two classification-boundary controls proving the exemption is scoped to the classification rather than a blanket bypass: `kind:'attribute'` **without** `clientMinted`, and an undeclared (`unclassified`) semantic, both of which must still report unsatisfied.

---

## Deliberately out of scope

- **`serverEmergent` is not exempted from the same gate.** `AgentDefinitionKey`, `AuditLogKey`, `VariableKey`, `ScopeKey`, `DeploymentKey`, `MessageSubscriptionKey`, and `AuditLogEntityKey` are all declared `serverEmergent`; exempting them would empty the `#54` offender set and silently retire the tracked upstream gap. Separate decision, separate change.
- **`featureCoverageGenerator.ts:174/237` untouched.** It hardcodes `unsatisfied: false` and reports every required semantic as satisfied without proving it — which is *why* a broken spec was emitted silently instead of failing loudly. A genuine latent defect, but a much larger blast radius; worth its own issue.

---

## Verification

- Layer-2 fixture: red → green.
- `npx vitest run configs/camunda-oca/regression-invariants.test.ts` — **201 passed**, 4 skipped. All three named failures green; both new required-setter assertions confirmed executing (not silently empty).
- `npm test` — **926 passed**, 12 skipped, 2 failed. Both failures are pre-existing and environmental: `tests/codegen/ontology-roundtrip.test.ts` needs `jsonld`, which is declared in `package.json:71` but absent from the local checkout (`npm ls jsonld` empty). CI's clean install should have it.
- `npx tsc --noEmit -p path-analyser` — clean.
- `npm run lint` — 3 warnings, all pre-existing in `tests/fixtures/planner/filter-scope-binding.test.ts`, a file this PR does not touch.
- Regenerated artifacts inspected directly; no `generated/` or `spec/` changes are committed, per the repo boundary.

## Remaining risks
- **Recurrence surface.** A future spec bump marking another client-minted attribute required now flows through correctly. A *new* client-minted semantic added to the ABox with a required leaf and no `bindSemanticInput` value path would still fail — the new fixture guards the fixed path, not that class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
